### PR TITLE
Legg til informasjon om reisetilskudd, behandlingsdager, avventende

### DIFF
--- a/src/frontend/js/components/motebehov/MulighetForArbeid.js
+++ b/src/frontend/js/components/motebehov/MulighetForArbeid.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Checkbox } from 'nav-frontend-skjema';
-import { erMulighetForArbeidInformasjon } from '../../utils/sykmeldingUtils';
+import {
+    erMulighetForArbeidInformasjon,
+    finnAvventendeSykmeldingTekst,
+} from '../../utils/sykmeldingUtils';
 
 const tekster = {
     mulighetForArbeid: {
+        avventende: {
+            tittel: 'Innspill til arbeidsgiveren ved avventende sykmelding',
+        },
         beskrivelse: 'Nærmere beskrivelse',
         medisinskAarsak: {
             tittel: 'Det er medisinske årsaker som hindrer arbeidsrelatert aktivitet',
@@ -13,6 +19,20 @@ const tekster = {
             tittel: 'Forhold på arbeidsplassen vanskeliggjør arbeidsrelatert aktivitet',
         },
     },
+};
+
+const AvventendeSykmelding = (
+    {
+        avventendeTekst,
+    }) => {
+    return (<div>
+        <h5 className="undertittel">{tekster.mulighetForArbeid.avventende.tittel}</h5>
+        <p>{avventendeTekst}</p>
+    </div>);
+};
+
+AvventendeSykmelding.propTypes = {
+    avventendeTekst: PropTypes.string,
 };
 
 const AktivitetIkkeMulig = (
@@ -49,12 +69,17 @@ export const MulighetForArbeid = (
         sykmelding,
     }) => {
     const mulighetForArbeid = sykmelding.mulighetForArbeid;
+    const avventendeTekst = finnAvventendeSykmeldingTekst(sykmelding);
     const aktivitetIkkeMulig433 = mulighetForArbeid.aktivitetIkkeMulig433;
     const aarsakAktivitetIkkeMulig433 = mulighetForArbeid.aarsakAktivitetIkkeMulig433;
     const aktivitetIkkeMulig434 = mulighetForArbeid.aktivitetIkkeMulig434;
     const aarsakAktivitetIkkeMulig434 = mulighetForArbeid.aarsakAktivitetIkkeMulig434;
     const skalVise = erMulighetForArbeidInformasjon(sykmelding);
-    return (skalVise && <div className="sykmeldingMotebehovVisning__avsnitt">
+    return ((skalVise || !!avventendeTekst) && <div className="sykmeldingMotebehovVisning__avsnitt">
+        {
+            !!avventendeTekst &&
+                <AvventendeSykmelding avventendeTekst={avventendeTekst} />
+        }
         {
             aktivitetIkkeMulig433 && aktivitetIkkeMulig433.length > 0 &&
                 <AktivitetIkkeMulig beskrivelse={aarsakAktivitetIkkeMulig433} ikkeMuligListe={aktivitetIkkeMulig433} tittel={tekster.mulighetForArbeid.medisinskAarsak.tittel} />

--- a/src/frontend/js/components/motebehov/Perioder.js
+++ b/src/frontend/js/components/motebehov/Perioder.js
@@ -3,6 +3,23 @@ import PropTypes from 'prop-types';
 import { tilLesbarPeriodeMedArUtenManednavn } from '../../utils/datoUtils';
 import BoksRad from './BoksRad';
 
+const kolonne2Tekst = (periode) => {
+    if (!!periode.behandlingsdager) {
+        return periode.behandlingsdager === 1
+            ? `${periode.behandlingsdager} behandlingsdag`
+            : `${periode.behandlingsdager} behandlingsdager`;
+    }
+    if (!!periode.reisetilskudd) {
+        return !!periode.grad
+            ? `${periode.grad}% sykmeldt med reisetilskudd`
+            : 'Full jobb med reisetilskudd';
+    }
+    if (!!periode.avventende) {
+        return `${periode.grad}% Avventende`;
+    }
+    return `${periode.grad}%`;
+};
+
 export const PeriodeBoks = (
     {
         periode,
@@ -10,7 +27,7 @@ export const PeriodeBoks = (
     return (<div className="sykmeldingMotebehovVisning__periodeBoks">
         <BoksRad
             kolonne1Tekst={`${tilLesbarPeriodeMedArUtenManednavn(periode.fom, periode.tom)}`}
-            kolonne2Tekst={`${periode.grad}%`}
+            kolonne2Tekst={kolonne2Tekst(periode)}
             erTittel
         />
     </div>);

--- a/src/frontend/js/components/motebehov/UtdragFraSykefravaeret.js
+++ b/src/frontend/js/components/motebehov/UtdragFraSykefravaeret.js
@@ -86,7 +86,7 @@ export const UtvidbarTittel = (
     return (<div className="utdragFraSykefravaeret__utvidbarTittel">
         <div>
             <span className="utvidbarTittel__periode">{`${tilLesbarPeriodeMedArstall(tidligsteFom(sykmelding.mulighetForArbeid.perioder), senesteTom(sykmelding.mulighetForArbeid.perioder))}: `}</span>
-            <span className="utvidbarTittel__grad">{` ${stringMedAlleGraderingerFraSykmeldingPerioder(sykmeldingPerioderSortertEtterDato)}%`}</span>
+            <span className="utvidbarTittel__grad">{stringMedAlleGraderingerFraSykmeldingPerioder(sykmeldingPerioderSortertEtterDato)}</span>
         </div>
         {
             erViktigInformasjon && <div className="utvidbarTittel__erViktig">

--- a/src/frontend/js/utils/sykmeldingUtils.js
+++ b/src/frontend/js/utils/sykmeldingUtils.js
@@ -5,6 +5,22 @@ import {
     FRILANSER,
 } from '../enums/arbeidssituasjoner';
 
+export const finnAvventendeSykmeldingTekst = (sykmelding) => {
+    const avventendePeriode = sykmelding.mulighetForArbeid.perioder
+        && sykmelding.mulighetForArbeid.perioder.find((periode) => {
+            return !!periode.avventende;
+        });
+    return avventendePeriode && avventendePeriode.avventende;
+};
+
+export const erBehandlingsdagerEllerReisetilskudd = (sykmelding) => {
+    const erEkstraInformasjon = sykmelding.mulighetForArbeid.perioder
+        && sykmelding.mulighetForArbeid.perioder.find((periode) => {
+            return !!periode.reisetilskudd || !!periode.behandlingsdager;
+        });
+    return !!erEkstraInformasjon;
+};
+
 export const erEkstraDiagnoseInformasjon = (sykmelding) => {
     const erEkstraInformasjon = sykmelding.diagnose
         && (sykmelding.diagnose.fravaersgrunnLovfestet
@@ -79,7 +95,8 @@ export const erEkstraInformasjonISykmeldingen = (sykmelding) => {
         || erUtdypendeOpplysningerInformasjon(sykmelding)
         || erBedringAvArbeidsevnenInformasjon(sykmelding)
         || erMeldingTilNavInformasjon(sykmelding)
-        || erMeldingTilArbeidsgiverInformasjon(sykmelding);
+        || erMeldingTilArbeidsgiverInformasjon(sykmelding)
+        || erBehandlingsdagerEllerReisetilskudd(sykmelding);
 };
 
 export const arbeidsgivernavnEllerArbeidssituasjon = (sykmelding) => {
@@ -153,8 +170,19 @@ export const sykmeldingperioderSortertEldstTilNyest = (perioder) => {
     });
 };
 
+const sykmeldingperioderMedGradering = (sykmeldingperioder) => {
+    return sykmeldingperioder.filter((periode) => {
+        return !!periode.grad;
+    });
+};
+
 export const stringMedAlleGraderingerFraSykmeldingPerioder = (sykmeldingPerioderSortertEtterDato) => {
-    return sykmeldingPerioderSortertEtterDato.map((periode) => {
+    const perioderMedGradering = sykmeldingperioderMedGradering(sykmeldingPerioderSortertEtterDato);
+    const stringMedAlleGraderinger = perioderMedGradering.map((periode) => {
         return periode.grad;
     }).join('% - ');
+
+    return !!stringMedAlleGraderinger
+        ? `${stringMedAlleGraderinger}%`
+        : '';
 };


### PR DESCRIPTION
Vis i periodelisten i sykmeldingen på møtebehovsiden om en periode gjelder reisetilskudd, behandlingsdager, eller er avventende.

Ikke vis prosenttegn i headeren til sykmeldingen hvis det ikke er oppgitt grad.

Vis innspill til arbeidsgiver hvis det er avventende sykmelding.

Legg til reisetilskudd og behandlingsdager i sjekken for ekstra informasjon.