### PR TITLE
Get all ledere, store current and former separately in reducer

### DIFF
--- a/mock/data/ledere.json
+++ b/mock/data/ledere.json
@@ -35,10 +35,24 @@
     "epost": "test3@test.no",
     "aktiv": null,
     "erOppgitt": true,
-    "fomDato": "2018-12-03T12:00:00+01:00",
+    "fomDato": "2019-03-10T12:00:00+01:00",
     "orgnummer": "555666444",
     "organisasjonsnavn": "BRANN OG BIL AS",
     "aktivTom": null,
+    "arbeidsgiverForskuttererLoenn": null
+  },
+  {
+    "navn": "F. Orrige Leder",
+    "id": 3,
+    "aktoerId": "9909909909902",
+    "tlf": "87654329",
+    "epost": "test4@test.no",
+    "aktiv": false,
+    "erOppgitt": true,
+    "fomDato": "2019-02-03T12:00:00+01:00",
+    "orgnummer": "000999000",
+    "organisasjonsnavn": "KONKURS BEDRIFT OG VENNER AS",
+    "aktivTom": "2020-02-02T12:00:00+01:00",
     "arbeidsgiverForskuttererLoenn": null
   }
 ]

--- a/mock/mockModiasyforest.js
+++ b/mock/mockModiasyforest.js
@@ -12,7 +12,7 @@ function mockForLokal(server) {
         res.send(JSON.stringify(mockData[enums.SYKMELDINGER]));
     });
 
-    server.get('/modiasyforest/api/internad/naermesteleder', (req, res) => {
+    server.get('/modiasyforest/api/internad/allnaermesteledere', (req, res) => {
         res.setHeader('Content-Type', 'application/json');
         res.send(JSON.stringify(mockData[enums.LEDERE]));
     });

--- a/src/reducers/ledere.js
+++ b/src/reducers/ledere.js
@@ -1,7 +1,12 @@
 import * as actiontype from '../actions/actiontyper';
+import {
+    currentLedere,
+    formerLedere,
+} from '../utils/ledereUtils';
 
 const defaultState = {
     data: [],
+    formerLedere: [],
     henter: false,
     hentet: false,
     hentingFeilet: false,
@@ -11,7 +16,8 @@ const ledere = (state = defaultState, action = {}) => {
     switch (action.type) {
         case actiontype.LEDERE_HENTET: {
             return {
-                data: action.data,
+                data: currentLedere(action.data),
+                formerLedere: formerLedere(action.data),
                 henter: false,
                 hentet: true,
                 hentingFeilet: false,
@@ -23,6 +29,7 @@ const ledere = (state = defaultState, action = {}) => {
                 hentet: false,
                 hentingFeilet: false,
                 data: [],
+                formerLedere: [],
             };
         }
         case actiontype.HENT_LEDERE_FEILET: {
@@ -31,6 +38,7 @@ const ledere = (state = defaultState, action = {}) => {
                 hentet: false,
                 hentingFeilet: true,
                 data: [],
+                formerLedere: [],
             };
         }
         default: {

--- a/src/sagas/ledereSagas.js
+++ b/src/sagas/ledereSagas.js
@@ -12,7 +12,7 @@ import * as actiontype from '../actions/actiontyper';
 export function* hentLedere(action) {
     yield put({ type: actiontype.HENTER_LEDERE });
     try {
-        const path = `${process.env.REACT_APP_REST_ROOT}/internad/naermesteleder?fnr=${action.fnr}`;
+        const path = `${process.env.REACT_APP_REST_ROOT}/internad/allnaermesteledere?fnr=${action.fnr}`;
         const data = yield call(get, path);
         yield put({ type: actiontype.LEDERE_HENTET, data });
     } catch (e) {

--- a/src/utils/ledereUtils.js
+++ b/src/utils/ledereUtils.js
@@ -106,3 +106,15 @@ export const virksomheterWithoutLeder = (ledere, sykmeldinger) => {
 
     return removeDuplicatesFromLederList(virksomheterAsLedere);
 };
+
+export const currentLedere = (ledere) => {
+    return ledere.filter((leder) => {
+        return leder.aktivTom === null;
+    });
+};
+
+export const formerLedere = (ledere) => {
+    return ledere.filter((leder) => {
+        return leder.aktivTom !== null;
+    });
+};

--- a/test/reducers/ledereReducerTest.js
+++ b/test/reducers/ledereReducerTest.js
@@ -12,6 +12,7 @@ describe('ledere', () => {
         const nextState = ledere();
         expect(nextState).to.deep.equal({
             data: [],
+            formerLedere: [],
             henter: false,
             hentet: false,
             hentingFeilet: false,
@@ -24,10 +25,13 @@ describe('ledere', () => {
             type: LEDERE_HENTET,
             data: [{
                 navn: 'Kurt Nilsen',
+                aktivTom: null,
             }, {
                 navn: 'Hans Hansen',
+                aktivTom: "2020-02-20T12:00:00+01:00",
             }, {
                 navn: 'Nina Knutsen',
+                aktivTom: null,
             }],
         };
         const nextState = ledere(initialState, action);
@@ -38,11 +42,15 @@ describe('ledere', () => {
             hentingFeilet: false,
             data: [{
                 navn: 'Kurt Nilsen',
-            }, {
-                navn: 'Hans Hansen',
+                aktivTom: null,
             }, {
                 navn: 'Nina Knutsen',
+                aktivTom: null,
             }],
+            formerLedere: [{
+                navn: 'Hans Hansen',
+                aktivTom: "2020-02-20T12:00:00+01:00",
+            }]
         });
     });
 
@@ -54,6 +62,7 @@ describe('ledere', () => {
         const nextState = ledere(initialState, action);
         expect(nextState).to.deep.equal({
             data: [],
+            formerLedere: [],
             henter: true,
             hentet: false,
             hentingFeilet: false,
@@ -71,6 +80,7 @@ describe('ledere', () => {
             hentet: false,
             hentingFeilet: true,
             data: [],
+            formerLedere: [],
         });
     });
 });

--- a/test/sagas/ledereSagasTest.js
+++ b/test/sagas/ledereSagasTest.js
@@ -24,7 +24,7 @@ describe('ledereSagas', () => {
     });
 
     it('Skal dernest hente ledere', () => {
-        const nextCall = call(get, '/sykefravaer/internad/naermesteleder?fnr=55');
+        const nextCall = call(get, '/sykefravaer/internad/allnaermesteledere?fnr=55');
         expect(generator.next().value).to.deep.equal(nextCall);
     });
 


### PR DESCRIPTION
Nå får vi også inn tidligere ledere, men vi trenger ikke endre eksisterende kode for å ta høyde for endringen.