### PR TITLE
Remove code that redirects to user in contextholder.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,14 +138,6 @@ store.dispatch(hentAktivEnhet({
     },
 }));
 
-if (!fnr || fnr.length < 1) {
-    store.dispatch(hentAktivBruker({
-        callback: (aktivBruker) => {
-            window.location.href = `/sykefravaer/${aktivBruker}`;
-        },
-    }));
-}
-
 store.dispatch(hentLedetekster());
 
 if (hasURLParameter('visLedetekster')) {


### PR DESCRIPTION
Dette kan skape forvirring, og det er bedre å bare havne på "mangler fnr"-siden.