### PR TITLE
Forhandsvis innkalling first edition

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -38,6 +38,7 @@ export enum PaddingSize {
 interface RowProps {
   topPadding?: PaddingSize;
   bottomPadding?: PaddingSize;
+  justifyContent?: JustifyContentType;
 }
 
 export const FlexRow = styled.div<RowProps>`
@@ -47,6 +48,8 @@ export const FlexRow = styled.div<RowProps>`
   width: 100%;
   padding-top: ${(props) => props.topPadding || 0};
   padding-bottom: ${(props) => props.bottomPadding || 0};
+  justify-content: ${(props) =>
+    props.justifyContent || JustifyContentType.FLEX_START};
 `;
 
 export const H2NoMargins = styled.h2`

--- a/src/components/dialogmote/Forhandsvisning.tsx
+++ b/src/components/dialogmote/Forhandsvisning.tsx
@@ -45,24 +45,30 @@ const DocumentComponentText = ({ type, texts }: DocumentComponentTextProps) => {
     return null;
   }
   //  TODO: Implement DocumentComponentType.HEADER for referat
-  if (type === DocumentComponentType.LINK) {
-    const link = texts[0];
-    return (
-      <Lenke target="_blank" rel="noopener noreferrer" href={link}>
-        {link}
-      </Lenke>
-    );
-  } else {
-    return (
-      <>
-        {texts.map((text, index) => (
-          <Normaltekst key={index}>
-            {text}
-            <br />
-          </Normaltekst>
-        ))}
-      </>
-    );
+  switch (type) {
+    case DocumentComponentType.LINK: {
+      const link = texts[0];
+      return (
+        <Lenke target="_blank" rel="noopener noreferrer" href={link}>
+          {link}
+        </Lenke>
+      );
+    }
+    case DocumentComponentType.PARAGRAPH: {
+      return (
+        <>
+          {texts.map((text, index) => (
+            <Normaltekst key={index}>
+              {text}
+              <br />
+            </Normaltekst>
+          ))}
+        </>
+      );
+    }
+    default: {
+      return null;
+    }
   }
 };
 

--- a/src/components/dialogmote/Forhandsvisning.tsx
+++ b/src/components/dialogmote/Forhandsvisning.tsx
@@ -46,9 +46,10 @@ const DocumentComponentText = ({ type, texts }: DocumentComponentTextProps) => {
   }
   //  TODO: Implement DocumentComponentType.HEADER for referat
   if (type === DocumentComponentType.LINK) {
+    const link = texts[0];
     return (
-      <Lenke target="_blank" rel="noopener noreferrer" href={texts[0]}>
-        {texts}
+      <Lenke target="_blank" rel="noopener noreferrer" href={link}>
+        {link}
       </Lenke>
     );
   } else {

--- a/src/components/dialogmote/Forhandsvisning.tsx
+++ b/src/components/dialogmote/Forhandsvisning.tsx
@@ -1,0 +1,130 @@
+import ModalWrapper from "nav-frontend-modal";
+import {
+  FlexRow,
+  JustifyContentType,
+  ModalContentContainer,
+  PaddingSize,
+} from "../Layout";
+import {
+  Element,
+  Innholdstittel,
+  Normaltekst,
+  Sidetittel,
+} from "nav-frontend-typografi";
+import { Hovedknapp } from "nav-frontend-knapper";
+import React, { ReactElement } from "react";
+import {
+  DocumentComponentDto,
+  DocumentComponentType,
+} from "../../data/dialogmote/dialogmoteTypes";
+import styled from "styled-components";
+import Lenke from "nav-frontend-lenker";
+
+const texts = {
+  close: "Lukk",
+};
+
+const Paragraph = styled.div`
+  margin-bottom: 1em;
+`;
+
+const TitledParagraph = styled.div`
+  margin-bottom: 2em;
+`;
+
+const ForhandsvisningModal = styled(ModalWrapper)`
+  max-width: 50em;
+`;
+
+type DocumentComponentTextProps = Required<
+  Pick<DocumentComponentDto, "type" | "texts">
+>;
+
+const DocumentComponentText = ({ type, texts }: DocumentComponentTextProps) => {
+  if (texts.length === 0) {
+    return null;
+  }
+  //  TODO: Implement DocumentComponentType.HEADER for referat
+  if (type === DocumentComponentType.LINK) {
+    return (
+      <Lenke target="_blank" rel="noopener noreferrer" href={texts[0]}>
+        {texts}
+      </Lenke>
+    );
+  } else {
+    return (
+      <>
+        {texts.map((text, index) => (
+          <Normaltekst key={index}>
+            {text}
+            <br />
+          </Normaltekst>
+        ))}
+      </>
+    );
+  }
+};
+
+interface DocumentComponentVisningProps {
+  documentComponent: DocumentComponentDto;
+}
+
+const DocumentComponentVisning = ({
+  documentComponent: { type, title, texts },
+}: DocumentComponentVisningProps) => {
+  return title ? (
+    <TitledParagraph>
+      <Element>{title}</Element>
+      <DocumentComponentText type={type} texts={texts} />
+    </TitledParagraph>
+  ) : (
+    <Paragraph>
+      <DocumentComponentText type={type} texts={texts} />
+    </Paragraph>
+  );
+};
+
+interface ForhandsvisningProps {
+  title: string;
+  subtitle: string;
+  contentLabel: string;
+  isOpen: boolean;
+  handleClose: () => void;
+  documentComponents: () => DocumentComponentDto[];
+}
+
+export const Forhandsvisning = ({
+  isOpen,
+  handleClose,
+  title,
+  subtitle,
+  contentLabel,
+  documentComponents,
+}: ForhandsvisningProps): ReactElement => {
+  return (
+    <ForhandsvisningModal
+      isOpen={isOpen}
+      onRequestClose={handleClose}
+      closeButton={true}
+      contentLabel={contentLabel}
+      ariaHideApp={false}
+    >
+      <ModalContentContainer>
+        <FlexRow
+          topPadding={PaddingSize.SM}
+          bottomPadding={PaddingSize.MD}
+          justifyContent={JustifyContentType.CENTER}
+        >
+          <Sidetittel>{title}</Sidetittel>
+          <Innholdstittel>{subtitle}</Innholdstittel>
+        </FlexRow>
+        {documentComponents().map((component, index) => (
+          <DocumentComponentVisning key={index} documentComponent={component} />
+        ))}
+        <FlexRow topPadding={PaddingSize.MD}>
+          <Hovedknapp onClick={handleClose}>{texts.close}</Hovedknapp>
+        </FlexRow>
+      </ModalContentContainer>
+    </ForhandsvisningModal>
+  );
+};

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -23,8 +23,12 @@ import { SkjemaFeiloppsummering } from "../../SkjemaFeiloppsummering";
 import { useFeilUtbedret } from "../../../hooks/useFeilUtbedret";
 import { TrackedFlatknapp } from "../../buttons/TrackedFlatknapp";
 import { TrackedHovedknapp } from "../../buttons/TrackedHovedknapp";
+import {
+  ForhandsvisInnkallingGenerator,
+  useForhandsvisInnkalling,
+} from "../../../hooks/useForhandsvisInnkalling";
 
-interface DialogmoteInnkallingSkjemaValues {
+export interface DialogmoteInnkallingSkjemaValues {
   arbeidsgiver: string;
   klokkeslett: string;
   dato: string;
@@ -55,18 +59,19 @@ const texts = {
 const toInnkalling = (
   values: DialogmoteInnkallingSkjemaValues,
   fnr: string,
-  navEnhet: string
+  navEnhet: string,
+  innkallingDocumentGenerator: ForhandsvisInnkallingGenerator
 ): DialogmoteInnkallingDTO => ({
   tildeltEnhet: navEnhet,
   arbeidsgiver: {
     virksomhetsnummer: values.arbeidsgiver,
     fritekstInnkalling: values.fritekstArbeidsgiver,
-    innkalling: [], // TODO: Implementeres ifm forhåndsvisning av innkalling
+    innkalling: innkallingDocumentGenerator.arbeidsgiverInnkalling(values),
   },
   arbeidstaker: {
     personIdent: fnr,
     fritekstInnkalling: values.fritekstArbeidstaker,
-    innkalling: [], // TODO: Implementeres ifm forhåndsvisning av innkalling
+    innkalling: innkallingDocumentGenerator.arbeidstakerInnkalling(values),
   },
   tidSted: {
     sted: values.sted,
@@ -90,6 +95,7 @@ const DialogmoteInnkallingSkjema = ({
     resetFeilUtbedret,
     updateFeilUtbedret,
   } = useFeilUtbedret();
+  const innkallingDocumentGenerator = useForhandsvisInnkalling();
 
   const validate = (
     values: Partial<DialogmoteInnkallingSkjemaValues>
@@ -108,7 +114,12 @@ const DialogmoteInnkallingSkjema = ({
   };
 
   const submit = (values: DialogmoteInnkallingSkjemaValues) => {
-    const dialogmoteInnkalling = toInnkalling(values, fnr, navEnhet);
+    const dialogmoteInnkalling = toInnkalling(
+      values,
+      fnr,
+      navEnhet,
+      innkallingDocumentGenerator
+    );
     dispatch(opprettInnkalling(fnr, dialogmoteInnkalling));
   };
 

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
@@ -1,12 +1,15 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 import { Knapp } from "nav-frontend-knapper";
-import { Field } from "react-final-form";
+import { Field, useFormState } from "react-final-form";
 import DialogmoteInnkallingSkjemaSeksjon from "./DialogmoteInnkallingSkjemaSeksjon";
 import styled from "styled-components";
 import AlertStripe from "nav-frontend-alertstriper";
 import { FlexColumn, FlexRow, PaddingSize } from "../../Layout";
 import FritekstStor from "../../FritekstStor";
 import { Innholdstittel } from "nav-frontend-typografi";
+import { DialogmoteInnkallingSkjemaValues } from "./DialogmoteInnkallingSkjema";
+import InnkallingArbeidstakerForhandsvisning from "./InnkallingArbeidstakerForhandsvisning";
+import InnkallingArbeidsgiverForhandsvisning from "./InnkallingArbeidsgiverForhandsvisning";
 
 const texts = {
   title: "Tekster i innkallingen",
@@ -19,6 +22,7 @@ const texts = {
 interface FritekstSeksjonProps {
   fieldName: string;
   label: string;
+  handlePreviewClick: () => void;
 }
 
 const TeksterAlert = styled(AlertStripe)`
@@ -36,7 +40,11 @@ const TeksterTittel = styled(Innholdstittel)`
   margin-bottom: 0.5em;
 `;
 
-const FritekstSeksjon = ({ fieldName, label }: FritekstSeksjonProps) => (
+const FritekstSeksjon = ({
+  fieldName,
+  label,
+  handlePreviewClick,
+}: FritekstSeksjonProps) => (
   <FritekstWrapper>
     <FlexRow bottomPadding={PaddingSize.SM}>
       <FlexColumn flex={1}>
@@ -48,24 +56,49 @@ const FritekstSeksjon = ({ fieldName, label }: FritekstSeksjonProps) => (
       </FlexColumn>
     </FlexRow>
     <FlexRow>
-      <Knapp htmlType="button">{texts.preview}</Knapp>
+      <Knapp htmlType="button" onClick={handlePreviewClick}>
+        {texts.preview}
+      </Knapp>
     </FlexRow>
   </FritekstWrapper>
 );
 
-const DialogmoteInnkallingTekster = (): ReactElement => (
-  <DialogmoteInnkallingSkjemaSeksjon>
-    <TeksterTittel>{texts.title}</TeksterTittel>
-    <TeksterAlert type="info">{texts.alert}</TeksterAlert>
-    <FritekstSeksjon
-      fieldName="fritekstArbeidstaker"
-      label={texts.arbeidstakerLabel}
-    />
-    <FritekstSeksjon
-      fieldName="fritekstArbeidsgiver"
-      label={texts.arbeidsgiverLabel}
-    />
-  </DialogmoteInnkallingSkjemaSeksjon>
-);
+const DialogmoteInnkallingTekster = (): ReactElement => {
+  const { values } = useFormState<DialogmoteInnkallingSkjemaValues>();
+  const [
+    visInnkallingArbeidstakerPreview,
+    setVisInnkallingArbeidstakerPreview,
+  ] = useState(false);
+  const [
+    visInnkallingArbeidsgiverPreview,
+    setVisInnkallingArbeidsgiverPreview,
+  ] = useState(false);
+  return (
+    <DialogmoteInnkallingSkjemaSeksjon>
+      <TeksterTittel>{texts.title}</TeksterTittel>
+      <TeksterAlert type="info">{texts.alert}</TeksterAlert>
+      <FritekstSeksjon
+        fieldName="fritekstArbeidstaker"
+        label={texts.arbeidstakerLabel}
+        handlePreviewClick={() => setVisInnkallingArbeidstakerPreview(true)}
+      />
+      <InnkallingArbeidstakerForhandsvisning
+        isOpen={visInnkallingArbeidstakerPreview}
+        handleClose={() => setVisInnkallingArbeidstakerPreview(false)}
+        innkallingSkjemaValues={values}
+      />
+      <FritekstSeksjon
+        fieldName="fritekstArbeidsgiver"
+        label={texts.arbeidsgiverLabel}
+        handlePreviewClick={() => setVisInnkallingArbeidsgiverPreview(true)}
+      />
+      <InnkallingArbeidsgiverForhandsvisning
+        isOpen={visInnkallingArbeidsgiverPreview}
+        handleClose={() => setVisInnkallingArbeidsgiverPreview(false)}
+        innkallingSkjemaValues={values}
+      />
+    </DialogmoteInnkallingSkjemaSeksjon>
+  );
+};
 
 export default DialogmoteInnkallingTekster;

--- a/src/components/dialogmote/innkalling/InnkallingArbeidsgiverForhandsvisning.tsx
+++ b/src/components/dialogmote/innkalling/InnkallingArbeidsgiverForhandsvisning.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from "react";
+import { DialogmoteInnkallingSkjemaValues } from "./DialogmoteInnkallingSkjema";
+import { useForhandsvisInnkalling } from "../../../hooks/useForhandsvisInnkalling";
+import { Forhandsvisning } from "../Forhandsvisning";
+
+export const texts = {
+  title: "Innkalling til dialogmøte",
+  subtitle: "(brev til nærmeste leder)",
+  contentLabel: "Forhåndsvis innkalling til dialogmøte arbeidsgiver",
+  close: "Lukk",
+};
+
+interface InnkallingArbeidsgiverForhandsvisningProps {
+  isOpen: boolean;
+  handleClose: () => void;
+  innkallingSkjemaValues: DialogmoteInnkallingSkjemaValues;
+}
+
+const InnkallingArbeidsgiverForhandsvisning = ({
+  isOpen,
+  handleClose,
+  innkallingSkjemaValues,
+}: InnkallingArbeidsgiverForhandsvisningProps): ReactElement => {
+  const { arbeidsgiverInnkalling } = useForhandsvisInnkalling();
+  return (
+    <Forhandsvisning
+      contentLabel={texts.contentLabel}
+      title={texts.title}
+      subtitle={texts.subtitle}
+      isOpen={isOpen}
+      handleClose={handleClose}
+      documentComponents={() => arbeidsgiverInnkalling(innkallingSkjemaValues)}
+    />
+  );
+};
+
+export default InnkallingArbeidsgiverForhandsvisning;

--- a/src/components/dialogmote/innkalling/InnkallingArbeidstakerForhandsvisning.tsx
+++ b/src/components/dialogmote/innkalling/InnkallingArbeidstakerForhandsvisning.tsx
@@ -1,0 +1,37 @@
+import React, { ReactElement } from "react";
+import { DialogmoteInnkallingSkjemaValues } from "./DialogmoteInnkallingSkjema";
+import { useForhandsvisInnkalling } from "../../../hooks/useForhandsvisInnkalling";
+import { Forhandsvisning } from "../Forhandsvisning";
+
+export const texts = {
+  title: "Innkalling til dialogmøte",
+  subtitle: "(brev til arbeidstakeren)",
+  contentLabel: "Forhåndsvis innkalling til dialogmøte arbeidstaker",
+  close: "Lukk",
+};
+
+interface InnkallingArbeidstakerForhandsvisningProps {
+  isOpen: boolean;
+  handleClose: () => void;
+  innkallingSkjemaValues: DialogmoteInnkallingSkjemaValues;
+}
+
+const InnkallingArbeidstakerForhandsvisning = ({
+  isOpen,
+  handleClose,
+  innkallingSkjemaValues,
+}: InnkallingArbeidstakerForhandsvisningProps): ReactElement => {
+  const { arbeidstakerInnkalling } = useForhandsvisInnkalling();
+  return (
+    <Forhandsvisning
+      contentLabel={texts.contentLabel}
+      title={texts.title}
+      subtitle={texts.subtitle}
+      isOpen={isOpen}
+      handleClose={handleClose}
+      documentComponents={() => arbeidstakerInnkalling(innkallingSkjemaValues)}
+    />
+  );
+};
+
+export default InnkallingArbeidstakerForhandsvisning;

--- a/src/data/behandlendeenhet/behandlendeEnhet.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhet.ts
@@ -9,13 +9,13 @@ import { BehandlendeEnhet } from "./types/BehandlendeEnhet";
 export interface BehandlendeEnhetState {
   henter: boolean;
   hentingFeilet: boolean;
-  data: BehandlendeEnhet | Record<string, any>;
+  data: BehandlendeEnhet;
 }
 
 export const initialState: BehandlendeEnhetState = {
   henter: false,
   hentingFeilet: false,
-  data: {},
+  data: { navn: "", enhetId: "" },
 };
 
 const behandlendeEnhet: Reducer<BehandlendeEnhetState> = (
@@ -26,14 +26,13 @@ const behandlendeEnhet: Reducer<BehandlendeEnhetState> = (
     case HENT_BEHANDLENDE_ENHET_FEILET: {
       return {
         ...state,
-        data: {},
         henter: false,
         hentingFeilet: true,
       };
     }
     case HENTER_BEHANDLENDE_ENHET: {
       return {
-        data: {},
+        ...state,
         henter: true,
         hentingFeilet: false,
       };

--- a/src/data/behandlendeenhet/behandlendeEnhet_hooks.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhet_hooks.ts
@@ -1,0 +1,5 @@
+import { useAppSelector } from "../../hooks/hooks";
+import { BehandlendeEnhet } from "./types/BehandlendeEnhet";
+
+export const useBehandlendeEnhet = (): BehandlendeEnhet =>
+  useAppSelector((state) => state.behandlendeEnhet.data);

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -1,0 +1,29 @@
+export const innkallingTexts = {
+  moteTidTitle: "Møtetidspunkt",
+  moteStedTitle: "Møtested",
+  videoLinkTitle: "Lenke til videomøte",
+  foerMoteTitle: "Før møtet",
+  foerMoteText:
+    "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
+  hilsenText: "Med hilsen",
+  arbeidstaker: {
+    intro1:
+      "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre.",
+    intro2:
+      "I møtet vil vi høre både hva du og arbeidsgiveren sier om arbeidssituasjonen og mulighetene for å jobbe.",
+    outro1:
+      "Den som har sykmeldt deg, eller en annen behandler, kan også bli invitert til å delta i møtet. Til dette møtet har vi ikke sett behov for det.",
+  },
+  arbeidsgiver: {
+    intro1:
+      "Velkommen til dialogmøte i regi av NAV. NAV har ansvar for å innkalle til dialogmøte senest når en sykmelding har vart i seks måneder, eventuelt på et annet tidspunkt hvis noen av partene ser behov for det.",
+    intro2:
+      "Før møtet er det viktig at dere fyller ut oppfølgingsplanen sammen, den er et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
+    outro1:
+      "Vi gjør oppmerksom på at det er obligatorisk å delta i dialogmøter med NAV og å sende inn oppfølgingsplan på forhånd. Oppdatert oppfølgingsplan skal sendes til NAV senest 1 uke før møtet avholdes.",
+    outro2:
+      "Hvis vårt forslag til møtetidspunkt, møtested eller møteform ikke passer, ber vi om at du tar kontakt for å diskutere alternativer. I så fall kan du sende e-post eller ringe undertegnede på telefon. Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS.",
+    outro3:
+      "NAV kan be fastlegen eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det.",
+  },
+};

--- a/src/data/dialogmote/dialogmoteTypes.ts
+++ b/src/data/dialogmote/dialogmoteTypes.ts
@@ -6,6 +6,18 @@ interface DialogmotedeltakerArbeidstakerVarselDTO {
   readonly fritekst: string;
 }
 
+export enum DocumentComponentType {
+  HEADER = "HEADER",
+  PARAGRAPH = "PARAGRAPH",
+  LINK = "LINK",
+}
+
+export interface DocumentComponentDto {
+  readonly type: DocumentComponentType;
+  readonly title?: string;
+  readonly texts: string[];
+}
+
 export enum DialogmoteStatus {
   INNKALT = "INNKALT",
   AVLYST = "AVLYST",
@@ -31,12 +43,12 @@ export interface DialogmoteInnkallingDTO {
   arbeidstaker: {
     personIdent: string;
     fritekstInnkalling?: string;
-    innkalling: unknown[]; // TODO: Definer riktig type ifm forhåndsvisning av innkalling
+    innkalling: DocumentComponentDto[];
   };
   arbeidsgiver: {
     virksomhetsnummer: string;
     fritekstInnkalling?: string;
-    innkalling: unknown[]; // TODO: Definer riktig type ifm forhåndsvisning av innkalling
+    innkalling: DocumentComponentDto[];
   };
   tidSted: {
     sted: string;
@@ -52,7 +64,7 @@ export interface AvlysDialogmoteDTO {
 
 interface AvlysningDto {
   begrunnelse: string;
-  avlysning: unknown[]; // TODO: Definer riktig type ifm forhåndsvisning av avlysning
+  avlysning: DocumentComponentDto[];
 }
 
 export interface DialogmoteDTO {

--- a/src/hooks/useForhandsvisInnkalling.ts
+++ b/src/hooks/useForhandsvisInnkalling.ts
@@ -1,0 +1,160 @@
+import { DialogmoteInnkallingSkjemaValues } from "../components/dialogmote/innkalling/DialogmoteInnkallingSkjema";
+import {
+  DocumentComponentDto,
+  DocumentComponentType,
+} from "../data/dialogmote/dialogmoteTypes";
+import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "../utils/datoUtils";
+import { genererDato } from "../components/mote/utils";
+import { useBehandlendeEnhet } from "../data/behandlendeenhet/behandlendeEnhet_hooks";
+import { useVeilederinfo } from "./useVeilederinfo";
+import { useNavBrukerData } from "../data/navbruker/navbruker_hooks";
+import { Brukerinfo } from "../data/navbruker/types/Brukerinfo";
+import { BehandlendeEnhet } from "../data/behandlendeenhet/types/BehandlendeEnhet";
+import { VeilederinfoDTO } from "../data/veilederinfo/types/VeilederinfoDTO";
+import { innkallingTexts } from "../data/dialogmote/dialogmoteTexts";
+
+export interface ForhandsvisInnkallingGenerator {
+  arbeidstakerInnkalling(
+    values: Partial<DialogmoteInnkallingSkjemaValues>
+  ): DocumentComponentDto[];
+
+  arbeidsgiverInnkalling(
+    values: Partial<DialogmoteInnkallingSkjemaValues>
+  ): DocumentComponentDto[];
+}
+
+export const useForhandsvisInnkalling = (): ForhandsvisInnkallingGenerator => {
+  const behandlendeEnhet = useBehandlendeEnhet();
+  const { veilederinfo } = useVeilederinfo();
+  const navBruker = useNavBrukerData();
+
+  const arbeidstakerInnkalling = (
+    values: Partial<DialogmoteInnkallingSkjemaValues>
+  ) => {
+    const documentComponents = [
+      ...fellesInfo(values),
+      ...arbeidstakerIntro(navBruker),
+    ];
+    if (values.fritekstArbeidstaker) {
+      documentComponents.push(paragraph(values.fritekstArbeidstaker));
+    }
+    documentComponents.push(
+      ...arbeidstakerOutro(behandlendeEnhet, veilederinfo)
+    );
+
+    return documentComponents;
+  };
+
+  const arbeidsgiverInnkalling = (
+    values: Partial<DialogmoteInnkallingSkjemaValues>
+  ) => {
+    const documentComponents = [
+      ...fellesInfo(values),
+      ...arbeidsgiverIntro(navBruker),
+    ];
+    if (values.fritekstArbeidsgiver) {
+      documentComponents.push(paragraph(values.fritekstArbeidsgiver));
+    }
+    documentComponents.push(
+      ...arbeidsgiverOutro(behandlendeEnhet, veilederinfo)
+    );
+
+    return documentComponents;
+  };
+
+  return {
+    arbeidstakerInnkalling,
+    arbeidsgiverInnkalling,
+  };
+};
+
+const fellesInfo = (
+  values: Partial<DialogmoteInnkallingSkjemaValues>
+): DocumentComponentDto[] => {
+  const { dato, klokkeslett, sted, videoLink } = values;
+  const components = [
+    paragraphWithTitle(
+      innkallingTexts.moteTidTitle,
+      dato && klokkeslett
+        ? tilDatoMedUkedagOgManedNavnOgKlokkeslett(
+            genererDato(dato, klokkeslett)
+          )
+        : ""
+    ),
+    paragraphWithTitle(innkallingTexts.moteStedTitle, sted || ""),
+  ];
+  if (videoLink) {
+    components.push(link(innkallingTexts.videoLinkTitle, videoLink));
+  }
+  return components;
+};
+
+const arbeidstakerIntro = (navBruker: Brukerinfo): DocumentComponentDto[] => {
+  return [
+    paragraph(`Hei ${navBruker.navn}`),
+    paragraph(innkallingTexts.arbeidstaker.intro1),
+    paragraph(innkallingTexts.arbeidstaker.intro2),
+  ];
+};
+
+const arbeidsgiverIntro = (navBruker: Brukerinfo): DocumentComponentDto[] => {
+  return [
+    paragraph(`Gjelder ${navBruker.navn}, f.nr. ${navBruker.kontaktinfo.fnr}`),
+    paragraph(innkallingTexts.arbeidsgiver.intro1),
+    paragraph(innkallingTexts.arbeidsgiver.intro2),
+  ];
+};
+
+const arbeidstakerOutro = (
+  behandlendeEnhet: BehandlendeEnhet,
+  veilederinfo?: VeilederinfoDTO
+): DocumentComponentDto[] => {
+  return [
+    paragraph(innkallingTexts.arbeidstaker.outro1),
+    paragraphWithTitle(
+      innkallingTexts.foerMoteTitle,
+      innkallingTexts.foerMoteText
+    ),
+    paragraph(innkallingTexts.hilsenText, behandlendeEnhet.navn),
+    paragraph(veilederinfo?.navn ?? ""),
+  ];
+};
+
+const arbeidsgiverOutro = (
+  behandlendeEnhet: BehandlendeEnhet,
+  veilederinfo?: VeilederinfoDTO
+): DocumentComponentDto[] => {
+  return [
+    paragraph(innkallingTexts.arbeidsgiver.outro1),
+    paragraph(innkallingTexts.arbeidsgiver.outro2),
+    paragraph(innkallingTexts.arbeidsgiver.outro3),
+    paragraphWithTitle(
+      innkallingTexts.foerMoteTitle,
+      innkallingTexts.foerMoteText
+    ),
+    paragraph(innkallingTexts.hilsenText, behandlendeEnhet.navn),
+    paragraph(
+      veilederinfo?.navn ?? "",
+      "-Epost mangler-", // TODO: Hent epost for veileder
+      "-Telefon mangler-" // TODO: Hent tlf for veileder)
+    ),
+  ];
+};
+
+const link = (title: string, text: string): DocumentComponentDto => ({
+  type: DocumentComponentType.LINK,
+  title,
+  texts: [text],
+});
+const paragraphWithTitle = (
+  title: string,
+  ...texts: string[]
+): DocumentComponentDto => ({
+  type: DocumentComponentType.PARAGRAPH,
+  title,
+  texts,
+});
+const paragraph = (...texts: string[]): DocumentComponentDto => ({
+  type: DocumentComponentType.PARAGRAPH,
+  texts,
+});

--- a/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
@@ -298,7 +298,7 @@ describe("DialogmoteInnkallingSkjema", () => {
       <MemoryRouter initialEntries={["/sykefravaer/05087321470/dialogmote"]}>
         <Route path="/sykefravaer/:fnr/dialogmote">
           <Provider store={mockStore}>
-            <DialogmoteInnkallingSkjema />
+            <DialogmoteInnkallingSkjema pageTitle="Test" />
           </Provider>
         </Route>
       </MemoryRouter>

--- a/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
@@ -9,31 +9,59 @@ import configureStore from "redux-mock-store";
 import DialogmoteInnkallingSkjema from "../../src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema";
 import {
   leggTilDagerPaDato,
+  tilDatoMedUkedagOgManedNavnOgKlokkeslett,
   toDatePrettyPrint,
 } from "../../src/utils/datoUtils";
 import { InputDateStringToISODateString } from "nav-datovelger/lib/utils/dateFormatUtils";
 import { Feilmelding } from "nav-frontend-typografi";
 import { Feiloppsummering } from "nav-frontend-skjema";
-import { Hovedknapp } from "nav-frontend-knapper";
+import { Hovedknapp, Knapp } from "nav-frontend-knapper";
 import { texts as skjemaFeilOppsummeringTexts } from "../../src/components/SkjemaFeiloppsummering";
 import { texts as valideringsTexts } from "../../src/utils/valideringUtils";
+import { genererDato } from "../../src/components/mote/utils";
+import { innkallingTexts } from "../../src/data/dialogmote/dialogmoteTexts";
+import { Forhandsvisning } from "../../src/components/dialogmote/Forhandsvisning";
+import { texts as innkallingArbeidsgiverTexts } from "../../src/components/dialogmote/innkalling/InnkallingArbeidsgiverForhandsvisning";
+import { texts as innkallingArbeidstakerTexts } from "../../src/components/dialogmote/innkalling/InnkallingArbeidstakerForhandsvisning";
+import Lukknapp from "nav-frontend-lukknapp";
 
 const realState = createStore(rootReducer).getState();
 
 const arbeigsgiverOrgnr = "110110110";
 const moteSted = "Møtested";
 const moteDato = toDatePrettyPrint(leggTilDagerPaDato(new Date(), 1)) as string;
+const moteDatoAsISODateString = InputDateStringToISODateString(moteDato);
 const moteKlokkeslett = "08:00";
-const moteDatoTid = `${InputDateStringToISODateString(
-  moteDato
-)}T${moteKlokkeslett}:00`;
+const moteDatoTid = `${moteDatoAsISODateString}T${moteKlokkeslett}:00`;
 const moteVideoLink = "https://www.link.no";
 const fritekstTilArbeidstaker = "Noe fritekst til arbeidstaker";
 const fritekstTilArbeidsgiver = "Noe fritekst til arbeidsgiver";
 const arbeidstakerFnr = "05087321470";
-const navEnhet = "1000";
+const arbeidstakerNavn = "Arne Arbeistaker";
+const navEnhet = "0315";
+const navEnhetNavn = "NAV Grünerløkka";
+const veilederNavn = "Vetle Veileder";
 const store = configureStore([]);
 const mockState = {
+  behandlendeEnhet: {
+    data: {
+      enhetId: navEnhet,
+      navn: navEnhetNavn,
+    },
+  },
+  veilederinfo: {
+    data: {
+      navn: veilederNavn,
+    },
+  },
+  navbruker: {
+    data: {
+      navn: arbeidstakerNavn,
+      kontaktinfo: {
+        fnr: arbeidstakerFnr,
+      },
+    },
+  },
   enhet: {
     valgtEnhet: navEnhet,
   },
@@ -246,12 +274,12 @@ describe("DialogmoteInnkallingSkjema", () => {
         arbeidsgiver: {
           virksomhetsnummer: arbeigsgiverOrgnr,
           fritekstInnkalling: fritekstTilArbeidsgiver,
-          innkalling: [],
+          innkalling: expectedArbeidsgiverInnkalling,
         },
         arbeidstaker: {
           personIdent: arbeidstakerFnr,
           fritekstInnkalling: fritekstTilArbeidstaker,
-          innkalling: [],
+          innkalling: expectedArbeidstakerInnkalling,
         },
         tidSted: {
           sted: moteSted,
@@ -263,6 +291,101 @@ describe("DialogmoteInnkallingSkjema", () => {
 
     expect(mockStore.getActions()[0]).to.deep.equal(expectedAction);
   });
+
+  it("forhåndsviser innkalling til arbeidstaker og arbeidsgiver", () => {
+    const mockStore = store({ ...realState, ...mockState });
+    const wrapper = mount(
+      <MemoryRouter initialEntries={["/sykefravaer/05087321470/dialogmote"]}>
+        <Route path="/sykefravaer/:fnr/dialogmote">
+          <Provider store={mockStore}>
+            <DialogmoteInnkallingSkjema />
+          </Provider>
+        </Route>
+      </MemoryRouter>
+    );
+
+    const arbeidsgiverDropdown = wrapper.find("select");
+    changeFieldValue(arbeidsgiverDropdown, arbeigsgiverOrgnr);
+    const datoVelger = wrapper.find("ForwardRef(DateInput)");
+    changeFieldValue(datoVelger, moteDato);
+    datoVelger.simulate("blur");
+
+    const inputs = wrapper.find("input");
+    const stedInput = inputs.findWhere((w) => w.prop("name") === "sted");
+    const videoLinkInput = inputs.findWhere(
+      (w) => w.prop("name") === "videoLink"
+    );
+    const klokkeslettInput = inputs.findWhere(
+      (w) => w.prop("name") === "klokkeslett"
+    );
+    changeFieldValue(stedInput, moteSted);
+    changeFieldValue(videoLinkInput, moteVideoLink);
+    changeFieldValue(klokkeslettInput, moteKlokkeslett);
+
+    const textAreas = wrapper.find("textarea");
+    const fritekstArbeidsgiverTextArea = textAreas.findWhere(
+      (w) => w.prop("name") === "fritekstArbeidsgiver"
+    );
+    const fritekstArbeidstakerTextArea = textAreas.findWhere(
+      (w) => w.prop("name") === "fritekstArbeidstaker"
+    );
+    changeFieldValue(fritekstArbeidsgiverTextArea, fritekstTilArbeidsgiver);
+    changeFieldValue(fritekstArbeidstakerTextArea, fritekstTilArbeidstaker);
+
+    const getForhandsvisningsModaler = () => wrapper.find(Forhandsvisning);
+    let forhandsvisninger = getForhandsvisningsModaler();
+    expect(forhandsvisninger.at(0).props().documentComponents()).to.deep.equal(
+      expectedArbeidstakerInnkalling
+    );
+    expect(forhandsvisninger.at(1).props().documentComponents()).to.deep.equal(
+      expectedArbeidsgiverInnkalling
+    );
+
+    const previewButtons = wrapper.find(Knapp);
+
+    // Forhåndsvis innkalling til arbeidstaker og sjekk at modal vises med riktig tittel
+    previewButtons.at(0).simulate("click");
+    forhandsvisninger = getForhandsvisningsModaler();
+    let forhandsvisningInnkallingArbeidstaker = forhandsvisninger.at(0);
+    let forhandsvisningInnkallingArbeidsgiver = forhandsvisninger.at(1);
+    expect(forhandsvisningInnkallingArbeidstaker.prop("isOpen")).to.be.true;
+    expect(forhandsvisningInnkallingArbeidsgiver.prop("isOpen")).to.be.false;
+    expect(forhandsvisningInnkallingArbeidstaker.text()).to.contain(
+      innkallingArbeidstakerTexts.title
+    );
+    expect(forhandsvisningInnkallingArbeidstaker.text()).to.contain(
+      innkallingArbeidstakerTexts.subtitle
+    );
+    expect(forhandsvisningInnkallingArbeidsgiver.text()).not.to.contain(
+      innkallingArbeidsgiverTexts.title
+    );
+    expect(forhandsvisningInnkallingArbeidsgiver.text()).not.to.contain(
+      innkallingArbeidsgiverTexts.subtitle
+    );
+
+    // Lukk forhåndsvis innkalling til arbeidstaker
+    forhandsvisningInnkallingArbeidstaker.find(Lukknapp).simulate("click");
+
+    // Forhåndsvis innkalling til arbeidsgiver og sjekk at modal vises med riktig tittel
+    previewButtons.at(1).simulate("click");
+    forhandsvisninger = getForhandsvisningsModaler();
+    forhandsvisningInnkallingArbeidstaker = forhandsvisninger.at(0);
+    forhandsvisningInnkallingArbeidsgiver = forhandsvisninger.at(1);
+    expect(forhandsvisningInnkallingArbeidstaker.prop("isOpen")).to.be.false;
+    expect(forhandsvisningInnkallingArbeidsgiver.prop("isOpen")).to.be.true;
+    expect(forhandsvisningInnkallingArbeidstaker.text()).not.to.contain(
+      innkallingArbeidstakerTexts.title
+    );
+    expect(forhandsvisningInnkallingArbeidstaker.text()).not.to.contain(
+      innkallingArbeidstakerTexts.subtitle
+    );
+    expect(forhandsvisningInnkallingArbeidsgiver.text()).to.contain(
+      innkallingArbeidsgiverTexts.title
+    );
+    expect(forhandsvisningInnkallingArbeidsgiver.text()).to.contain(
+      innkallingArbeidsgiverTexts.subtitle
+    );
+  });
 });
 
 const changeFieldValue = (field: ReactWrapper<any, any>, newValue: string) => {
@@ -272,3 +395,120 @@ const changeFieldValue = (field: ReactWrapper<any, any>, newValue: string) => {
     },
   });
 };
+
+const expectedArbeidsgiverInnkalling = [
+  {
+    texts: [
+      tilDatoMedUkedagOgManedNavnOgKlokkeslett(
+        genererDato(moteDatoAsISODateString, moteKlokkeslett)
+      ),
+    ],
+    title: innkallingTexts.moteTidTitle,
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [moteSted],
+    title: innkallingTexts.moteStedTitle,
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [moteVideoLink],
+    title: innkallingTexts.videoLinkTitle,
+    type: "LINK",
+  },
+  {
+    texts: [`Gjelder ${arbeidstakerNavn}, f.nr. ${arbeidstakerFnr}`],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidsgiver.intro1],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidsgiver.intro2],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [fritekstTilArbeidsgiver],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidsgiver.outro1],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidsgiver.outro2],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidsgiver.outro3],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.foerMoteText],
+    title: innkallingTexts.foerMoteTitle,
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.hilsenText, navEnhetNavn],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [veilederNavn, "-Epost mangler-", "-Telefon mangler-"],
+    type: "PARAGRAPH",
+  },
+];
+const expectedArbeidstakerInnkalling = [
+  {
+    texts: [
+      tilDatoMedUkedagOgManedNavnOgKlokkeslett(
+        genererDato(moteDatoAsISODateString, moteKlokkeslett)
+      ),
+    ],
+    title: innkallingTexts.moteTidTitle,
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [moteSted],
+    title: innkallingTexts.moteStedTitle,
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [moteVideoLink],
+    title: innkallingTexts.videoLinkTitle,
+    type: "LINK",
+  },
+  {
+    texts: [`Hei ${arbeidstakerNavn}`],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidstaker.intro1],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidstaker.intro2],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [fritekstTilArbeidstaker],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.arbeidstaker.outro1],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.foerMoteText],
+    title: innkallingTexts.foerMoteTitle,
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [innkallingTexts.hilsenText, navEnhetNavn],
+    type: "PARAGRAPH",
+  },
+  {
+    texts: [veilederNavn],
+    type: "PARAGRAPH",
+  },
+];


### PR DESCRIPTION
- Forhandsvisning-komponent som håndterer visning av liste med DocumentComponentDto i modal
- useForhandsvisInnkalling-hook som gir to funksjoner for å generere liste med med DocumentComponentDto for innkalling til arbeidsgiver og arbeidstaker basert skjema-verdier og standardtekster. Brukes ifm forhåndsvisning og sending til backend.
- standardtekster samlet i dialogmoteTexts.ts

Nå styres rekkefølgen på tekstene (og type) ut i fra hvordan liste med DocumentComponentDtos bygges opp i funksjonene som defineres i hooken, mens selve tekstene ligger i konstanter i dialogmoteTexts.ts. Mulig dette bør organiseres på en annen måte så absolutt åpen for forslag.