### PR TITLE
Add tag in personkortHeader if sykmeldt has active corona diagnose

### DIFF
--- a/mock/data/sykmeldinger.json
+++ b/mock/data/sykmeldinger.json
@@ -96,8 +96,8 @@
       },
       {
         "aktivitetIkkeMulig": null,
-        "fom": "2020-01-25",
-        "tom": "2020-02-25",
+        "fom": "2020-02-25",
+        "tom": "2020-04-25",
         "gradert": null,
         "behandlingsdager": null,
         "innspillTilArbeidsgiver": null,
@@ -157,8 +157,8 @@
     },
     "medisinskVurdering": {
       "hovedDiagnose": {
-        "kode": "L87",
-        "system": "2.16.578.1.12.4.1.1.7170",
+        "kode": "U071",
+        "system": "ICD-10",
         "tekst": "TENDINITT INA"
       },
       "biDiagnoser": [
@@ -329,8 +329,8 @@
       },
       "biDiagnoser": [
         {
-          "kode": "L87",
-          "system": "2.16.578.1.12.4.1.1.7170",
+          "kode": "U071",
+          "system": "ICD-10",
           "tekst": "GANGLION SENE"
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2675,7 +2675,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-6.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
@@ -12419,7 +12419,7 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": "https://repo.adeo.no/repository/npm-public/kind-of/-/kind-of-6.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }

--- a/src/components/personkort/Personkort.js
+++ b/src/components/personkort/Personkort.js
@@ -41,6 +41,7 @@ class Personkort extends Component {
         if (brukerFnr && !henterEllerHarHentetFastleger(fastleger)) {
             this.props.actions.hentFastleger(brukerFnr);
         }
+        this.props.actions.hentSykmeldinger(brukerFnr);
     }
 
     byttVisning(visning) {
@@ -54,6 +55,7 @@ class Personkort extends Component {
             diskresjonskode,
             egenansatt,
             navbruker,
+            sykmeldinger,
         } = this.props;
         const visning = this.state.visning;
 
@@ -65,6 +67,7 @@ class Personkort extends Component {
                     diskresjonskode={diskresjonskode}
                     egenansatt={egenansatt}
                     navbruker={navbruker}
+                    sykmeldinger={sykmeldinger}
                 />}
             >
                 <div>
@@ -122,6 +125,6 @@ Personkort.propTypes = {
     navbruker: PropTypes.object,
     ledere: PropTypes.array,
     behandlendeEnhet: PropTypes.object,
-
+    sykmeldinger: PropTypes.arrayOf(PropTypes.object),
 };
 export default Personkort;

--- a/src/components/personkort/PersonkortHeader.js
+++ b/src/components/personkort/PersonkortHeader.js
@@ -7,11 +7,14 @@ import {
     hentBrukersKjoennFraFnr,
 } from '../../utils/fnrUtils';
 import { KJOENN } from '../../konstanter';
+import { sykmeldingerHasCoronaDiagnose } from '../../utils/sykmeldinger/sykmeldingUtils';
 
-const PersonkortHeader = ({ diskresjonskode, egenansatt, navbruker }) => {
+const PersonkortHeader = ({ diskresjonskode, egenansatt, navbruker, sykmeldinger }) => {
+    const hasCoronaDiagnose = sykmeldingerHasCoronaDiagnose(sykmeldinger);
     const visEtiketter = diskresjonskode.data.diskresjonskode === '6'
         || diskresjonskode.data.diskresjonskode === '7'
-        || egenansatt.data.erEgenAnsatt;
+        || egenansatt.data.erEgenAnsatt
+        || hasCoronaDiagnose;
     const tittelImg = hentBrukersKjoennFraFnr(navbruker.kontaktinfo.fnr) === KJOENN.KVINNE ?
         '/sykefravaer/img/svg/kvinne.svg' : '/sykefravaer/img/svg/mann.svg';
 
@@ -37,6 +40,10 @@ const PersonkortHeader = ({ diskresjonskode, egenansatt, navbruker }) => {
                     egenansatt.data.erEgenAnsatt
                     && <EtikettBase type="fokus">Egenansatt</EtikettBase>
                 }
+                {
+                    hasCoronaDiagnose
+                    && <EtikettBase type="fokus">Koronasykmeldt</EtikettBase>
+                }
             </div>
         }
     </div>);
@@ -46,6 +53,7 @@ PersonkortHeader.propTypes = {
     egenansatt: PropTypes.object,
     diskresjonskode: PropTypes.object,
     navbruker: PropTypes.object,
+    sykmeldinger: PropTypes.arrayOf(PropTypes.object),
 };
 
 export default PersonkortHeader;

--- a/src/containers/PersonKortContainer.js
+++ b/src/containers/PersonKortContainer.js
@@ -4,13 +4,15 @@ import Personkort from '../components/personkort/Personkort';
 import * as egenansattActions from '../actions/egenansatt_actions';
 import * as diskresjonskodeActions from '../actions/diskresjonskode_actions';
 import * as fastlegeActions from '../actions/fastleger_actions';
+import * as sykmeldingerActions from '../actions/sykmeldinger_actions';
 
 
 export function mapDispatchToProps(dispatch) {
     const actions = Object.assign({},
         diskresjonskodeActions,
         egenansattActions,
-        fastlegeActions
+        fastlegeActions,
+        sykmeldingerActions
     );
     return {
         actions: bindActionCreators(actions, dispatch),
@@ -26,6 +28,7 @@ export const mapStateToProps = (state) => {
         fastleger: state.fastleger,
         ledere: state.ledere.data,
         navbruker: state.navbruker.data,
+        sykmeldinger: state.sykmeldinger.data,
     };
 };
 

--- a/src/styles/_personKort.less
+++ b/src/styles/_personKort.less
@@ -89,7 +89,6 @@
   }
 
   & > div {
-    flex-grow: 1;
     &:not(:last-child) {
       margin-bottom: 1em;
     }

--- a/test/components/personkort/PersonkortTest.js
+++ b/test/components/personkort/PersonkortTest.js
@@ -8,17 +8,20 @@ import Personkort from '../../../src/components/personkort/Personkort';
 import PersonkortVisning from '../../../src/components/personkort/PersonkortVisning';
 import { hentBrukersAlderFraFnr } from '../../../src/utils/fnrUtils';
 import PersonkortHeader from '../../../src/components/personkort/PersonkortHeader';
+import mockOldSykmeldinger from '../../mockdata/sykmeldinger/mockOldSykmeldinger';
 
 describe('Personkort', () => {
     let hentDiskresjonskode;
     let hentEgenansatt;
     let hentFastleger;
+    let hentSykmeldinger;
     let actions;
     let egenansatt;
     let diskresjonskode;
     let navbruker;
     let fastleger;
     let komponent;
+    let sykmeldinger;
 
     beforeEach(() => {
         diskresjonskode = { data: {} };
@@ -34,13 +37,16 @@ describe('Personkort', () => {
                 fnr: '1234',
             },
         };
+        sykmeldinger = mockOldSykmeldinger;
         hentDiskresjonskode = sinon.spy();
         hentEgenansatt = sinon.spy();
         hentFastleger = sinon.spy();
+        hentSykmeldinger = sinon.spy();
         actions = {
             hentDiskresjonskode,
             hentEgenansatt,
             hentFastleger,
+            hentSykmeldinger,
         };
         komponent = shallow(<Personkort
             actions={actions}
@@ -48,6 +54,7 @@ describe('Personkort', () => {
             egenansatt={egenansatt}
             fastleger={fastleger}
             navbruker={navbruker}
+            sykmeldinger={sykmeldinger}
         />);
     });
 
@@ -58,6 +65,7 @@ describe('Personkort', () => {
             egenansatt={egenansatt}
             fastleger={fastleger}
             navbruker={navbruker}
+            sykmeldinger={sykmeldinger}
         />);
         expect(komponent.find(PersonkortHeader)).to.have.length(1);
     });
@@ -84,6 +92,7 @@ describe('Personkort', () => {
                 diskresjonskode={diskresjonskode}
                 egenansatt={egenansatt}
                 navbruker={navbruker}
+                sykmeldinger={sykmeldinger}
             />);
         });
 
@@ -98,6 +107,7 @@ describe('Personkort', () => {
                 diskresjonskode={diskresjonskode}
                 egenansatt={egenansatt}
                 navbruker={navbruker}
+                sykmeldinger={sykmeldinger}
             />);
             expect(komponent.find(EtikettBase)).to.have.length(0);
         });
@@ -112,6 +122,7 @@ describe('Personkort', () => {
                 diskresjonskode={diskresjonskode}
                 egenansatt={egenansatt}
                 navbruker={navbruker}
+                sykmeldinger={sykmeldinger}
             />);
             expect(komponent.find(EtikettBase)).to.have.length(1);
         });
@@ -126,6 +137,7 @@ describe('Personkort', () => {
                 diskresjonskode={diskresjonskode}
                 egenansatt={egenansatt}
                 navbruker={navbruker}
+                sykmeldinger={sykmeldinger}
             />);
             expect(komponent.find(EtikettBase)).to.have.length(1);
         });
@@ -140,6 +152,7 @@ describe('Personkort', () => {
                 diskresjonskode={diskresjonskode}
                 egenansatt={egenansatt}
                 navbruker={navbruker}
+                sykmeldinger={sykmeldinger}
             />);
             expect(komponent.find(EtikettBase)).to.have.length(1);
         });

--- a/test/utils/sykmeldingUtilsTest.js
+++ b/test/utils/sykmeldingUtilsTest.js
@@ -18,6 +18,7 @@ import {
     stringMedAlleGraderingerFraSykmeldingPerioder,
     erBehandlingsdagerEllerReisetilskudd,
     finnAvventendeSykmeldingTekst,
+    sykmeldingerHasCoronaDiagnose,
 } from '../../src/utils/sykmeldinger/sykmeldingUtils';
 import { ANTALL_MS_DAG } from '../../src/utils/datoUtils';
 
@@ -689,6 +690,142 @@ describe('sykmeldingUtils', () => {
            const stringMedAllegraderinger = stringMedAlleGraderingerFraSykmeldingPerioder(sykmeldingPerioderSortertEtterDato);
 
            expect(stringMedAllegraderinger).to.equal('');
+        });
+    });
+
+    describe('sykmeldingerHasCoronaDiagnose', () => {
+        it('skal returnere true hvis det finnes minst én aktiv sykmelding med korona-diagnose', () => {
+            const sykmeldinger = [
+                {
+                    status: 'SENDT',
+                    mulighetForArbeid: {
+                        perioder: [
+                            {
+                                fom: new Date(Date.now() - 1000),
+                                tom: new Date(Date.now() + 1000),
+                            },
+                        ],
+                    },
+                    diagnose: {
+                        hoveddiagnose: {
+                            diagnosekode: 'R991',
+                        },
+                        bidiagnoser: [],
+                    },
+                },
+            ];
+
+            const hasCorona = sykmeldingerHasCoronaDiagnose(sykmeldinger);
+
+            expect(hasCorona).to.equal(true);
+        });
+
+        it('skal returnere true hvis det finnes minst én aktiv sykmelding med korona-bidiagnose', () => {
+            const sykmeldinger = [
+                {
+                    status: 'SENDT',
+                    mulighetForArbeid: {
+                        perioder: [
+                            {
+                                fom: new Date(Date.now() - 1000),
+                                tom: new Date(Date.now() + 1000),
+                            },
+                        ],
+                    },
+                    diagnose: {
+                        hoveddiagnose: {
+                            diagnosekode: 'L87',
+                        },
+                        bidiagnoser: [
+                            {
+                                diagnosekode: 'R991',
+                            },
+                        ],
+                    },
+                },
+            ];
+
+            const hasCorona = sykmeldingerHasCoronaDiagnose(sykmeldinger);
+
+            expect(hasCorona).to.equal(true);
+        });
+
+        it('skal returnere false hvis sykmelding med korona-diagnose ikke er innsendt eller bekreftet', () => {
+            const sykmeldinger = [
+                {
+                    status: 'NY',
+                    mulighetForArbeid: {
+                        perioder: [
+                            {
+                                fom: new Date(Date.now() - 1000),
+                                tom: new Date(Date.now() + 1000),
+                            },
+                        ],
+                    },
+                    diagnose: {
+                        hoveddiagnose: {
+                            diagnosekode: 'R991',
+                        },
+                        bidiagnoser: [],
+                    },
+                },
+            ];
+
+            const hasCorona = sykmeldingerHasCoronaDiagnose(sykmeldinger);
+
+            expect(hasCorona).to.equal(false);
+        });
+
+        it('skal returnere false hvis aktiv sykmelding ikke har korona-diagnose', () => {
+            const sykmeldinger = [
+                {
+                    status: 'SENDT',
+                    mulighetForArbeid: {
+                        perioder: [
+                            {
+                                fom: new Date(Date.now() - 1000),
+                                tom: new Date(Date.now() + 1000),
+                            },
+                        ],
+                    },
+                    diagnose: {
+                        hoveddiagnose: {
+                            diagnosekode: 'L87',
+                        },
+                        bidiagnoser: [],
+                    },
+                },
+            ];
+
+            const hasCorona = sykmeldingerHasCoronaDiagnose(sykmeldinger);
+
+            expect(hasCorona).to.equal(false);
+        });
+
+        it('skal returnere false hvis sykmeldingen ikke er aktiv i dag', () => {
+            const sykmeldinger = [
+                {
+                    status: 'SENDT',
+                    mulighetForArbeid: {
+                        perioder: [
+                            {
+                                fom: new Date(Date.now() + 1000),
+                                tom: new Date(Date.now() + 2000),
+                            },
+                        ],
+                    },
+                    diagnose: {
+                        hoveddiagnose: {
+                            diagnosekode: 'R991',
+                        },
+                        bidiagnoser: [],
+                    },
+                },
+            ];
+
+            const hasCorona = sykmeldingerHasCoronaDiagnose(sykmeldinger);
+
+            expect(hasCorona).to.equal(false);
         });
     });
 });


### PR DESCRIPTION
Kun vis merkelapp når den sykmeldte har minst én sykmelding med korona-diagnose, som er innsendt/bekreftet, og som er aktiv.
Fjern flex-grow, for å unngå at det ser rart ut når det bare er én merkelapp.