### PR TITLE
Show only motebehovsvar connected to the latest current syketilfelle

### DIFF
--- a/src/components/motebehov/container/MotebehovContainer.tsx
+++ b/src/components/motebehov/container/MotebehovContainer.tsx
@@ -5,8 +5,8 @@ import { MOETEPLANLEGGER } from "../../../enums/menypunkter";
 import { hentBegrunnelseTekst } from "../../../utils/tilgangUtils";
 import {
   sorterMotebehovDataEtterDato,
-  finnNyesteMotebehovsvarFraHverDeltaker,
   motebehovlisteMedKunJaSvar,
+  motebehovFromLatestActiveTilfelle,
 } from "../../../utils/motebehovUtils";
 import {
   harForsoktHentetLedere,
@@ -53,9 +53,6 @@ const MotebehovSide = () => {
   const sortertMotebehovListe = motebehovData.sort(
     sorterMotebehovDataEtterDato
   );
-  const motebehovListeUtenFlereSvarFraSammePerson = finnNyesteMotebehovsvarFraHverDeltaker(
-    sortertMotebehovListe
-  );
 
   const motebehovListeMedJaSvarTilOppgavebehandling = motebehovlisteMedKunJaSvar(
     motebehovData
@@ -73,6 +70,12 @@ const MotebehovSide = () => {
   const oppfolgingstilfelleperioder = useSelector(
     (state: any) => state.oppfolgingstilfelleperioder
   );
+
+  const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+    sortertMotebehovListe,
+    oppfolgingstilfelleperioder
+  );
+
   const ledereUtenInnsendtMotebehov = ledereUtenMotebehovsvar(
     ledereData,
     motebehovData,
@@ -132,7 +135,7 @@ const MotebehovSide = () => {
             fnr={fnr}
             ledereData={ledereData}
             ledereUtenInnsendtMotebehov={ledereUtenInnsendtMotebehov}
-            motebehovListe={motebehovListeUtenFlereSvarFraSammePerson}
+            motebehovListe={activeMotebehovSvar}
             sykmeldt={sykmeldt}
             motebehovListeMedJaSvarTilOppgavebehandling={
               motebehovListeMedJaSvarTilOppgavebehandling

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -1,4 +1,5 @@
 import { dagerMellomDatoer } from "./datoUtils";
+import { startDateFromLatestActiveTilfelle } from "./periodeUtils";
 
 export const sorterMotebehovDataEtterDato = (a: any, b: any) => {
   return b.opprettetDato === a.opprettetDato
@@ -95,5 +96,22 @@ export const hentSistBehandletMotebehov = (motebehovListe: any) => {
 export const motebehovlisteMedKunJaSvar = (motebehovliste: any[]) => {
   return motebehovliste.filter((motebehov) => {
     return motebehov.motebehovSvar && motebehov.motebehovSvar.harMotebehov;
+  });
+};
+
+export const motebehovFromLatestActiveTilfelle = (
+  sortertMotebehovListe: any[],
+  oppfolgingstilfelleperioder: any
+) => {
+  const startDateNewestActiveTilfelle = startDateFromLatestActiveTilfelle(
+    oppfolgingstilfelleperioder
+  );
+
+  if (startDateNewestActiveTilfelle === null) {
+    return [];
+  }
+
+  return sortertMotebehovListe.filter((svar) => {
+    return svar.opprettetDato >= startDateNewestActiveTilfelle;
   });
 };

--- a/test/utils/motebehovUtilsTest.js
+++ b/test/utils/motebehovUtilsTest.js
@@ -294,7 +294,7 @@ describe("motebehovUtils", () => {
     const tenDaysAgo = new Date(Date.now() - oneDayInMillis * 10);
     const fiveDaysAgo = new Date(Date.now() - oneDayInMillis * 5);
     const now = new Date(Date.now());
-    const fiveDayFromNow = new Date(Date.now() + oneDayInMillis * 5);
+    const fiveDaysFromNow = new Date(Date.now() + oneDayInMillis * 5);
     const tenDaysFromNow = new Date(Date.now() + oneDayInMillis * 10);
 
     it("Get one motebehovsvar when inside active tilfelle", () => {
@@ -310,7 +310,7 @@ describe("motebehovUtils", () => {
           data: [
             {
               fom: fiveDaysAgo,
-              tom: fiveDayFromNow,
+              tom: fiveDaysFromNow,
             },
           ],
         },
@@ -338,7 +338,7 @@ describe("motebehovUtils", () => {
           data: [
             {
               fom: fiveDaysAgo,
-              tom: fiveDayFromNow,
+              tom: fiveDaysFromNow,
             },
           ],
         },

--- a/test/utils/motebehovUtilsTest.js
+++ b/test/utils/motebehovUtilsTest.js
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import sinon from "sinon";
 import {
   erMotebehovBehandlet,
   erOppfoelgingsdatoPassertMed16UkerOgIkke26Uker,
@@ -6,6 +7,7 @@ import {
   finnArbeidstakerMotebehovSvar,
   finnNyesteMotebehovsvarFraHverDeltaker,
   harArbeidstakerSvartPaaMotebehov,
+  motebehovFromLatestActiveTilfelle,
 } from "../../src/utils/motebehovUtils";
 import { ANTALL_MS_DAG } from "../../src/utils/datoUtils";
 
@@ -272,6 +274,202 @@ describe("motebehovUtils", () => {
         const exp = erMotebehovBehandlet([]);
         expect(exp).to.equal(true);
       });
+    });
+  });
+
+  describe("motebehovFromLatestActiveTilfelle", () => {
+    let clock;
+    const today = new Date(Date.now());
+
+    beforeEach(() => {
+      clock = sinon.useFakeTimers(today.getTime());
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
+    const oneDayInMillis = 1000 * 60 * 60 * 24;
+    const seventeenDaysAgo = new Date(Date.now() - oneDayInMillis * 17);
+    const tenDaysAgo = new Date(Date.now() - oneDayInMillis * 10);
+    const fiveDaysAgo = new Date(Date.now() - oneDayInMillis * 5);
+    const now = new Date(Date.now());
+    const fiveDayFromNow = new Date(Date.now() + oneDayInMillis * 5);
+    const tenDaysFromNow = new Date(Date.now() + oneDayInMillis * 10);
+
+    it("Get one motebehovsvar when inside active tilfelle", () => {
+      const motebehovData = [
+        {
+          aktorId: "1",
+          opprettetDato: now,
+        },
+      ];
+
+      const activeTilfelle = {
+        123456789: {
+          data: [
+            {
+              fom: fiveDaysAgo,
+              tom: fiveDayFromNow,
+            },
+          ],
+        },
+      };
+
+      const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+        motebehovData,
+        activeTilfelle
+      );
+
+      expect(activeMotebehovSvar.length).to.equal(1);
+      expect(activeMotebehovSvar[0].aktorId).to.equal("1");
+    });
+
+    it("Get zero motebehovsvar when all was sent before active tilfelle", () => {
+      const motebehovData = [
+        {
+          aktorId: "1",
+          opprettetDato: tenDaysAgo,
+        },
+      ];
+
+      const activeTilfelle = {
+        123456789: {
+          data: [
+            {
+              fom: fiveDaysAgo,
+              tom: fiveDayFromNow,
+            },
+          ],
+        },
+      };
+
+      const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+        motebehovData,
+        activeTilfelle
+      );
+
+      expect(activeMotebehovSvar.length).to.equal(0);
+    });
+
+    it("Get zero motebehovsvar when no active tilfelle, even if motebehov was sent in the last tilfelle", () => {
+      const motebehovData = [
+        {
+          aktorId: "1",
+          opprettetDato: seventeenDaysAgo,
+        },
+      ];
+
+      const activeTilfelle = {
+        123456789: {
+          data: [
+            {
+              fom: seventeenDaysAgo,
+              tom: seventeenDaysAgo,
+            },
+          ],
+        },
+      };
+
+      const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+        motebehovData,
+        activeTilfelle
+      );
+
+      expect(activeMotebehovSvar.length).to.equal(0);
+    });
+
+    it("Get applicable motebehovsvar if tilfelle ended less than 16 days ago", () => {
+      const motebehovData = [
+        {
+          aktorId: "1",
+          opprettetDato: fiveDaysAgo,
+        },
+      ];
+
+      const activeTilfelle = {
+        123456789: {
+          data: [
+            {
+              fom: tenDaysAgo,
+              tom: fiveDaysAgo,
+            },
+          ],
+        },
+      };
+
+      const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+        motebehovData,
+        activeTilfelle
+      );
+
+      expect(activeMotebehovSvar.length).to.equal(1);
+      expect(activeMotebehovSvar[0].aktorId).to.equal("1");
+    });
+
+    it("Get two motebehovsvar if both were sent within active tilfelle", () => {
+      const motebehovData = [
+        {
+          aktorId: "1",
+          opprettetDato: fiveDaysAgo,
+        },
+        {
+          aktorId: "2",
+          opprettetDato: tenDaysAgo,
+        },
+      ];
+
+      const activeTilfelle = {
+        123456789: {
+          data: [
+            {
+              fom: tenDaysAgo,
+              tom: tenDaysFromNow,
+            },
+          ],
+        },
+      };
+
+      const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+        motebehovData,
+        activeTilfelle
+      );
+
+      expect(activeMotebehovSvar.length).to.equal(2);
+    });
+
+    it("Get motebehovsvar from AG if sent within active tilfelle, even if tilfelle is from different virksomhet", () => {
+      const differentVirksomhet = "differentVirksomhet";
+      const motebehovData = [
+        {
+          aktorId: "1",
+          opprettetDato: fiveDaysAgo,
+          opprettetAv: "leder",
+          virksomhetsnummer: differentVirksomhet,
+        },
+      ];
+
+      const activeTilfelle = {
+        123456789: {
+          data: [
+            {
+              fom: tenDaysAgo,
+              tom: tenDaysFromNow,
+            },
+          ],
+        },
+      };
+
+      const activeMotebehovSvar = motebehovFromLatestActiveTilfelle(
+        motebehovData,
+        activeTilfelle
+      );
+
+      expect(activeMotebehovSvar.length).to.equal(1);
+      expect(activeMotebehovSvar[0].aktorId).to.equal("1");
+      expect(activeMotebehovSvar[0].virksomhetsnummer).to.equal(
+        differentVirksomhet
+      );
     });
   });
 });


### PR DESCRIPTION
Slå sammen alle tilfeller som henger sammen innenfor 16 dager, uavhengig av virksomhet
Finn startdatoen for det nyeste, aktive tilfellet, null hvis ingen tilfeller er aktive nå
Filtrer bort alle møtebehovsvar som ble opprettet etter den datoen, tom liste hvis startdato er null