### PR TITLE
Fix isNewerLeader util method

### DIFF
--- a/src/utils/ledereUtils.ts
+++ b/src/utils/ledereUtils.ts
@@ -67,7 +67,7 @@ const isNewerLeader = (ledere: Leder[], givenLeder: Leder): boolean => {
     (lederCandidate) =>
       givenLeder.aktoerId !== lederCandidate.aktoerId &&
       givenLeder.orgnummer === lederCandidate.orgnummer &&
-      givenLeder.fomDato < lederCandidate.fomDato
+      new Date(givenLeder.fomDato) < new Date(lederCandidate.fomDato)
   );
 };
 


### PR DESCRIPTION
Legg på new Date rundt datoene, slik at vi sammenligner faktiske datoer, ikke string.
"20.05" > "30.01" === false // Her sammenlignes string "2" med string "3"
new Date("20.05") > New Date("30.01") === true