### PR TITLE
Use correct field name when sorting planer by deltMedNAVTidspunkt

### DIFF
--- a/src/components/oppfoelgingsdialoger/OppfoelgingsPlanerOversikt.js
+++ b/src/components/oppfoelgingsdialoger/OppfoelgingsPlanerOversikt.js
@@ -54,11 +54,11 @@ export class OppfoelgingsPlanerOversikt extends Component {
             inaktiveDialoger,
         } = this.props;
         aktiveDialoger.sort((a, b) => {
-            return new Date(a.godkjentPlan.deltMedNavTidspunkt) < new Date(b.godkjentPlan.deltMedNavTidspunkt) ? 1 : -1;
+            return new Date(b.godkjentPlan.deltMedNAVTidspunkt) - new Date(a.godkjentPlan.deltMedNAVTidspunkt);
         });
 
         inaktiveDialoger.sort((a, b) => {
-            return new Date(a.godkjentPlan.deltMedNavTidspunkt) < new Date(b.godkjentPlan.deltMedNavTidspunkt) ? 1 : -1;
+            return new Date(b.godkjentPlan.deltMedNAVTidspunkt) - new Date(a.godkjentPlan.deltMedNAVTidspunkt);
         });
 
         return (<div>


### PR DESCRIPTION
deltMedNavTidspunkt -> deltMedNAVTidspunkt, also simplify sorting.