### PR TITLE
Use double exclamation to check if innspillTilArbeidsgiver is present

### DIFF
--- a/src/components/motebehov/MeldingTilArbeidsgiver.tsx
+++ b/src/components/motebehov/MeldingTilArbeidsgiver.tsx
@@ -16,7 +16,6 @@ interface MeldingTilArbeidsgiverProps {
 export const MeldingTilArbeidsgiver = ({
   sykmelding,
 }: MeldingTilArbeidsgiverProps) => {
-  const innspillTilArbeidsgiver = sykmelding.innspillTilArbeidsgiver;
   const skalVise = erMeldingTilArbeidsgiverInformasjon(sykmelding);
   return (
     <>
@@ -25,14 +24,10 @@ export const MeldingTilArbeidsgiver = ({
           <h5 className="undertittel">
             {tekster.meldingTilArbeidsgiver.header}
           </h5>
-          {innspillTilArbeidsgiver && (
-            <div>
-              <h6 className="sporsmal">
-                {tekster.meldingTilArbeidsgiver.innspillTittel}
-              </h6>
-              <p>{innspillTilArbeidsgiver}</p>
-            </div>
-          )}
+          <h6 className="sporsmal">
+            {tekster.meldingTilArbeidsgiver.innspillTittel}
+          </h6>
+          <p>{sykmelding.innspillTilArbeidsgiver}</p>
         </div>
       )}
     </>

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -108,7 +108,7 @@ export const erMeldingTilNavInformasjon = (
 export const erMeldingTilArbeidsgiverInformasjon = (
   sykmelding: SykmeldingOldFormat
 ): boolean => {
-  return sykmelding.innspillTilArbeidsgiver !== null;
+  return !!sykmelding.innspillTilArbeidsgiver;
 };
 
 export const erUtdypendeOpplysninger = (

--- a/test/utils/sykmeldingUtilsTest.js
+++ b/test/utils/sykmeldingUtilsTest.js
@@ -368,6 +368,13 @@ describe("sykmeldingUtils", () => {
 
       expect(erIkkeEkstraInfo).to.equal(false);
     });
+    it("skal returnere false dersom sykmeldingen ikke inneholder innspillTilArbeidsgiver-felt, er undefined", () => {
+      const sykmelding = {};
+
+      const erIkkeEkstraInfo = erMeldingTilArbeidsgiverInformasjon(sykmelding);
+
+      expect(erIkkeEkstraInfo).to.equal(false);
+    });
   });
 
   describe("arbeidsgivernavnEllerArbeidssituasjon", () => {


### PR DESCRIPTION
Denne kan bli `undefined`, og da blir `!== null` true, selv om vi ikke egentlig har mer info.
Fjern unødvendig sjekk på innspillTilArbeidsgiver i MeldingTilArbeidsgiver-komponenten, siden den skal være true hvis `skalVise` er true.