### PR TITLE
Bruk egne tekstobjekter i bekreftMote-komponentene, fiks feilmelding

### DIFF
--- a/src/frontend/js/mote/components/BekreftMote.js
+++ b/src/frontend/js/mote/components/BekreftMote.js
@@ -50,7 +50,6 @@ class BekreftMote extends Component {
         return (
             <BekreftMoteUtenSvarSkjema
                 mote={this.props.mote}
-                ledetekster={this.props.ledetekster}
                 avbrytHref={this.props.avbrytHref}
                 bekrefter={this.props.bekrefter}
                 bekreftFeilet={this.props.bekreftFeilet}

--- a/src/frontend/js/mote/components/BekreftMoteSkjema.js
+++ b/src/frontend/js/mote/components/BekreftMoteSkjema.js
@@ -4,7 +4,6 @@ import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import AlertStripe from 'nav-frontend-alertstriper';
 import KnappBase from 'nav-frontend-knapper';
-import { getLedetekst } from '@navikt/digisyfo-npm';
 import * as motePropTypes from '../../propTypes';
 import Epostmottakere from './Epostmottakere';
 import Innholdsviser from './Innholdsviser';
@@ -12,18 +11,29 @@ import { mapStateToInnholdsviserProps } from './AvbrytMote';
 
 export const InnholdsviserContainer = connect(mapStateToInnholdsviserProps)(Innholdsviser);
 
+export const tekster = {
+    mote: {
+        bekreftmote: {
+            feil: 'Det skjedde en feil',
+            lightboxOverskrift: 'Send bekreftelse på møtetidspunkt',
+            lightboxSendKnapp: 'Send bekreftelse',
+            lightboxAvbrytKnapp: 'Avbryt',
+        },
+    },
+};
+
 const BekreftMoteSkjema = (props) => {
     const { mote, ledetekster, bekrefter, bekreftFeilet, onSubmit, avbrytHref, hentEpostinnhold, arbeidstaker } = props;
 
     return (<div className="epostinnhold">
-        <h2 className="epostinnhold__tittel">{getLedetekst('mote.bekreftmote.lightbox-overskrift', ledetekster)}</h2>
+        <h2 className="epostinnhold__tittel">{tekster.mote.bekreftmote.lightboxOverskrift}</h2>
         <Epostmottakere mote={mote} ledetekster={ledetekster} arbeidstaker={arbeidstaker} />
         <InnholdsviserContainer mote={mote} hentEpostinnhold={hentEpostinnhold} ledetekster={ledetekster} />
         <div aria-live="polite" role="alert">
             { bekreftFeilet && (<div className="blokk">
                 <AlertStripe
                     type="advarsel">
-                    <p>{getLedetekst('mote.bekreftmote.feil', ledetekster)}</p>
+                    <p>{tekster.mote.bekreftmote.feil}</p>
                 </AlertStripe>
             </div>)}
         </div>
@@ -34,9 +44,9 @@ const BekreftMoteSkjema = (props) => {
                 disabled={bekrefter}
                 className="blokk--s knapp--enten"
                 onClick={onSubmit}>
-                {getLedetekst('mote.bekreftmote.lightbox-send-knapp', ledetekster)}
+                {tekster.mote.bekreftmote.lightboxSendKnapp}
             </KnappBase>
-            <Link to={avbrytHref} className="lenke">{getLedetekst('mote.bekreftmote.lightbox-avbryt-knapp', ledetekster)}</Link>
+            <Link to={avbrytHref} className="lenke">{tekster.mote.bekreftmote.lightboxAvbrytKnapp}</Link>
         </div>
     </div>);
 };

--- a/src/frontend/js/mote/components/BekreftMoteUtenSvarSkjema.js
+++ b/src/frontend/js/mote/components/BekreftMoteUtenSvarSkjema.js
@@ -3,18 +3,30 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import AlertStripe from 'nav-frontend-alertstriper';
 import KnappBase from 'nav-frontend-knapper';
-import { getLedetekst } from '@navikt/digisyfo-npm';
+
+export const tekster = {
+    mote: {
+        bekreftmote: {
+            feil: 'Det skjedde en feil',
+        },
+        bekreftmoteutensvar: {
+            lightboxOverskrift: 'Har du avklart møtet på andre måter?',
+            lightboxSendKnapp: 'ja, dette er avklart',
+            lightboxAvbrytKnapp: 'Avbryt',
+        },
+    },
+};
 
 const BekreftMoteUtenSvarSkjema = (props) => {
-    const { ledetekster, bekrefter, bekreftFeilet, avbrytHref, bekreftMoteUtenSvar } = props;
+    const { bekrefter, bekreftFeilet, avbrytHref, bekreftMoteUtenSvar } = props;
 
     return (<div className="bekreftutensvarinnhold">
-        <h2 className="sidetopp__tittel">{getLedetekst('mote.bekreftmoteutensvar.lightbox-overskrift', ledetekster)}</h2>
+        <h2 className="sidetopp__tittel">{tekster.mote.bekreftmoteutensvar.lightboxOverskrift}</h2>
         <div aria-live="polite" role="alert">
             { bekreftFeilet && (<div className="blokk">
                 <AlertStripe
                     type="advarsel">
-                    <p>{getLedetekst('mote.bekreftmote.feil', ledetekster)}</p>
+                    <p>{tekster.mote.bekreftmote.feil}</p>
                 </AlertStripe>
             </div>)}
         </div>
@@ -24,15 +36,14 @@ const BekreftMoteUtenSvarSkjema = (props) => {
                 spinner={bekrefter}
                 disabled={bekrefter}
                 onClick={bekreftMoteUtenSvar}>
-                {getLedetekst('mote.bekreftmoteutensvar.lightbox-send-knapp', ledetekster)}
+                {tekster.mote.bekreftmoteutensvar.lightboxSendKnapp}
             </KnappBase>
-            <Link to={avbrytHref} className="hjelpetekstlenke">{getLedetekst('mote.bekreftmoteutensvar.lightbox-avbryt-knapp', ledetekster)}</Link>
+            <Link to={avbrytHref} className="hjelpetekstlenke">{tekster.mote.bekreftmoteutensvar.lightboxAvbrytKnapp}</Link>
         </div>
     </div>);
 };
 
 BekreftMoteUtenSvarSkjema.propTypes = {
-    ledetekster: PropTypes.object,
     avbrytHref: PropTypes.string,
     bekrefter: PropTypes.bool,
     bekreftFeilet: PropTypes.bool,

--- a/src/frontend/test/mote/components/BekreftMoteTest.js
+++ b/src/frontend/test/mote/components/BekreftMoteTest.js
@@ -3,8 +3,9 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import sinon from 'sinon';
 import KnappBase from 'nav-frontend-knapper';
-import BekreftMoteSkjema, { InnholdsviserContainer } from '../../../js/mote/components/BekreftMoteSkjema';
-import BekreftMoteUtenSvarSkjema from '../../../js/mote/components/BekreftMoteUtenSvarSkjema';
+import
+    BekreftMoteSkjema, { InnholdsviserContainer, tekster as bekreftMoteTeskter } from '../../../js/mote/components/BekreftMoteSkjema';
+import BekreftMoteUtenSvarSkjema, { tekster as bekreftMoteUtenSvarTekster} from '../../../js/mote/components/BekreftMoteUtenSvarSkjema';
 import {
     ARBEIDSGIVER,
     BRUKER,
@@ -156,9 +157,8 @@ describe('BekreftMoteSkjemaComponent', () => {
     it('Viser tittel', () => {
         component = shallow(<BekreftMoteSkjema
             mote={mote}
-            ledetekster={ledetekster}
         />);
-        expect(component.text()).to.contain('Bekreft møteforespørsel');
+        expect(component.text()).to.contain(bekreftMoteTeskter.mote.bekreftmote.lightboxOverskrift);
     });
 
     it('Viser mottakere det er to mottakere', () => {
@@ -182,30 +182,24 @@ describe('BekreftMoteSkjemaComponent', () => {
 
 describe('BekreftMoteUtenSvarSkjemaComponent', () => {
     let component;
-    let ledetekster;
     let mote;
     let handleSubmit;
 
     beforeEach(() => {
         mote = getMoteUtenSvar();
-        ledetekster = {
-            'mote.bekreftmoteutensvar.lightbox-overskrift': 'Har du avklart møtet på andre måter?',
-        };
         handleSubmit = sinon.spy();
     });
 
     it('Viser tittel', () => {
         component = shallow(<BekreftMoteUtenSvarSkjema
             mote={mote}
-            ledetekster={ledetekster}
         />);
-        expect(component.text()).to.contain('Har du avklart møtet på andre måter?');
+        expect(component.text()).to.contain(bekreftMoteUtenSvarTekster.mote.bekreftmoteutensvar.lightboxOverskrift);
     });
 
     it('Bekrefter at møte er avtalt på annen måte', () => {
         component = shallow(<BekreftMoteUtenSvarSkjema
             mote={mote}
-            ledetekster={ledetekster}
             bekreftMoteUtenSvar={handleSubmit}
         />);
         component.find(KnappBase).simulate('click');


### PR DESCRIPTION
Bruk egne tekstobjekter i stedet for syfotekster, slik at det er lettere å gjøre endringer
Endre feilmelding fra "Dette skjedde en feil" til "Det skjedde en feil"