### PR TITLE
Show virksomheter without leder from sykmeldinger in personkort

### DIFF
--- a/mock/data/ledere.json
+++ b/mock/data/ledere.json
@@ -34,7 +34,7 @@
     "tlf": "87654321",
     "epost": "test3@test.no",
     "aktiv": null,
-    "erOppgitt": false,
+    "erOppgitt": true,
     "fomDato": "2018-12-03T12:00:00+01:00",
     "orgnummer": "555666444",
     "organisasjonsnavn": "BRANN OG BIL AS",

--- a/mock/data/sykmeldinger.json
+++ b/mock/data/sykmeldinger.json
@@ -1094,5 +1094,147 @@
     "egenmeldt": true,
     "papirsykmelding": false,
     "harRedusertArbeidsgiverperiode": true
+  },
+  {
+    "id": "9999a750-7f39-4974-9a06-fa1775f987c9",
+    "mottattTidspunkt": "2020-01-21T23:00:00Z",
+    "behandlingsutfall": {
+      "status": "MANUAL_PROCESSING",
+      "ruleHits": [
+        {
+          "messageForSender": "Behandlers TSS-ident er ikke funnet automatisk av systemet",
+          "messageForUser": "Behandlers TSS-ident er ikke funnet automatisk av systemet",
+          "ruleName": "TSS_IDENT_MANGLER",
+          "ruleStatus": "MANUAL_PROCESSING"
+        }
+      ]
+    },
+    "legekontorOrgnummer": "223456789",
+    "arbeidsgiver": {
+      "navn": "X-Files",
+      "stillingsprosent": 100
+    },
+    "sykmeldingsperioder": [
+      {
+        "aktivitetIkkeMulig": {
+          "medisinskArsak": {
+            "beskrivelse": "Medisinsk årsak som hindrer arbeid",
+            "arsak": [
+              "TILSTAND_HINDRER_AKTIVITET",
+              "ANNET"
+            ]
+          },
+          "arbeidsrelatertArsak": {
+            "beskrivelse": "Forhold på arbeidsplassen vanskeliggjør arbeid",
+            "arsak": [
+              "MANGLENDE_TILRETTELEGGING",
+              "ANNET"
+            ]
+          }
+        },
+        "fom": "2020-03-22",
+        "tom": "2020-05-22",
+        "gradert": null,
+        "behandlingsdager": null,
+        "innspillTilArbeidsgiver": null,
+        "type": "AKTIVITET_IKKE_MULIG"
+      }
+    ],
+    "sykmeldingStatus": {
+      "statusEvent": "SENDT",
+      "timestamp": "2020-03-29T09:38:05.414834Z",
+      "arbeidsgiver": {
+        "orgnummer": "333666999",
+        "juridiskOrgnummer": "111444777",
+        "orgNavn": "X-Files"
+      },
+      "sporsmalOgSvarListe": null
+    },
+    "medisinskVurdering": {
+      "hovedDiagnose": {
+        "kode": "L87",
+        "system": "ICD-10",
+        "tekst": "TENDINITT INA"
+      },
+      "biDiagnoser": [],
+      "svangerskap": false,
+      "yrkesskade": false,
+      "yrkesskadeDato": null
+    },
+    "skjermesForPasient": false,
+    "prognose": {
+      "arbeidsforEtterPeriode": true,
+      "hensynArbeidsplassen": "Må ta det pent",
+      "erIArbeid": {
+        "egetArbeidPaSikt": true,
+        "annetArbeidPaSikt": true,
+        "arbeidFOM": "2020-05-22",
+        "vurderingsdato": "2020-05-22"
+      },
+      "erIkkeIArbeid": null
+    },
+    "utdypendeOpplysninger": {
+      "6.2": {
+        "6.2.1": {
+          "sporsmal": "Beskriv kort sykehistorie, symptomer og funn i dagens situasjon.",
+          "svar": "Langvarig korsryggsmerter. Ømhet og smerte",
+          "restriksjoner": [
+            "SKJERMET_FOR_ARBEIDSGIVER"
+          ]
+        },
+        "6.2.2": {
+          "sporsmal": "Hvordan påvirker sykdommen arbeidsevnen",
+          "svar": "Kan ikke utføre arbeidsoppgaver 100% som kreves fra yrket.",
+          "restriksjoner": [
+            "SKJERMET_FOR_ARBEIDSGIVER"
+          ]
+        },
+        "6.2.3": {
+          "sporsmal": "Har behandlingen frem til nå bedret arbeidsevnen?",
+          "svar": "Nei",
+          "restriksjoner": [
+            "SKJERMET_FOR_ARBEIDSGIVER"
+          ]
+        },
+        "6.2.4": {
+          "sporsmal": "Beskriv Pågående og planlagt henvisning, utredning og/eller behandling",
+          "svar": "Henvist til fysio",
+          "restriksjoner": [
+            "SKJERMET_FOR_ARBEIDSGIVER"
+          ]
+        }
+      }
+    },
+    "tiltakArbeidsplassen": "Fortsett som sist.",
+    "tiltakNAV": "Pasienten har plager som er kommet tilbake etter operasjon. Det er nylig tatt MR bildet som viser forandringer i hånd som mulig må opereres. Venter på time. Det er mulig sykemledingen vil vare utover aktuell sm periode. ",
+    "andreTiltak": null,
+    "meldingTilNAV": null,
+    "meldingTilArbeidsgiver": null,
+    "kontaktMedPasient": {
+      "kontaktDato": null,
+      "begrunnelseIkkeKontakt": null
+    },
+    "behandletTidspunkt": "2020-03-21T22:00:00Z",
+    "behandler": {
+      "fornavn": "Lego",
+      "mellomnavn": "Las",
+      "etternavn": "Legesen",
+      "aktoerId": "1000014797129",
+      "fnr": "99900011122",
+      "hpr": null,
+      "her": 7777777,
+      "adresse": {
+        "gate": "Kirkegårdsveien 3",
+        "postnummer": 1348,
+        "kommune": "Rykkinn",
+        "postboks": null,
+        "land": "Country"
+      },
+      "tlf": "12345678"
+    },
+    "syketilfelleStartDato": "2020-01-22",
+    "navnFastlege": "Lego Las Legesen",
+    "egenmeldt": false,
+    "harRedusertArbeidsgiverperiode": false
   }
 ]

