### PR TITLE
Referat container with route and link

### DIFF
--- a/src/components/dialogmote/DialogmoteSideContainer.tsx
+++ b/src/components/dialogmote/DialogmoteSideContainer.tsx
@@ -1,0 +1,70 @@
+import React, { ReactElement, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { useAppSelector } from "../../hooks/hooks";
+import { useTilgang } from "../../hooks/useTilgang";
+import { useDispatch } from "react-redux";
+import { fetchDialogmote } from "../../data/dialogmote/dialogmote_actions";
+import Side from "../../sider/Side";
+import { MOETEPLANLEGGER } from "../../enums/menypunkter";
+import SideLaster from "../SideLaster";
+import Sidetopp from "../Sidetopp";
+import Feilmelding from "../Feilmelding";
+import { DialogmoteDTO } from "../../data/dialogmote/dialogmoteTypes";
+
+interface DialogmoteSideProps {
+  title: string;
+  header: string;
+  children: (dialogmote: DialogmoteDTO) => ReactElement;
+}
+
+const texts = {
+  moteNotFound: "Fant ikke dialogmøte",
+};
+
+export const DialogmoteSideContainer = ({
+  title,
+  header,
+  children,
+}: DialogmoteSideProps): ReactElement => {
+  const { dialogmoteUuid, fnr } = useParams<{
+    dialogmoteUuid: string;
+    fnr: string;
+  }>();
+  const {
+    henterMote,
+    henterMoteFeilet,
+    dialogmoter,
+    moterHentet,
+  } = useAppSelector((state) => state.dialogmote);
+  const { tilgang, hentingTilgangFeilet, henterTilgang } = useTilgang();
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (!moterHentet) {
+      dispatch(fetchDialogmote(fnr));
+    }
+  }, [moterHentet]);
+
+  const henter = henterTilgang || henterMote;
+  const hentingFeilet = hentingTilgangFeilet || henterMoteFeilet;
+  const dialogmote = dialogmoter.find(
+    (dialogmote) => dialogmote.uuid === dialogmoteUuid
+  );
+
+  return (
+    <Side fnr={fnr} tittel={title} aktivtMenypunkt={MOETEPLANLEGGER}>
+      <SideLaster
+        henter={henter}
+        hentingFeilet={hentingFeilet}
+        tilgang={tilgang}
+      >
+        <Sidetopp tittel={header} />
+        {dialogmote ? (
+          children(dialogmote)
+        ) : (
+          <Feilmelding tittel={texts.moteNotFound} />
+        )}
+      </SideLaster>
+    </Side>
+  );
+};

