### PR TITLE
Make pengestopp button less angry, update texts

### DIFF
--- a/src/components/pengestopp/Pengestopp.tsx
+++ b/src/components/pengestopp/Pengestopp.tsx
@@ -22,8 +22,9 @@ import {
 } from '../../utils/pengestoppUtils';
 
 export const texts = {
-    stansSykepenger: 'Stopp utbetaling',
-    hentingFeiletMessage: 'Vi har problemer med baksystemene. Du kan stoppe utbetalingen, men det vil ikke bli synlig her før vi er tilbake i normal drift',
+    stansSykepenger: 'Stanse sykepenger?',
+    explanation: 'Her sender du beskjed til NAV Arbeid og ytelser om at de må se nærmere på saken. Foreløpig må du også lage notat i Gosys med begrunnelse.',
+    hentingFeiletMessage: 'Vi har problemer med baksystemene. Du kan sende beskjeden, men det vil ikke bli synlig her før vi er tilbake i normal drift',
     sykmeldtNotEligibleError: 'Den sykmeldte behandles ikke i vedtaksløsningen. Du må sende en “Vurder konsekvens for ytelse”-oppgave i Gosys, jf servicerutinene.',
 };
 
@@ -32,7 +33,6 @@ const Wrapper = styled.div`
 `;
 
 interface IPengestoppProps {
-    brukernavn: String,
     sykmeldinger: Sykmelding[],
     flaggperson: FlaggpersonState,
     fnr: string,
@@ -42,7 +42,18 @@ const Alert = styled(AlertStripe)`
   margin-bottom: 1em;
 `
 
-const Pengestopp = ({ brukernavn, sykmeldinger }: IPengestoppProps) => {
+interface KnappWithExplanationProps {
+    handleClick: () => void,
+}
+
+const KnappWithExplanation = ({ handleClick }: KnappWithExplanationProps) => {
+    return (<>
+        <Knapp type="hoved" mini onClick={handleClick}>{texts.stansSykepenger}</Knapp>
+        <p>{texts.explanation}</p>
+    </>)
+}
+
+const Pengestopp = ({ sykmeldinger }: IPengestoppProps) => {
     const [modalIsOpen, setModalIsOpen] = useState(false);
     const flaggperson: FlaggpersonState = useSelector((state: any) => state.flaggperson);
     const [sykmeldtNotEligible, setSykmeldtNotEligible] = useState(false);
@@ -72,12 +83,13 @@ const Pengestopp = ({ brukernavn, sykmeldinger }: IPengestoppProps) => {
         <Wrapper>
             {flaggperson.hentingFeilet && <Alert type="feil">{texts.hentingFeiletMessage}</Alert>}
             {sykmeldtNotEligible && <Alert type="feil">{texts.sykmeldtNotEligibleError}</Alert>}
+
             {pengestopp?.status === Status.STOPP_AUTOMATIKK
                 ? <PengestoppDropdown dato={pengestopp.opprettet} stoppedArbeidsgivere={stoppedArbeidsgivere} />
-                : <Knapp type="fare" onClick={() => {toggleModal(uniqueArbeidsgivereWithSykmeldingLast3Months)}}>{texts.stansSykepenger}</Knapp>
+                : <KnappWithExplanation handleClick={() => {toggleModal(uniqueArbeidsgivereWithSykmeldingLast3Months)}} />
             }
 
-            <PengestoppModal brukernavn={brukernavn} arbeidsgivere={uniqueArbeidsgivereWithSykmeldingLast3Months} isOpen={modalIsOpen} toggle={() => {toggleModal(uniqueArbeidsgivereWithSykmeldingLast3Months)}} />
+            <PengestoppModal arbeidsgivere={uniqueArbeidsgivereWithSykmeldingLast3Months} isOpen={modalIsOpen} toggle={() => {toggleModal(uniqueArbeidsgivereWithSykmeldingLast3Months)}} />
         </Wrapper>
     );
 };

--- a/src/components/pengestopp/PengestoppDropdown.tsx
+++ b/src/components/pengestopp/PengestoppDropdown.tsx
@@ -3,11 +3,11 @@ import Ekspanderbartpanel from 'nav-frontend-ekspanderbartpanel';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { Checkbox, CheckboxGruppe } from 'nav-frontend-skjema';
 import { Element } from 'nav-frontend-typografi';
-import { tilDatoMedUkedagOgManedNavn } from '../../utils/datoUtils';
+import { restdatoTilLesbarDato } from '../../utils/datoUtils';
 import { Arbeidsgiver } from '../../types/FlaggPerson';
 
 const texts = {
-    tittel: 'Automatisk utbetaling av sykepenger er stoppet',
+    tittel: 'Beskjed til NAV Arbeid og ytelser er sendt',
     stans: 'Stanset: ',
 };
 
@@ -18,12 +18,12 @@ interface IPengestoppDropdown {
 
 const PengestoppDropdown = ({ dato, stoppedArbeidsgivere }: IPengestoppDropdown) => {
     const warning =
-        <AlertStripe type="feil" form="inline">
+        <AlertStripe type="suksess" form="inline">
             <Element>{texts.tittel}</Element>
         </AlertStripe>;
     return (
         <Ekspanderbartpanel tittel={warning}>
-            <p>{texts.stans}<time>{tilDatoMedUkedagOgManedNavn(dato)}</time></p>
+            <p>{texts.stans}<time>{restdatoTilLesbarDato(dato)}</time></p>
             <CheckboxGruppe>
                 {
                     stoppedArbeidsgivere.map((arbeidsgiver: Arbeidsgiver, index: number) => {

--- a/src/components/pengestopp/PengestoppDropdown.tsx
+++ b/src/components/pengestopp/PengestoppDropdown.tsx
@@ -8,11 +8,11 @@ import { Arbeidsgiver } from '../../types/FlaggPerson';
 
 const texts = {
     tittel: 'Beskjed til NAV Arbeid og ytelser er sendt',
-    stans: 'Stanset: ',
+    sendt: 'Sendt: ',
 };
 
 interface IPengestoppDropdown {
-    dato: Date
+    dato: string
     stoppedArbeidsgivere: Arbeidsgiver[]
 }
 
@@ -23,7 +23,7 @@ const PengestoppDropdown = ({ dato, stoppedArbeidsgivere }: IPengestoppDropdown)
         </AlertStripe>;
     return (
         <Ekspanderbartpanel tittel={warning}>
-            <p>{texts.stans}<time>{restdatoTilLesbarDato(dato)}</time></p>
+            <p>{texts.sendt}<time>{restdatoTilLesbarDato(dato)}</time></p>
             <CheckboxGruppe>
                 {
                     stoppedArbeidsgivere.map((arbeidsgiver: Arbeidsgiver, index: number) => {

--- a/src/components/pengestopp/PengestoppModal.tsx
+++ b/src/components/pengestopp/PengestoppModal.tsx
@@ -29,16 +29,19 @@ import { endreStatus } from '../../actions/flaggperson_actions';
 import { FlaggpersonState } from '../../reducers/flaggperson';
 
 const texts = {
-    tittel: 'Stopp automatisk utbetaling av sykepenger',
+    notStoppedTittel: 'Send beskjed til NAV Arbeid og ytelser om mulig stans av sykepenger',
+    stoppedTittel: 'Beskjeden din er sendt',
+    stoppedInfo: 'Nå har du sendt beskjed til NAV Arbeid og ytelser. Du må også lage et notat i Gosys hvor du begrunner hvorfor du mener sykepengene bør stanses.',
+    seServicerutinen: 'Se servicerutinen hvis du er i tvil.',
     arbeidsgiver: 'Velg arbeidsgiver',
     stansSykepenger: 'Stans sykepenger',
+    send: 'Send',
     avbryt: 'Avbryt',
     submitError: 'Du må velge minst én arbeidsgiver',
     serverError: 'Det er ikke mulig å stoppe automatisk utbetaling av sykepenger akkurat nå. Prøv igjen senere.'
 };
 
 interface IPengestoppModal {
-    brukernavn: String,
     isOpen: boolean,
     arbeidsgivere: Arbeidsgiver[],
 
@@ -59,7 +62,13 @@ const BottomGroup = styled.div`
     margin-top: 1em;
 `;
 
-const PengestoppModal = ({ brukernavn, isOpen, arbeidsgivere, toggle }: IPengestoppModal) => {
+const tittel = (stopped: boolean) => {
+    return stopped
+        ? texts.stoppedTittel
+        : texts.notStoppedTittel;
+}
+
+const PengestoppModal = ({ isOpen, arbeidsgivere, toggle }: IPengestoppModal) => {
     const enhet = useSelector((state: any) => state.enhet);
     const flaggperson: FlaggpersonState = useSelector((state: any) => state.flaggperson);
 
@@ -129,7 +138,7 @@ const PengestoppModal = ({ brukernavn, isOpen, arbeidsgivere, toggle }: IPengest
             closeButton={true}
             onRequestClose={handleCloseModal}
         >
-            <Systemtittel>{texts.tittel}</Systemtittel>
+            <Systemtittel>{tittel(stopped)}</Systemtittel>
 
             {!stopped
                 ? <>
@@ -148,14 +157,16 @@ const PengestoppModal = ({ brukernavn, isOpen, arbeidsgivere, toggle }: IPengest
                         </CheckboxGruppe>
                     </Group>
                     <Knapp type="flat" onClick={handleCloseModal}>{texts.avbryt}</Knapp>
-                    <Knapp type="fare" spinner={flaggperson.endrer} disabled={flaggperson.endrer} onClick={handleStoppAutomatikkButtonPress}>{texts.stansSykepenger}</Knapp>
+                    <Knapp type="hoved" mini spinner={flaggperson.endrer} disabled={flaggperson.endrer} onClick={handleStoppAutomatikkButtonPress}>{texts.send}</Knapp>
 
                 </>
                 : <>
                     <Group>
-                        <AlertStripeInfo>{`Sykepengene til ${brukernavn} er stanset. Du kan lage en oppgave i Gosys nå for stans av sykepenger. Det er også mulig å gjøre dette senere`}</AlertStripeInfo>
+                        <AlertStripeInfo>
+                            <p>{texts.stoppedInfo}</p>
+                            <p>{texts.seServicerutinen}</p>
+                        </AlertStripeInfo>
                     </Group>
-                    <Knapp type="flat" onClick={toggle}>{texts.avbryt}</Knapp>
                 </>
             }
             {serverError && <BottomGroup><Feilmelding>{texts.serverError}</Feilmelding></BottomGroup>}

--- a/src/containers/SykmeldingerContainer.js
+++ b/src/containers/SykmeldingerContainer.js
@@ -70,7 +70,7 @@ export class SykmeldingerSide extends Component {
                     }
                     return (<div>
                         {erPreProd() || erLokal()
-                            ? <Pengestopp brukernavn={brukernavn} sykmeldinger={sykmeldinger} />
+                            ? <Pengestopp sykmeldinger={sykmeldinger} />
                             : <TemporaryPengestopp />}
                         <Speilingvarsel brukernavn={brukernavn} />
                         <div className="speiling">

--- a/src/reducers/flaggperson.ts
+++ b/src/reducers/flaggperson.ts
@@ -48,13 +48,7 @@ const flaggperson = (state = initialState, action = { type: '', data: [] }) => {
                 henter: false,
                 hentingFeilet: false,
                 hentet: true,
-                data: action.data.map((se: StatusEndring & { opprettet: string }) => (
-                    {
-                        ...se,
-                        opprettet: Date.parse(se.opprettet)
-
-                    }
-                )),
+                data: action.data,
             };
         }
         case HENT_STATUS_FEILET: {

--- a/src/types/FlaggPerson.ts
+++ b/src/types/FlaggPerson.ts
@@ -48,6 +48,6 @@ export interface StatusEndring {
     sykmeldtFnr: SykmeldtFnr,
     status: Status,
     virksomhetNr: VirksomhetNr,
-    opprettet: Date,
+    opprettet: string,
     enhetNr: EnhetNr
 }

--- a/src/utils/pengestoppUtils.ts
+++ b/src/utils/pengestoppUtils.ts
@@ -61,7 +61,7 @@ export const stoppAutomatikk2StatusEndring = (stoppAutomatikk: StoppAutomatikk) 
             sykmeldtFnr: stoppAutomatikk.sykmeldtFnr,
             status: Status.STOPP_AUTOMATIKK,
             virksomhetNr: virksomhet,
-            opprettet: new Date(),
+            opprettet: new Date().toISOString(),
             enhetNr: stoppAutomatikk.enhetNr
         }
     })


### PR DESCRIPTION
Bruk blå knapp, med spørsmålstegn
Vis ekstra informasjon under knappen
Ikke map dato i flaggPersonReducer, nå er det lettere å printe datoen
Oppdater tekster, bruk "stans" i stedet for "stopp"
Fjern avbryt-knapp fra modal etter innsending