### PR TITLE
Update namespace of Syfo-tilgangskontroll

### DIFF
--- a/server.js
+++ b/server.js
@@ -117,7 +117,7 @@ server.use(
 
 server.use(
   "/syfo-tilgangskontroll/api",
-  proxy("syfo-tilgangskontroll.default", {
+  proxy("syfo-tilgangskontroll.teamsykefravr", {
     https: false,
     proxyReqPathResolver: function (req) {
       return `/syfo-tilgangskontroll/api${req.url}`;


### PR DESCRIPTION
Syfo-tilgangskontroll has been moved from namespace default to team namespace teamsykefravr