### PR TITLE
Fjern Tilbakedatering fra sjekk om det er ekstra info i sykmelding

### DIFF
--- a/src/frontend/js/utils/sykmeldingUtils.js
+++ b/src/frontend/js/utils/sykmeldingUtils.js
@@ -67,12 +67,6 @@ export const erMeldingTilArbeidsgiverInformasjon = (sykmelding) => {
     return !!erEkstraInformasjon;
 };
 
-export const erTilbakeDateringInformasjon = (sykmelding) => {
-    const erEkstraInformasjon = sykmelding.tilbakedatering
-        && (sykmelding.tilbakedatering.dokumenterbarPasientkontakt
-            || sykmelding.tilbakedatering.tilbakedatertBegrunnelse);
-    return !!erEkstraInformasjon;
-};
 
 export const erEkstraInformasjonISykmeldingen = (sykmelding) => {
     return erEkstraDiagnoseInformasjon(sykmelding)
@@ -83,8 +77,7 @@ export const erEkstraInformasjonISykmeldingen = (sykmelding) => {
         || erUtdypendeOpplysningerInformasjon(sykmelding)
         || erBedringAvArbeidsevnenInformasjon(sykmelding)
         || erMeldingTilNavInformasjon(sykmelding)
-        || erMeldingTilArbeidsgiverInformasjon(sykmelding)
-        || erTilbakeDateringInformasjon(sykmelding);
+        || erMeldingTilArbeidsgiverInformasjon(sykmelding);
 };
 
 export const arbeidsgivernavnEllerArbeidssituasjon = (sykmelding) => {

--- a/src/frontend/test/utils/sykmeldingUtilsTest.js
+++ b/src/frontend/test/utils/sykmeldingUtilsTest.js
@@ -8,7 +8,6 @@ import {
     erMeldingTilArbeidsgiverInformasjon,
     erMeldingTilNavInformasjon,
     erMulighetForArbeidInformasjon,
-    erTilbakeDateringInformasjon,
     erUtdypendeOpplysningerInformasjon,
     arbeidsgivernavnEllerArbeidssituasjon,
     sykmeldingerMedStatusSendt,
@@ -296,34 +295,6 @@ describe('sykmeldingUtils', () => {
 
 
             const erIkkeEkstraInfo = erMeldingTilArbeidsgiverInformasjon(sykmelding);
-
-            expect(erIkkeEkstraInfo).to.equal(false);
-        });
-    });
-
-    describe('erTilbakeDateringInformasjon', () => {
-        it('skal returnere true dersom sykmeldingen inneholder informasjon om tilbakedatering', () => {
-            const sykmelding = {
-                tilbakedatering: {
-                    dokumenterbarPasientkontakt: '2018-09-05',
-                    tilbakedatertBegrunnelse: 'Pasienten ville heller ligge på sofaen!',
-                },
-            };
-
-           const erEkstraInfo = erTilbakeDateringInformasjon(sykmelding);
-
-           expect(erEkstraInfo).to.equal(true);
-        });
-        it('skal returnere false dersom sykmeldingen ikke inneholder informasjon om tilbakedatering', () => {
-            const sykmelding = {
-                tilbakedatering: {
-                    dokumenterbarPasientkontakt: null,
-                    tilbakedatertBegrunnelse: null,
-                },
-            };
-
-
-            const erIkkeEkstraInfo = erTilbakeDateringInformasjon(sykmelding);
 
             expect(erIkkeEkstraInfo).to.equal(false);
         });


### PR DESCRIPTION
Dette punktet gir prikker i sykmeldingene på møtebehovsiden, uten at det vises noe ekstra info i sykmeldingen