### PR TITLE
Fix bug with prop feil for <TextArea>

### DIFF
--- a/src/mote/TextField.js
+++ b/src/mote/TextField.js
@@ -10,7 +10,7 @@ const TextField = (props) => {
         input,
         maxLength,
     } = props;
-    const feilmelding = meta.touched && meta.error ? { feilmelding: meta.error } : undefined;
+    const feilmelding = meta.touched && meta.error ? meta.error : undefined;
     return (
         <Textarea
             id={id}


### PR DESCRIPTION
TextArea no longer takes in prop Feil of type object, but requires type ReactNode. This change was introduced after bumping nav-frontend-skjema to v.3.0.16