### PR TITLE
Show correct leder name in motebehovKvittering

### DIFF
--- a/src/components/motebehov/MotebehovKvittering.js
+++ b/src/components/motebehov/MotebehovKvittering.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types';
 import { finnArbeidstakerMotebehovSvar } from '../../utils/motebehovUtils';
 import { tilLesbarDatoMedArUtenManedNavn } from '../../utils/datoUtils';
 
-export const finnRiktigLeder = (virksomhetsnummer, ledere) => {
+export const lederMedGittAktorId = (aktorId, ledere) => {
     return ledere.find((leder) => {
-        return leder.orgnummer === virksomhetsnummer;
+        return leder.aktoerId === aktorId;
     });
 };
 
@@ -132,7 +132,7 @@ export const MotebehovKvitteringInnholdArbeidsgiver = (
 ) => {
     return motebehovListeMedBareArbeidsgiversMotebehov.map((motebehov, index) => {
         const arbeidsgiverOnskerMote = motebehov.motebehovSvar.harMotebehov;
-        const riktigLeder = finnRiktigLeder(motebehov.virksomhetsnummer, ledereData);
+        const riktigLeder = lederMedGittAktorId(motebehov.opprettetAv, ledereData);
         const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverNavnEllerTomStreng(riktigLeder)} ${ikonAlternativTekst(arbeidsgiverOnskerMote)}`;
 
         return (<MotebehovKvitteringInnhold

--- a/src/utils/ledereUtils.js
+++ b/src/utils/ledereUtils.js
@@ -17,7 +17,7 @@ export const ledereIVirksomheterMedMotebehovsvarFraArbeidstaker = (ledereData, m
     });
 };
 
-export const fjernLedereMedInnsendtMotebehov = (ledereListe, motebehovData) => {
+export const ledereIVirksomheterDerIngenLederHarSvartPaMotebehov = (ledereListe, motebehovData) => {
     return ledereListe.filter((leder) => {
         return motebehovData.findIndex((motebehov) => {
             return motebehov.opprettetAv !== motebehov.aktorId && motebehov.virksomhetsnummer === leder.orgnummer;
@@ -40,6 +40,19 @@ export const ledereMedOppfolgingstilfelleInnenforMotebehovperioden = (ledereData
     });
 };
 
+const isNewerLeader = (ledere, givenLeder) => {
+    return ledere.findIndex((lederCandidate) => {
+        return givenLeder.aktoerId !== lederCandidate.aktoerId
+            && givenLeder.orgnummer === lederCandidate.orgnummer
+            && givenLeder.fomDato < lederCandidate.fomDato;
+    }) > -1;
+};
+
+const newestLederForEachVirksomhet = (ledere) => {
+    return ledere.filter((leder) => {
+        return !isNewerLeader(ledere, leder);
+    });
+};
 
 export const ledereUtenMotebehovsvar = (ledereData, motebehovData, oppfolgingstilfelleperioder) => {
     const arbeidstakerHarSvartPaaMotebehov = motebehovData && harArbeidstakerSvartPaaMotebehov(motebehovData);
@@ -47,7 +60,10 @@ export const ledereUtenMotebehovsvar = (ledereData, motebehovData, oppfolgingsti
     const filtrertLederListe = arbeidstakerHarSvartPaaMotebehov
         ? ledereIVirksomheterMedMotebehovsvarFraArbeidstaker(ledereData, motebehovData)
         : ledereMedOppfolgingstilfelleInnenforMotebehovperioden(ledereData, oppfolgingstilfelleperioder);
-    return fjernLedereMedInnsendtMotebehov(filtrertLederListe, motebehovData);
+
+    const ledereIVirksomhetUtenMotebehovSvarFraLeder = ledereIVirksomheterDerIngenLederHarSvartPaMotebehov(filtrertLederListe, motebehovData);
+
+    return newestLederForEachVirksomhet(ledereIVirksomhetUtenMotebehovSvarFraLeder);
 };
 
 export const lederHasActiveSykmelding = (leder, sykmeldinger) => {


### PR DESCRIPTION
Finn riktig leder for møtebehovsvar med aktørID ikke virksomhetsnummer
Vis bare nyeste leder hvis kun SM har svart, uavhengig av innsendtDato