### PR TITLE
Replace fnr in url with fnr from modiacontext - aktivbruker

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Du må ha Node installert.
 - Kjør tester med `npm test` eller `npm test:watch`
 - Lint JS-kode med `npm run lint` eller `npm run lint:fix`
 
-Appen nås på [http://localhost:8080/sykefravaer/:fnr](http://localhost:8080/sykefravaer/:fnr) hvor 'fnr' må ha et gyldig format.
+Appen nås på [http://localhost:8080/sykefravaer](http://localhost:8080/sykefravaer)

--- a/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
+++ b/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
@@ -2,7 +2,7 @@ import Panel from "nav-frontend-paneler";
 import React, { ReactElement } from "react";
 import styled from "styled-components";
 import { Link } from "react-router-dom";
-import { useFnrParam } from "../../../hooks/useFnrParam";
+import { useValgtPersonident } from "../../../hooks/useValgtBruker";
 import { FlexRow, PaddingSize } from "../../Layout";
 import { useDispatch } from "react-redux";
 import { avlysMote } from "../../../data/dialogmote/dialogmote_actions";
@@ -50,7 +50,7 @@ const AvlysDialogmoteSkjema = ({
   pageTitle,
 }: AvlysDialogmoteSkjemaProps): ReactElement => {
   const dispatch = useDispatch();
-  const fnr = useFnrParam();
+  const fnr = useValgtPersonident();
   const { avlyserMote, avlysMoteFeilet } = useAppSelector(
     (state) => state.dialogmote
   );
@@ -118,7 +118,7 @@ const AvlysDialogmoteSkjema = ({
               >
                 {texts.send}
               </SendButton>
-              <Link to={`/sykefravaer/${fnr}/moteoversikt`}>
+              <Link to={`/sykefravaer/moteoversikt`}>
                 <TrackedFlatknapp context={pageTitle} htmlType="button">
                   {texts.avbryt}
                 </TrackedFlatknapp>

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingContainer.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingContainer.tsx
@@ -8,7 +8,7 @@ import styled from "styled-components";
 import AlertStripe from "nav-frontend-alertstriper";
 import { useLedere } from "../../../hooks/useLedere";
 import { useTilgang } from "../../../hooks/useTilgang";
-import { useFnrParam } from "../../../hooks/useFnrParam";
+import { useValgtPersonident } from "../../../hooks/useValgtBruker";
 
 const texts = {
   pageTitle: "Innkalling til dialogmøte",
@@ -25,7 +25,7 @@ const DialogmoteInnkallingWarningAlert = styled(AlertStripe)`
 `;
 
 const DialogmoteInnkallingContainer = (): ReactElement => {
-  const fnr = useFnrParam();
+  const fnr = useValgtPersonident();
   const { henterLedere, hentingLedereFeilet } = useLedere();
   const { henterTilgang, hentingTilgangFeilet, tilgang } = useTilgang();
 

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -17,7 +17,7 @@ import { Link } from "react-router-dom";
 import { useNavEnhet } from "../../../hooks/useNavEnhet";
 import { AlertStripeFeil } from "nav-frontend-alertstriper";
 import { useAppSelector } from "../../../hooks/hooks";
-import { useFnrParam } from "../../../hooks/useFnrParam";
+import { useValgtPersonident } from "../../../hooks/useValgtBruker";
 import { FlexRow, PaddingSize } from "../../Layout";
 import { SkjemaFeiloppsummering } from "../../SkjemaFeiloppsummering";
 import { useFeilUtbedret } from "../../../hooks/useFeilUtbedret";
@@ -85,7 +85,7 @@ const DialogmoteInnkallingSkjema = ({
 }: DialogmoteInnkallingSkjemaProps): ReactElement => {
   const initialValues: Partial<DialogmoteInnkallingSkjemaValues> = {};
   const dispatch = useDispatch();
-  const fnr = useFnrParam();
+  const fnr = useValgtPersonident();
   const navEnhet = useNavEnhet();
   const { senderInnkalling, sendInnkallingFeilet } = useAppSelector(
     (state) => state.dialogmote
@@ -149,7 +149,7 @@ const DialogmoteInnkallingSkjema = ({
               >
                 {texts.send}
               </TrackedHovedknapp>
-              <Link to={`/sykefravaer/${fnr}/moteoversikt`}>
+              <Link to={`/sykefravaer/moteoversikt`}>
                 <TrackedFlatknapp context={pageTitle} htmlType="button">
                   {texts.cancel}
                 </TrackedFlatknapp>

--- a/src/components/globalnavigasjon/GlobalNavigasjon.js
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.js
@@ -114,7 +114,6 @@ class GlobalNavigasjon extends Component {
 
   render() {
     const {
-      fnr,
       aktivtMenypunkt,
       motebehovReducer,
       moterReducer,
@@ -152,7 +151,7 @@ class GlobalNavigasjon extends Component {
               <a
                 ref={this.getRef(index)}
                 className={className}
-                href={`/sykefravaer/${fnr}/${sti}`}
+                href={`/sykefravaer/${sti}`}
                 onFocus={() => {
                   this.setFocusIndex(index);
                 }}
@@ -163,7 +162,7 @@ class GlobalNavigasjon extends Component {
                   e.preventDefault();
                   // Dette gjøres slik for å slippe å laste siden på nytt.
                   // <Link /> fra react-router kan ikke brukes da den ikke støtter ref-attributtet.
-                  history.push(`/sykefravaer/${fnr}/${sti}`);
+                  history.push(`/sykefravaer/${sti}`);
                 }}
               >
                 <span

--- a/src/components/historikk/container/HistorikkContainer.js
+++ b/src/components/historikk/container/HistorikkContainer.js
@@ -108,7 +108,7 @@ export function mapDispatchToProps(dispatch) {
   };
 }
 
-export const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state) => {
   const oppfolgingstilfelleperioder = state.oppfolgingstilfelleperioder;
   const henterTilfeller =
     Object.keys(oppfolgingstilfelleperioder).findIndex((orgnummer) => {
@@ -120,8 +120,10 @@ export const mapStateToProps = (state, ownProps) => {
   const formerLedere = state.ledere.formerLedere;
   const allLedere = [...currentLedere, ...formerLedere];
 
+  const fnr = state.valgtbruker.personident;
+
   return {
-    fnr: ownProps.match.params.fnr,
+    fnr,
     oppfolgingstilfelleperioder,
     historikk: state.historikk,
     henter,

--- a/src/components/mote/components/BesvarteTidspunkter.tsx
+++ b/src/components/mote/components/BesvarteTidspunkter.tsx
@@ -19,7 +19,6 @@ const texts = {
 interface BesvarteTidspunkterProps {
   alternativer: MoteAlternativDTO[];
   deltakertype: MotedeltakerType;
-  fnr: string;
   mote: MoteDTO;
 }
 
@@ -29,7 +28,6 @@ const BesvarteTidspunkter = (
   const {
     alternativer,
     deltakertype = BRUKER,
-    fnr,
     mote,
   } = besvarteTidspunkterProps;
   const arbeidsgiver = mote.deltakere.filter((d) => {
@@ -112,7 +110,7 @@ const BesvarteTidspunkter = (
               {deltakertype === NAV_VEILEDER && (
                 <div className="alternativsvar__bekreft">
                   <Link
-                    to={`/sykefravaer/${fnr}/mote/bekreft/${field.id}`}
+                    to={`/sykefravaer/mote/bekreft/${field.id}`}
                     className="knapp knapp--hoved knapp--mini js-bekreft-tidspunkt"
                   >
                     {texts.bekreft}

--- a/src/components/mote/components/MotebookingStatus.js
+++ b/src/components/mote/components/MotebookingStatus.js
@@ -166,7 +166,7 @@ const MotebookingStatus = (props) => {
     <Link
       role="button"
       className="knapp knapp--enten js-avbryt"
-      to={`/sykefravaer/${fnr}/mote/${mote.moteUuid}/avbryt`}
+      to={`/sykefravaer/mote/${mote.moteUuid}/avbryt`}
     >
       {texts.avbrytMote}
     </Link>
@@ -180,11 +180,7 @@ const MotebookingStatus = (props) => {
       <div className="panel">
         {status === BEKREFTET && <BekreftetMotetidspunkt {...props} />}
         {status !== BEKREFTET && !motePassert && (
-          <Svarstatus
-            fnr={fnr}
-            mote={mote}
-            visFlereAlternativ={visFlereAlternativ}
-          >
+          <Svarstatus mote={mote} visFlereAlternativ={visFlereAlternativ}>
             {flereTidspunktBoks}
           </Svarstatus>
         )}

--- a/src/components/mote/components/Svarstatus.tsx
+++ b/src/components/mote/components/Svarstatus.tsx
@@ -73,14 +73,13 @@ export const getGamleAlternativer = (mote: MoteDTO) => {
 };
 
 interface SvarstatusProps {
-  fnr: string;
   mote: MoteDTO;
   visFlereAlternativ: any;
   children: any;
 }
 
 const Svarstatus = (svarstatusProps: SvarstatusProps) => {
-  const { mote, visFlereAlternativ, children, fnr } = svarstatusProps;
+  const { mote, visFlereAlternativ, children } = svarstatusProps;
   const nyeAlternativer = getNyeAlternativer(mote);
   const gamleAlternativer = getGamleAlternativer(mote);
   return (
@@ -90,7 +89,6 @@ const Svarstatus = (svarstatusProps: SvarstatusProps) => {
           mote={mote}
           alternativer={nyeAlternativer}
           deltakertype={MotedeltakerType.NAV_VEILEDER}
-          fnr={fnr}
         />
         <button className="nyetidspunktknapp" onClick={visFlereAlternativ}>
           {texts.flereTidpunkt}
@@ -108,7 +106,6 @@ const Svarstatus = (svarstatusProps: SvarstatusProps) => {
             mote={mote}
             alternativer={gamleAlternativer}
             deltakertype={MotedeltakerType.NAV_VEILEDER}
-            fnr={fnr}
           />
         </Utvidbar>
       )}

--- a/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -17,7 +17,6 @@ import {
 import { useNavBrukerData } from "../../../../data/navbruker/navbruker_hooks";
 import { Brukerinfo } from "../../../../data/navbruker/types/Brukerinfo";
 import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "../../../../utils/datoUtils";
-import { useFnrParam } from "../../../../hooks/useFnrParam";
 import { Link } from "react-router-dom";
 import { TrackedKnapp } from "../../../buttons/TrackedKnapp";
 import { TrackedHovedknapp } from "../../../buttons/TrackedHovedknapp";
@@ -109,7 +108,6 @@ interface Props {
 
 export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
   const bruker = useNavBrukerData();
-  const fnr = useFnrParam();
 
   return (
     <DialogmotePanel
@@ -129,7 +127,7 @@ export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
         <TrackedKnapp context={texts.innkallingSendtTrackingContext}>
           {texts.endreMote}
         </TrackedKnapp>
-        <Link to={`/sykefravaer/${fnr}/dialogmote/${dialogmote.uuid}/avlys`}>
+        <Link to={`/sykefravaer/dialogmote/${dialogmote.uuid}/avlys`}>
           <TrackedKnapp context={texts.innkallingSendtTrackingContext}>
             {texts.avlysMote}
           </TrackedKnapp>

--- a/src/components/mote/components/innkalling/Moteplanleggeren.tsx
+++ b/src/components/mote/components/innkalling/Moteplanleggeren.tsx
@@ -5,7 +5,6 @@ import { MoteIkonBlaaImage } from "../../../../../img/ImageComponents";
 import { DialogmotePanel } from "../DialogmotePanel";
 import { tilDatoMedUkedagOgManedNavn } from "../../../../utils/datoUtils";
 import { useAktivtMoteplanleggerMote } from "../../../../data/mote/moter_hooks";
-import { useFnrParam } from "../../../../hooks/useFnrParam";
 import { Knapp } from "nav-frontend-knapper";
 import { FlexRow } from "../../../Layout";
 import { useHistory } from "react-router";
@@ -35,7 +34,6 @@ const resolveUndertittelForMoteStatus = (mote: MoteDTO) => {
 export const Moteplanleggeren = (): ReactElement => {
   const aktivtMote = useAktivtMoteplanleggerMote();
   const history = useHistory();
-  const fnr = useFnrParam();
 
   return aktivtMote ? (
     <DialogmotePanel
@@ -58,7 +56,7 @@ export const Moteplanleggeren = (): ReactElement => {
       <FlexRow>
         <Knapp
           onClick={() => {
-            history.push(`/sykefravaer/${fnr}/mote`);
+            history.push(`/sykefravaer/mote`);
           }}
         >
           {texts.nyttMote}

--- a/src/components/mote/components/innkalling/NyttDialogMote.tsx
+++ b/src/components/mote/components/innkalling/NyttDialogMote.tsx
@@ -5,7 +5,6 @@ import styled from "styled-components";
 import { useHistory } from "react-router";
 import Veileder from "nav-frontend-veileder";
 import { FlexColumn, FlexRow, ModalContentContainer } from "../../../Layout";
-import { useFnrParam } from "../../../../hooks/useFnrParam";
 import { TrackedKnapp } from "../../../buttons/TrackedKnapp";
 import { TrackedFlatknapp } from "../../../buttons/TrackedFlatknapp";
 
@@ -35,7 +34,6 @@ export const NyttDialogMote = (): ReactElement => {
   const [behandlerModalIsOpen, setBehandlerModalIsOpen] = useState(false);
   const [nyLosningModalIsOpen, setNyLosningModalIsOpen] = useState(false);
   const history = useHistory();
-  const fnr = useFnrParam();
 
   return (
     <>
@@ -68,7 +66,7 @@ export const NyttDialogMote = (): ReactElement => {
                 context={texts.behandlerVaereMedTrackingContext}
                 onClick={() => {
                   setBehandlerModalIsOpen(false);
-                  history.push(`/sykefravaer/${fnr}/mote`);
+                  history.push(`/sykefravaer/mote`);
                 }}
               >
                 {texts.ja}
@@ -127,7 +125,7 @@ export const NyttDialogMote = (): ReactElement => {
                 context={texts.modalOnskerDuProveTrackingContext}
                 onClick={() => {
                   setNyLosningModalIsOpen(false);
-                  history.push(`/sykefravaer/${fnr}/dialogmote`);
+                  history.push(`/sykefravaer/dialogmote`);
                 }}
               >
                 {texts.ja}
@@ -138,7 +136,7 @@ export const NyttDialogMote = (): ReactElement => {
                 context={texts.modalOnskerDuProveTrackingContext}
                 onClick={() => {
                   setNyLosningModalIsOpen(false);
-                  history.push(`/sykefravaer/${fnr}/mote`);
+                  history.push(`/sykefravaer/mote`);
                 }}
               >
                 {texts.nei}

--- a/src/components/mote/components/innkalling/SeMoteStatus.tsx
+++ b/src/components/mote/components/innkalling/SeMoteStatus.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useHistory } from "react-router";
 import { FlexRow } from "../../../Layout";
-import { useFnrParam } from "../../../../hooks/useFnrParam";
 import { TrackedKnapp } from "../../../buttons/TrackedKnapp";
 
 const texts = {
@@ -11,14 +10,13 @@ const texts = {
 
 export const SeMoteStatus = () => {
   const history = useHistory();
-  const fnr = useFnrParam();
 
   return (
     <FlexRow>
       <TrackedKnapp
         context={texts.moteStatusTrackingContext}
         onClick={() => {
-          history.push(`/sykefravaer/${fnr}/mote`);
+          history.push(`/sykefravaer/mote`);
         }}
       >
         {texts.gaTilMotestatus}

--- a/src/components/mote/container/AvbrytMoteContainer.js
+++ b/src/components/mote/container/AvbrytMoteContainer.js
@@ -51,7 +51,7 @@ export class AvbrytMoteSide extends Component {
             return (
               <Lightbox
                 onClose={() => {
-                  history.replace(`/sykefravaer/${fnr}/mote`);
+                  history.replace(`/sykefravaer/mote`);
                 }}
               >
                 {(() => {
@@ -64,7 +64,7 @@ export class AvbrytMoteSide extends Component {
                       onSubmit={() => {
                         this.avbrytMote();
                       }}
-                      avbrytHref={`/sykefravaer/${fnr}/mote`}
+                      avbrytHref={`/sykefravaer/mote`}
                     />
                   );
                 })()}
@@ -96,7 +96,7 @@ export function mapStateToProps(state, ownProps) {
     return m.moteUuid === ownProps.match.params.moteUuid;
   })[0];
   return {
-    fnr: ownProps.match.params.fnr,
+    fnr: state.valgtbruker.personident,
     mote,
     arbeidstaker: state.navbruker.data,
     hentingFeiletBool:

--- a/src/components/mote/container/BekreftMoteContainer.js
+++ b/src/components/mote/container/BekreftMoteContainer.js
@@ -68,7 +68,7 @@ export class BekreftMoteSide extends Component {
                   <Lightbox
                     scrollOverflowY={this.state.scrollOverflowY}
                     onClose={() => {
-                      history.replace(`/sykefravaer/${fnr}/mote`);
+                      history.replace(`/sykefravaer/mote`);
                     }}
                   >
                     {(() => {
@@ -80,7 +80,7 @@ export class BekreftMoteSide extends Component {
                           mote={mote}
                           arbeidstaker={arbeidstaker}
                           alternativ={alternativ}
-                          avbrytHref={`/sykefravaer/${fnr}/mote`}
+                          avbrytHref={`/sykefravaer/mote`}
                           bekrefter={bekrefter}
                           hentEpostinnhold={(moteUuid) => {
                             hentBekreftMoteEpostinnhold(
@@ -146,7 +146,7 @@ export const mapStateToProps = (state, ownProps) => {
       })[0]
     : null;
   return {
-    fnr: ownProps.match.params.fnr,
+    fnr: state.valgtbruker.personident,
     bekrefter: state.moter.bekrefter,
     bekreftFeilet: state.moter.bekreftFeilet,
     henterMoterBool: state.moter.henter || state.navbruker.henter,

--- a/src/components/mote/container/MotebookingContainer.js
+++ b/src/components/mote/container/MotebookingContainer.js
@@ -85,14 +85,14 @@ MotebookingSide.propTypes = {
   moterTilgang: PropTypes.object,
 };
 
-export const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state) => {
   const aktivtMote = state.moter.data.filter((mote) => {
     return mote.status !== "AVBRUTT";
   })[0];
 
   const harForsoktHentetAlt = state.moter.hentingForsokt;
   return {
-    fnr: ownProps.match.params.fnr,
+    fnr: state.valgtbruker.personident,
     mote: aktivtMote,
     henter: !harForsoktHentetAlt || state.ledere.henter || state.tilgang.henter,
     sender: state.moter.sender,

--- a/src/components/mote/container/MotelandingssideContainer.tsx
+++ b/src/components/mote/container/MotelandingssideContainer.tsx
@@ -2,14 +2,14 @@ import React from "react";
 import Side from "../../../sider/Side";
 import { MOETEPLANLEGGER } from "../../../enums/menypunkter";
 import Motelandingsside from "../components/Motelandingsside";
-import { useFnrParam } from "../../../hooks/useFnrParam";
+import { useValgtPersonident } from "../../../hooks/useValgtBruker";
 
 const texts = {
   pageTitle: "Møtelandingsside",
 };
 
 const MotelandingssideContainer = () => {
-  const fnr = useFnrParam();
+  const fnr = useValgtPersonident();
 
   return (
     <Side fnr={fnr} tittel={texts.pageTitle} aktivtMenypunkt={MOETEPLANLEGGER}>

--- a/src/components/motebehov/BehandleMotebehovKnapp.tsx
+++ b/src/components/motebehov/BehandleMotebehovKnapp.tsx
@@ -11,7 +11,7 @@ import {
 import { toDatePrettyPrint } from "../../utils/datoUtils";
 import { behandleMotebehov } from "../../data/motebehov/behandlemotebehov_actions";
 import { MotebehovDTO } from "../../data/motebehov/types/motebehovTypes";
-import { useFnrParam } from "../../hooks/useFnrParam";
+import { useValgtPersonident } from "../../hooks/useValgtBruker";
 import { useTrackButtonClick } from "../../data/logging/loggingHooks";
 
 const texts = {
@@ -43,7 +43,7 @@ const BehandleMotebehovKnapp = ({
   const motebehovListe = motebehovlisteMedKunJaSvar(motebehovData);
   const sistBehandletMotebehov = hentSistBehandletMotebehov(motebehovListe);
   const erBehandlet = erMotebehovBehandlet(motebehovListe);
-  const fnr = useFnrParam();
+  const fnr = useValgtPersonident();
   const trackButtonClick = useTrackButtonClick();
 
   const dispatch = useDispatch();

--- a/src/components/nokkelinformasjon/container/NokkelinformasjonContainer.tsx
+++ b/src/components/nokkelinformasjon/container/NokkelinformasjonContainer.tsx
@@ -14,6 +14,7 @@ import AppSpinner from "../../AppSpinner";
 import Nokkelinformasjon from "../Nokkelinformasjon";
 import { useOppfoelgingsDialoger } from "../../../hooks/useOppfoelgingsDialoger";
 import { useTilgang } from "../../../hooks/useTilgang";
+import { useValgtPersonident } from "../../../hooks/useValgtBruker";
 
 const texts = {
   pageTitle: "Nøkkelinformasjon",
@@ -21,7 +22,7 @@ const texts = {
 };
 
 export const NokkelinformasjonSide = () => {
-  const fnr = window.location.pathname.split("/")[2];
+  const fnr = useValgtPersonident();
 
   const {
     aktiveDialoger,

--- a/src/components/oppfolgingsplan/container/OppfoelgingsPlanerOversiktContainer.js
+++ b/src/components/oppfolgingsplan/container/OppfoelgingsPlanerOversiktContainer.js
@@ -95,7 +95,7 @@ OppfoelgingsPlanerOversiktSide.propTypes = {
   veilederIdent: PropTypes.string,
 };
 
-export function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state) {
   const harForsoktHentetAlt =
     harForsoktHentetOppfoelgingsdialoger(state.oppfoelgingsdialoger) &&
     state.oppfolgingsplanerlps.hentingForsokt &&
@@ -123,7 +123,7 @@ export function mapStateToProps(state, ownProps) {
 
   return {
     brukernavn: state.navbruker.data.navn,
-    fnr: ownProps.match.params.fnr,
+    fnr: state.valgtbruker.personident,
     henter,
     hentingFeilet,
     inaktiveDialoger,

--- a/src/components/oppfolgingsplan/container/OppfoelgingsplanContainer.js
+++ b/src/components/oppfolgingsplan/container/OppfoelgingsplanContainer.js
@@ -48,9 +48,7 @@ const OppfoelgingsPlanerOversiktSide = ({
         if (hentingFeilet) {
           return <Feilmelding />;
         }
-        return (
-          <Oppfolgingsplan oppfolgingsplan={oppfoelgingsdialog} fnr={fnr} />
-        );
+        return <Oppfolgingsplan oppfolgingsplan={oppfoelgingsdialog} />;
       })()}
     </SideFullbredde>
   );
@@ -82,7 +80,7 @@ export function mapStateToProps(state, ownProps) {
   return {
     brukernavn: state.navbruker.data.navn,
     oppfoelgingsdialog,
-    fnr: ownProps.match.params.fnr,
+    fnr: state.valgtbruker.personident,
     henter,
     hentingFeilet,
     tilgang: state.tilgang.data,

--- a/src/components/oppfolgingsplan/oppfoelgingsdialoger/Oppfolgingsplan.tsx
+++ b/src/components/oppfolgingsplan/oppfoelgingsdialoger/Oppfolgingsplan.tsx
@@ -10,12 +10,11 @@ import AppSpinner from "../../AppSpinner";
 
 interface PlanVisningProps {
   dokumentinfo: DokumentinfoDTO;
-  fnr: string;
   oppfolgingsplan: OppfolgingsplanDTO;
 }
 
 const PlanVisning = (planVisningProps: PlanVisningProps) => {
-  const { dokumentinfo, fnr, oppfolgingsplan } = planVisningProps;
+  const { dokumentinfo, oppfolgingsplan } = planVisningProps;
   const bildeUrler: string[] = [];
   for (let i = 1; i <= dokumentinfo.antallSider; i += 1) {
     bildeUrler.push(
@@ -26,10 +25,7 @@ const PlanVisning = (planVisningProps: PlanVisningProps) => {
   const TilbakeTilOppfolgingsplaner = () => {
     return (
       <div className="blokk">
-        <Link
-          to={`/sykefravaer/${fnr}/oppfoelgingsplaner`}
-          className="tilbakelenke"
-        >
+        <Link to={`/sykefravaer/oppfoelgingsplaner`} className="tilbakelenke">
           Til oppfølgingsplaner
         </Link>
       </div>
@@ -74,12 +70,11 @@ const PlanVisning = (planVisningProps: PlanVisningProps) => {
 };
 
 interface OppfolgingsplanProps {
-  fnr: string;
   oppfolgingsplan: OppfolgingsplanDTO;
 }
 
 const Oppfolgingsplan = (oppfolgingsplanWrapperProps: OppfolgingsplanProps) => {
-  const { fnr, oppfolgingsplan } = oppfolgingsplanWrapperProps;
+  const { oppfolgingsplan } = oppfolgingsplanWrapperProps;
 
   const dispatch = useDispatch();
 
@@ -109,7 +104,6 @@ const Oppfolgingsplan = (oppfolgingsplanWrapperProps: OppfolgingsplanProps) => {
       <PlanVisning
         oppfolgingsplan={oppfolgingsplan}
         dokumentinfo={dokumentinfo}
-        fnr={fnr}
       />
     );
   })();

--- a/src/components/oppfolgingsplan/oppfoelgingsdialoger/OppfolgingsplanerOversikt.tsx
+++ b/src/components/oppfolgingsplan/oppfoelgingsdialoger/OppfolgingsplanerOversikt.tsx
@@ -56,7 +56,6 @@ const OppfolgingsplanerOversikt = (
   oppfolgingsplanerOversiktProps: OppfolgingsplanerOversiktProps
 ) => {
   const {
-    fnr,
     aktiveDialoger,
     inaktiveDialoger,
     oppfolgingsplanerLPS,
@@ -153,7 +152,7 @@ const OppfolgingsplanerOversikt = (
             <Link
               key={index}
               className="navigasjonspanel navigasjonspanel--stor"
-              to={`/sykefravaer/${fnr}/oppfoelgingsplaner/${dialog.id}`}
+              to={`/sykefravaer/oppfoelgingsplaner/${dialog.id}`}
             >
               <div className="navigasjonselement">
                 <h3 className="panel__tittel navigasjonselement__tittel">
@@ -185,7 +184,7 @@ const OppfolgingsplanerOversikt = (
           <Link
             key={index}
             className="navigasjonspanel navigasjonspanel--stor"
-            to={`/sykefravaer/${fnr}/oppfoelgingsplaner/${dialog.id}`}
+            to={`/sykefravaer/oppfoelgingsplaner/${dialog.id}`}
           >
             <div className="navigasjonselement">
               <h3 className="panel__tittel navigasjonselement__tittel">

--- a/src/components/pengestopp/PengestoppModal.tsx
+++ b/src/components/pengestopp/PengestoppModal.tsx
@@ -17,6 +17,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { endreStatus } from "../../data/pengestopp/flaggperson_actions";
 import { FlaggpersonState } from "../../data/pengestopp/flaggperson";
 import { useNavEnhet } from "../../hooks/useNavEnhet";
+import { useValgtPersonident } from "../../hooks/useValgtBruker";
 
 const texts = {
   notStoppedTittel:
@@ -112,7 +113,7 @@ const PengestoppModal = ({
   const [submitErrorArsak, setSubmitErrorArsak] = useState<boolean>(false);
   const [serverError, setServerError] = useState<boolean>(false);
 
-  const fnr = window.location.pathname.split("/")[2];
+  const fnr = useValgtPersonident();
   const [stoppAutomatikk, setStoppAutomatikk] = useState<StoppAutomatikk>({
     sykmeldtFnr: { value: fnr },
     arsakList: [],

--- a/src/components/speiling/sykepengsoknader/container/SykepengesoknadContainer.js
+++ b/src/components/speiling/sykepengsoknader/container/SykepengesoknadContainer.js
@@ -92,7 +92,6 @@ export class Container extends Component {
           ) {
             return (
               <SykepengesoknadSelvstendig
-                fnr={fnr}
                 brodsmuler={brodsmuler}
                 brukernavn={brukernavn}
                 sykmelding={sykmelding}
@@ -103,7 +102,6 @@ export class Container extends Component {
           if (soknad && soknad.soknadstype === OPPHOLD_UTLAND) {
             return (
               <SykepengesoknadUtland
-                fnr={fnr}
                 brodsmuler={brodsmuler}
                 brukernavn={brukernavn}
                 soknad={soknad}
@@ -126,7 +124,7 @@ export class Container extends Component {
                 soknad={soknad}
               />
             ) : (
-              <IkkeInnsendtSoknad fnr={fnr} />
+              <IkkeInnsendtSoknad />
             );
           }
           if (soknad && soknad.soknadstype === BEHANDLINGSDAGER) {
@@ -179,7 +177,7 @@ export function mapStateToProps(state, ownProps) {
 
   return {
     brukernavn: state.navbruker.data.navn,
-    fnr: ownProps.match.params.fnr,
+    fnr: state.valgtbruker.personident,
     henter,
     hentingFeilet,
     tilgang: state.tilgang.data,

--- a/src/components/speiling/sykepengsoknader/container/SykepengesoknaderContainer.js
+++ b/src/components/speiling/sykepengsoknader/container/SykepengesoknaderContainer.js
@@ -75,7 +75,7 @@ export class SykepengesoknaderSide extends Component {
               <Speilingvarsel brukernavn={brukernavn} />
               <div className="speiling">
                 <Brodsmuler brodsmuler={brodsmuler} />
-                <Soknader soknader={soknader} fnr={fnr} />
+                <Soknader soknader={soknader} />
               </div>
             </div>
           );
@@ -102,15 +102,17 @@ export function mapDispatchToProps(dispatch) {
   };
 }
 
-export function mapStateToProps(state, ownProps) {
+export function mapStateToProps(state) {
   const harForsoktHentetAlt = harForsoktHentetSoknader(state.soknader);
   const henter = !harForsoktHentetAlt || state.tilgang.henter;
   const hentingFeilet = state.tilgang.hentingFeilet;
   const hentingFeiletSoknader = state.soknader.hentingFeilet;
 
+  const fnr = state.valgtbruker.personident;
+
   return {
     brukernavn: state.navbruker.data.navn,
-    fnr: ownProps.match.params.fnr,
+    fnr,
     henter,
     hentingFeilet: hentingFeilet || hentingFeiletSoknader,
     hentingFeiletSoknader,

--- a/src/components/speiling/sykepengsoknader/soknad-arbeidstaker-ny/AvbruttSoknadArbeidtakerNy.js
+++ b/src/components/speiling/sykepengsoknader/soknad-arbeidstaker-ny/AvbruttSoknadArbeidtakerNy.js
@@ -50,7 +50,6 @@ const AvbruttSoknadArbeidstaker = ({ brukernavn, brodsmuler, soknad, fnr }) => {
         tittel="Søknad om sykepenger"
         brukernavn={brukernavn}
         brodsmuler={brodsmuler}
-        fnr={fnr}
       >
         <AvbruttSoknadArbeidstakerStatuspanel soknad={soknad} />
         <SykmeldingUtdrag soknad={soknad} fnr={fnr} />

--- a/src/components/speiling/sykepengsoknader/soknad-arbeidstaker-ny/SendtSoknadArbeidstakerNy.js
+++ b/src/components/speiling/sykepengsoknader/soknad-arbeidstaker-ny/SendtSoknadArbeidstakerNy.js
@@ -33,7 +33,6 @@ const SendtSoknadArbeidstakerNy = ({ brukernavn, brodsmuler, soknad, fnr }) => {
       tittel="Søknad om sykepenger"
       brukernavn={brukernavn}
       brodsmuler={brodsmuler}
-      fnr={fnr}
     >
       {soknad.status === KORRIGERT && (
         <KorrigertAvContainer sykepengesoknad={soknad} fnr={fnr} />

--- a/src/components/speiling/sykepengsoknader/soknad-arbeidstaker/KorrigertAvContainer.js
+++ b/src/components/speiling/sykepengsoknader/soknad-arbeidstaker/KorrigertAvContainer.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 import AlertStripe from "nav-frontend-alertstriper";
@@ -16,7 +15,7 @@ const textKorrigert = (dato) => {
   return `${texts.korrigert} ${dato}.`;
 };
 
-export const KorrigertAv = ({ korrigertAvSoknad, fnr }) => {
+export const KorrigertAv = ({ korrigertAvSoknad }) => {
   return (
     <AlertStripe type="info" className="blokk">
       <p className="sist">
@@ -27,7 +26,7 @@ export const KorrigertAv = ({ korrigertAvSoknad, fnr }) => {
       <p className="sist">
         <Link
           className="lenke"
-          to={`/sykefravaer/${fnr}/sykepengesoknader/${korrigertAvSoknad.id}`}
+          to={`/sykefravaer/sykepengesoknader/${korrigertAvSoknad.id}`}
         >
           {texts.lenketekst}
         </Link>
@@ -38,7 +37,6 @@ export const KorrigertAv = ({ korrigertAvSoknad, fnr }) => {
 
 KorrigertAv.propTypes = {
   korrigertAvSoknad: soknadEllerSykepengesoknad,
-  fnr: PropTypes.string,
 };
 
 export const mapStateToProps = (state, ownProps) => {

--- a/src/components/speiling/sykepengsoknader/soknad-arbeidstaker/RelaterteSoknaderContainer.js
+++ b/src/components/speiling/sykepengsoknader/soknad-arbeidstaker/RelaterteSoknaderContainer.js
@@ -14,7 +14,7 @@ const texts = {
   sendt: "Sendt",
 };
 
-const RelaterteSoknader = ({ relaterteSoknader, fnr }) => {
+const RelaterteSoknader = ({ relaterteSoknader }) => {
   if (relaterteSoknader.length === 0) {
     return null;
   }
@@ -25,7 +25,7 @@ const RelaterteSoknader = ({ relaterteSoknader, fnr }) => {
         {relaterteSoknader.sort(sorterEtterDato).map((s, index) => {
           return (
             <li key={index}>
-              <Link to={`/sykefravaer/${fnr}/sykepengesoknader/${s.id}`}>
+              <Link to={`/sykefravaer/sykepengesoknader/${s.id}`}>
                 {texts.sendt}{" "}
                 {tilLesbarDatoMedArstall(getTidligsteSendtDato(s))}
               </Link>

--- a/src/components/speiling/sykepengsoknader/soknad-felles/IkkeInnsendtSoknad.js
+++ b/src/components/speiling/sykepengsoknader/soknad-felles/IkkeInnsendtSoknad.js
@@ -1,9 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Panel from "nav-frontend-paneler";
 import TilbakeTilSoknader from "./TilbakeTilSoknader";
 
-const IkkeInnsendtSoknad = ({ fnr }) => {
+const IkkeInnsendtSoknad = () => {
   return (
     <div>
       <Panel className="panel--melding blokk">
@@ -15,13 +14,9 @@ const IkkeInnsendtSoknad = ({ fnr }) => {
           og/eller NAV vil du kunne se statusen på søknaden her.
         </p>
       </Panel>
-      <TilbakeTilSoknader fnr={fnr} />
+      <TilbakeTilSoknader />
     </div>
   );
-};
-
-IkkeInnsendtSoknad.propTypes = {
-  fnr: PropTypes.string,
 };
 
 export default IkkeInnsendtSoknad;

--- a/src/components/speiling/sykepengsoknader/soknad-felles/SoknadSpeiling.js
+++ b/src/components/speiling/sykepengsoknader/soknad-felles/SoknadSpeiling.js
@@ -7,7 +7,6 @@ import TilbakeTilSoknader from "./TilbakeTilSoknader";
 import { brodsmule } from "../../../../propTypes";
 
 const SoknadSpeiling = ({
-  fnr,
   brukernavn,
   children,
   brodsmuler,
@@ -20,14 +19,13 @@ const SoknadSpeiling = ({
         <Brodsmuler brodsmuler={brodsmuler} />
         <SidetoppSpeilet tittel={tittel} />
         <div className="blokk">{children}</div>
-        <TilbakeTilSoknader fnr={fnr} />
+        <TilbakeTilSoknader />
       </div>
     </div>
   );
 };
 
 SoknadSpeiling.propTypes = {
-  fnr: PropTypes.string,
   brukernavn: PropTypes.string,
   children: PropTypes.node,
   brodsmuler: PropTypes.arrayOf(brodsmule),

--- a/src/components/speiling/sykepengsoknader/soknad-felles/TilbakeTilSoknader.js
+++ b/src/components/speiling/sykepengsoknader/soknad-felles/TilbakeTilSoknader.js
@@ -1,18 +1,13 @@
 import React from "react";
-import PropTypes from "prop-types";
 import Tilbakelenke from "../../../Tilbakelenke";
 
-const TilbakeTilSoknader = ({ fnr }) => {
+const TilbakeTilSoknader = () => {
   return (
     <Tilbakelenke
-      to={`/sykefravaer/${fnr}/sykepengesoknader`}
+      to={`/sykefravaer/sykepengesoknader`}
       tekst="Gå til sykepengesøknader"
     />
   );
-};
-
-TilbakeTilSoknader.propTypes = {
-  fnr: PropTypes.string,
 };
 
 export default TilbakeTilSoknader;

--- a/src/components/speiling/sykepengsoknader/soknad-selvstendig/SykepengesoknadSelvstendig.js
+++ b/src/components/speiling/sykepengsoknader/soknad-selvstendig/SykepengesoknadSelvstendig.js
@@ -17,11 +17,11 @@ const texts = {
 };
 
 const SykepengesoknadSelvstendig = (props) => {
-  const { soknad, fnr } = props;
+  const { soknad } = props;
   switch (soknad.status) {
     case NY:
     case FREMTIDIG: {
-      return <IkkeInnsendtSoknad fnr={fnr} />;
+      return <IkkeInnsendtSoknad />;
     }
     case AVBRUTT: {
       return (

--- a/src/components/speiling/sykepengsoknader/soknad-utland/SykepengesoknadUtland.js
+++ b/src/components/speiling/sykepengsoknader/soknad-utland/SykepengesoknadUtland.js
@@ -22,13 +22,12 @@ OppsummeringPanel.propTypes = {
   soknad: soknadPt,
 };
 
-const SykepengesoknadUtland = ({ brukernavn, brodsmuler, soknad, fnr }) => {
+const SykepengesoknadUtland = ({ brukernavn, brodsmuler, soknad }) => {
   return (
     <SoknadSpeiling
       tittel="Søknad om sykepenger under opphold utenfor Norge"
       brukernavn={brukernavn}
       brodsmuler={brodsmuler}
-      fnr={fnr}
     >
       <StatuspanelUtland soknad={soknad} />
       <OppsummeringPanel soknad={soknad} />
@@ -40,7 +39,6 @@ SykepengesoknadUtland.propTypes = {
   brukernavn: PropTypes.string,
   brodsmuler: PropTypes.arrayOf(brodsmule),
   soknad: soknadPt,
-  fnr: PropTypes.string,
 };
 
 export default SykepengesoknadUtland;

--- a/src/components/speiling/sykepengsoknader/soknader/SoknadTeaser.tsx
+++ b/src/components/speiling/sykepengsoknader/soknader/SoknadTeaser.tsx
@@ -222,14 +222,9 @@ const TeaserPeriode = ({ soknad }: TeaserComponentProps) => (
   </p>
 );
 
-interface SykepengesoknadTeaserProps extends TeaserComponentProps {
-  fnr: string;
-}
-
 const SykepengesoknadTeaser = ({
   soknad,
-  fnr,
-}: SykepengesoknadTeaserProps): ReactElement => {
+}: TeaserComponentProps): ReactElement => {
   const status = soknad.status ? soknad.status.toLowerCase() : "";
   const visStatus =
     [
@@ -242,7 +237,7 @@ const SykepengesoknadTeaser = ({
     <article aria-labelledby={`soknader-header-${soknad.id}`}>
       <Link
         className={`inngangspanel js-panel js-soknad-${status}`}
-        to={`/sykefravaer/${fnr}/sykepengesoknader/${soknad.id}`}
+        to={`/sykefravaer/sykepengesoknader/${soknad.id}`}
       >
         <span className="inngangspanel__ikon inngangspanel__ikon--normal">
           {visIkon(soknad.soknadstype)}

--- a/src/components/speiling/sykepengsoknader/soknader/Soknader.tsx
+++ b/src/components/speiling/sykepengsoknader/soknader/Soknader.tsx
@@ -36,7 +36,7 @@ interface SoknaderProps {
 }
 
 const Soknader = (soknaderProps: SoknaderProps): ReactElement => {
-  const { fnr, soknader = [] } = soknaderProps;
+  const { soknader = [] } = soknaderProps;
   const alleSoknader = [...soknader];
 
   const nyeSoknader = alleSoknader
@@ -71,7 +71,6 @@ const Soknader = (soknaderProps: SoknaderProps): ReactElement => {
       <Sidetopp tittel={texts.sidetittel} />
       <SoknadTeasere
         sykepengesoknader={nyeSoknader}
-        fnr={fnr}
         tittel={texts.nyeSoknader}
         tomListeTekst={texts.ingenSoknader}
         className="js-til-behandling"
@@ -88,7 +87,6 @@ const Soknader = (soknaderProps: SoknaderProps): ReactElement => {
       {sendteSoknader.length > 0 && (
         <SoknadTeasere
           sykepengesoknader={sendteSoknader}
-          fnr={fnr}
           tittel={texts.tidligereSoknader}
           tomListeTekst={texts.tidligereSoknader}
           className="js-sendt"

--- a/src/components/speiling/sykepengsoknader/soknader/SoknaderTeasere.tsx
+++ b/src/components/speiling/sykepengsoknader/soknader/SoknaderTeasere.tsx
@@ -4,7 +4,6 @@ import { SykepengesoknadDTO } from "../../../../data/sykepengesoknad/types/Sykep
 
 interface SoknaderTeasereProps {
   sykepengesoknader: SykepengesoknadDTO[];
-  fnr: string;
   id: string;
   tomListeTekst: string;
   tittel?: string;
@@ -13,7 +12,6 @@ interface SoknaderTeasereProps {
 
 const SoknaderTeasere = ({
   sykepengesoknader,
-  fnr,
   className,
   tittel = "",
   tomListeTekst,
@@ -26,7 +24,7 @@ const SoknaderTeasere = ({
     <div id={id} className={className || "js-content"}>
       {sykepengesoknader.length > 0 ? (
         sykepengesoknader.map((soknad, idx) => (
-          <SoknadTeaser key={idx} soknad={soknad} fnr={fnr} />
+          <SoknadTeaser key={idx} soknad={soknad} />
         ))
       ) : (
         <p className="panel typo-infotekst">{tomListeTekst}</p>

--- a/src/components/speiling/sykmeldinger/container/DinSykmeldingContainer.tsx
+++ b/src/components/speiling/sykmeldinger/container/DinSykmeldingContainer.tsx
@@ -17,6 +17,7 @@ import { ARBEIDSTAKER } from "../../../../enums/arbeidssituasjoner";
 import { hentBegrunnelseTekst } from "../../../../utils/tilgangUtils";
 import { harForsoktHentetSykmeldinger } from "../../../../utils/reducerUtils";
 import { useTilgang } from "../../../../hooks/useTilgang";
+import { useValgtPersonident } from "../../../../hooks/useValgtBruker";
 
 const texts = {
   pageTitleSykmelding: "Sykmelding",
@@ -40,8 +41,8 @@ export function getSykmelding(
 }
 
 const DinSykmeldingSide = () => {
-  const fnr = window.location.pathname.split("/")[2];
-  const sykmeldingId = window.location.pathname.split("/")[4];
+  const fnr = useValgtPersonident();
+  const sykmeldingId = window.location.pathname.split("/")[3];
 
   const navbrukerState = useSelector((state: any) => state.navbruker);
   const sykmeldingerState = useSelector((state: any) => state.sykmeldinger);
@@ -115,7 +116,6 @@ const DinSykmeldingSide = () => {
               <SykmeldingSide
                 dinSykmelding={dinSykmelding}
                 arbeidsgiversSykmelding={arbeidsgiversSykmelding}
-                fnr={fnr}
               />
             </div>
           </div>

--- a/src/components/speiling/sykmeldinger/container/SykmeldingerContainer.tsx
+++ b/src/components/speiling/sykmeldinger/container/SykmeldingerContainer.tsx
@@ -13,6 +13,7 @@ import { hentBegrunnelseTekst } from "../../../../utils/tilgangUtils";
 import { harForsoktHentetSykmeldinger } from "../../../../utils/reducerUtils";
 import Pengestopp from "../../../pengestopp/Pengestopp";
 import { useTilgang } from "../../../../hooks/useTilgang";
+import { useValgtPersonident } from "../../../../hooks/useValgtBruker";
 
 const texts = {
   introduksjonstekst:
@@ -21,7 +22,7 @@ const texts = {
 };
 
 const SykmeldingerSide = () => {
-  const fnr = window.location.pathname.split("/")[2];
+  const fnr = useValgtPersonident();
 
   const navbrukerState = useSelector((state: any) => state.navbruker);
   const sykmeldingerState = useSelector((state: any) => state.sykmeldinger);

--- a/src/components/speiling/sykmeldinger/sykmelding/LenkeTilDineSykmeldinger.tsx
+++ b/src/components/speiling/sykmeldinger/sykmelding/LenkeTilDineSykmeldinger.tsx
@@ -5,19 +5,9 @@ const texts = {
   tilbake: "Gå til dine sykmeldinger\n",
 };
 
-interface LenkeTilDineSykmeldingerProps {
-  fnr: string;
-}
-
-const LenkeTilDineSykmeldinger = (
-  lenkeTilDineSykmeldingerProps: LenkeTilDineSykmeldingerProps
-) => {
-  const { fnr } = lenkeTilDineSykmeldingerProps;
+const LenkeTilDineSykmeldinger = () => {
   return (
-    <Tilbakelenke
-      to={`/sykefravaer/${fnr}/sykmeldinger`}
-      tekst={texts.tilbake}
-    />
+    <Tilbakelenke to={`/sykefravaer/sykmeldinger`} tekst={texts.tilbake} />
   );
 };
 

--- a/src/components/speiling/sykmeldinger/sykmelding/SykmeldingSide.tsx
+++ b/src/components/speiling/sykmeldinger/sykmelding/SykmeldingSide.tsx
@@ -19,11 +19,10 @@ import KoronaSykmeldingAvbrutt from "./koronasykmeldinger/KoronaSykmelding-Avbru
 interface SykmeldingSideProps {
   dinSykmelding?: SykmeldingOldFormat;
   arbeidsgiversSykmelding?: SykmeldingOldFormat;
-  fnr: string;
 }
 
 const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
-  const { dinSykmelding, arbeidsgiversSykmelding, fnr } = sykmeldingSideProps;
+  const { dinSykmelding, arbeidsgiversSykmelding } = sykmeldingSideProps;
   return (() => {
     if (!dinSykmelding) {
       return <Feilmelding tittel="Fant ikke sykmelding" />;
@@ -35,7 +34,7 @@ const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
       return (
         <div>
           <AvvistSykmelding sykmelding={dinSykmelding} />
-          <LenkeTilDineSykmeldinger fnr={fnr} />
+          <LenkeTilDineSykmeldinger />
         </div>
       );
     }
@@ -45,7 +44,7 @@ const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
           return (
             <div>
               <KoronaSykmeldingBekreftet dinSykmelding={dinSykmelding} />
-              <LenkeTilDineSykmeldinger fnr={fnr} />
+              <LenkeTilDineSykmeldinger />
             </div>
           );
         }
@@ -53,7 +52,7 @@ const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
           return (
             <>
               <KoronaSykmeldingNy sykmelding={dinSykmelding} />
-              <LenkeTilDineSykmeldinger fnr={fnr} />
+              <LenkeTilDineSykmeldinger />
             </>
           );
         }
@@ -61,7 +60,7 @@ const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
           return (
             <div>
               <KoronaSykmeldingAvbrutt sykmelding={dinSykmelding} />
-              <LenkeTilDineSykmeldinger fnr={fnr} />
+              <LenkeTilDineSykmeldinger />
             </div>
           );
         }
@@ -79,7 +78,7 @@ const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
             dinSykmelding={dinSykmelding}
             arbeidsgiversSykmelding={arbeidsgiversSykmelding}
           />
-          <LenkeTilDineSykmeldinger fnr={fnr} />
+          <LenkeTilDineSykmeldinger />
         </div>
       );
     } else if (
@@ -92,28 +91,28 @@ const SykmeldingSide = (sykmeldingSideProps: SykmeldingSideProps) => {
             dinSykmelding={dinSykmelding}
             arbeidsgiversSykmelding={arbeidsgiversSykmelding}
           />
-          <LenkeTilDineSykmeldinger fnr={fnr} />
+          <LenkeTilDineSykmeldinger />
         </div>
       );
     } else if (dinSykmelding.status === gamleSMStatuser.UTGAATT) {
       return (
         <div>
           <DinUtgaatteSykmelding sykmelding={dinSykmelding} />
-          <LenkeTilDineSykmeldinger fnr={fnr} />
+          <LenkeTilDineSykmeldinger />
         </div>
       );
     } else if (dinSykmelding.status === gamleSMStatuser.NY) {
       return (
         <div>
           <DinSykmelding sykmelding={dinSykmelding} />
-          <LenkeTilDineSykmeldinger fnr={fnr} />
+          <LenkeTilDineSykmeldinger />
         </div>
       );
     } else if (dinSykmelding.status === gamleSMStatuser.AVBRUTT) {
       return (
         <div>
           <DinAvbrutteSykmelding sykmelding={dinSykmelding} />
-          <LenkeTilDineSykmeldinger fnr={fnr} />
+          <LenkeTilDineSykmeldinger />
         </div>
       );
     }

--- a/src/components/speiling/sykmeldinger/sykmeldinger/SykmeldingTeaser.js
+++ b/src/components/speiling/sykmeldinger/sykmeldinger/SykmeldingTeaser.js
@@ -124,7 +124,7 @@ class SykmeldingTeaser extends Component {
       >
         <Link
           className="inngangspanel inngangspanel--sykmelding"
-          to={`/sykefravaer/${this.props.fnr}/sykmeldinger/${this.props.sykmelding.id}`}
+          to={`/sykefravaer/sykmeldinger/${this.props.sykmelding.id}`}
           onMouseEnter={() => {
             this.onMouseEnter(behandlingsutfallStatus);
           }}

--- a/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
@@ -24,7 +24,6 @@ const texts = {
 };
 
 interface AktiveDialogerProps {
-  fnr: string;
   aktiveDialoger: OppfolgingsplanDTO[];
 }
 
@@ -41,7 +40,7 @@ const Gyldighetsperiode = styled.span`
   margin-left: 2em;
 `;
 
-const AktiveDialoger = ({ fnr, aktiveDialoger }: AktiveDialogerProps) => {
+const AktiveDialoger = ({ aktiveDialoger }: AktiveDialogerProps) => {
   return (
     <>
       {aktiveDialoger.map((dialog, index) => {
@@ -51,7 +50,7 @@ const AktiveDialoger = ({ fnr, aktiveDialoger }: AktiveDialogerProps) => {
             <span>
               <Lenke
                 className="lenke"
-                href={`/sykefravaer/${fnr}/oppfoelgingsplaner/${dialog.id}`}
+                href={`/sykefravaer/oppfoelgingsplaner/${dialog.id}`}
               >
                 {virksomhetsNavn && virksomhetsNavn.length > 0
                   ? virksomhetsNavn.toLowerCase()
@@ -99,19 +98,17 @@ const LpsPlaner = ({ lpsPlaner }: LpsPlanerProps) => {
 };
 
 interface OppfolgingsplanerProps {
-  fnr: string;
   aktiveDialoger: OppfolgingsplanDTO[];
   lpsPlaner: OppfolgingsplanLPS[];
 }
 
 const Oppfolgingsplaner = ({
-  fnr,
   aktiveDialoger,
   lpsPlaner,
 }: OppfolgingsplanerProps) => {
   return (
     <div>
-      <AktiveDialoger fnr={fnr} aktiveDialoger={aktiveDialoger} />
+      <AktiveDialoger aktiveDialoger={aktiveDialoger} />
       <LpsPlaner lpsPlaner={lpsPlaner} />
     </div>
   );
@@ -179,7 +176,6 @@ export const UtdragOppfolgingsplaner = ({
       <H3NoMargins>{texts.header}</H3NoMargins>
       {anyActivePlaner ? (
         <Oppfolgingsplaner
-          fnr={fnr}
           aktiveDialoger={aktiveDialoger}
           lpsPlaner={activeLpsPlaner}
         />

--- a/src/components/vedtak/container/VedtakContainer.tsx
+++ b/src/components/vedtak/container/VedtakContainer.tsx
@@ -19,6 +19,7 @@ import {
   MappeAdvarselImage,
   MappeFeilImage,
 } from "../../../../img/ImageComponents";
+import { useValgtPersonident } from "../../../hooks/useValgtBruker";
 
 const texts = {
   pageTitle: "Vedtak",
@@ -35,7 +36,7 @@ const StyledAlertStripe = styled(AlertStripeInfo)`
 `;
 
 const VedtakContainer = () => {
-  const fnr = window.location.pathname.split("/")[2];
+  const fnr = useValgtPersonident();
 
   const vedtakState = useSelector((state: any) => state.vedtak);
   const { tilgang, hentetTilgang, henterTilgang } = useTilgang();

--- a/src/data/dialogmote/dialogmoteSagas.ts
+++ b/src/data/dialogmote/dialogmoteSagas.ts
@@ -22,7 +22,7 @@ function* opprettInnkalling(action: OpprettInnkallingAction) {
     const path = `${process.env.REACT_APP_ISDIALOGMOTE_ROOT}/post/v1/dialogmote/personident`;
     yield call(post, path, action.data, action.fnr);
     yield put(opprettInnkallingFullfort());
-    window.location.href = `/sykefravaer/${action.fnr}/moteoversikt`;
+    window.location.href = `/sykefravaer/moteoversikt`;
   } catch (e) {
     yield put(opprettInnkallingFeilet());
   }
@@ -45,7 +45,7 @@ function* avlysDialogmote(action: AvlysMoteAction) {
     const path = `${process.env.REACT_APP_ISDIALOGMOTE_ROOT}/post/v1/dialogmote/${action.moteUuid}/avlys`;
     yield call(post, path, action.data);
     yield put(avlysMoteFullfort());
-    window.location.href = `/sykefravaer/${action.fnr}/moteoversikt`;
+    window.location.href = `/sykefravaer/moteoversikt`;
   } catch (e) {
     yield put(avlysMoteFeilet());
   }

--- a/src/data/modiacontext/modiacontext.ts
+++ b/src/data/modiacontext/modiacontext.ts
@@ -7,7 +7,9 @@ import {
   HENT_AKTIVBRUKER_FEILET,
   HENTER_AKTIVENHET,
   HENT_AKTIVENHET_FEILET,
+  AKTIVBRUKER_HENTET,
 } from "./modiacontext_actions";
+import { RSContext } from "./modiacontextTypes";
 
 export interface ModiaContextState {
   pushet: boolean;
@@ -17,7 +19,8 @@ export interface ModiaContextState {
   hentingEnhetFeilet: boolean;
   henterBruker: boolean;
   hentingBrukerFeilet: boolean;
-  data: any;
+  hentingBrukerForsokt: boolean;
+  data: RSContext | Record<string, unknown>;
 }
 
 export const initialState: ModiaContextState = {
@@ -28,6 +31,7 @@ export const initialState: ModiaContextState = {
   hentingEnhetFeilet: false,
   henterBruker: false,
   hentingBrukerFeilet: false,
+  hentingBrukerForsokt: false,
   data: {},
 };
 
@@ -57,16 +61,24 @@ const modiacontext: Reducer<ModiaContextState> = (
         pushingFeilet: false,
       });
     }
+    case AKTIVBRUKER_HENTET: {
+      return Object.assign({}, state, {
+        henterBruker: false,
+        hentingBrukerForsokt: true,
+      });
+    }
     case HENT_AKTIVBRUKER_FEILET: {
       return Object.assign({}, state, {
         henterBruker: false,
         hentingBrukerFeilet: true,
+        hentingBrukerForsokt: true,
       });
     }
     case HENTER_AKTIVBRUKER: {
       return Object.assign({}, state, {
         henterBruker: true,
         hentingBrukerFeilet: false,
+        hentingBrukerForsokt: false,
       });
     }
     case HENT_AKTIVENHET_FEILET: {

--- a/src/data/modiacontext/modiacontextSagas.ts
+++ b/src/data/modiacontext/modiacontextSagas.ts
@@ -2,7 +2,11 @@ import { call, put, fork, takeEvery, all } from "redux-saga/effects";
 import { get, post } from "../../api";
 import * as actions from "./modiacontext_actions";
 
-export function* pushModiacontextSaga(action: any) {
+const redirectWithoutFnrInUrl = (fnr: string) => {
+  window.location.href = window.location.pathname.replace(`/${fnr}`, "");
+};
+
+export function* pushModiacontextSaga(action: actions.PushModiaContextAction) {
   yield put(actions.pusherModiaContext());
   try {
     const path = `${process.env.REACT_APP_CONTEXTHOLDER_ROOT}/context`;
@@ -10,18 +14,18 @@ export function* pushModiacontextSaga(action: any) {
       verdi: action.data.verdi,
       eventType: action.data.eventType,
     });
-    yield put(actions.modiaContextPushet());
+    redirectWithoutFnrInUrl(action.data.verdi);
   } catch (e) {
     yield put(actions.pushModiaContextFeilet());
   }
 }
 
-export function* aktivBrukerSaga(action: any) {
+export function* aktivBrukerSaga() {
   yield put(actions.henterAktivBruker());
   try {
     const path = `${process.env.REACT_APP_CONTEXTHOLDER_ROOT}/context/aktivbruker`;
     const data = yield call(get, path);
-    action.data.callback(data.aktivBruker);
+    yield put(actions.aktivBrukerHentet(data));
   } catch (e) {
     yield put(actions.hentAktivBrukerFeilet());
   }

--- a/src/data/modiacontext/modiacontextTypes.ts
+++ b/src/data/modiacontext/modiacontextTypes.ts
@@ -1,0 +1,14 @@
+export enum EventType {
+  NY_AKTIV_BRUKER = "NY_AKTIV_BRUKER",
+  NY_AKTIV_ENHET = "NY_AKTIV_ENHET",
+}
+
+export interface RSContext {
+  aktivBruker: string;
+  aktivEnhet: string;
+}
+
+export interface RSNyContext {
+  verdi: string;
+  eventType: string;
+}

--- a/src/data/modiacontext/modiacontext_actions.ts
+++ b/src/data/modiacontext/modiacontext_actions.ts
@@ -1,3 +1,5 @@
+import { RSContext, RSNyContext } from "./modiacontextTypes";
+
 export const PUSH_MODIACONTEXT_FORESPURT = "PUSH_MODIACONTEXT_FORESPURT";
 export const PUSH_MODIACONTEXT_FEILET = "PUSH_MODIACONTEXT_FEILET";
 export const MODIACONTEXT_PUSHET = "MODIACONTEXT_PUSHET";
@@ -13,10 +15,19 @@ export const HENTER_AKTIVENHET = "HENTER_AKTIVENHET";
 export const HENT_AKTIVENHET_FEILET = "HENT_AKTIVENHET_FEILET";
 export const AKTIVENHET_HENTET = "AKTIVENHET_HENTET";
 
-export function hentAktivBruker(data: any) {
+export interface AktivBrukerHentetAction {
+  type: typeof AKTIVBRUKER_HENTET;
+  data: RSContext;
+}
+
+export interface PushModiaContextAction {
+  type: typeof PUSH_MODIACONTEXT_FORESPURT;
+  data: RSNyContext;
+}
+
+export function hentAktivBruker() {
   return {
     type: HENT_AKTIVBRUKER_FORESPURT,
-    data,
   };
 }
 
@@ -32,7 +43,7 @@ export function henterAktivBruker() {
   };
 }
 
-export function aktivBrukerHentet(data: any) {
+export function aktivBrukerHentet(data: RSContext): AktivBrukerHentetAction {
   return {
     type: AKTIVBRUKER_HENTET,
     data,
@@ -77,7 +88,7 @@ export function pusherModiaContext() {
   };
 }
 
-export function pushModiaContext(data: any) {
+export function pushModiaContext(data: RSNyContext): PushModiaContextAction {
   return {
     type: PUSH_MODIACONTEXT_FORESPURT,
     data,

--- a/src/data/mote/moterSagas.ts
+++ b/src/data/mote/moterSagas.ts
@@ -51,7 +51,7 @@ export function* avbrytMote(action: any) {
 
     yield put(actions.moteAvbrutt(action.uuid));
     yield put(historikkActions.hentHistorikk(action.fnr, "MOTER"));
-    window.location.href = `/sykefravaer/${action.fnr}/moteoversikt`;
+    window.location.href = `/sykefravaer/moteoversikt`;
   } catch (e) {
     yield put(actions.avbrytMoteFeilet());
   }

--- a/src/data/rootState.ts
+++ b/src/data/rootState.ts
@@ -21,6 +21,7 @@ import oppfolgingsplanerlps, {
   OppfolgingsplanerlpsState,
 } from "./oppfolgingsplan/oppfolgingsplanerlps";
 import enhet, { EnhetState } from "./valgtenhet/enhet";
+import valgtbruker, { ValgtBrukerState } from "./valgtbruker/valgtbruker";
 import sykmeldinger, { SykmeldingerState } from "./sykmelding/sykmeldinger";
 import behandlendeEnhet, {
   BehandlendeEnhetState,
@@ -65,6 +66,7 @@ export interface RootState {
   oppfoelgingsdialoger: OppfolgingsplanerState;
   oppfolgingsplanerlps: OppfolgingsplanerlpsState;
   enhet: EnhetState;
+  valgtbruker: ValgtBrukerState;
   sykmeldinger: SykmeldingerState;
   behandlendeEnhet: BehandlendeEnhetState;
   diskresjonskode: DiskresjonskodeState;
@@ -98,6 +100,7 @@ export const rootReducer = combineReducers<RootState>({
   oppfoelgingsdialoger,
   oppfolgingsplanerlps,
   enhet,
+  valgtbruker,
   sykmeldinger,
   behandlendeEnhet,
   diskresjonskode,

--- a/src/data/valgtbruker/valgtbruker.ts
+++ b/src/data/valgtbruker/valgtbruker.ts
@@ -1,0 +1,32 @@
+import { Reducer } from "redux";
+import {
+  AKTIVBRUKER_HENTET,
+  AktivBrukerHentetAction,
+} from "../modiacontext/modiacontext_actions";
+
+export interface ValgtBrukerState {
+  personident: string;
+}
+
+const initialState: ValgtBrukerState = {
+  personident: "",
+};
+
+const valgtbruker: Reducer<ValgtBrukerState, AktivBrukerHentetAction> = (
+  state = initialState,
+  action
+) => {
+  switch (action.type) {
+    case AKTIVBRUKER_HENTET: {
+      return {
+        ...state,
+        personident: action.data.aktivBruker,
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};
+
+export default valgtbruker;

--- a/src/decorator/Decorator.tsx
+++ b/src/decorator/Decorator.tsx
@@ -1,9 +1,17 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect } from "react";
 import { useDispatch } from "react-redux";
 import NAVSPA from "@navikt/navspa";
 import { DecoratorProps } from "./decoratorProps";
 import decoratorConfig from "./decoratorConfig";
 import { valgtEnhet } from "../data/valgtenhet/enhet_actions";
+import { useValgtPersonident } from "../hooks/useValgtBruker";
+import { hentVeilederinfo } from "../data/veilederinfo/veilederinfo_actions";
+import { hentBehandlendeEnhet } from "../data/behandlendeenhet/behandlendeEnhet_actions";
+import { hentNavbruker } from "../data/navbruker/navbruker_actions";
+import { hentLedere } from "../data/leder/ledere_actions";
+import { hentPersonAdresse } from "../data/personinfo/personInfo_actions";
+import { sjekkTilgang } from "../data/tilgang/tilgang_actions";
+import { erGyldigFodselsnummer } from "../utils/frnValideringUtils";
 
 const InternflateDecorator = NAVSPA.importer<DecoratorProps>(
   "internarbeidsflatefs"
@@ -12,11 +20,21 @@ const InternflateDecorator = NAVSPA.importer<DecoratorProps>(
 const Decorator = () => {
   const dispatch = useDispatch();
 
-  const handlePersonsokSubmit = (nyttFnr: string) => {
-    const fnr = window.location.pathname.split("/")[2];
-    if (nyttFnr !== fnr) {
-      window.location.href = `/sykefravaer/${nyttFnr}`;
+  const fnr = useValgtPersonident();
+
+  useEffect(() => {
+    if (erGyldigFodselsnummer(fnr)) {
+      dispatch(hentVeilederinfo());
+      dispatch(hentBehandlendeEnhet(fnr));
+      dispatch(hentNavbruker(fnr));
+      dispatch(hentLedere(fnr));
+      dispatch(hentPersonAdresse(fnr));
+      dispatch(sjekkTilgang(fnr));
     }
+  }, []);
+
+  const handlePersonsokSubmit = () => {
+    window.location.reload();
   };
 
   const handleChangeEnhet = (nyEnhet: string) => {
@@ -24,9 +42,10 @@ const Decorator = () => {
   };
 
   const config = useCallback(decoratorConfig, [
+    fnr,
     handlePersonsokSubmit,
     handleChangeEnhet,
-  ])(handlePersonsokSubmit, handleChangeEnhet);
+  ])(fnr, handlePersonsokSubmit, handleChangeEnhet);
 
   return <InternflateDecorator {...config} />;
 };

--- a/src/decorator/decoratorConfig.ts
+++ b/src/decorator/decoratorConfig.ts
@@ -1,6 +1,7 @@
 import { DecoratorProps, EnhetDisplay, FnrDisplay } from "./decoratorProps";
 
 const decoratorConfig = (
+  initValueFnr: string,
   setFnr: (fnr: string) => void,
   setEnhet: (enhet: string) => void
 ): DecoratorProps => {
@@ -10,7 +11,7 @@ const decoratorConfig = (
       initialValue: null,
       display: FnrDisplay.SOKEFELT,
       onChange: (value) => {
-        if (value) {
+        if (value && value !== initValueFnr) {
           setFnr(value);
         }
       },

--- a/src/hooks/useFnrParam.ts
+++ b/src/hooks/useFnrParam.ts
@@ -1,6 +1,0 @@
-import { useParams } from "react-router-dom";
-
-export const useFnrParam = (): string => {
-  const { fnr } = useParams<{ fnr: string }>();
-  return fnr;
-};

--- a/src/hooks/useValgtBruker.ts
+++ b/src/hooks/useValgtBruker.ts
@@ -1,0 +1,5 @@
+import { useAppSelector } from "./hooks";
+
+export const useValgtPersonident = (): string => {
+  return useAppSelector((state) => state.valgtbruker.personident);
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,31 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import AppRouter from "./routers/AppRouter";
-import { sjekkTilgang } from "./data/tilgang/tilgang_actions";
-import { hentVeilederinfo } from "./data/veilederinfo/veilederinfo_actions";
-import { hentBehandlendeEnhet } from "./data/behandlendeenhet/behandlendeEnhet_actions";
-import { hentNavbruker } from "./data/navbruker/navbruker_actions";
-import { hentLedere } from "./data/leder/ledere_actions";
-import { hentPersonAdresse } from "./data/personinfo/personInfo_actions";
 import { setupStore } from "./data/store";
 import "./styles/styles.less";
 import { initAmplitude } from "./amplitude/amplitude";
 
 const store = setupStore();
 
-const fnr = window.location.pathname.split("/")[2];
-
 initAmplitude();
-
-const fnrRegex = new RegExp("^[0-9]{11}$");
-if (fnrRegex.test(fnr)) {
-  store.dispatch(hentVeilederinfo());
-  store.dispatch(hentBehandlendeEnhet(fnr));
-  store.dispatch(hentNavbruker(fnr));
-  store.dispatch(hentLedere(fnr));
-  store.dispatch(hentPersonAdresse(fnr));
-  store.dispatch(sjekkTilgang(fnr));
-}
 
 ReactDOM.render(
   <Provider store={store}>

--- a/test/actions/modiacontext_actionsTest.js
+++ b/test/actions/modiacontext_actionsTest.js
@@ -35,16 +35,9 @@ describe("modiacontext_actions", () => {
   });
 
   it("har en hentAktivBruker-funksjon som returnerer riktig action", () => {
-    const action = actions.hentAktivBruker({
-      verdi: "fnr",
-      eventType: "NY_AKTIV_BRUKER",
-    });
+    const action = actions.hentAktivBruker();
     expect(action).to.deep.equal({
       type: actions.HENT_AKTIVBRUKER_FORESPURT,
-      data: {
-        verdi: "fnr",
-        eventType: "NY_AKTIV_BRUKER",
-      },
     });
   });
 

--- a/test/containers/AvbrytMoteContainerTest.js
+++ b/test/containers/AvbrytMoteContainerTest.js
@@ -142,11 +142,13 @@ describe("AvbrytMoteContainer", () => {
         match: {
           params: {
             moteUuid: "2fedc0da-efec-4b6e-8597-a021628058ae",
-            fnr: "123",
           },
         },
       };
       state = {
+        valgtbruker: {
+          personident: "123",
+        },
         epostinnhold: {
           hentingFeilet: false,
         },

--- a/test/containers/BekreftMoteContainerTest.js
+++ b/test/containers/BekreftMoteContainerTest.js
@@ -124,11 +124,13 @@ describe("BekreftMoteContainer", () => {
         match: {
           params: {
             alternativId: "328",
-            fnr: "123",
           },
         },
       };
       state = {
+        valgtbruker: {
+          personident: "123",
+        },
         epostinnhold: { henter: false, data: {} },
         moter: {
           data: [

--- a/test/containers/MotebookingContainerTest.js
+++ b/test/containers/MotebookingContainerTest.js
@@ -103,7 +103,6 @@ describe("MotebookingContainer", () => {
 
   describe("mapStateToProps", () => {
     let state;
-    let ownProps;
 
     beforeEach(() => {
       state = {
@@ -130,18 +129,14 @@ describe("MotebookingContainer", () => {
           hentingFeilet: false,
           henter: false,
         },
-      };
-      ownProps = {
-        match: {
-          params: {
-            fnr: "887766",
-          },
+        valgtbruker: {
+          personident: "887766",
         },
       };
     });
 
     it("Skal returnere fnr", () => {
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.fnr).to.equal("887766");
     });
 
@@ -152,7 +147,7 @@ describe("MotebookingContainer", () => {
           status: "OPPRETTET",
         },
       ];
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.mote).to.deep.equal({
         id: 1,
         status: "OPPRETTET",
@@ -166,7 +161,7 @@ describe("MotebookingContainer", () => {
           status: "BEKREFTET",
         },
       ];
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.mote).to.deep.equal({
         id: 1,
         status: "BEKREFTET",
@@ -180,13 +175,13 @@ describe("MotebookingContainer", () => {
           status: "AVBRUTT",
         },
       ];
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.mote).to.be.equal(undefined);
     });
 
     it("Skal returnere mote === undefined dersom det ikke finnes møter", () => {
       state.moter.data = [];
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.mote).to.be.equal(undefined);
     });
 
@@ -197,7 +192,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.henter = true;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.henter).to.be.equal(true);
     });
 
@@ -209,7 +204,7 @@ describe("MotebookingContainer", () => {
       ];
       state.moter.hentingForsokt = true;
       state.ledere.henter = false;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.henter).to.be.equal(false);
     });
 
@@ -221,7 +216,7 @@ describe("MotebookingContainer", () => {
       ];
       state.moter.hentingForsokt = false;
       state.ledere.henter = false;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.henter).to.be.equal(true);
     });
 
@@ -232,7 +227,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.sender = true;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.sender).to.be.equal(true);
     });
 
@@ -243,7 +238,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.sender = false;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.sender).to.be.equal(false);
     });
 
@@ -254,7 +249,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.hentingFeilet = true;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.hentingFeilet).to.be.equal(true);
     });
 
@@ -265,7 +260,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.hentingFeilet = false;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.hentingFeilet).to.be.equal(false);
     });
 
@@ -276,7 +271,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.sendingFeilet = true;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.sendingFeilet).to.be.equal(true);
     });
 
@@ -287,7 +282,7 @@ describe("MotebookingContainer", () => {
         },
       ];
       state.moter.sendingFeilet = false;
-      const props = mapStateToProps(state, ownProps);
+      const props = mapStateToProps(state);
       expect(props.sendingFeilet).to.be.equal(false);
     });
   });

--- a/test/containers/SykepengesoknadContainerTest.js
+++ b/test/containers/SykepengesoknadContainerTest.js
@@ -45,6 +45,9 @@ describe("SykepengesoknadContainer", () => {
           navn: "Ola Nordmann",
         },
       },
+      valgtbruker: {
+        personident: "887766",
+      },
     };
     ownProps = {
       match: {

--- a/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
@@ -19,6 +19,12 @@ import { texts as valideringsTexts } from "../../src/utils/valideringUtils";
 
 const realState = createStore(rootReducer).getState();
 const store = configureStore([]);
+const arbeidstakerPersonIdent = "05087321470";
+const mockState = {
+  valgtbruker: {
+    personident: arbeidstakerPersonIdent,
+  },
+};
 const moteUuid = "123abc";
 const mote: DialogmoteDTO = {
   arbeidsgiver: {
@@ -27,7 +33,7 @@ const mote: DialogmoteDTO = {
     varselList: [],
   },
   arbeidstaker: {
-    personIdent: "05087321470",
+    personIdent: arbeidstakerPersonIdent,
     type: "ARBEIDSTAKER",
     varselList: [],
   },
@@ -47,11 +53,9 @@ const tekstTilArbeidsgiver = "Noe tekst til arbeidsgiver";
 describe("AvlysDialogmoteSkjemaTest", () => {
   it("viser møtetidspunkt", () => {
     const wrapper = mount(
-      <MemoryRouter
-        initialEntries={["/sykefravaer/05087321470/dialogmote/123abc/avlys"]}
-      >
-        <Route path="/sykefravaer/:fnr/dialogmote/:dialogmoteUuid/avlys">
-          <Provider store={store({ ...realState })}>
+      <MemoryRouter initialEntries={["/sykefravaer/dialogmote/123abc/avlys"]}>
+        <Route path="/sykefravaer/dialogmote/:dialogmoteUuid/avlys">
+          <Provider store={store({ ...realState, ...mockState })}>
             <AvlysDialogmoteSkjema dialogmote={mote} pageTitle="test" />
           </Provider>
         </Route>
@@ -63,11 +67,9 @@ describe("AvlysDialogmoteSkjemaTest", () => {
   });
   it("validerer begrunnelser", () => {
     const wrapper = mount(
-      <MemoryRouter
-        initialEntries={["/sykefravaer/05087321470/dialogmote/123abc/avlys"]}
-      >
-        <Route path="/sykefravaer/:fnr/dialogmote/:dialogmoteUuid/avlys">
-          <Provider store={store({ ...realState })}>
+      <MemoryRouter initialEntries={["/sykefravaer/dialogmote/123abc/avlys"]}>
+        <Route path="/sykefravaer/dialogmote/:dialogmoteUuid/avlys">
+          <Provider store={store({ ...realState, ...mockState })}>
             <AvlysDialogmoteSkjema dialogmote={mote} pageTitle="test" />
           </Provider>
         </Route>
@@ -105,11 +107,9 @@ describe("AvlysDialogmoteSkjemaTest", () => {
   });
   it("valideringsmeldinger forsvinner ved utbedring", () => {
     const wrapper = mount(
-      <MemoryRouter
-        initialEntries={["/sykefravaer/05087321470/dialogmote/123abc/avlys"]}
-      >
-        <Route path="/sykefravaer/:fnr/dialogmote/:dialogmoteUuid/avlys">
-          <Provider store={store({ ...realState })}>
+      <MemoryRouter initialEntries={["/sykefravaer/dialogmote/123abc/avlys"]}>
+        <Route path="/sykefravaer/dialogmote/:dialogmoteUuid/avlys">
+          <Provider store={store({ ...realState, ...mockState })}>
             <AvlysDialogmoteSkjema dialogmote={mote} pageTitle="test" />
           </Provider>
         </Route>
@@ -173,12 +173,10 @@ describe("AvlysDialogmoteSkjemaTest", () => {
     expect(wrapper.find(Feiloppsummering)).to.have.length(1);
   });
   it("avlyser møte ved submit av skjema", () => {
-    const mockStore = store({ ...realState });
+    const mockStore = store({ ...realState, ...mockState });
     const wrapper = mount(
-      <MemoryRouter
-        initialEntries={["/sykefravaer/05087321470/dialogmote/123abc/avlys"]}
-      >
-        <Route path="/sykefravaer/:fnr/dialogmote/:dialogmoteUuid/avlys">
+      <MemoryRouter initialEntries={["/sykefravaer/dialogmote/123abc/avlys"]}>
+        <Route path="/sykefravaer/dialogmote/:dialogmoteUuid/avlys">
           <Provider store={mockStore}>
             <AvlysDialogmoteSkjema dialogmote={mote} pageTitle="test" />
           </Provider>
@@ -201,7 +199,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
 
     expect(mockStore.getActions()[0]).to.deep.equal({
       type: "AVLYS_MOTE_FORESPURT",
-      fnr: "05087321470",
+      fnr: arbeidstakerPersonIdent,
       moteUuid: moteUuid,
       data: {
         arbeidsgiver: {

--- a/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
@@ -69,6 +69,9 @@ const mockState = {
   enhet: {
     valgtEnhet: navEnhet,
   },
+  valgtbruker: {
+    personident: arbeidstakerFnr,
+  },
   ledere: {
     data: [
       {
@@ -89,10 +92,8 @@ const mockState = {
 describe("DialogmoteInnkallingSkjema", () => {
   it("validerer arbeidsgiver, dato, tid og sted", () => {
     const wrapper = mount(
-      <MemoryRouter
-        initialEntries={[`/sykefravaer/${arbeidstakerFnr}/dialogmote`]}
-      >
-        <Route path="/sykefravaer/:fnr/dialogmote">
+      <MemoryRouter initialEntries={[`/sykefravaer/dialogmote`]}>
+        <Route path="/sykefravaer/dialogmote">
           <Provider store={store({ ...realState, ...mockState })}>
             <DialogmoteInnkallingSkjema pageTitle="Test" />
           </Provider>
@@ -138,10 +139,8 @@ describe("DialogmoteInnkallingSkjema", () => {
 
   it("valideringsmeldinger forsvinner ved utbedring", () => {
     const wrapper = mount(
-      <MemoryRouter
-        initialEntries={[`/sykefravaer/${arbeidstakerFnr}/dialogmote`]}
-      >
-        <Route path="/sykefravaer/:fnr/dialogmote">
+      <MemoryRouter initialEntries={[`/sykefravaer/dialogmote`]}>
+        <Route path="/sykefravaer/dialogmote">
           <Provider store={store({ ...realState, ...mockState })}>
             <DialogmoteInnkallingSkjema pageTitle="Test" />
           </Provider>
@@ -231,8 +230,8 @@ describe("DialogmoteInnkallingSkjema", () => {
   it("oppretter innkalling med verdier fra skjema", () => {
     const mockStore = store({ ...realState, ...mockState });
     const wrapper = mount(
-      <MemoryRouter initialEntries={["/sykefravaer/05087321470/dialogmote"]}>
-        <Route path="/sykefravaer/:fnr/dialogmote">
+      <MemoryRouter initialEntries={["/sykefravaer/dialogmote"]}>
+        <Route path="/sykefravaer/dialogmote">
           <Provider store={mockStore}>
             <DialogmoteInnkallingSkjema pageTitle="Test" />
           </Provider>
@@ -299,8 +298,8 @@ describe("DialogmoteInnkallingSkjema", () => {
   it("forhåndsviser innkalling til arbeidstaker og arbeidsgiver", () => {
     const mockStore = store({ ...realState, ...mockState });
     const wrapper = mount(
-      <MemoryRouter initialEntries={["/sykefravaer/05087321470/dialogmote"]}>
-        <Route path="/sykefravaer/:fnr/dialogmote">
+      <MemoryRouter initialEntries={["/sykefravaer/dialogmote"]}>
+        <Route path="/sykefravaer/dialogmote">
           <Provider store={mockStore}>
             <DialogmoteInnkallingSkjema pageTitle="Test" />
           </Provider>

--- a/test/mote/components/BesvarteTidspunkterTest.js
+++ b/test/mote/components/BesvarteTidspunkterTest.js
@@ -87,7 +87,6 @@ describe("BesvarteTidspunkter", () => {
             mote={moteBesvartTrueAvArbeidsgiver}
             alternativer={moteBesvartTrueAvArbeidsgiver.alternativer}
             deltakertype={NAV_VEILEDER}
-            fnr="123"
           />
         </BrowserRouter>
       );
@@ -100,7 +99,7 @@ describe("BesvarteTidspunkter", () => {
 
     it("Lenken skal ha riktig to-parameter", () => {
       component.find(Link).forEach((l) => {
-        expect(l.prop("to")).to.contain("/sykefravaer/123/mote/bekreft/");
+        expect(l.prop("to")).to.contain("/sykefravaer/mote/bekreft/");
       });
     });
 
@@ -117,7 +116,6 @@ describe("BesvarteTidspunkter", () => {
             mote={moteIkkeBesvart}
             alternativer={moteIkkeBesvart.alternativer}
             deltakertype={NAV_VEILEDER}
-            fnr="123"
           />
         </BrowserRouter>
       );
@@ -130,7 +128,7 @@ describe("BesvarteTidspunkter", () => {
 
     it("Lenken skal ha riktig to-parameter", () => {
       component.find(Link).forEach((l) => {
-        expect(l.prop("to")).to.contain("/sykefravaer/123/mote/bekreft/");
+        expect(l.prop("to")).to.contain("/sykefravaer/mote/bekreft/");
       });
     });
   });
@@ -147,7 +145,6 @@ describe("BesvarteTidspunkter", () => {
           mote={mote}
           alternativer={moteBesvartTrueAvArbeidsgiver.alternativer}
           deltakertype={NAV_VEILEDER}
-          fnr="123"
         />
       );
     });
@@ -165,7 +162,6 @@ describe("BesvarteTidspunkter", () => {
           mote={mote}
           alternativer={moteBesvartTrueAvArbeidsgiver.alternativer}
           deltakertype={NAV_VEILEDER}
-          fnr="123"
         />
       );
     });

--- a/test/reducers/modiacontextTest.js
+++ b/test/reducers/modiacontextTest.js
@@ -33,6 +33,7 @@ describe("modiacontext", () => {
     expect(state).to.deep.equal({
       henterBruker: true,
       hentingBrukerFeilet: false,
+      hentingBrukerForsokt: false,
       data: {},
     });
   });
@@ -43,6 +44,7 @@ describe("modiacontext", () => {
     expect(state).to.deep.equal({
       henterBruker: false,
       hentingBrukerFeilet: true,
+      hentingBrukerForsokt: true,
       data: {},
     });
   });


### PR DESCRIPTION
Use Fodselsnummer from Modiacontext instead of Fodselsnummer from url:
- Get AktivBruker from modiacontextholder
- If AktivBruker is not null, then AktivBruker is used.
- If AktivBruker is null, then the user must submit a valid Fodselsnumer in Decorator.
- Support linking to Syfomodiaperson with Fodselsnummer in url from external applications by taking Fodselsnummer from url, changing modiacontext and the redirecting user to url without Fodselsnummer in url. This feature is added to avoid changing multiple applications simultaneously and to provide backward compatibility.