### PR TITLE
Fix navfarger

### DIFF
--- a/src/colors.ts
+++ b/src/colors.ts
@@ -1,0 +1,7 @@
+export const navLysBlaLighten80 = "#D8F9FF";
+export const navBlaLighten80 = "#cce1f3";
+export const navLysBlaDarken40 = "#368DA8";
+export const navGraBakgrunn = "#f1f1f1";
+export const navGra60 = "#6a6a6a";
+export const white = "#fff";
+export const navBla = "#0067c5";

--- a/src/components/TextDropdown.tsx
+++ b/src/components/TextDropdown.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { useState } from "react";
 import styled from "styled-components";
 import NavFrontendChevron from "nav-frontend-chevron";
-import navFarger from "nav-frontend-core";
+import { navBla } from "../colors";
 
 const BlueText = styled.span`
-  color: ${navFarger.navBla};
+  color: ${navBla};
 `;
 
 const TextAndChevronWrapper = styled.div`

--- a/src/components/dialogmote/referat/ReferatInfoColumn.tsx
+++ b/src/components/dialogmote/referat/ReferatInfoColumn.tsx
@@ -1,13 +1,13 @@
 import styled from "styled-components";
 import Panel from "nav-frontend-paneler";
-import navFarger from "nav-frontend-core";
 import { FlexColumn } from "../../Layout";
 import { ReactElement } from "react";
 import React from "react";
+import { navLysBlaDarken40, navLysBlaLighten80 } from "../../../colors";
 
 const InfoPanel = styled(Panel)`
-  background-color: ${navFarger.navLysBlaLighten80};
-  border: 1px solid ${navFarger.navLysBlaDarken40};
+  background-color: ${navLysBlaLighten80};
+  border: 1px solid ${navLysBlaDarken40};
   margin-top: 1.9em;
 `;
 

--- a/src/components/pengestopp/PengestoppHistorikk.tsx
+++ b/src/components/pengestopp/PengestoppHistorikk.tsx
@@ -11,7 +11,7 @@ import { SykmeldingOldFormat } from "../../data/sykmelding/types/SykmeldingOldFo
 import Panel from "nav-frontend-paneler";
 import styled from "styled-components";
 import { texts } from "./Pengestopp";
-import navFarger from "nav-frontend-core";
+import { navLysBlaDarken40, navLysBlaLighten80 } from "../../colors";
 
 interface IPengestoppDropdown {
   statusEndringList: StatusEndring[];
@@ -19,8 +19,8 @@ interface IPengestoppDropdown {
 }
 
 const StyledBorderedPanel = styled(Panel)`
-  background: ${navFarger.navLysBlaLighten80};
-  border-color: ${navFarger.navLysBlaDarken40};
+  background: ${navLysBlaLighten80};
+  border-color: ${navLysBlaDarken40};
   margin: 0.5em 0;
 `;
 

--- a/src/components/personkort/ledere/PersonKortVirksomhetHeader.tsx
+++ b/src/components/personkort/ledere/PersonKortVirksomhetHeader.tsx
@@ -6,7 +6,7 @@ import { formaterOrgnr } from "../../../utils";
 import { lederHasActiveSykmelding } from "../../../utils/ledereUtils";
 import kanskjeBooleanTilJaNeiKanskje from "../kanskjeBooleanTilJaNeiKanskje";
 import { FabrikkImage } from "../../../../img/ImageComponents";
-import navFarger from "nav-frontend-core";
+import { navGraBakgrunn } from "../../../colors";
 
 const texts = {
   activeSykmelding: "Sykmeldt nå",
@@ -27,7 +27,7 @@ const FlexColumn = styled.div`
 `;
 
 const HeaderStyled = styled.div`
-  background-color: ${navFarger.navGraBakgrunn};
+  background-color: ${navGraBakgrunn};
   padding: 0.5em;
   border: none;
 `;

--- a/src/components/vedtak/VedtakEkspanderbartPanel.tsx
+++ b/src/components/vedtak/VedtakEkspanderbartPanel.tsx
@@ -9,15 +9,14 @@ import { useDispatch, useSelector } from "react-redux";
 import { hentVirksomhet } from "../../data/virksomhet/virksomhet_actions";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import { VedtakDTO } from "../../data/vedtak/vedtak";
-import navFarger from "nav-frontend-core";
+import { navBlaLighten80, white } from "../../colors";
 
 interface StyledPanelProps {
   readonly isActive: boolean;
 }
 
 const StyledPanel = styled(Panel)<StyledPanelProps>`
-  background: ${(props) =>
-    props.isActive ? navFarger.navBlaLighten80 : navFarger.white};
+  background: ${(props) => (props.isActive ? navBlaLighten80 : white)};
 `;
 
 const StyledButton = styled.button`

--- a/src/components/vedtak/VedtakInfoBox.tsx
+++ b/src/components/vedtak/VedtakInfoBox.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Column } from "nav-frontend-grid";
 import styled from "styled-components";
-import navFarger from "nav-frontend-core";
+import { navGra60 } from "../../colors";
 
 const StyledColumn = styled(Column)`
   display: flex;
@@ -18,7 +18,7 @@ const StyledIcon = styled.img`
 const StyledCenteredText = styled.h3`
   text-align: center;
   font-weight: normal;
-  color: ${navFarger.navGra60};
+  color: ${navGra60};
 `;
 
 interface Props {

--- a/src/components/vedtak/VedtakUnselected.tsx
+++ b/src/components/vedtak/VedtakUnselected.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import styled from "styled-components";
 import { Column } from "nav-frontend-grid";
 import { DocumentImage } from "../../../img/ImageComponents";
-import navFarger from "nav-frontend-core";
+import { navGra60 } from "../../colors";
 
 const texts = {
   noSelectedVedtak: "Ingen vedtak er valgt",
@@ -23,7 +23,7 @@ const StyledIcon = styled.img`
 const StyledCenteredText = styled.h4`
   text-align: center;
   font-weight: normal;
-  color: ${navFarger.navGra60};
+  color: ${navGra60};
 `;
 
 const VedtakUnselected = () => {

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -21,6 +21,11 @@ module.exports = merge(common, {
           },
           {
             loader: "css-loader",
+            options: {
+              modules: {
+                compileType: "icss",
+              },
+            },
           },
           {
             loader: "postcss-loader",

--- a/webpack.prod.ts
+++ b/webpack.prod.ts
@@ -21,11 +21,6 @@ module.exports = merge(common, {
           },
           {
             loader: "css-loader",
-            options: {
-              modules: {
-                compileType: "icss",
-              },
-            },
           },
           {
             loader: "postcss-loader",


### PR DESCRIPTION
Bruk av `import navFarger from "nav-frontend-core";` fungerte ikke i preprod/prod (verdiene blir undefined så farger mangler der de nå brukes). Endrer foreløpig tilbake til egendefinerte konstanter for nav-farger og lager egen sak på å få fikset webpack slik at vi kan bruke navFarger i preprod/prod.