### PR TITLE
Remove veilederoppgaver for oppfolgingsplaner

### DIFF
--- a/mock/data/oppfoelgingsdialoger.json
+++ b/mock/data/oppfoelgingsdialoger.json
@@ -28,6 +28,34 @@
     "arbeidstaker": null
   },
   {
+    "id": 2957,
+    "uuid": "2f1e2629-062b-442d-ae1f-3b08e9574cd1",
+    "sistEndretAvAktoerId": "1101101101102",
+    "sistEndretDato": "2020-01-30T08:49:05.621",
+    "status": "AKTIV",
+    "virksomhet": {
+      "navn": "BRANN OG BIL AS",
+      "virksomhetsnummer": "555666444"
+    },
+    "godkjentPlan": {
+      "opprettetTidspunkt": "2020-01-20T08:49:05.621",
+      "gyldighetstidspunkt": {
+        "fom": "2020-01-20",
+        "tom": "2020-03-30",
+        "evalueres": "2020-03-21"
+      },
+      "tvungenGodkjenning": false,
+      "deltMedNAVTidspunkt": "2020-01-20T08:49:05.621",
+      "deltMedNAV": true,
+      "deltMedFastlegeTidspunkt": "2020-01-20T08:49:05.621",
+      "deltMedFastlege": true,
+      "dokumentUuid": "264fb21f-48c3-4669-82ca-d61f51d20c84"
+    },
+    "oppgaver": [],
+    "arbeidsgiver": null,
+    "arbeidstaker": null
+  },
+  {
     "id": 2963,
     "uuid": "7ad362e9-c5a7-42c0-b2d0-2a053518272b",
     "sistEndretAvAktoerId": "1101101101102",

--- a/src/components/UnfinishedTasks.js
+++ b/src/components/UnfinishedTasks.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as menypunkter from '../enums/menypunkter';
+
+const opActivePlanerText = (tasks) => {
+    const activeText = tasks > 1
+        ? 'aktive'
+        : 'aktiv';
+
+    return `(${tasks} ${activeText})`;
+};
+
+const UnfinishedTasks = ({ tasks, menypunkt }) => {
+    return menypunkt === menypunkter.OPPFOELGINGSPLANER
+        ? <p className="antallNytt__oppfolgingsplan">{opActivePlanerText(tasks)}</p>
+        : <i className="antallNytt">{tasks}</i>;
+};
+
+UnfinishedTasks.propTypes = {
+    tasks: PropTypes.number,
+    menypunkt: PropTypes.string,
+};
+
+export default UnfinishedTasks;

--- a/src/components/oppfoelgingsdialoger/OppfoelgingsPlanerOversikt.js
+++ b/src/components/oppfoelgingsdialoger/OppfoelgingsPlanerOversikt.js
@@ -8,11 +8,11 @@ import { restdatoTilLesbarDato } from '../../utils/datoUtils';
 
 const texts = {
     titles: {
-        relevantOppfolgingsplaner: 'Aktuelle oppfølgingsplaner',
+        relevantOppfolgingsplaner: 'Aktive oppfølgingsplaner',
         inactiveOppfolgingsplaner: 'Tidligere oppfølgingsplaner',
     },
     alertMessages: {
-        noRelevantOppfolgingsplaner: 'Det er ingen aktuelle oppfølgingsplaner.',
+        noRelevantOppfolgingsplaner: 'Det er ingen aktive oppfølgingsplaner.',
         noInactiveOppfolgingsplaner: 'Det er ingen tidligere oppfølgingsplaner.',
     },
     duration: 'Varighet',
@@ -26,12 +26,6 @@ const durationText = (dialog) => {
 const deltMedNavText = (dialog) => {
     const sharedDate = dialog.godkjentPlan && restdatoTilLesbarDato(dialog.godkjentPlan.deltMedNAVTidspunkt);
     return `${texts.shared} ${sharedDate}`;
-};
-
-const finnAntallOppgaver = (dialog) => {
-    return dialog.oppgaver.filter((oppgave) => {
-        return oppgave.type === 'SE_OPPFOLGINGSPLAN' && oppgave.status !== 'FERDIG';
-    }).length;
 };
 
 export class OppfoelgingsPlanerOversikt extends Component {
@@ -76,14 +70,12 @@ export class OppfoelgingsPlanerOversikt extends Component {
                 </Alertstripe>}
                 {
                     aktiveDialoger.map((dialog, index) => {
-                        const antallOppgaver = finnAntallOppgaver(dialog);
                         return (<Link key={index} className="navigasjonspanel navigasjonspanel--stor" to={`/sykefravaer/${fnr}/oppfoelgingsplaner/${dialog.id}`}>
                             <div className="navigasjonselement">
                                 <h3 className="panel__tittel navigasjonselement__tittel">{dialog.virksomhet.navn}</h3>
                                 <p className="navigasjonselement__undertittel">{durationText(dialog)}</p>
                                 <p className="navigasjonselement__undertekst">{deltMedNavText(dialog)}</p>
                             </div>
-                            { antallOppgaver > 0 && <i className="antallNytt">{antallOppgaver}</i> }
                         </Link>);
                     })
                 }
@@ -97,14 +89,12 @@ export class OppfoelgingsPlanerOversikt extends Component {
             }
             {
                 inaktiveDialoger.map((dialog, index) => {
-                    const antallOppgaver = finnAntallOppgaver(dialog);
                     return (<Link key={index} className="navigasjonspanel navigasjonspanel--stor" to={`/sykefravaer/${fnr}/oppfoelgingsplaner/${dialog.id}`}>
                         <div className="navigasjonselement">
                             <h3 className="panel__tittel navigasjonselement__tittel">{dialog.virksomhet.navn}</h3>
                             <p className="navigasjonselement__undertittel">{durationText(dialog)}</p>
                             <p className="navigasjonselement__undertekst">{deltMedNavText(dialog)}</p>
                         </div>
-                        { antallOppgaver > 0 && <i className="antallNytt">{antallOppgaver}</i> }
                     </Link>);
                 })
             }

--- a/src/components/oppfoelgingsdialoger/Oppfoelgingsplan.js
+++ b/src/components/oppfoelgingsdialoger/Oppfoelgingsplan.js
@@ -3,63 +3,21 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
-import { tilLesbarDatoMedArstall } from '@navikt/digisyfo-npm';
-import { Checkbox } from 'nav-frontend-skjema';
-import Alertstripe from 'nav-frontend-alertstriper';
 import Knapp from 'nav-frontend-knapper';
 import * as dokumentActions from '../../actions/dokumentinfo_actions';
-import * as veilederoppgaverActions from '../../actions/veilederoppgaver_actions';
 import Feilmelding from '../Feilmelding';
 import AppSpinner from '../AppSpinner';
 
-const FERDIG = 'FERDIG';
-
-const erOppgaveFullfoert = (oppgave) => {
-    return oppgave.status === FERDIG;
-};
-
-const seOppfolgingsplanOppgave = (oppfolgingsplan) => {
-    return oppfolgingsplan.oppgaver.filter((oppgave) => {
-        return oppgave.type === 'SE_OPPFOLGINGSPLAN';
-    })[0];
-};
-
 const PlanVisning = (
     {
-        actions,
         dokumentinfo,
         fnr,
         oppfolgingsplan,
-        veilederinfo,
     }) => {
-    const sePlanOppgave = seOppfolgingsplanOppgave(oppfolgingsplan);
     const bildeUrler = [];
     for (let i = 1; i <= dokumentinfo.antallSider; i += 1) {
         bildeUrler.push(`${process.env.REACT_APP_OPPFOLGINGSPLANREST_ROOT}/internad/dokument/${oppfolgingsplan.id}/side/${i}`);
     }
-
-    const Skjema = () => {
-        return sePlanOppgave && sePlanOppgave.status === FERDIG
-            ? <Alertstripe type="suksess">
-                <p>Ferdig behandlet av {sePlanOppgave.sistEndretAv} {tilLesbarDatoMedArstall(sePlanOppgave.sistEndret)}</p>
-            </Alertstripe>
-            : sePlanOppgave && sePlanOppgave.status !== FERDIG
-                ? <Checkbox
-                    label="Marker som behandlet"
-                    onClick={() => {
-                        actions.behandleOppgave(sePlanOppgave.id, {
-                            status: FERDIG,
-                            sistEndretAv: veilederinfo.ident,
-                        }, fnr);
-                    }}
-                    id="marker__utfoert"
-                    disabled={erOppgaveFullfoert(sePlanOppgave)}
-                    checked={erOppgaveFullfoert(sePlanOppgave)}
-                />
-                : (<Alertstripe type="info">
-                    <p>Fant dessverre ingen oppgave knyttet til denne planen</p>
-                </Alertstripe>);
-    };
 
     const TilbakeTilOppfolgingsplaner = () => {
         return (<div className="blokk">
@@ -68,9 +26,6 @@ const PlanVisning = (
     };
 
     return (<div className="blokk--l">
-        <div className="blokk">
-            <Skjema />
-        </div>
         <TilbakeTilOppfolgingsplaner />
         <div className="pdfbilder blokk--s">
             {
@@ -150,7 +105,7 @@ OppfoelgingsplanWrapper.propTypes = {
 };
 
 export function mapDispatchToProps(dispatch) {
-    const actions = Object.assign({}, dokumentActions, veilederoppgaverActions);
+    const actions = Object.assign({}, dokumentActions);
     return {
         actions: bindActionCreators(actions, dispatch),
     };
@@ -158,9 +113,6 @@ export function mapDispatchToProps(dispatch) {
 
 export function mapStateToProps(state, ownProps) {
     const oppfolgingsplan = ownProps.oppfoelgingsdialog;
-    oppfolgingsplan.oppgaver = state.veilederoppgaver.data.filter((_oppgave) => {
-        return _oppgave.uuid === oppfolgingsplan.uuid;
-    });
     const veilederinfo = state.veilederinfo.data;
     let oppfolgingsplanDokumentinfoReducer = {};
     if (oppfolgingsplan) {
@@ -174,7 +126,6 @@ export function mapStateToProps(state, ownProps) {
         oppfolgingsplan,
         veilederinfo,
         fnr: ownProps.fnr,
-        veilderoppgaver: state.veilederoppgaver.data,
     };
 }
 

--- a/src/containers/GlobalNavigasjonContainer.js
+++ b/src/containers/GlobalNavigasjonContainer.js
@@ -2,17 +2,18 @@ import { connect } from 'react-redux';
 import GlobalNavigasjon from '../components/GlobalNavigasjon';
 import * as motebehovActions from '../actions/motebehov_actions';
 import * as moterActions from '../actions/moter_actions';
+import * as oppfoelgingsdialogerActions from '../actions/oppfoelgingsdialoger_actions';
 
 export const mapStateToProps = (state, ownProps) => {
     return {
-        oppgaver: state.veilederoppgaver.data,
         fnr: ownProps.fnr,
         aktivtMenypunkt: ownProps.aktivtMenypunkt,
         motebehovReducer: state.motebehov,
         moterReducer: state.moter,
+        oppfolgingsplanerReducer: state.oppfoelgingsdialoger,
     };
 };
 
-const GlobalNavigasjonContainer = connect(mapStateToProps, Object.assign({}, motebehovActions, moterActions))(GlobalNavigasjon);
+const GlobalNavigasjonContainer = connect(mapStateToProps, Object.assign({}, motebehovActions, moterActions, oppfoelgingsdialogerActions))(GlobalNavigasjon);
 
 export default GlobalNavigasjonContainer;

--- a/src/containers/OppfoelgingsPlanerOversiktContainer.js
+++ b/src/containers/OppfoelgingsPlanerOversiktContainer.js
@@ -96,14 +96,8 @@ export function mapStateToProps(state, ownProps) {
     const hentetDialoger = state.oppfoelgingsdialoger.hentet;
     const henterDialoger = state.oppfoelgingsdialoger.henter;
 
-    const oppfoelgingsdialoger = state.oppfoelgingsdialoger.data.map((dialog) => {
-        const oppgaver = state.veilederoppgaver.data.filter((oppgave) => {
-            return oppgave.type === 'SE_OPPFOLGINGSPLAN' && oppgave.uuid === dialog.uuid;
-        });
-        return Object.assign({}, dialog, {
-            oppgaver,
-        });
-    });
+    const oppfoelgingsdialoger = state.oppfoelgingsdialoger.data;
+
     const aktiveDialoger = oppfoelgingsdialoger.filter((dialog) => {
         return dialog.status !== 'AVBRUTT' && new Date(dialog.godkjentPlan.gyldighetstidspunkt.tom) > new Date();
     });
@@ -120,7 +114,6 @@ export function mapStateToProps(state, ownProps) {
         hentingFeilet,
         hentetDialoger,
         henterDialoger,
-        veilederoppgaver: state.veilederoppgaver.data,
         inaktiveDialoger,
         aktiveDialoger,
         tilgang: state.tilgang.data,

--- a/src/styles/_antallNytt.less
+++ b/src/styles/_antallNytt.less
@@ -64,3 +64,7 @@
     animation: alarm 1.5s infinite cubic-bezier(0.175, 0.885, 0.32, 1.275);
   }
 }
+
+.antallNytt__oppfolgingsplan {
+  font-size: 14px;
+}

--- a/src/utils/GlobalNavigasjonUtils.js
+++ b/src/utils/GlobalNavigasjonUtils.js
@@ -1,0 +1,44 @@
+import * as menypunkter from '../enums/menypunkter';
+import { harUbehandletMotebehov } from './motebehovUtils';
+
+const isUnfinishedMotebehovTask = (motebehovReducer) => {
+    return harUbehandletMotebehov(motebehovReducer.data);
+};
+
+const isUnfinishedMoterTask = (moterReducer) => {
+    return moterReducer
+        && moterReducer.data
+        && moterReducer.data[0]
+        && moterReducer.data[0].trengerBehandling;
+};
+
+const activeOppfolgingsplaner = (oppfolgingsplanerReducer) => {
+    return oppfolgingsplanerReducer
+        && oppfolgingsplanerReducer.data
+        && oppfolgingsplanerReducer.data.filter((dialog) => {
+            return dialog.status !== 'AVBRUTT' && new Date(dialog.godkjentPlan.gyldighetstidspunkt.tom) > new Date();
+        }).length;
+};
+
+const moteplanleggerTasks = (motebehovReducer, moterReducer) => {
+    const motebehovPrikker = isUnfinishedMotebehovTask(motebehovReducer)
+        ? 1
+        : 0;
+
+    const moterPrikker = isUnfinishedMoterTask(moterReducer)
+        ? 1
+        : 0;
+
+    return motebehovPrikker + moterPrikker;
+};
+
+export const numberOfTasks = (menypunkt, motebehovReducer, moterReducer, oppfolgingsplanerReducer) => {
+    switch (menypunkt) {
+        case menypunkter.MOETEPLANLEGGER:
+            return moteplanleggerTasks(motebehovReducer, moterReducer);
+        case menypunkter.OPPFOELGINGSPLANER:
+            return activeOppfolgingsplaner(oppfolgingsplanerReducer);
+        default:
+            return 0;
+    }
+};


### PR DESCRIPTION
Vis `(x aktive)` på oppfølgingsplaner-fanen i stedet for prikk.

Nå er det ikke lenger noe veilederen trenger å behandle, kun informasjon om det finnes én eller flere aktive planer.