### PR TITLE
Bruk "stopp" som type på Alertstripe

### DIFF
--- a/src/frontend/js/mote/components/DropdownInnholdsviser.js
+++ b/src/frontend/js/mote/components/DropdownInnholdsviser.js
@@ -22,7 +22,7 @@ Innhold.propTypes = {
 };
 
 const Feil = ({ melding = 'Beklager, det oppstod en feil' }) => {
-    return (<Alertstripe type="feil" className="blokk">
+    return (<Alertstripe type="stopp" className="blokk">
         <p>{melding}</p>
     </Alertstripe>);
 };


### PR DESCRIPTION
Typen "feil" finnes ikke i den versjonen vi bruker av nav-frontend-alertstriper