### PR TITLE
Make egenmeldte sykmeldinger equal to Ditt Sykefravær

### DIFF
--- a/mock/data/sykmeldinger.json
+++ b/mock/data/sykmeldinger.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "e425a750-7f39-4974-9a06-fa1775f987c9",
+    "id": "1111a750-7f39-4974-9a06-fa1775f987c9",
     "mottattTidspunkt": "2020-01-21T23:00:00Z",
     "behandlingsutfall": {
       "status": "MANUAL_PROCESSING",
@@ -204,11 +204,11 @@
     },
     "syketilfelleStartDato": "2020-01-22",
     "navnFastlege": "Lego Las Legesen",
-    "egenmeldt": true,
+    "egenmeldt": false,
     "harRedusertArbeidsgiverperiode": true
   },
   {
-    "id": "289148ba-4c3c-4b3f-b7a3-385b7e7c927d",
+    "id": "222248ba-4c3c-4b3f-b7a3-385b7e7c927d",
     "mottattTidspunkt": "2020-01-21T23:00:00Z",
     "behandlingsutfall": {
       "status": "MANUAL_PROCESSING",
@@ -621,7 +621,7 @@
     "harRedusertArbeidsgiverperiode": false
   },
   {
-    "id": "7895a750-7f39-4974-9a06-fa1775f987c9",
+    "id": "5555a750-7f39-4974-9a06-fa1775f987c9",
     "mottattTidspunkt": "2020-03-21T23:00:00Z",
     "behandlingsutfall": {
       "status": "MANUAL_PROCESSING",
@@ -811,6 +811,288 @@
     "syketilfelleStartDato": "2020-03-22",
     "navnFastlege": "Lego Las Legesen",
     "egenmeldt": false,
+    "harRedusertArbeidsgiverperiode": true
+  },
+  {
+    "id": "6666cab3-bcb0-4dcb-9c97-bdb2ec867ec8",
+    "mottattTidspunkt": "2020-03-30T15:31:45.629405Z",
+    "behandlingsutfall": {
+      "status": "MANUAL_PROCESSING",
+      "ruleHits": [
+        {
+          "messageForSender": "Hvis pasienten ikke finnes i infotrygd",
+          "messageForUser": "Hvis pasienten ikke finnes i infotrygd",
+          "ruleName": "PATIENT_NOT_IN_IP",
+          "ruleStatus": "MANUAL_PROCESSING"
+        }
+      ]
+    },
+    "legekontorOrgnummer": "889640782",
+    "arbeidsgiver": {
+      "navn": null,
+      "stillingsprosent": null
+    },
+    "sykmeldingsperioder": [
+      {
+        "fom": "2020-03-30",
+        "tom": "2020-04-14",
+        "gradert": null,
+        "behandlingsdager": null,
+        "innspillTilArbeidsgiver": null,
+        "type": "AKTIVITET_IKKE_MULIG",
+        "aktivitetIkkeMulig": {
+          "medisinskArsak": {
+            "beskrivelse": null,
+            "arsak": []
+          },
+          "arbeidsrelatertArsak": null
+        },
+        "reisetilskudd": false
+      }
+    ],
+    "sykmeldingStatus": {
+      "statusEvent": "APEN",
+      "timestamp": "2020-03-30T17:31:45.629405Z",
+      "arbeidsgiver": null,
+      "sporsmalOgSvarListe": []
+    },
+    "medisinskVurdering": {
+      "hovedDiagnose": {
+        "kode": "R991",
+        "system": "ICPC-2",
+        "tekst": "Covid-19 (mistenkt eller bekreftet)"
+      },
+      "biDiagnoser": [],
+      "annenFraversArsak": null,
+      "svangerskap": false,
+      "yrkesskade": false,
+      "yrkesskadeDato": null
+    },
+    "skjermesForPasient": false,
+    "prognose": null,
+    "utdypendeOpplysninger": {},
+    "tiltakArbeidsplassen": null,
+    "tiltakNAV": null,
+    "andreTiltak": null,
+    "meldingTilNAV": null,
+    "meldingTilArbeidsgiver": null,
+    "kontaktMedPasient": {
+      "kontaktDato": "2020-03-30",
+      "begrunnelseIkkeKontakt": null
+    },
+    "behandletTidspunkt": "2020-03-30T17:31:45.629313Z",
+    "behandler": {
+      "fornavn": "Samuel \"Sam\"",
+      "mellomnavn": null,
+      "etternavn": "Jones",
+      "aktoerId": "110110110111",
+      "fnr": "11011011011",
+      "hpr": "egenmeldt",
+      "her": null,
+      "adresse": {
+        "gate": null,
+        "postnummer": null,
+        "kommune": null,
+        "postboks": null,
+        "land": null
+      },
+      "tlf": "tel:55553336"
+    },
+    "syketilfelleStartDato": "2020-03-30",
+    "navnFastlege": null,
+    "egenmeldt": true,
+    "papirsykmelding": false,
+    "harRedusertArbeidsgiverperiode": true
+  },
+  {
+    "id": "7777cab3-bcb0-4dcb-9c97-bdb2ec867ec8",
+    "mottattTidspunkt": "2020-03-30T15:31:45.629405Z",
+    "behandlingsutfall": {
+      "status": "MANUAL_PROCESSING",
+      "ruleHits": [
+        {
+          "messageForSender": "Hvis pasienten ikke finnes i infotrygd",
+          "messageForUser": "Hvis pasienten ikke finnes i infotrygd",
+          "ruleName": "PATIENT_NOT_IN_IP",
+          "ruleStatus": "MANUAL_PROCESSING"
+        }
+      ]
+    },
+    "legekontorOrgnummer": "889640782",
+    "arbeidsgiver": {
+      "navn": null,
+      "stillingsprosent": null
+    },
+    "sykmeldingsperioder": [
+      {
+        "fom": "2020-03-30",
+        "tom": "2020-04-14",
+        "gradert": null,
+        "behandlingsdager": null,
+        "innspillTilArbeidsgiver": null,
+        "type": "AKTIVITET_IKKE_MULIG",
+        "aktivitetIkkeMulig": {
+          "medisinskArsak": {
+            "beskrivelse": null,
+            "arsak": []
+          },
+          "arbeidsrelatertArsak": null
+        },
+        "reisetilskudd": false
+      }
+    ],
+    "sykmeldingStatus": {
+      "statusEvent": "BEKREFTET",
+      "timestamp": "2020-03-30T17:55:12.426177Z",
+      "arbeidsgiver": null,
+      "sporsmalOgSvarListe": [
+        {
+          "tekst": "Jeg er sykmeldt fra",
+          "shortName": "ARBEIDSSITUASJON",
+          "svar": {
+            "svarType": "ARBEIDSSITUASJON",
+            "svar": "NAERINGSDRIVENDE"
+          }
+        }
+      ]
+    },
+    "medisinskVurdering": {
+      "hovedDiagnose": {
+        "kode": "R991",
+        "system": "ICPC-2",
+        "tekst": "Covid-19 (mistenkt eller bekreftet)"
+      },
+      "biDiagnoser": [],
+      "annenFraversArsak": null,
+      "svangerskap": false,
+      "yrkesskade": false,
+      "yrkesskadeDato": null
+    },
+    "skjermesForPasient": false,
+    "prognose": null,
+    "utdypendeOpplysninger": {},
+    "tiltakArbeidsplassen": null,
+    "tiltakNAV": null,
+    "andreTiltak": null,
+    "meldingTilNAV": null,
+    "meldingTilArbeidsgiver": null,
+    "kontaktMedPasient": {
+      "kontaktDato": "2020-03-30",
+      "begrunnelseIkkeKontakt": null
+    },
+    "behandletTidspunkt": "2020-03-30T17:31:45.629313Z",
+    "behandler": {
+      "fornavn": "Samuel \"Sam\"",
+      "mellomnavn": null,
+      "etternavn": "Jones",
+      "aktoerId": "110110110111",
+      "fnr": "11011011011",
+      "hpr": "egenmeldt",
+      "her": null,
+      "adresse": {
+        "gate": null,
+        "postnummer": null,
+        "kommune": null,
+        "postboks": null,
+        "land": null
+      },
+      "tlf": "tel:55553336"
+    },
+    "syketilfelleStartDato": "2020-03-30",
+    "navnFastlege": null,
+    "egenmeldt": true,
+    "papirsykmelding": false,
+    "harRedusertArbeidsgiverperiode": true
+  },
+  {
+    "id": "8888895e-b124-4c14-bc12-94a182da3ff6",
+    "mottattTidspunkt": "2020-03-30T18:24:34.496227Z",
+    "behandlingsutfall": {
+      "status": "MANUAL_PROCESSING",
+      "ruleHits": [
+        {
+          "messageForSender": "Infotrygd returnerte en feil, vi kan ikke automatisk oppdatere Infotrygd",
+          "messageForUser": "Infotrygd returnerte en feil, vi kan ikke automatisk oppdatere Infotrygd",
+          "ruleName": "ERROR_FROM_IT_HOUVED_STATUS_KODEMELDING",
+          "ruleStatus": "MANUAL_PROCESSING"
+        }
+      ]
+    },
+    "legekontorOrgnummer": "889640782",
+    "arbeidsgiver": {
+      "navn": null,
+      "stillingsprosent": null
+    },
+    "sykmeldingsperioder": [
+      {
+        "fom": "2020-03-01",
+        "tom": "2020-03-16",
+        "gradert": null,
+        "behandlingsdager": null,
+        "innspillTilArbeidsgiver": null,
+        "type": "AKTIVITET_IKKE_MULIG",
+        "aktivitetIkkeMulig": {
+          "medisinskArsak": {
+            "beskrivelse": null,
+            "arsak": []
+          },
+          "arbeidsrelatertArsak": null
+        },
+        "reisetilskudd": false
+      }
+    ],
+    "sykmeldingStatus": {
+      "statusEvent": "AVBRUTT",
+      "timestamp": "2020-03-30T20:25:38.90325Z",
+      "arbeidsgiver": null,
+      "sporsmalOgSvarListe": []
+    },
+    "medisinskVurdering": {
+      "hovedDiagnose": {
+        "kode": "R991",
+        "system": "ICPC-2",
+        "tekst": "Covid-19 (mistenkt eller bekreftet)"
+      },
+      "biDiagnoser": [],
+      "annenFraversArsak": null,
+      "svangerskap": false,
+      "yrkesskade": false,
+      "yrkesskadeDato": null
+    },
+    "skjermesForPasient": false,
+    "prognose": null,
+    "utdypendeOpplysninger": {},
+    "tiltakArbeidsplassen": null,
+    "tiltakNAV": null,
+    "andreTiltak": null,
+    "meldingTilNAV": null,
+    "meldingTilArbeidsgiver": null,
+    "kontaktMedPasient": {
+      "kontaktDato": "2020-03-30",
+      "begrunnelseIkkeKontakt": null
+    },
+    "behandletTidspunkt": "2020-03-30T20:24:34.496114Z",
+    "behandler": {
+      "fornavn": "Samuel \"Sam\"",
+      "mellomnavn": null,
+      "etternavn": "Jones",
+      "aktoerId": "110110110111",
+      "fnr": "11011011011",
+      "hpr": "egenmeldt",
+      "her": null,
+      "adresse": {
+        "gate": null,
+        "postnummer": null,
+        "kommune": null,
+        "postboks": null,
+        "land": null
+      },
+      "tlf": "tel:55553336"
+    },
+    "syketilfelleStartDato": "2020-03-01",
+    "navnFastlege": null,
+    "egenmeldt": true,
+    "papirsykmelding": false,
     "harRedusertArbeidsgiverperiode": true
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@navikt/digisyfo-npm": {
-      "version": "17.3.0",
-      "resolved": "https://repo.adeo.no/repository/npm-public/@navikt/digisyfo-npm/-/digisyfo-npm-17.3.0.tgz",
-      "integrity": "sha512-zUaMV7ymuYpiGi2iRiYBdfoJSxZE+ip7jXszgnC5Dlju2yuO03kDfUqIHGd1juT3DMytVsQ195PQg/jlDt5g2A==",
+      "version": "17.4.3",
+      "resolved": "https://registry.npmjs.org/@navikt/digisyfo-npm/-/digisyfo-npm-17.4.3.tgz",
+      "integrity": "sha512-KkuRkeoJOin448MGWCWFiLQtEVrO0f1qdxCk4UlmbleCE48FK5O9hJ87Bw+aZc8NwZXbqGIdUpPKyupSevCGsA==",
       "requires": {
         "fetch-ponyfill": "4.1.0",
         "nav-frontend-hjelpetekst": "1.0.37",
@@ -9210,7 +9210,7 @@
     },
     "nav-frontend-modal": {
       "version": "1.0.23",
-      "resolved": "https://repo.adeo.no/repository/npm-public/nav-frontend-modal/-/nav-frontend-modal-1.0.23.tgz",
+      "resolved": "https://registry.npmjs.org/nav-frontend-modal/-/nav-frontend-modal-1.0.23.tgz",
       "integrity": "sha512-iiqDMHc1aflia35v3tRLr2SQgTIoaZ3Iojw5TycJQ59fjRGzE+eFrhKMVWFgcDRAM9PqNZNNh19MkOuocyuSoA=="
     },
     "nav-frontend-modal-style": {
@@ -11194,7 +11194,7 @@
       "dependencies": {
         "prop-types": {
           "version": "15.7.2",
-          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "resolved": "https://repo.adeo.no/repository/npm-public/prop-types/-/prop-types-15.7.2.tgz",
           "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
           "requires": {
             "loose-envify": "^1.4.0",
@@ -11204,7 +11204,7 @@
           "dependencies": {
             "loose-envify": {
               "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+              "resolved": "https://repo.adeo.no/repository/npm-public/loose-envify/-/loose-envify-1.4.0.tgz",
               "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
               "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Team DigiSyfo <digisyfo@nav.no>",
   "license": "ISC",
   "dependencies": {
-    "@navikt/digisyfo-npm": "17.3.0",
+    "@navikt/digisyfo-npm": "17.4.3",
     "axios": "0.19.2",
     "babel-loader": "7.1.4",
     "babel-polyfill": "6.26.0",

--- a/src/components/sykmelding/SykmeldingSide.js
+++ b/src/components/sykmelding/SykmeldingSide.js
@@ -14,6 +14,9 @@ import Feilmelding from '../Feilmelding';
 import { erDev } from '../../selectors/toggleSelectors';
 import { behandlingsutfallStatuser } from '../../utils/sykmeldinger/sykmeldingstatuser';
 import AvvistSykmelding from './avvisteSykmeldinger/AvvistSykmelding';
+import KoronaSykmeldingBekreftet from './koronasykmeldinger/KoronaSykmelding-Bekreftet';
+import KoronaSykmeldingNy from './koronasykmeldinger/KoronaSykmelding-Ny';
+import KoronaSykmeldingAvbrutt from './koronasykmeldinger/KoronaSykmelding-Avbrutt';
 
 const SykmeldingSide = ({ dinSykmelding, arbeidsgiversSykmelding, ledetekster, fnr }) => {
     return (
@@ -26,6 +29,32 @@ const SykmeldingSide = ({ dinSykmelding, arbeidsgiversSykmelding, ledetekster, f
                     />
                     <LenkeTilDineSykmeldinger ledetekster={ledetekster} fnr={fnr} />
                 </div>);
+            }
+            if (dinSykmelding.egenmeldt) {
+                switch (dinSykmelding.status) {
+                    case sykmeldingstatuser.BEKREFTET: {
+                        return (
+                            <div>
+                                <KoronaSykmeldingBekreftet dinSykmelding={dinSykmelding} />
+                                <LenkeTilDineSykmeldinger />
+                            </div>
+                        );
+                    }
+                    case sykmeldingstatuser.NY: {
+                        return (<KoronaSykmeldingNy sykmelding={dinSykmelding} />);
+                    }
+                    case sykmeldingstatuser.AVBRUTT: {
+                        return (
+                            <div>
+                                <KoronaSykmeldingAvbrutt sykmelding={dinSykmelding} />
+                                <LenkeTilDineSykmeldinger />
+                            </div>
+                        );
+                    }
+                    default: {
+                        return <Feilmelding tittel="Egenmeldingen har ukjent status" />;
+                    }
+                }
             } else if (dinSykmelding.status === sykmeldingstatuser.SENDT && (arbeidsgiversSykmelding || erDev())) {
                 return (<div>
                     <DinSendteSykmelding

--- a/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Avbrutt.js
+++ b/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Avbrutt.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+    DineKoronaSykmeldingOpplysninger,
+    Utvidbar,
+    sykmelding as sykmeldingPt,
+} from '@navikt/digisyfo-npm';
+import { Undertittel } from 'nav-frontend-typografi';
+import SykmeldingStatuspanel from '../../sykmeldingstatuspanel/SykmeldingStatuspanel';
+
+const texts = {
+    pageSubtitle: 'for selvstendig næringsdrivende og frilansere',
+    expandableTitle: 'Dine opplysninger',
+};
+
+const KoronaSykmeldingAvbrutt = ({ sykmelding }) => {
+    return (
+        <div>
+            <Undertittel style={{ marginBottom: '2.5rem', textAlign: 'center' }}>{texts.pageSubtitle}</Undertittel>
+            <SykmeldingStatuspanel sykmelding={sykmelding} />
+            <Utvidbar
+                erApen
+                tittel={texts.expandableTitle}
+                ikon="svg/person.svg"
+                ikonHover="svg/person_hover.svg"
+                ikonAltTekst="Du"
+                className="blokk"
+                variant="lysebla"
+                Overskrift="h2">
+                <DineKoronaSykmeldingOpplysninger sykmelding={sykmelding} />
+            </Utvidbar>
+        </div>
+    );
+};
+
+KoronaSykmeldingAvbrutt.propTypes = {
+    sykmelding: sykmeldingPt,
+};
+
+export default KoronaSykmeldingAvbrutt;

--- a/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Bekreftet.js
+++ b/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Bekreftet.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import {
+    DineKoronaSykmeldingOpplysninger,
+    Utvidbar,
+    sykmelding as sykmeldingPt,
+} from '@navikt/digisyfo-npm';
+import { Undertittel } from 'nav-frontend-typografi';
+import BekreftetSykmeldingStatuspanel from '../../sykmeldingstatuspanel/BekreftetSykmeldingStatuspanel';
+
+const texts = {
+    pageSubtitle: 'for selvstendig næringsdrivende og frilansere',
+    expandableTitle: 'Dine opplysninger',
+};
+
+const KoronaSykmeldingBekreftet = ({ dinSykmelding }) => {
+    return (
+        <div>
+            <Undertittel style={{ marginBottom: '2.5rem', textAlign: 'center' }}>{texts.pageSubtitle}</Undertittel>
+            <BekreftetSykmeldingStatuspanel sykmelding={dinSykmelding} />
+            <Utvidbar
+                erApen
+                tittel={texts.expandableTitle}
+                ikon="svg/person.svg"
+                ikonHover="svg/person_hover.svg"
+                ikonAltTekst="Du"
+                className="blokk"
+                variant="lysebla"
+                Overskrift="h2">
+                <DineKoronaSykmeldingOpplysninger sykmelding={dinSykmelding} />
+            </Utvidbar>
+        </div>
+    );
+};
+
+KoronaSykmeldingBekreftet.propTypes = {
+    dinSykmelding: sykmeldingPt,
+};
+
+export default KoronaSykmeldingBekreftet;

--- a/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Ny.js
+++ b/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Ny.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {
+    DineKoronaSykmeldingOpplysninger,
+    sykmelding as sykmeldingPt,
+} from '@navikt/digisyfo-npm';
+import {
+    Undertittel,
+    Normaltekst,
+} from 'nav-frontend-typografi';
+
+const texts = {
+    pageSubtitle: 'for selvstendig næringsdrivende og frilansere',
+    infotext1: 'Her sjekker du at opplysningene fra da du opprettet egenmeldingen stemmer. Om alt stemmer kan du bekrefte og sende inn egenmeldingen.',
+    infoText2: 'Vennligst se nøye over og påse at opplysningene du har oppgitt er riktige.',
+};
+
+const KoronaSykmeldingNy = ({ sykmelding }) => {
+    return (
+        <div>
+            <Undertittel style={{ marginBottom: '2.5rem', textAlign: 'center' }}>{texts.pageSubtitle}</Undertittel>
+            <Normaltekst style={{ marginBottom: '1rem' }}>{texts.infotext1}</Normaltekst>
+            <Normaltekst style={{ marginBottom: '2rem' }}>{texts.infoText2}</Normaltekst>
+            <article>
+                <header className="panelHeader panelHeader--lysebla">
+                    <img
+                        className="panelHeader__ikon"
+                        src={`${process.env.REACT_APP_CONTEXT_ROOT}/img/svg/person.svg`}
+                        alt="Du"
+                    />
+                    <h2 className="panelHeader__tittel">
+                        {sykmelding.pasient.fornavn}
+                        {' '}
+                        {sykmelding.pasient.mellomnavn}
+                        {' '}
+                        {sykmelding.pasient.etternavn}
+                    </h2>
+                </header>
+                <div className="panel blokk">
+                    <DineKoronaSykmeldingOpplysninger sykmelding={sykmelding} />
+                </div>
+            </article>
+        </div>
+    );
+};
+
+KoronaSykmeldingNy.propTypes = {
+    sykmelding: sykmeldingPt,
+};
+
+export default KoronaSykmeldingNy;

--- a/src/components/sykmeldingstatuspanel/SykmeldingStatuspanel.js
+++ b/src/components/sykmeldingstatuspanel/SykmeldingStatuspanel.js
@@ -41,7 +41,7 @@ const SykmeldingStatuspanel = ({ sykmelding }) => {
     return (<Statuspanel>
         <Nokkelopplysninger sykmelding={sykmelding} />
         {
-            sykmelding.status === sykmeldingstatuser.AVBRUTT
+            sykmelding.status === sykmeldingstatuser.AVBRUTT && !sykmelding.egenmeldt
                 && <GjenapneSykmelding />
         }
     </Statuspanel>);

--- a/src/containers/DinSykmeldingContainer.js
+++ b/src/containers/DinSykmeldingContainer.js
@@ -22,7 +22,15 @@ import { erDev } from '../selectors/toggleSelectors';
 import { ARBEIDSTAKER } from '../enums/arbeidssituasjoner';
 
 const texts = {
+    pageTitleSykmelding: 'Sykmelding',
+    pageTitleEgenmelding: 'Egenmelding',
     feilmelding: 'Du har ikke tilgang til denne tjenesten',
+};
+
+const pageTitle = (dinSykmelding) => {
+    return dinSykmelding.egenmeldt
+        ? texts.pageTitleEgenmelding
+        : texts.pageTitleSykmelding;
 };
 
 export class DinSykmeldingSide extends Component {
@@ -72,7 +80,7 @@ export class DinSykmeldingSide extends Component {
                         <Speilingvarsel brukernavn={brukernavn} />
                         <div className="speiling">
                             <Brodsmuler brodsmuler={brodsmuler} />
-                            <SidetoppSpeilet tittel="Sykmelding" />
+                            <SidetoppSpeilet tittel={pageTitle(dinSykmelding)} />
                             <SykmeldingSide dinSykmelding={dinSykmelding} ledetekster={ledetekster} arbeidsgiversSykmelding={arbeidsgiversSykmelding} fnr={fnr} />
                         </div>
                     </div>);

--- a/src/utils/sykmeldinger/sykmeldingParser.js
+++ b/src/utils/sykmeldinger/sykmeldingParser.js
@@ -190,13 +190,6 @@ const mapPasient = (fnr) => {
     };
 };
 
-const mapSendtdato = (sykmelding) => {
-    const sykmeldingStatus = sykmelding.sykmeldingStatus;
-    return (sykmeldingStatus.statusEvent === nyeSMStatuser.SENDT || sykmeldingStatus.statusEvent === nyeSMStatuser.BEKREFTET)
-        ? toDate(sykmeldingStatus.timestamp)
-        : null;
-};
-
 const mapTilbakedatering = (sykmelding) => {
     const kontaktMedPasient = sykmelding.kontaktMedPasient;
     return {
@@ -332,8 +325,11 @@ const mapFravaersperioder = (sporsmal) => {
     return JSON.parse(sporsmal.svar.svar);
 };
 
-const mapJaNeiSporsmalToBoolean = (sporsmal) => {
-    return sporsmal && sporsmal.svar && sporsmal.svar.svar === 'JA';
+const mapJaNeiSporsmalToBooleanEllerNull = (sporsmal) => {
+    if (isNullOrUndefined(sporsmal) || isNullOrUndefined(sporsmal.svar)) {
+        return null;
+    }
+    return sporsmal.svar.svar === 'JA';
 };
 
 const mapSporsmal = (sykmelding) => {
@@ -349,8 +345,8 @@ const mapSporsmal = (sykmelding) => {
         arbeidssituasjon: arbeidssituasjonSporsmal && arbeidssituasjonSporsmal.svar.svar,
         dekningsgrad: null,
         fravaersperioder: mapFravaersperioder(periodeSporsmal),
-        harAnnetFravaer: mapJaNeiSporsmalToBoolean(fravaerSporsmal),
-        harForsikring: mapJaNeiSporsmalToBoolean(forsikringSporsmal),
+        harAnnetFravaer: mapJaNeiSporsmalToBooleanEllerNull(fravaerSporsmal),
+        harForsikring: mapJaNeiSporsmalToBooleanEllerNull(forsikringSporsmal),
     };
 };
 
@@ -392,7 +388,7 @@ export const newSMFormat2OldFormat = (sykmelding, fnr) => {
         naermesteLederStatus: null,
         orgnummer: mapOrgnummer(sykmelding),
         pasient: mapPasient(fnr),
-        sendtdato: mapSendtdato(sykmelding),
+        sendtdato: toDate(sykmelding.sykmeldingStatus.timestamp),
         mottattTidspunkt: sykmelding.mottattTidspunkt,
         skalViseSkravertFelt: !sykmelding.skjermesForPasient,
         sporsmal: mapSporsmal(sykmelding),

--- a/test/utils/sykmeldingParserTest.js
+++ b/test/utils/sykmeldingParserTest.js
@@ -490,12 +490,6 @@ describe('sykmeldingParser', () => {
 
             expect(outputSM.sendtdato).to.deep.equal(expectedMottakendeArbeidsgiver);
         });
-
-        it('Returns correct sendtdato when status is not SENDT', () => {
-            const outputSM = newSMFormat2OldFormat(mockSykmeldingWithStatus(nyeSMStatuser.APEN), sykmeldtFnr);
-
-            expect(outputSM.sendtdato).to.deep.equal(null);
-        });
     });
 
     describe('sporsmal', () => {


### PR DESCRIPTION
Legg til en egen if på sykmeldingvisning, slik at egenmeldte sykmeldinger håndteres separat fra vanlige.
Gjør også om på mappingen fra nytt til gammelt sykmeldingformat, slik at spørsmål som ikke er fylt ut settes til null i stedet for undefined; da unngår vi at en null-sjekk feiler, og felter i statuspanelet vises kun da de skal.
Endre sendtdato-feltet til å være dato for siste statusoppdatering, slik at vi også får dato for når en sykmelding ble avbrutt.