### PR TITLE
Use same field in SM for sendtdato and bekreftetdato

### DIFF
--- a/src/components/sykmelding/avvisteSykmeldinger/AvvistSykmeldingStatuspanel.js
+++ b/src/components/sykmelding/avvisteSykmeldinger/AvvistSykmeldingStatuspanel.js
@@ -19,7 +19,7 @@ export const AvvistSykmeldingStatuspanel = ({ sykmelding }) => (
                     <p>{tilLesbarDatoMedArstall(sykmelding.mottattTidspunkt)}</p>
                 </StatusNokkelopplysning>
                 <StatusNokkelopplysning tittel="Bekreftet av deg">
-                    <p>{tilLesbarDatoMedArstall(sykmelding.bekreftetDato)}</p>
+                    <p>{tilLesbarDatoMedArstall(sykmelding.sendtdato)}</p>
                 </StatusNokkelopplysning>
             </Statusopplysninger>
         </div>

--- a/src/utils/sykmeldinger/sykmeldingParser.js
+++ b/src/utils/sykmeldinger/sykmeldingParser.js
@@ -192,14 +192,7 @@ const mapPasient = (fnr) => {
 
 const mapSendtdato = (sykmelding) => {
     const sykmeldingStatus = sykmelding.sykmeldingStatus;
-    return sykmeldingStatus.statusEvent === nyeSMStatuser.SENDT
-        ? toDate(sykmeldingStatus.timestamp)
-        : null;
-};
-
-const mapBekreftetDato = (sykmelding) => {
-    const sykmeldingStatus = sykmelding.sykmeldingStatus;
-    return sykmeldingStatus.statusEvent === nyeSMStatuser.BEKREFTET
+    return (sykmeldingStatus.statusEvent === nyeSMStatuser.SENDT || sykmeldingStatus.statusEvent === nyeSMStatuser.BEKREFTET)
         ? toDate(sykmeldingStatus.timestamp)
         : null;
 };
@@ -400,7 +393,6 @@ export const newSMFormat2OldFormat = (sykmelding, fnr) => {
         orgnummer: mapOrgnummer(sykmelding),
         pasient: mapPasient(fnr),
         sendtdato: mapSendtdato(sykmelding),
-        bekreftetDato: mapBekreftetDato(sykmelding),
         mottattTidspunkt: sykmelding.mottattTidspunkt,
         skalViseSkravertFelt: !sykmelding.skjermesForPasient,
         sporsmal: mapSporsmal(sykmelding),

--- a/test/mockdata/sykmeldinger/mockOldSykmeldinger.js
+++ b/test/mockdata/sykmeldinger/mockOldSykmeldinger.js
@@ -75,7 +75,6 @@ const mockOldSykmeldinger = [
             mellomnavn: null,
         },
         sendtdato: toDate('2020-01-29T09:38:05.414834Z'),
-        bekreftetDato: null,
         mottattTidspunkt: '2020-01-21T23:00:00Z',
         skalViseSkravertFelt: true,
         sporsmal: {


### PR DESCRIPTION
Bekreftetdatoen i statuspanelet på bekreftede sykmeldinger manglet, fordi koden ville ha `sendtDato`, men den ble bare satt hvis sykmeldingen var sendt (til AG). I forbindelse med avviste sykmeldinger, ble det lagt til et felt som heter `bekreftetDato`. Det siste er nå flettet inn i sendtDato-feltet, slik at man bruker samme datofelt til alt som har med innsending/bekreftelse å gjøre.