### PR TITLE
Let Bjorn tell extra info, instead of floating text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@navikt/digisyfo-npm": {
-      "version": "17.4.3",
-      "resolved": "https://registry.npmjs.org/@navikt/digisyfo-npm/-/digisyfo-npm-17.4.3.tgz",
-      "integrity": "sha512-KkuRkeoJOin448MGWCWFiLQtEVrO0f1qdxCk4UlmbleCE48FK5O9hJ87Bw+aZc8NwZXbqGIdUpPKyupSevCGsA==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@navikt/digisyfo-npm/-/digisyfo-npm-17.4.4.tgz",
+      "integrity": "sha512-IxBY0/Ago7nTnK4WXy/9C5EaEKCWGfTRtvXrELTOfCzDUzvYVgx0AH9NKL4q87ZWXshiOnMTLQxzDNElGHqbaQ==",
       "requires": {
         "fetch-ponyfill": "4.1.0",
         "nav-frontend-hjelpetekst": "1.0.37",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "Team DigiSyfo <digisyfo@nav.no>",
   "license": "ISC",
   "dependencies": {
-    "@navikt/digisyfo-npm": "17.4.3",
+    "@navikt/digisyfo-npm": "17.4.4",
     "axios": "0.19.2",
     "babel-loader": "7.1.4",
     "babel-polyfill": "6.26.0",

--- a/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Ny.js
+++ b/src/components/sykmelding/koronasykmeldinger/KoronaSykmelding-Ny.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Bjorn,
     DineKoronaSykmeldingOpplysninger,
     sykmelding as sykmeldingPt,
 } from '@navikt/digisyfo-npm';
@@ -7,24 +8,43 @@ import {
     Undertittel,
     Normaltekst,
 } from 'nav-frontend-typografi';
+import { Knapp } from 'nav-frontend-knapper';
 
 const texts = {
     pageSubtitle: 'for selvstendig næringsdrivende og frilansere',
-    infotext1: 'Her sjekker du at opplysningene fra da du opprettet egenmeldingen stemmer. Om alt stemmer kan du bekrefte og sende inn egenmeldingen.',
-    infoText2: 'Vennligst se nøye over og påse at opplysningene du har oppgitt er riktige.',
+    infotext1: 'Her sjekker du at opplysningene fra når du opprettet egenmeldingen stemmer. Om alt stemmer kan du bekrefte og sende inn egenmeldingen.',
+    infoText2: 'Vennligst se nøye over at opplysningene du har oppgitt er riktige.',
+    button: 'Gå til utfyllingen',
 };
 
 const KoronaSykmeldingNy = ({ sykmelding }) => {
     return (
         <div>
             <Undertittel style={{ marginBottom: '2.5rem', textAlign: 'center' }}>{texts.pageSubtitle}</Undertittel>
-            <Normaltekst style={{ marginBottom: '1rem' }}>{texts.infotext1}</Normaltekst>
-            <Normaltekst style={{ marginBottom: '2rem' }}>{texts.infoText2}</Normaltekst>
+            <Bjorn
+                className="blokk"
+                hvit
+                stor>
+                <Normaltekst style={{ marginBottom: '1rem' }}>
+                    {texts.infotext1}
+                </Normaltekst>
+                <Normaltekst>
+                    {texts.infoText2}
+                </Normaltekst>
+                <div className="skjul-pa-desktop">
+                    <Knapp
+                        mini
+                        disabled
+                        style={{ marginTop: '2rem' }}>
+                        {texts.button}
+                    </Knapp>
+                </div>
+            </Bjorn>
             <article>
                 <header className="panelHeader panelHeader--lysebla">
                     <img
                         className="panelHeader__ikon"
-                        src={`${process.env.REACT_APP_CONTEXT_ROOT}/img/svg/person.svg`}
+                        src="/sykefravaer/img/svg/person.svg"
                         alt="Du"
                     />
                     <h2 className="panelHeader__tittel">


### PR DESCRIPTION
Legg til Bjørn, inkludert knapp for "Gå til utfyllingen". Den knappen skal egentlig bare være synlig for mobilbrukere på Ditt Sykefravær, men vi viser den hele tiden.
Også bump digisyfo-npm. Dette fjerner "Diagnosen vises ikke til arbeidsgiveren", som ikke trengs, siden den egenmeldte sykmeldingen kun gjelder for frilansere og selvstendig næringsdrivende.