### PR TITLE
Alltid vis møtebehovsiden uavhengig av om møtebehov er innsendt,

### DIFF
--- a/src/frontend/js/components/GlobalNavigasjon.js
+++ b/src/frontend/js/components/GlobalNavigasjon.js
@@ -57,19 +57,6 @@ const finnAntallPrikker = (menypunkt, oppgaver) => {
     }).length;
 };
 
-const setMotemodulSti = (motebehovReducer, motebehovet) => {
-    if (motebehovReducer.hentet && motebehovet) {
-        return 'moteoversikt';
-    }
-    return 'mote';
-};
-
-const setNySti = (sti, menypunkt, motebehovet, motebehovReducer) => {
-    if (menypunkt === menypunkter.MOETEPLANLEGGER) {
-        return setMotemodulSti(motebehovReducer, motebehovet);
-    }
-    return sti;
-};
 
 class GlobalNavigasjon extends Component {
     constructor(props) {
@@ -77,9 +64,6 @@ class GlobalNavigasjon extends Component {
         this.state = {
             focusIndex: -1,
         };
-        if (!this.props.motebehovForsoktHentet) {
-            this.props.hentMotebehov(this.props.fnr);
-        }
     }
 
     setFocus(fokusId) {
@@ -131,7 +115,7 @@ class GlobalNavigasjon extends Component {
     }
 
     render() {
-        const { fnr, aktivtMenypunkt, oppgaver, motebehovet, motebehovReducer } = this.props;
+        const { fnr, aktivtMenypunkt, oppgaver } = this.props;
         this.menypunkter = [historikkMenypunkt, tidslinjeMenypunkt, sykmeldingerMenypunkt, sykepengesoknadMenypunkt, oppfoelgingsplanMenypunkt, motemodulMenypunkt];
 
         return (<ul aria-label="Navigasjon" className="navigasjon">
@@ -140,13 +124,12 @@ class GlobalNavigasjon extends Component {
                     const className = cn('navigasjonspanel', {
                         'navigasjonspanel--aktiv': menypunkt === aktivtMenypunkt,
                     });
-                    const nySti = setNySti(sti, menypunkt, motebehovet, motebehovReducer);
                     const antallPrikker = finnAntallPrikker(menypunkt, oppgaver);
                     return (<li key={index} className="navigasjon__element">
                         <a
                             ref={this.getRef(index)}
                             className={className}
-                            href={`/sykefravaer/${fnr}/${nySti}`}
+                            href={`/sykefravaer/${fnr}/${sti}`}
                             onFocus={() => {
                                 this.setFocusIndex(index);
                             }}
@@ -157,7 +140,7 @@ class GlobalNavigasjon extends Component {
                                 e.preventDefault();
                                 // Dette gjøres slik for å slippe å laste siden på nytt.
                                 // <Link /> fra react-router kan ikke brukes da den ikke støtter ref-attributtet.
-                                browserHistory.push(`/sykefravaer/${fnr}/${nySti}`);
+                                browserHistory.push(`/sykefravaer/${fnr}/${sti}`);
                             }}>
                             <span className="navigasjon__element__tekst" dangerouslySetInnerHTML={{ __html: navn }} />
                             {
@@ -175,10 +158,6 @@ GlobalNavigasjon.propTypes = {
     fnr: PropTypes.string,
     aktivtMenypunkt: PropTypes.string,
     oppgaver: PropTypes.arrayOf(PropTypes.object),
-    motebehovForsoktHentet: PropTypes.bool,
-    motebehovet: PropTypes.object,
-    motebehovReducer: PropTypes.object,
-    hentMotebehov: PropTypes.func,
 };
 
 export default GlobalNavigasjon;

--- a/src/frontend/js/containers/GlobalNavigasjonContainer.js
+++ b/src/frontend/js/containers/GlobalNavigasjonContainer.js
@@ -1,18 +1,14 @@
 import { connect } from 'react-redux';
 import GlobalNavigasjon from '../components/GlobalNavigasjon';
-import * as motebehovActions from '../actions/motebehov_actions';
 
 export const mapStateToProps = (state, ownProps) => {
     return {
         oppgaver: state.veilederoppgaver.data,
         fnr: ownProps.fnr,
         aktivtMenypunkt: ownProps.aktivtMenypunkt,
-        motebehovForsoktHentet: state.motebehov.henter || state.motebehov.hentet || state.motebehov.hentingFeilet,
-        motebehovet: state.motebehov.data[0],
-        motebehovReducer: state.motebehov,
     };
 };
 
-const GlobalNavigasjonContainer = connect(mapStateToProps, motebehovActions)(GlobalNavigasjon);
+const GlobalNavigasjonContainer = connect(mapStateToProps)(GlobalNavigasjon);
 
 export default GlobalNavigasjonContainer;

--- a/src/frontend/js/containers/MotebehovContainer.js
+++ b/src/frontend/js/containers/MotebehovContainer.js
@@ -111,26 +111,20 @@ export class MotebehovSide extends Component {
                     if (hentingFeilet) {
                         return <Feilmelding />;
                     }
-                    if (motebehovListeUtenFlereSvarFraSammePerson.length > 0) {
-                        return (<Motebehov
-                            actions={actions}
-                            fnr={fnr}
-                            ledereData={ledereData}
-                            ledereUtenInnsendtMotebehov={ledereUtenInnsendtMotebehov}
-                            ledetekster={ledetekster}
-                            motebehovListe={motebehovListeUtenFlereSvarFraSammePerson}
-                            oppgaver={oppgaver}
-                            sykmeldt={sykmeldt}
-                            ufiltrertMotebehovListeTilOppgavebehandling={ufiltrertMotebehovListeTilOppgavebehandling}
-                            veilederinfo={veilederinfo}
-                            aktiveDialoger={aktiveDialoger}
-                            oppfolgingstilfelleperioder={oppfolgingstilfelleperioder}
-                            sykmeldinger={sykmeldinger}
-                        />);
-                    }
-                    return (<Feilmelding
-                        tittel={getLedetekst('mote.motebehov.feilmelding.tittel', ledetekster)}
-                        melding={getHtmlLedetekst('mote.motebehov.feilmelding.ikkeFunnet', ledetekster)}
+                    return (<Motebehov
+                        actions={actions}
+                        fnr={fnr}
+                        ledereData={ledereData}
+                        ledereUtenInnsendtMotebehov={ledereUtenInnsendtMotebehov}
+                        ledetekster={ledetekster}
+                        motebehovListe={motebehovListeUtenFlereSvarFraSammePerson}
+                        oppgaver={oppgaver}
+                        sykmeldt={sykmeldt}
+                        ufiltrertMotebehovListeTilOppgavebehandling={ufiltrertMotebehovListeTilOppgavebehandling}
+                        veilederinfo={veilederinfo}
+                        aktiveDialoger={aktiveDialoger}
+                        oppfolgingstilfelleperioder={oppfolgingstilfelleperioder}
+                        sykmeldinger={sykmeldinger}
                     />);
                 })()
             }
@@ -175,7 +169,8 @@ export const mapStateToProps = (state, ownProps) => {
     const motebehovListeUtenFlereSvarFraSammePerson = finnNyesteMotebehovsvarFraHverDeltaker(sortertMotebehovListe);
 
     const ledereData = state.ledere.data;
-    const ledereUtenInnsendtMotebehov = finnLedereUtenInnsendtMotebehov(ledereData, motebehovData);
+    const oppfolgingstilfelleperioder = state.oppfolgingstilfelleperioder;
+    const ledereUtenInnsendtMotebehov = finnLedereUtenInnsendtMotebehov(ledereData, motebehovData, oppfolgingstilfelleperioder);
 
     const aktiveDialoger = state.oppfoelgingsdialoger.data.filter((dialog) => {
         return dialog.status !== 'AVBRUTT' && new Date(dialog.godkjentPlan.gyldighetstidspunkt.tom) > new Date();
@@ -206,7 +201,7 @@ export const mapStateToProps = (state, ownProps) => {
         ufiltrertMotebehovListeTilOppgavebehandling: state.motebehov.data,
         veilederinfo: state.veilederinfo.data,
         aktiveDialoger,
-        oppfolgingstilfelleperioder: state.oppfolgingstilfelleperioder,
+        oppfolgingstilfelleperioder,
         sykmeldinger: state.sykmeldinger.data,
     };
 };

--- a/src/frontend/js/utils/datoUtils.js
+++ b/src/frontend/js/utils/datoUtils.js
@@ -104,3 +104,7 @@ export const tilLesbarDatoMedAarUtenMaanedNavn = (datoArg) => {
 export const tilLesbarPeriodeMedAarUtenMaanednavn = (fomArg, tomArg) => {
     return `${tilLesbarDatoMedAarUtenMaanedNavn(fomArg)} - ${tilLesbarDatoMedAarUtenMaanedNavn(tomArg)}`;
 };
+
+export const hentDagerMellomDatoer = (startDato, sluttDato) => {
+    return Math.round(Math.abs((sluttDato.getTime() - startDato.getTime()) / (ANTALL_MS_DAG)));
+};

--- a/src/frontend/js/utils/ledereUtils.js
+++ b/src/frontend/js/utils/ledereUtils.js
@@ -1,3 +1,12 @@
+import {
+    senesteTom,
+    tidligsteFom,
+} from './periodeUtils';
+import {
+    erOppfoelgingsdatoPassertMed16UkerOgIkke26Uker,
+    erOppfolgingstilfelleSluttDatoPassert,
+} from './motebehovUtils';
+
 export const filtrerLederePaaArbeidstakersMotebehov = (ledereData, motebehovData) => {
     return ledereData.filter((leder) => {
         return motebehovData.findIndex((motebehov) => {
@@ -14,7 +23,24 @@ export const fjernLedereMedInnsendtMotebehov = (ledereListe, motebehovData) => {
     });
 };
 
-export const finnLedereUtenInnsendtMotebehov = (ledereData, motebehovData) => {
-    const ledereFiltrertPaaArbeidstakersMotebehov = filtrerLederePaaArbeidstakersMotebehov(ledereData, motebehovData);
-    return fjernLedereMedInnsendtMotebehov(ledereFiltrertPaaArbeidstakersMotebehov, motebehovData);
+export const filtrerLederePaaOppfolgingstilfelleperioder = (ledereData, oppfolgingstilfelleperioder) => {
+    return ledereData.filter((leder) => {
+        const startOppfolgingsdato = oppfolgingstilfelleperioder[leder.orgnummer] ? tidligsteFom(oppfolgingstilfelleperioder[leder.orgnummer].data) : new Date();
+        const sluttOppfolgingsdato = oppfolgingstilfelleperioder[leder.orgnummer] ? senesteTom(oppfolgingstilfelleperioder[leder.orgnummer].data) : new Date();
+        const today = new Date();
+
+        startOppfolgingsdato.setHours(0, 0, 0, 0);
+        sluttOppfolgingsdato.setHours(0, 0, 0, 0);
+        today.setHours(0, 0, 0, 0);
+
+        return (startOppfolgingsdato && sluttOppfolgingsdato)
+            && !erOppfolgingstilfelleSluttDatoPassert(sluttOppfolgingsdato)
+            && erOppfoelgingsdatoPassertMed16UkerOgIkke26Uker(startOppfolgingsdato);
+    });
+};
+
+
+export const finnLedereUtenInnsendtMotebehov = (ledereData, motebehovData, oppfolgingstilfelleperioder) => {
+    const ledereFiltrertPaaOppfolgingstilfelleperioder = filtrerLederePaaOppfolgingstilfelleperioder(ledereData, oppfolgingstilfelleperioder);
+    return fjernLedereMedInnsendtMotebehov(ledereFiltrertPaaOppfolgingstilfelleperioder, motebehovData);
 };

--- a/src/frontend/js/utils/motebehovUtils.js
+++ b/src/frontend/js/utils/motebehovUtils.js
@@ -1,3 +1,5 @@
+import { hentDagerMellomDatoer } from './datoUtils';
+
 export const sorterMotebehovDataEtterDato = (a, b) => {
     return b.opprettetDato === a.opprettetDato ? 0 : b.opprettetDato > a.opprettetDato ? 1 : -1;
 };
@@ -26,4 +28,28 @@ export const finnArbeidstakerMotebehovSvar = (motebehovListe) => {
     return motebehovListe.find((motebehov) => {
         return motebehov.opprettetAv === motebehov.aktorId;
     });
+};
+
+export const OPPFOLGINGSFORLOP_MOTEBEHOV_START_DAGER = 16 * 7;
+export const OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER = 26 * 7;
+
+export const erOppfoelgingsdatoPassertMed16UkerOgIkke26Uker = (startOppfolgingsdato) => {
+    const oppfoelgingstilfelleStartDato = new Date(startOppfolgingsdato);
+    oppfoelgingstilfelleStartDato.setHours(0, 0, 0, 0);
+    const dagensDato = new Date();
+    dagensDato.setHours(0, 0, 0, 0);
+
+    const antallDagerSidenOppfoelgingsTilfelleStart = hentDagerMellomDatoer(oppfoelgingstilfelleStartDato, dagensDato);
+
+    return antallDagerSidenOppfoelgingsTilfelleStart >= OPPFOLGINGSFORLOP_MOTEBEHOV_START_DAGER
+        && antallDagerSidenOppfoelgingsTilfelleStart < OPPFOLGINGSFORLOP_MOTEBEHOV_SLUTT_DAGER;
+};
+
+export const erOppfolgingstilfelleSluttDatoPassert = (sluttOppfolgingsdato) => {
+    const oppfolgingstilfelleSluttDato = new Date(sluttOppfolgingsdato);
+    oppfolgingstilfelleSluttDato.setHours(0, 0, 0, 0);
+    const dagensDato = new Date();
+    dagensDato.setHours(0, 0, 0, 0);
+
+    return dagensDato > oppfolgingstilfelleSluttDato;
 };

--- a/src/frontend/js/utils/sykmeldingUtils.js
+++ b/src/frontend/js/utils/sykmeldingUtils.js
@@ -14,9 +14,9 @@ export const erEkstraDiagnoseInformasjon = (sykmelding) => {
 
 export const erMulighetForArbeidInformasjon = (sykmelding) => {
     return sykmelding.mulighetForArbeid
-    && ((sykmelding.mulighetForArbeid.aktivitetIkkeMulig433 && sykmelding.mulighetForArbeid.aktivitetIkkeMulig433.length)
+    && ((sykmelding.mulighetForArbeid.aktivitetIkkeMulig433 && sykmelding.mulighetForArbeid.aktivitetIkkeMulig433.length > 0)
         || sykmelding.mulighetForArbeid.aarsakAktivitetIkkeMulig433
-        || (sykmelding.mulighetForArbeid.aktivitetIkkeMulig434 && sykmelding.mulighetForArbeid.aktivitetIkkeMulig434.length)
+        || (sykmelding.mulighetForArbeid.aktivitetIkkeMulig434 && sykmelding.mulighetForArbeid.aktivitetIkkeMulig434.length > 0)
         || sykmelding.mulighetForArbeid.aarsakAktivitetIkkeMulig434);
 };
 

--- a/src/frontend/test/containers/GlobalNavigasjonContainerTest.js
+++ b/src/frontend/test/containers/GlobalNavigasjonContainerTest.js
@@ -36,40 +36,5 @@ describe('GlobalNavigasjonContainer', () => {
             const props = mapStateToProps(state, ownProps);
             expect(props.aktivtMenypunkt).to.equal('OLSEN');
         });
-
-        it('Skal returnere motebehov === undefined dersom det ikke finnes møtebehov', () => {
-            const ownProps = {
-                fnr: '887766',
-                aktivtMenypunkt: 'OLSEN',
-            };
-
-            const props = mapStateToProps(state, ownProps);
-
-            expect(props.motebehov).to.be.equal(undefined);
-        });
-
-        it('Skal returnere hentingFeilet når henting av møtebehov feiler', () => {
-            const ownProps = {
-                fnr: '887766',
-                aktivtMenypunkt: 'OLSEN',
-            };
-            state.motebehov.hentingFeilet = true;
-
-            const props = mapStateToProps(state, ownProps);
-
-            expect(props.motebehovReducer.hentingFeilet).to.be.equal(true);
-        });
-
-        it('Skal returnere hentingFeilet når henting av møtebehov ikke feiler', () => {
-            const ownProps = {
-                fnr: '887766',
-                aktivtMenypunkt: 'OLSEN',
-            };
-            state.motebehov.hentingFeilet = false;
-
-            const props = mapStateToProps(state, ownProps);
-
-            expect(props.motebehovReducer.hentingFeilet).to.be.equal(false);
-        });
     });
 });

--- a/src/frontend/test/containers/MotebehovContainerTest.js
+++ b/src/frontend/test/containers/MotebehovContainerTest.js
@@ -6,6 +6,7 @@ import AppSpinner from '../../js/components/AppSpinner';
 import Feilmelding from '../../js/components/Feilmelding';
 import Motebehov from '../../js/components/Motebehov';
 import { mapStateToProps, MotebehovSide } from '../../js/containers/MotebehovContainer';
+import { ANTALL_MS_DAG } from '../../js/utils/datoUtils';
 
 describe('MotebehovContainer', () => {
     describe('MotebehovSide', () => {
@@ -138,7 +139,8 @@ describe('MotebehovContainer', () => {
                 },
                 sykmeldinger: {
                     data: [],
-                }
+                },
+                oppfolgingstilfelleperioder: [],
             };
             ownProps = {
                 params: {
@@ -275,32 +277,12 @@ describe('MotebehovContainer', () => {
             expect(motebehovet.opprettetDato).to.equal(nyesteDato);
         });
 
-        it('Skal returnere ledereUtenInnsendtMotebehov hvis sykmeldt har sendt inn svar men ikke leder i samme virksomhet', () => {
+        it('Skal returnere ledereUtenInnsendtMotebehov hvis den sykmeldte er i et aktivt oppfølgingstilfelle i møtebehovperioden', () => {
             const leder1 = 'Leder1';
             const leder2 = 'Leder2';
             const virksomhet1 = '123';
             const virksomhet2 = '999';
             const sykmeldt = 'Sykmeldt';
-            state.motebehov.data = [
-                {
-                    id: '1',
-                    virksomhetsnummer: virksomhet1,
-                    opprettetAv: sykmeldt,
-                    aktorId: sykmeldt,
-                },
-                {
-                    id: '2',
-                    virksomhetsnummer: virksomhet2,
-                    opprettetAv: leder2,
-                    aktorId: sykmeldt,
-                },
-                {
-                    id: '3',
-                    virksomhetsnummer: virksomhet2,
-                    opprettetAv: sykmeldt,
-                    aktorId: sykmeldt,
-                },
-            ];
 
             state.ledere.data = [
                 {
@@ -312,6 +294,45 @@ describe('MotebehovContainer', () => {
                     orgnummer: virksomhet2,
                 },
             ];
+
+            state.oppfolgingstilfelleperioder[virksomhet1] = {
+                data: [
+                    {
+                        orgnummer: virksomhet1,
+                        fom: new Date(Date.now() - (ANTALL_MS_DAG * 120)),
+                        tom: new Date(Date.now() - (ANTALL_MS_DAG * 90)),
+                    },
+                    {
+                        orgnummer: virksomhet1,
+                        fom: new Date(Date.now() - (ANTALL_MS_DAG * 80)),
+                        tom: new Date(Date.now() - (ANTALL_MS_DAG * 50)),
+                    },
+                    {
+                        orgnummer: virksomhet1,
+                        fom: new Date(Date.now() - (ANTALL_MS_DAG * 40)),
+                        tom: new Date(Date.now() - (ANTALL_MS_DAG * 10)),
+                    },
+                    {
+                        orgnummer: virksomhet1,
+                        fom: new Date(Date.now() - (ANTALL_MS_DAG * 5)),
+                        tom: new Date(Date.now() + (ANTALL_MS_DAG * 15)),
+                    },
+                ]
+        };
+            state.oppfolgingstilfelleperioder[virksomhet2] = {
+                data: [
+                    {
+                        orgnummer: virksomhet2,
+                        fom: new Date(Date.now() - (ANTALL_MS_DAG * 80)),
+                        tom: new Date(Date.now() - (ANTALL_MS_DAG * 50)),
+                    },
+                    {
+                        orgnummer: virksomhet2,
+                        fom: new Date(Date.now() - (ANTALL_MS_DAG * 40)),
+                        tom: new Date(Date.now() - (ANTALL_MS_DAG * 10)),
+                    },
+                ]
+            };
 
             const props = mapStateToProps(state, ownProps);
             const leder = props.ledereUtenInnsendtMotebehov[0];


### PR DESCRIPTION
Vis "ikke svart" for alle ledere i møtebehovperioden
Fjern sjekk på om møtebehov finnes i GlobalNavigasjon, slik at man alltid kommer til møtelandingssiden.
Finn alle ledere som skal vises som "ikke svart" ved å sjekke om de har oppfølgingstilfelle som startet for 16 - 26 uker siden, og som slutter etter dagens dato.