### PR TITLE
Do not get Virksomhetsnavn for orgnr=null

### DIFF
--- a/src/components/vedtak/VedtakEkspanderbartPanel.tsx
+++ b/src/components/vedtak/VedtakEkspanderbartPanel.tsx
@@ -71,7 +71,9 @@ const VedtakEkspanderbartPanel = (
   const orgnr = vedtakPerArbeidsgiver[0].vedtak.organisasjonsnummer;
 
   useEffect(() => {
-    dispatch(hentVirksomhet(orgnr));
+    if (orgnr) {
+      dispatch(hentVirksomhet(orgnr));
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
If Vedtak has a `orgnr` that is `null` the name of the `Virksomhet` is request from Syfomoteadmin, resulting in an error.  A check to see if `Orgnr` before calling `hentVirksomhet` for Vedtak is added to solve this issue.