### PR TITLE
Change logic for active planer

### DIFF
--- a/mock/data/oppfoelgingsdialoger.json
+++ b/mock/data/oppfoelgingsdialoger.json
@@ -45,7 +45,7 @@
         "evalueres": "2020-03-21"
       },
       "tvungenGodkjenning": false,
-      "deltMedNAVTidspunkt": "2020-01-20T08:49:05.621",
+      "deltMedNAVTidspunkt": "2020-02-20T08:49:05.621",
       "deltMedNAV": true,
       "deltMedFastlegeTidspunkt": "2020-01-20T08:49:05.621",
       "deltMedFastlege": true,
@@ -68,12 +68,12 @@
     "godkjentPlan": {
       "opprettetTidspunkt": "2019-02-20T11:41:09.374",
       "gyldighetstidspunkt": {
-        "fom": "2019-02-20",
-        "tom": "2019-04-01",
+        "fom": "2020-02-20",
+        "tom": "2020-04-01",
         "evalueres": "2019-03-29"
       },
       "tvungenGodkjenning": false,
-      "deltMedNAVTidspunkt": "2019-03-27T11:41:18.165",
+      "deltMedNAVTidspunkt": "2020-03-27T11:41:18.165",
       "deltMedNAV": true,
       "deltMedFastlegeTidspunkt": null,
       "deltMedFastlege": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3224,7 +3224,7 @@
     },
     "classnames": {
       "version": "2.2.6",
-      "resolved": "https://repo.adeo.no/repository/npm-public/classnames/-/classnames-2.2.6.tgz",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "cli-cursor": {
@@ -9140,12 +9140,12 @@
     },
     "nav-frontend-etiketter": {
       "version": "1.0.17",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-etiketter/-/nav-frontend-etiketter-1.0.17.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-etiketter/-/nav-frontend-etiketter-1.0.17.tgz",
       "integrity": "sha512-8I5XEhYihP4h3kqbXe3HMcWkqFcw//abZpjVgfKoyF8/l/5ld0Ev0HJEVcwD/lRMFA70/GnxkGSghnG/CCpRUQ=="
     },
     "nav-frontend-etiketter-style": {
       "version": "0.3.15",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-etiketter-style/-/nav-frontend-etiketter-style-0.3.15.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-etiketter-style/-/nav-frontend-etiketter-style-0.3.15.tgz",
       "integrity": "sha512-z9qZMneYd26yjIZjfF6zSWa31c+PisEkBMRfnncAr+e3fHRSAKRny42LLLvqLooKO5jVDrzn/KVrr3MnaDyQwQ=="
     },
     "nav-frontend-grid": {
@@ -10869,7 +10869,7 @@
     },
     "prop-types": {
       "version": "15.6.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/prop-types/-/prop-types-15.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
       "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
       "requires": {
         "fbjs": "^0.8.16",

--- a/src/containers/OppfoelgingsPlanerOversiktContainer.js
+++ b/src/containers/OppfoelgingsPlanerOversiktContainer.js
@@ -11,6 +11,7 @@ import AppSpinner from '../components/AppSpinner';
 import IngenPlaner from '../components/oppfoelgingsdialoger/IngenPlaner';
 import { OPPFOELGINGSPLANER } from '../enums/menypunkter';
 import { hentBegrunnelseTekst } from '../utils/tilgangUtils';
+import { activeOppfolgingsplaner } from '../utils/oppfolgingsplanerUtils';
 
 const texts = {
     errorTitle: 'Du har ikke tilgang til denne tjenesten',
@@ -98,9 +99,7 @@ export function mapStateToProps(state, ownProps) {
 
     const oppfoelgingsdialoger = state.oppfoelgingsdialoger.data;
 
-    const aktiveDialoger = oppfoelgingsdialoger.filter((dialog) => {
-        return dialog.status !== 'AVBRUTT' && new Date(dialog.godkjentPlan.gyldighetstidspunkt.tom) > new Date();
-    });
+    const aktiveDialoger = activeOppfolgingsplaner(oppfoelgingsdialoger);
     const inaktiveDialoger = [];
     oppfoelgingsdialoger.forEach((dialog) => {
         if (!aktiveDialoger.includes(dialog)) {

--- a/src/utils/GlobalNavigasjonUtils.js
+++ b/src/utils/GlobalNavigasjonUtils.js
@@ -1,5 +1,6 @@
 import * as menypunkter from '../enums/menypunkter';
 import { harUbehandletMotebehov } from './motebehovUtils';
+import { activeOppfolgingsplaner } from './oppfolgingsplanerUtils';
 
 const isUnfinishedMotebehovTask = (motebehovReducer) => {
     return harUbehandletMotebehov(motebehovReducer.data);
@@ -10,14 +11,6 @@ const isUnfinishedMoterTask = (moterReducer) => {
         && moterReducer.data
         && moterReducer.data[0]
         && moterReducer.data[0].trengerBehandling;
-};
-
-const activeOppfolgingsplaner = (oppfolgingsplanerReducer) => {
-    return oppfolgingsplanerReducer
-        && oppfolgingsplanerReducer.data
-        && oppfolgingsplanerReducer.data.filter((dialog) => {
-            return dialog.status !== 'AVBRUTT' && new Date(dialog.godkjentPlan.gyldighetstidspunkt.tom) > new Date();
-        }).length;
 };
 
 const moteplanleggerTasks = (motebehovReducer, moterReducer) => {
@@ -32,12 +25,18 @@ const moteplanleggerTasks = (motebehovReducer, moterReducer) => {
     return motebehovPrikker + moterPrikker;
 };
 
+const numberOfActiveOppfolgingsplaner = (oppfolgingsplanerReducer) => {
+    return oppfolgingsplanerReducer
+        && oppfolgingsplanerReducer.data
+        && activeOppfolgingsplaner(oppfolgingsplanerReducer.data).length;
+};
+
 export const numberOfTasks = (menypunkt, motebehovReducer, moterReducer, oppfolgingsplanerReducer) => {
     switch (menypunkt) {
         case menypunkter.MOETEPLANLEGGER:
             return moteplanleggerTasks(motebehovReducer, moterReducer);
         case menypunkter.OPPFOELGINGSPLANER:
-            return activeOppfolgingsplaner(oppfolgingsplanerReducer);
+            return numberOfActiveOppfolgingsplaner(oppfolgingsplanerReducer);
         default:
             return 0;
     }

--- a/src/utils/oppfolgingsplanerUtils.js
+++ b/src/utils/oppfolgingsplanerUtils.js
@@ -1,0 +1,45 @@
+const oppfolgingsplanerValidNow = (oppfolgingsplaner) => {
+    return oppfolgingsplaner.filter((plan) => {
+        return new Date(plan.godkjentPlan.gyldighetstidspunkt.tom) > new Date() && plan.godkjentPlan.deltMedNAV;
+    });
+};
+
+const planerSortedDescendingByDeltMedNAVTidspunkt = (oppfolgingsplaner) => {
+    return oppfolgingsplaner.sort((a, b) => {
+        return new Date(b.godkjentPlan.deltMedNAVTidspunkt) - new Date(a.godkjentPlan.deltMedNAVTidspunkt);
+    });
+};
+
+const virksomheterWithPlan = (oppfolgingsplaner) => {
+    const uniqueVirksomheter = new Set(oppfolgingsplaner.map((plan) => {
+        return plan.virksomhet.virksomhetsnummer;
+    }));
+
+    return [...uniqueVirksomheter];
+};
+
+const firstPlanForEachVirksomhet = (oppfolgingsplaner, virksomheter) => {
+    const newestPlanPerVirksomhet = [];
+
+    virksomheter.forEach((nummer) => {
+        const newestPlanForVirksomhetsnummer = oppfolgingsplaner.find((plan) => {
+            return plan.virksomhet.virksomhetsnummer === nummer;
+        });
+        newestPlanPerVirksomhet.push(newestPlanForVirksomhetsnummer);
+    });
+
+    return newestPlanPerVirksomhet;
+};
+
+const newestPlanForEachVirksomhet = (oppfolgingsplaner) => {
+    const sortedPlaner = planerSortedDescendingByDeltMedNAVTidspunkt(oppfolgingsplaner);
+
+    const virksomheter = virksomheterWithPlan(sortedPlaner);
+
+    return firstPlanForEachVirksomhet(sortedPlaner, virksomheter);
+};
+
+export const activeOppfolgingsplaner = (oppfolgingsplaner) => {
+    const newestPlans = newestPlanForEachVirksomhet(oppfolgingsplaner);
+    return oppfolgingsplanerValidNow(newestPlans);
+};

--- a/test/mockdata/mockOppfolgingsplaner.js
+++ b/test/mockdata/mockOppfolgingsplaner.js
@@ -1,0 +1,102 @@
+const MILLISECONDS_PER_HOUR = 3600000;
+const DAY_IN_MILLISECONDS = MILLISECONDS_PER_HOUR * 24;
+
+const TODAY = new Date();
+const TOMORROW = new Date(Date.now() + DAY_IN_MILLISECONDS);
+const YESTERDAY = new Date(Date.now() - DAY_IN_MILLISECONDS);
+const TWO_DAYS_AGO = new Date(Date.now() - (DAY_IN_MILLISECONDS * 2));
+
+export const mockValidActiveOppfolgingsplan = {
+    id: 1,
+    uuid: '111e2629-062b-442d-ae1f-3b08e9574cd1',
+    sistEndretAvAktoerId: '1101101101102',
+    sistEndretDato: '2020-01-30T08:49:05.621',
+    status: 'AKTIV',
+    virksomhet: {
+        navn: 'X-Files',
+        virksomhetsnummer: '110110110',
+    },
+    godkjentPlan: {
+        opprettetTidspunkt: TODAY,
+        gyldighetstidspunkt: {
+            fom: TODAY,
+            tom: TOMORROW,
+            evalueres: TOMORROW,
+        },
+        tvungenGodkjenning: false,
+        deltMedNAVTidspunkt: TODAY,
+        deltMedNAV: true,
+        deltMedFastlegeTidspunkt: null,
+        deltMedFastlege: false,
+        dokumentUuid: '664fb21f-48c3-4669-82ca-d61f51d20c84',
+    },
+    oppgaver: [],
+    arbeidsgiver: null,
+    arbeidstaker: null,
+};
+
+export const mockAvbruttActiveOppfolgingsplan = {
+    id: 2,
+    uuid: '222e2629-062b-442d-ae1f-3b08e9574cd1',
+    sistEndretAvAktoerId: '1101101101102',
+    sistEndretDato: '2020-01-30T08:49:05.621',
+    status: 'AVBRUTT',
+    virksomhet: {
+        navn: 'X-Files',
+        virksomhetsnummer: '110110110',
+    },
+    godkjentPlan: {
+        opprettetTidspunkt: YESTERDAY,
+        gyldighetstidspunkt: {
+            fom: YESTERDAY,
+            tom: TOMORROW,
+            evalueres: YESTERDAY,
+        },
+        tvungenGodkjenning: false,
+        deltMedNAVTidspunkt: YESTERDAY,
+        deltMedNAV: true,
+        deltMedFastlegeTidspunkt: null,
+        deltMedFastlege: false,
+        dokumentUuid: '664fb21f-48c3-4669-82ca-d61f51d20c84',
+    },
+    oppgaver: [],
+    arbeidsgiver: null,
+    arbeidstaker: null,
+};
+
+export const mockAvbruttInactiveOppfolgingsplan = {
+    id: 3,
+    uuid: '333e2629-062b-442d-ae1f-3b08e9574cd1',
+    sistEndretAvAktoerId: '1101101101102',
+    sistEndretDato: '2020-01-30T08:49:05.621',
+    status: 'AVBRUTT',
+    virksomhet: {
+        navn: 'X-Files',
+        virksomhetsnummer: '110110110',
+    },
+    godkjentPlan: {
+        opprettetTidspunkt: TWO_DAYS_AGO,
+        gyldighetstidspunkt: {
+            fom: TWO_DAYS_AGO,
+            tom: YESTERDAY,
+            evalueres: YESTERDAY,
+        },
+        tvungenGodkjenning: false,
+        deltMedNAVTidspunkt: TWO_DAYS_AGO,
+        deltMedNAV: true,
+        deltMedFastlegeTidspunkt: null,
+        deltMedFastlege: false,
+        dokumentUuid: '664fb21f-48c3-4669-82ca-d61f51d20c84',
+    },
+    oppgaver: [],
+    arbeidsgiver: null,
+    arbeidstaker: null,
+};
+
+export const mockValidActiveOppfolgingsplanWithDifferentVirksomhet = {
+    ...mockValidActiveOppfolgingsplan,
+    virksomhet: {
+        navn: 'The Syndicate',
+        virksomhetsnummer: '987654321',
+    },
+};

--- a/test/utils/oppfolgingsplanerUtilsTest.js
+++ b/test/utils/oppfolgingsplanerUtilsTest.js
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import {
+    mockAvbruttActiveOppfolgingsplan,
+    mockAvbruttInactiveOppfolgingsplan,
+    mockValidActiveOppfolgingsplan,
+    mockValidActiveOppfolgingsplanWithDifferentVirksomhet,
+} from '../mockdata/mockOppfolgingsplaner';
+import { activeOppfolgingsplaner } from '../../src/utils/oppfolgingsplanerUtils';
+
+describe('oppfolgingsplanerUtils', () => {
+    let clock;
+    const today = new Date(Date.now());
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers(today.getTime());
+    });
+
+    afterEach(() => {
+        clock.restore();
+    });
+
+    describe('activeOppfolgingsplaner', () => {
+        it('Gives a list of one plan, when one is active', () => {
+            const planer = [
+                mockValidActiveOppfolgingsplan,
+            ];
+
+            const actualPlaner = activeOppfolgingsplaner(planer);
+
+            expect(actualPlaner.length).to.be.equal(planer.length);
+            expect(actualPlaner[0]).to.deep.equal(planer[0]);
+        });
+
+        it('Gives a list of one plan, when one is active and avbrutt', () => {
+            const planer = [
+                mockAvbruttActiveOppfolgingsplan,
+            ];
+
+            const actualPlaner = activeOppfolgingsplaner(planer);
+
+            expect(actualPlaner.length).to.be.equal(planer.length);
+            expect(actualPlaner[0]).to.deep.equal(planer[0]);
+        });
+
+        it('Gives empty list if all plans are invalid', () => {
+            const planer = [
+                mockAvbruttInactiveOppfolgingsplan,
+            ];
+
+            const actualPlaner = activeOppfolgingsplaner(planer);
+            expect(actualPlaner.length).to.be.equal(0);
+        });
+
+        it('Gives two plans if the are from different virksomheter', () => {
+            const planer = [
+                mockValidActiveOppfolgingsplanWithDifferentVirksomhet,
+                mockValidActiveOppfolgingsplan,
+            ];
+
+            const actualPlaner = activeOppfolgingsplaner(planer);
+
+            expect(actualPlaner.length).to.be.equal(planer.length);
+            expect(actualPlaner[0]).to.deep.equal(planer[0]);
+            expect(actualPlaner[1]).to.deep.equal(planer[1]);
+        });
+
+        it('Gives the plan shared lates, if more than one from a virksomhet', () => {
+            const planer = [
+                mockAvbruttActiveOppfolgingsplan,
+                mockValidActiveOppfolgingsplan,
+            ];
+
+            const expectedPlan = mockValidActiveOppfolgingsplan;
+
+            const actualPlaner = activeOppfolgingsplaner(planer);
+
+            expect(actualPlaner.length).to.be.equal(1);
+            expect(actualPlaner[0]).to.deep.equal(expectedPlan);
+        });
+    });
+});


### PR DESCRIPTION
En plan er aktiv hvis den er delt med NAV, vi er innenfor gyldighetstidspunktet, og det ikke har kommet inn en ny plan for samme virksomhet.
Før forsvant den fra aktive med én gang AG eller AT begynte å gjøre endringer, selv om den nye ikke var sendt inn enda.

Det er alltid den planen som sist er sendt inn til NAV som er gjeldende for hver bedrift. Alle andre er "tidligere", uavhengig av om de er innenfor gyldighetsperioden.

"Prikker" for oppfølgingsplaner er også oppdatert til å bruke den nye måten å beregne aktive på.