### PR TITLE
Add label to papirsykmeldinger

### DIFF
--- a/src/components/motebehov/UtdragFraSykefravaeret.js
+++ b/src/components/motebehov/UtdragFraSykefravaeret.js
@@ -7,6 +7,7 @@ import {
     sykmelding as sykmeldingPt,
 } from '@navikt/digisyfo-npm';
 import { Utvidbar } from '@navikt/digisyfo-npm';
+import EtikettBase from 'nav-frontend-etiketter';
 import SykmeldingMotebehovVisning from './SykmeldingMotebehovVisning';
 import {
     erEkstraInformasjonISykmeldingen,
@@ -30,6 +31,7 @@ const tekster = {
     },
     sykmeldinger: {
         header: 'Sykmeldinger',
+        papirLabelText: 'Papir',
     },
     samtalereferat: {
         header: 'Samtalereferat',
@@ -83,10 +85,12 @@ export const UtvidbarTittel = (
     }) => {
     const erViktigInformasjon = erEkstraInformasjonISykmeldingen(sykmelding);
     const sykmeldingPerioderSortertEtterDato = sykmeldingperioderSortertEldstTilNyest(sykmelding.mulighetForArbeid.perioder);
+    const showPapirLabel = sykmelding.papirsykmelding;
     return (<div className="utdragFraSykefravaeret__utvidbarTittel">
         <div>
             <span className="utvidbarTittel__periode">{`${tilLesbarPeriodeMedArstall(tidligsteFom(sykmelding.mulighetForArbeid.perioder), senesteTom(sykmelding.mulighetForArbeid.perioder))}: `}</span>
             <span className="utvidbarTittel__grad">{stringMedAlleGraderingerFraSykmeldingPerioder(sykmeldingPerioderSortertEtterDato)}</span>
+            {showPapirLabel && <EtikettBase className="utvidbarTittel__etikett" type="info">{tekster.sykmeldinger.papirLabelText}</EtikettBase>}
         </div>
         {
             erViktigInformasjon && <div className="utvidbarTittel__erViktig">

--- a/src/components/sykmeldinger/SykmeldingTeaser.js
+++ b/src/components/sykmeldinger/SykmeldingTeaser.js
@@ -6,6 +6,7 @@ import {
     senesteTom,
     tilLesbarPeriodeMedArstall,
 } from '@navikt/digisyfo-npm';
+import EtikettBase from 'nav-frontend-etiketter';
 import SykmeldingPeriodeInfo from './SykmeldingPeriodeInfo';
 import {
     sykmelding as sykmeldingPt,
@@ -25,6 +26,7 @@ const texts = {
     avbrutt: 'Avbrutt av deg\n',
     bekreftet: 'Bekreftet av deg\n',
     avvist: 'Avvist av NAV\n',
+    papirLabelText: 'Papir',
 };
 
 const teaserText = (egenmeldt) => {
@@ -97,6 +99,7 @@ class SykmeldingTeaser extends Component {
         const antallPerioder = sykmelding.mulighetForArbeid.perioder.length;
         const behandlingsutfallStatus = sykmelding.behandlingsutfall.status;
         const visStatus = sykmelding.status !== gamleSMStatuser.NY || behandlingsutfallStatus === behandlingsutfallStatuser.INVALID;
+        const showPapirLabel = !!sykmelding.papirsykmelding;
 
         return (<article aria-labelledby={`sykmelding-header-${this.props.sykmelding.id}`}>
             <Link
@@ -119,6 +122,7 @@ class SykmeldingTeaser extends Component {
                             </small>
                             <span className="inngangspanel__tittel">
                                 {teaserText(sykmelding.egenmeldt)}
+                                {showPapirLabel && <EtikettBase className="inngangspanel__merkelapp" type="info">{texts.papirLabelText}</EtikettBase>}
                             </span>
                         </h3>
                         {

--- a/src/styles/_inngangspanel.less
+++ b/src/styles/_inngangspanel.less
@@ -206,6 +206,11 @@
     margin: 0;
     margin-bottom: 8px;
     padding: 0;
+
+    .inngangspanel__merkelapp {
+        background-color: @lysGraEtikettBakgrunn;
+        margin-left: .5em;
+    }
 }
 
 .inngangspanel__status {

--- a/src/styles/_utdragFraSykefravaeret.less
+++ b/src/styles/_utdragFraSykefravaeret.less
@@ -30,6 +30,11 @@
         height: 1em;
         width: 1em;
     }
+
+    .utvidbarTittel__etikett {
+        background-color: @lysGraEtikettBakgrunn;
+        margin-left: .5em;
+    }
 }
 
 .utdragFraSykefravaeret__oppfolgingsplaner {

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -70,6 +70,7 @@
 @blueLight: #c3ddf4;
 @textColor: #3e3832;
 @bakgrunnGraa: #efefef;
+@lysGraEtikettBakgrunn: #CEC9C5;
 
 body {
   background-color: #f1f1f1;


### PR DESCRIPTION
Bruk merkelapp både på sykmeldingsiden, og på møtebehovsiden.
Bruk lysere gråfarge på bakgrunnen i merkelappen, for å være WCAG AAA-complient.