--- a/src/components/dialogmote/avlys/AvlysDialogmoteContainer.tsx
+++ b/src/components/dialogmote/avlys/AvlysDialogmoteContainer.tsx
@@ -1,67 +1,21 @@
-import React, { ReactElement, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import Side from "../../../sider/Side";
-import { MOETEPLANLEGGER } from "../../../enums/menypunkter";
-import SideLaster from "../../SideLaster";
-import Sidetopp from "../../Sidetopp";
-import { useTilgang } from "../../../hooks/useTilgang";
+import React, { ReactElement } from "react";
 import AvlysDialogmoteSkjema from "./AvlysDialogmoteSkjema";
-import { useAppSelector } from "../../../hooks/hooks";
-import Feilmelding from "../../Feilmelding";
-import { useDispatch } from "react-redux";
-import { fetchDialogmote } from "../../../data/dialogmote/dialogmote_actions";
+import { DialogmoteSideContainer } from "../DialogmoteSideContainer";
 
 const texts = {
   pageTitle: "Avlys dialogmøte",
   pageHeader: "Avlys dialogmøte",
-  moteNotFound: "Fant ikke dialogmøte",
 };
 
-const AvlysDialogmoteContainer = (): ReactElement => {
-  const { dialogmoteUuid, fnr } = useParams<{
-    dialogmoteUuid: string;
-    fnr: string;
-  }>();
-  const {
-    henterMote,
-    henterMoteFeilet,
-    dialogmoter,
-    moterHentet,
-  } = useAppSelector((state) => state.dialogmote);
-  const { tilgang, hentingTilgangFeilet, henterTilgang } = useTilgang();
-
-  const dispatch = useDispatch();
-  useEffect(() => {
-    if (!moterHentet) {
-      dispatch(fetchDialogmote(fnr));
-    }
-  }, [moterHentet]);
-
-  const henter = henterTilgang || henterMote;
-  const hentingFeilet = hentingTilgangFeilet || henterMoteFeilet;
-  const dialogmote = dialogmoter.find(
-    (dialogmote) => dialogmote.uuid === dialogmoteUuid
-  );
-
-  return (
-    <Side fnr={fnr} tittel={texts.pageTitle} aktivtMenypunkt={MOETEPLANLEGGER}>
-      <SideLaster
-        henter={henter}
-        hentingFeilet={hentingFeilet}
-        tilgang={tilgang}
-      >
-        <Sidetopp tittel={texts.pageHeader} />
-        {dialogmote ? (
-          <AvlysDialogmoteSkjema
-            dialogmote={dialogmote}
-            pageTitle={texts.pageTitle}
-          />
-        ) : (
-          <Feilmelding tittel={texts.moteNotFound} />
-        )}
-      </SideLaster>
-    </Side>
-  );
-};
+const AvlysDialogmoteContainer = (): ReactElement => (
+  <DialogmoteSideContainer title={texts.pageTitle} header={texts.pageHeader}>
+    {(dialogmote) => (
+      <AvlysDialogmoteSkjema
+        dialogmote={dialogmote}
+        pageTitle={texts.pageTitle}
+      />
+    )}
+  </DialogmoteSideContainer>
+);
 
 export default AvlysDialogmoteContainer;

--- a/src/components/dialogmote/referat/DialogmoteReferatContainer.tsx
+++ b/src/components/dialogmote/referat/DialogmoteReferatContainer.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ReactElement } from "react";
+import { DialogmoteSideContainer } from "../DialogmoteSideContainer";
+import Referat from "./Referat";
+
+const texts = {
+  pageTitle: "Referat fra dialogmøte",
+  pageHeader: "Referat fra dialogmøte",
+};
+
+const DialogmoteReferatContainer = (): ReactElement => (
+  <DialogmoteSideContainer title={texts.pageTitle} header={texts.pageHeader}>
+    {(dialogmote) => <Referat dialogmote={dialogmote} />}
+  </DialogmoteSideContainer>
+);
+
+export default DialogmoteReferatContainer;

--- a/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -132,9 +132,11 @@ export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
             {texts.avlysMote}
           </TrackedKnapp>
         </Link>
-        <TrackedHovedknapp context={texts.innkallingSendtTrackingContext}>
-          {texts.skrivReferat}
-        </TrackedHovedknapp>
+        <Link to={`/sykefravaer/dialogmote/${dialogmote.uuid}/referat`}>
+          <TrackedHovedknapp context={texts.innkallingSendtTrackingContext}>
+            {texts.skrivReferat}
+          </TrackedHovedknapp>
+        </Link>
       </FlexRow>
     </DialogmotePanel>
   );

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -27,6 +27,7 @@ import {
 import { EventType } from "../data/modiacontext/modiacontextTypes";
 import AppSpinner from "../components/AppSpinner";
 import { useAppSelector } from "../hooks/hooks";
+import DialogmoteReferatContainer from "../components/dialogmote/referat/DialogmoteReferatContainer";
 
 const getFnrFromParams = (): string => {
   return window.location.pathname.split("/")[2];
@@ -70,6 +71,13 @@ const AktivBrukerRouter = (): ReactElement => {
           path="/sykefravaer/dialogmote/:dialogmoteUuid/avlys"
           exact
           component={AvlysDialogmoteContainer}
+        />
+      )}
+      {erLokalEllerPreprod && (
+        <Route
+          path="/sykefravaer/dialogmote/:dialogmoteUuid/referat"
+          exact
+          component={DialogmoteReferatContainer}
         />
       )}
       <Route


### PR DESCRIPTION
- Lagt til referat-container med egen url og link fra knapp i dialogmøte-status-panel.
- Refaktorert til DialogmoteSideContainer som henter dialogmote med id fra url. Brukes av avlys- og referat-container.
