### PR TITLE
Fix SykmeldingUtil erEkstraInformasjonISykmeldingen for utdypendeOppl…

### DIFF
--- a/src/components/motebehov/SykmeldingMotebehovVisning.tsx
+++ b/src/components/motebehov/SykmeldingMotebehovVisning.tsx
@@ -20,9 +20,7 @@ const SykmeldingMotebehovVisning = (
       <GenerellSykmeldingInfo sykmelding={sykmelding} />
       <MulighetForArbeid sykmelding={sykmelding} />
       <TilbakeIArbeid sykmelding={sykmelding} />
-      <UtdypendeOpplysninger
-        utdypendeOpplysninger={sykmelding.utdypendeOpplysninger}
-      />
+      <UtdypendeOpplysninger sykmelding={sykmelding} />
       <BedreArbeidsevnen sykmelding={sykmelding} />
       <MeldingTilNav sykmelding={sykmelding} />
       <MeldingTilArbeidsgiver sykmelding={sykmelding} />

--- a/src/components/motebehov/UtdypendeOpplysninger.tsx
+++ b/src/components/motebehov/UtdypendeOpplysninger.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { UtdypendeOpplysning } from "../../data/sykmelding/types/SykmeldingNewFormatDTO";
+import { SykmeldingOldFormat } from "../../data/sykmelding/types/SykmeldingOldFormat";
+import { erUtdypendeOpplysninger } from "../../utils/sykmeldinger/sykmeldingUtils";
 
 const tekster = {
   UtdypendeOpplysninger: {
@@ -24,24 +26,23 @@ const OpplysningsGruppe = ({ opplysningGruppe }: OpplysningsGruppeProps) => {
 };
 
 interface UtdypendeOpplysningerProps {
-  utdypendeOpplysninger: Map<string, Map<string, UtdypendeOpplysning>>;
+  sykmelding: SykmeldingOldFormat;
 }
 
 export const UtdypendeOpplysninger = (
   utdypendeOpplysningerProps: UtdypendeOpplysningerProps
 ) => {
-  const utdypendeOpplysninger =
-    utdypendeOpplysningerProps.utdypendeOpplysninger;
-
+  const sykmelding = utdypendeOpplysningerProps.sykmelding;
+  const skalVise = sykmelding && erUtdypendeOpplysninger(sykmelding);
   return (
     <>
-      {utdypendeOpplysninger && (
+      {skalVise && (
         <div className="sykmeldingMotebehovVisning__avsnitt">
           <h5 className="undertittel">
             {tekster.UtdypendeOpplysninger.header}
           </h5>
 
-          {Object.entries(utdypendeOpplysninger).map(
+          {Object.entries(sykmelding.utdypendeOpplysninger).map(
             ([key, opplysningGruppe]) => (
               <OpplysningsGruppe
                 key={key}

--- a/src/utils/sykmeldinger/sykmeldingUtils.js
+++ b/src/utils/sykmeldinger/sykmeldingUtils.js
@@ -88,6 +88,13 @@ export const erMeldingTilArbeidsgiverInformasjon = (sykmelding) => {
   return !!erEkstraInformasjon;
 };
 
+export const erUtdypendeOpplysninger = (sykmelding) => {
+  const utdypendeOpplysninger = sykmelding.utdypendeOpplysninger;
+  const erEkstraInformasjon =
+    utdypendeOpplysninger && Object.keys(utdypendeOpplysninger).length > 0;
+  return !!erEkstraInformasjon;
+};
+
 export const erEkstraInformasjonISykmeldingen = (sykmelding) => {
   return (
     erEkstraDiagnoseInformasjon(sykmelding) ||
@@ -95,7 +102,7 @@ export const erEkstraInformasjonISykmeldingen = (sykmelding) => {
     erFriskmeldingInformasjon(sykmelding) ||
     erArbeidsforEtterPerioden(sykmelding) ||
     erHensynPaaArbeidsplassenInformasjon(sykmelding) ||
-    sykmelding.utdypendeOpplysninger ||
+    erUtdypendeOpplysninger(sykmelding) ||
     erBedringAvArbeidsevnenInformasjon(sykmelding) ||
     erMeldingTilNavInformasjon(sykmelding) ||
     erMeldingTilArbeidsgiverInformasjon(sykmelding) ||


### PR DESCRIPTION
…ysninger

Utdypendeopplysninger can be a defined map without any key/values in it and the map must therefore have atlest 1 key to be defined as containing relevant information.