### PR TITLE
Change title to week 28 in Prediksjontittel.tsx

### DIFF
--- a/src/components/Prediksjon/Prediksjontittel.tsx
+++ b/src/components/Prediksjon/Prediksjontittel.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import Hjelpetekst from "nav-frontend-hjelpetekst";
 
 const texts = {
-  title: "Vil den sykmeldte fortsatt være sykmeldt etter uke 26?",
+  title: "Vil den sykmeldte fortsatt være sykmeldt etter uke 28?",
   info: {
     title: "Om beregningen",
     subtitle:


### PR DESCRIPTION
Et "langt" sykefravær er definert som 28 uker i backend.