--- a/src/components/personkort/PersonkortLedere.js
+++ b/src/components/personkort/PersonkortLedere.js
@@ -9,6 +9,7 @@ import PersonkortElement from './PersonkortElement';
 import {
     lederHasActiveSykmelding,
     ledereWithActiveLedereFirst,
+    virksomheterWithoutLeder,
 } from '../../utils/ledereUtils';
 
 const texts = {
@@ -24,7 +25,9 @@ const texts = {
 };
 
 const PersonkortLedere = ({ ledere, sykmeldinger }) => {
-    const ledereWithActiveFirst = ledereWithActiveLedereFirst(ledere, sykmeldinger);
+    const virksomheterFromSykmeldinger = virksomheterWithoutLeder(ledere, sykmeldinger);
+    const ledereAndVirksomheter = [...ledere, ...virksomheterFromSykmeldinger];
+    const ledereWithActiveFirst = ledereWithActiveLedereFirst(ledereAndVirksomheter, sykmeldinger);
     const informasjonNokkelTekster = new Map([
         ['navn', texts.name],
         ['tlf', texts.phone],

--- a/src/utils/ledereUtils.js
+++ b/src/utils/ledereUtils.js
@@ -72,3 +72,37 @@ export const ledereWithActiveLedereFirst = (ledereData, sykmeldinger) => {
         return 0;
     });
 };
+
+const sykmeldingerWithoutMatchingLeder = (ledere, sykmeldinger) => {
+    return sykmeldinger.filter((sykmelding) => {
+        return ledere.findIndex((leder) => {
+            return leder.orgnummer === sykmelding.mottakendeArbeidsgiver.virksomhetsnummer;
+        }) === -1;
+    });
+};
+
+const sykmelding2Leder = (sykmelding) => {
+    return {
+        erOppgitt: false,
+        orgnummer: sykmelding.mottakendeArbeidsgiver.virksomhetsnummer,
+        organisasjonsnavn: sykmelding.mottakendeArbeidsgiver.navn,
+    };
+};
+
+const removeDuplicatesFromLederList = (ledere) => {
+    return ledere.filter((leder, index) => {
+        return ledere.findIndex((leder2) => {
+            return leder2.orgnummer === leder.orgnummer;
+        }) === index;
+    });
+};
+
+export const virksomheterWithoutLeder = (ledere, sykmeldinger) => {
+    const activeSykmeldinger = activeSykmeldingerSentToArbeidsgiver(sykmeldinger);
+
+    const sykmeldingerWithoutLeder = sykmeldingerWithoutMatchingLeder(ledere, activeSykmeldinger);
+
+    const virksomheterAsLedere = sykmeldingerWithoutLeder.map(sykmelding2Leder);
+
+    return removeDuplicatesFromLederList(virksomheterAsLedere);
+};

--- a/test/components/personkort/PersonkortVisningTest.js
+++ b/test/components/personkort/PersonkortVisningTest.js
@@ -135,21 +135,22 @@ describe('PersonkortVisning', () => {
             />);
         });
 
-        it('Skal vise antall PersonkortElement lik antall ledere', () => {
-            expect(komponent.find(PersonkortElement)).to.have.length(ledere.length);
+        it('Skal vise antall PersonkortElement lik antall ledere, pluss virksomhet fra sykmelding', () => {
+            expect(komponent.find(PersonkortElement)).to.have.length(ledere.length + sykmeldinger.length);
         });
 
         it('Skal vise antall PersonkortInformasjon for ledere som er oppgitt', () => {
             expect(komponent.find(PersonkortInformasjon)).to.have.length(1);
         });
 
-        it('Skal vise PersonkortElement med feilmelding, dersom ledere ikke er innmeldt', () => {
-            expect(komponent.find(Alertstripe)).to.have.length(1);
+        it('Skal vise PersonkortElement med feilmelding, dersom ledere ikke er innmeldt, og for virksomheter i sykmeldinger som ikke har leder', () => {
+            expect(komponent.find(Alertstripe)).to.have.length(2);
         });
 
         it('Skal vise PersonkortElement med feilmelding, dersom bruker ikke har noen ledere ', () => {
             komponent = mount(<PersonkortLedere
                 ledere={[]}
+                sykmeldinger={sykmeldinger}
             />);
             expect(komponent.find(Alertstripe)).to.have.length(1);
         });

--- a/test/mockdata/mockLedere.js
+++ b/test/mockdata/mockLedere.js
@@ -42,6 +42,7 @@ export const mockActiveSykmeldingForLeder = {
     status: 'SENDT',
     mottakendeArbeidsgiver: {
         virksomhetsnummer: VIRKSOMHETSNUMMER_WITH_ACTIVE_SYKMELDING,
+        navn: 'FBI',
     },
     mulighetForArbeid: {
         perioder: [
@@ -57,6 +58,7 @@ export const mockInactiveSykmeldingForLeder = {
     status: 'SENDT',
     mottakendeArbeidsgiver: {
         virksomhetsnummer: VIRKSOMHETSNUMMER_WITHOUT_ACTIVE_SYKMELDING,
+        navn: 'The Syndicate',
     },
     mulighetForArbeid: {
         perioder: [
@@ -72,6 +74,7 @@ export const mockSykmeldingWithStatusNyForLeder = {
     status: 'NY',
     mottakendeArbeidsgiver: {
         virksomhetsnummer: VIRKSOMHETSNUMMER_WITHOUT_ACTIVE_SYKMELDING,
+        navn: 'The Syndicate',
     },
     mulighetForArbeid: {
         perioder: [

--- a/test/utils/ledereUtilsTest.js
+++ b/test/utils/ledereUtilsTest.js
@@ -7,6 +7,7 @@ import {
     fjernLedereMedInnsendtMotebehov,
     lederHasActiveSykmelding,
     ledereWithActiveLedereFirst,
+    virksomheterWithoutLeder,
 } from '../../src/utils/ledereUtils';
 import { ANTALL_MS_DAG } from '../../src/utils/datoUtils';
 import {
@@ -324,7 +325,7 @@ describe('ledereUtils', () => {
         });
     });
 
-    describe('sortLedereWithActiveLedereFirst', () => {
+    describe('ledereWithActiveLedereFirst', () => {
         let clock;
         const today = new Date(Date.now());
 
@@ -344,6 +345,69 @@ describe('ledereUtils', () => {
 
             expect(sortedList[0]).to.deep.equal(mockLederWithActiveSykmelding);
             expect(sortedList[1]).to.deep.equal(mockLederWithoutActiveSykmelding);
-        })
-    })
+        });
+    });
+
+    describe('virksomheterWithoutLeder', () => {
+        let clock;
+        const today = new Date(Date.now());
+
+        beforeEach(() => {
+            clock = sinon.useFakeTimers(today.getTime());
+        });
+
+        afterEach(() => {
+            clock.restore();
+        });
+
+        it('Returns a list with one leder if virksomhet in sykmelding does not have leder ', () => {
+            const lederList = [mockLederWithoutActiveSykmelding];
+            const sykmeldinger = [mockActiveSykmeldingForLeder];
+
+            const ledereFromSykmeldinger = virksomheterWithoutLeder(lederList, sykmeldinger);
+
+            const expectedLeder = {
+                erOppgitt: false,
+                orgnummer: mockActiveSykmeldingForLeder.mottakendeArbeidsgiver.virksomhetsnummer,
+                organisasjonsnavn: mockActiveSykmeldingForLeder.mottakendeArbeidsgiver.navn,
+            };
+
+            expect(ledereFromSykmeldinger.length).to.equal(1);
+            expect(ledereFromSykmeldinger[0]).to.deep.equal(expectedLeder);
+        });
+
+        it('Returns empty list if there are no sykmeldinger', () => {
+            const lederList = [];
+            const sykmeldinger = [];
+
+            const ledereFromSykmeldinger = virksomheterWithoutLeder(lederList, sykmeldinger);
+
+            expect(ledereFromSykmeldinger.length).to.be.equal(0);
+        });
+
+        it('Returns empty list if virksomhet in sykmeldinger has leder', () => {
+            const lederList = [mockLederWithActiveSykmelding];
+            const sykmeldinger = [mockActiveSykmeldingForLeder];
+
+            const ledereFromSykmeldinger = virksomheterWithoutLeder(lederList, sykmeldinger);
+
+            expect(ledereFromSykmeldinger.length).to.be.equal(0);
+        });
+
+        it('Returns only one leder even if there are more than one active sykmelding for virksomhet without leder', () => {
+            const lederList = [mockLederWithoutActiveSykmelding];
+            const sykmeldinger = [mockActiveSykmeldingForLeder, mockActiveSykmeldingForLeder];
+
+            const ledereFromSykmeldinger = virksomheterWithoutLeder(lederList, sykmeldinger);
+
+            const expectedLeder = {
+                erOppgitt: false,
+                orgnummer: mockActiveSykmeldingForLeder.mottakendeArbeidsgiver.virksomhetsnummer,
+                organisasjonsnavn: mockActiveSykmeldingForLeder.mottakendeArbeidsgiver.navn,
+            };
+
+            expect(ledereFromSykmeldinger.length).to.equal(1);
+            expect(ledereFromSykmeldinger[0]).to.deep.equal(expectedLeder);
+        });
+    });
 });


### PR DESCRIPTION
Finn alle aktive sykmeldinger, deretter finn de virksomhetene som ikke har en tilknyttet leder, vis disse i PersonkortLeder med "ingen leder registrert"-infoboks.
Fjern duplikater, slik at selv om en virksomhet har mer enn én aktiv sykmelding, kommer virksomheten bare én gang i personkortet.