### PR TITLE
Håndterer nærmeste leder-navn på dialogmøter

### DIFF
--- a/mock/data/dialogmoterMock.ts
+++ b/mock/data/dialogmoterMock.ts
@@ -46,8 +46,6 @@ const createDialogmote = (
     arbeidsgiver: {
       uuid: uuid + 3,
       virksomhetsnummer: "912345678",
-      lederNavn: "He-man",
-      lederEpost: null,
       type: "ARBEIDSGIVER",
       varselList: [
         {

--- a/mock/data/ledereMock.ts
+++ b/mock/data/ledereMock.ts
@@ -83,4 +83,18 @@ export const ledereMock = [
     aktivTom: null,
     arbeidsgiverForskuttererLoenn: null,
   },
+  {
+    navn: "He-man",
+    id: 5,
+    aktoerId: "9909909909904",
+    tlf: "87654321",
+    epost: "test6@test.no",
+    aktiv: true,
+    erOppgitt: true,
+    fomDato: "2021-07-01T12:00:00+01:00",
+    orgnummer: "912345678",
+    organisasjonsnavn: "Skomaker Andersen",
+    aktivTom: null,
+    arbeidsgiverForskuttererLoenn: null,
+  },
 ];

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingContainer.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingContainer.tsx
@@ -23,12 +23,12 @@ const DialogmoteInnkallingContainer = (): ReactElement => {
   const fnr = useValgtPersonident();
   const { hentingLedereForsokt, hentingLedereFeilet } = useLedere();
 
-  const henter = !hentingLedereForsokt;
-  const hentingFeilet = hentingLedereFeilet;
-
   return (
     <Side fnr={fnr} tittel={texts.title} aktivtMenypunkt={MOETEPLANLEGGER}>
-      <SideLaster henter={henter} hentingFeilet={hentingFeilet}>
+      <SideLaster
+        henter={!hentingLedereForsokt}
+        hentingFeilet={hentingLedereFeilet}
+      >
         <Sidetopp tittel={texts.title} />
         <DialogmoteInnkallingWarningAlert type="advarsel">
           {texts.alert}

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingVelgArbeidsgiver.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingVelgArbeidsgiver.tsx
@@ -24,20 +24,23 @@ const ArbeidsgiverTittel = styled(Innholdstittel)`
 `;
 
 const DialogmoteInnkallingVelgArbeidsgiver = (): ReactElement => {
-  const { ledere } = useLedere();
+  const { currentLedere } = useLedere();
   const field = "arbeidsgiver";
   return (
     <DialogmoteInnkallingSkjemaSeksjon>
       <ArbeidsgiverTittel>{texts.title}</ArbeidsgiverTittel>
       <Field<string> name={field}>
         {({ input, meta }) => {
-          const valgtLeder = ledere.find((l) => l.orgnummer === input.value);
+          const valgtLeder = currentLedere.find(
+            (l) => l.orgnummer === input.value
+          );
+
           return (
             <>
               <ArbeidsgiverDropdown
                 id={field}
                 velgArbeidsgiver={input.onChange}
-                ledere={ledere}
+                ledere={currentLedere}
                 label={texts.selectLabel}
               />
               <SkjemaelementFeilmelding>

--- a/src/components/dialogmote/referat/Referat.tsx
+++ b/src/components/dialogmote/referat/Referat.tsx
@@ -32,6 +32,7 @@ import { Forhandsvisning } from "../Forhandsvisning";
 import { useForhandsvisReferat } from "../../../hooks/dialogmote/useForhandsvisReferat";
 import { StandardTekst } from "../../../data/dialogmote/dialogmoteTexts";
 import { NewDialogmotedeltakerAnnenDTO } from "../../../data/dialogmote/types/dialogmoteReferatTypes";
+import { useLedere } from "../../../hooks/useLedere";
 
 export const texts = {
   digitalReferat:
@@ -75,6 +76,7 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
     (state) => state.dialogmote
   );
   const navbruker = useNavBrukerData();
+  const { getCurrentNarmesteLeder } = useLedere();
   const [displayReferatPreview, setDisplayReferatPreview] = useState(false);
 
   const dateAndTimeForMeeting = tilDatoMedManedNavn(dialogmote.tid);
@@ -114,7 +116,9 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
   };
 
   const initialValues: Partial<ReferatSkjemaValues> = {
-    naermesteLeder: dialogmote.arbeidsgiver.lederNavn,
+    naermesteLeder: getCurrentNarmesteLeder(
+      dialogmote.arbeidsgiver.virksomhetsnummer
+    )?.navn,
   };
 
   return (

--- a/src/components/historikk/container/HistorikkContainer.js
+++ b/src/components/historikk/container/HistorikkContainer.js
@@ -116,7 +116,7 @@ export const mapStateToProps = (state) => {
     }) !== -1;
   const henter = state.tilgang.henter || state.ledere.henter || henterTilfeller;
 
-  const currentLedere = state.ledere.data;
+  const currentLedere = state.ledere.currentLedere;
   const formerLedere = state.ledere.formerLedere;
   const allLedere = [...currentLedere, ...formerLedere];
 

--- a/src/components/mote/components/Motelandingsside.tsx
+++ b/src/components/mote/components/Motelandingsside.tsx
@@ -83,7 +83,7 @@ export const Motelandingsside = ({ fnr }: Props) => {
 
       <DialogmoteOnskePanel
         motebehovData={motebehov.data}
-        ledereData={ledere.data}
+        ledereData={ledere.currentLedere}
         oppfolgingstilfelleperioder={oppfolgingstilfelleperioder}
         sykmeldt={navbruker.data}
         veilederinfo={veilederinfo.data}

--- a/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -20,6 +20,7 @@ import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "../../../../utils/dato
 import { Link } from "react-router-dom";
 import { TrackedKnapp } from "../../../buttons/TrackedKnapp";
 import { TrackedHovedknapp } from "../../../buttons/TrackedHovedknapp";
+import { useLedere } from "../../../../hooks/useLedere";
 
 const texts = {
   innkallingSendtTrackingContext: "Møtelandingsside: Sendt innkalling",
@@ -77,13 +78,18 @@ const ParticipantInfo = ({
     dialogmote.arbeidsgiver.varselList
   );
 
+  const { getCurrentNarmesteLeder } = useLedere();
+  const narmesteLederNavn = getCurrentNarmesteLeder(
+    dialogmote.arbeidsgiver.virksomhetsnummer
+  )?.navn;
+
   return (
     <FlexColumn>
       <InfoRow
         icon={getHarLestIcon(arbeidsgiverHarLestInnkallingen)}
         title={
           <span>
-            <b>{texts.naermesteLeder}</b> {dialogmote.arbeidsgiver.lederNavn},
+            <b>{texts.naermesteLeder}</b> {narmesteLederNavn ?? ""},
             {getHarLestText(arbeidsgiverHarLestInnkallingen)}
           </span>
         }

--- a/src/components/mote/container/MotebookingSkjemaContainer.js
+++ b/src/components/mote/container/MotebookingSkjemaContainer.js
@@ -100,7 +100,7 @@ MotebookingSkjemaContainer.propTypes = {
 };
 
 export function mapStateToProps(state, ownProps) {
-  const ledere = state.ledere.data.filter((leder) => {
+  const ledere = state.ledere.currentLedere.filter((leder) => {
     return leder.erOppgitt;
   });
 

--- a/src/data/dialogmote/types/dialogmoteTypes.ts
+++ b/src/data/dialogmote/types/dialogmoteTypes.ts
@@ -53,8 +53,6 @@ export interface DialogmotedeltakerArbeidstakerDTO {
 
 export interface DialogmotedeltakerArbeidsgiverDTO {
   readonly virksomhetsnummer: string;
-  readonly lederNavn?: string;
-  readonly lederEpost?: string;
   readonly type: string;
   readonly varselList: DialogmotedeltakerArbeidsgiverVarselDTO[];
 }

--- a/src/data/leder/ledere.ts
+++ b/src/data/leder/ledere.ts
@@ -3,6 +3,7 @@ import {
   HENTER_LEDERE,
   LEDERE_HENTET,
   HENT_LEDERE_FEILET,
+  LedereActions,
 } from "./ledere_actions";
 import { currentLedere, formerLedere } from "../../utils/ledereUtils";
 
@@ -24,7 +25,7 @@ export interface LedereState {
   hentet: boolean;
   hentingFeilet: boolean;
   hentingForsokt: boolean;
-  data: Leder[];
+  currentLedere: Leder[];
   allLedere: Leder[];
   formerLedere: Leder[];
 }
@@ -34,16 +35,19 @@ export const initialState: LedereState = {
   hentet: false,
   hentingFeilet: false,
   hentingForsokt: false,
-  data: [],
+  currentLedere: [],
   allLedere: [],
   formerLedere: [],
 };
 
-const ledere: Reducer<LedereState> = (state = initialState, action) => {
+const ledere: Reducer<LedereState, LedereActions> = (
+  state = initialState,
+  action
+) => {
   switch (action.type) {
     case LEDERE_HENTET: {
       return {
-        data: currentLedere(action.data),
+        currentLedere: currentLedere(action.data),
         formerLedere: formerLedere(action.data),
         allLedere: action.data,
         henter: false,
@@ -58,7 +62,7 @@ const ledere: Reducer<LedereState> = (state = initialState, action) => {
         hentet: false,
         hentingFeilet: false,
         hentingForsokt: false,
-        data: [],
+        currentLedere: [],
         formerLedere: [],
         allLedere: [],
       };
@@ -69,7 +73,7 @@ const ledere: Reducer<LedereState> = (state = initialState, action) => {
         hentet: false,
         hentingFeilet: true,
         hentingForsokt: true,
-        data: [],
+        currentLedere: [],
         formerLedere: [],
         allLedere: [],
       };

--- a/src/data/leder/ledereSagas.ts
+++ b/src/data/leder/ledereSagas.ts
@@ -1,24 +1,27 @@
 import { call, fork, put, select, takeEvery } from "redux-saga/effects";
 import { get } from "../../api";
 import * as actions from "./ledere_actions";
+import { HentLedereAction } from "./ledere_actions";
+import { RootState } from "../rootState";
+import { Leder } from "./ledere";
 
-export function* hentLedere(action: any) {
-  yield put({ type: actions.HENTER_LEDERE });
+export function* hentLedere(action: HentLedereAction) {
+  yield put(actions.henterLedere());
   try {
     const path = `${process.env.REACT_APP_REST_ROOT}/internad/allnaermesteledere?fnr=${action.fnr}`;
-    const data = yield call(get, path);
-    yield put({ type: actions.LEDERE_HENTET, data });
+    const data: Leder[] = yield call(get, path);
+    yield put(actions.ledereHentet(data));
   } catch (e) {
-    yield put({ type: actions.HENT_LEDERE_FEILET });
+    yield put(actions.hentLedereFailed());
   }
 }
 
-export const skalHenteLedere = (state: any) => {
+export const skalHenteLedere = (state: RootState) => {
   const reducer = state.ledere;
   return !(reducer.henter || reducer.hentet || reducer.hentingFeilet);
 };
 
-export function* hentLedereHvisIkkeHentet(action: any) {
+export function* hentLedereHvisIkkeHentet(action: HentLedereAction) {
   const skalHente = yield select(skalHenteLedere);
   if (skalHente) {
     yield hentLedere(action);

--- a/src/data/leder/ledere_actions.ts
+++ b/src/data/leder/ledere_actions.ts
@@ -1,11 +1,48 @@
+import { Leder } from "./ledere";
+
 export const HENT_LEDERE_FORESPURT = "HENT_LEDERE_FORESPURT";
 export const HENTER_LEDERE = "HENTER_LEDERE";
 export const LEDERE_HENTET = "LEDERE_HENTET";
 export const HENT_LEDERE_FEILET = "HENT_LEDERE_FEILET";
 
-export const hentLedere = (fnr: string) => {
-  return {
-    type: HENT_LEDERE_FORESPURT,
-    fnr,
-  };
-};
+export interface HentLedereAction {
+  type: typeof HENT_LEDERE_FORESPURT;
+  fnr: string;
+}
+
+export interface HenterLedereAction {
+  type: typeof HENTER_LEDERE;
+}
+
+export interface LedereHentetAction {
+  type: typeof LEDERE_HENTET;
+  data: Leder[];
+}
+
+export interface HentLedereFeiletAction {
+  type: typeof HENT_LEDERE_FEILET;
+}
+
+export type LedereActions =
+  | HentLedereAction
+  | HenterLedereAction
+  | LedereHentetAction
+  | HentLedereFeiletAction;
+
+export const hentLedere = (fnr: string): HentLedereAction => ({
+  type: HENT_LEDERE_FORESPURT,
+  fnr,
+});
+
+export const henterLedere = (): HenterLedereAction => ({
+  type: HENTER_LEDERE,
+});
+
+export const hentLedereFailed = (): HentLedereFeiletAction => ({
+  type: HENT_LEDERE_FEILET,
+});
+
+export const ledereHentet = (data: Leder[]): LedereHentetAction => ({
+  type: LEDERE_HENTET,
+  data,
+});

--- a/src/data/oppfolgingstilfelle/oppfolgingstilfelleperioderSagas.ts
+++ b/src/data/oppfolgingstilfelle/oppfolgingstilfelleperioderSagas.ts
@@ -20,7 +20,7 @@ export function* hentOppfolgingstilfelleperioder(
 export const hentLedereVirksomhetsnummerList = (ledere: LedereState) => {
   const erLedereHentet = ledere.hentet;
   if (erLedereHentet) {
-    return ledere.data.map((leder) => {
+    return ledere.currentLedere.map((leder) => {
       return leder.orgnummer;
     });
   }

--- a/src/hooks/useLedere.ts
+++ b/src/hooks/useLedere.ts
@@ -1,13 +1,29 @@
 import { useAppSelector } from "./hooks";
+import { newestLederForEachVirksomhet } from "../utils/ledereUtils";
+import { Leder } from "../data/leder/ledere";
 
-export const useLedere = () => {
+export const useLedere = (): {
+  currentLedere: Leder[];
+  hentingLedereFeilet: boolean;
+  getCurrentNarmesteLeder: (virksomhetsnummer: string) => Leder | undefined;
+  hentingLedereForsokt: boolean;
+} => {
   const {
-    data: ledere,
+    currentLedere,
     hentingForsokt: hentingLedereForsokt,
     hentingFeilet: hentingLedereFeilet,
   } = useAppSelector((state) => state.ledere);
+
+  const getCurrentNarmesteLeder = (
+    virksomhetsnummer: string
+  ): Leder | undefined => {
+    const newestLedere = newestLederForEachVirksomhet(currentLedere);
+    return newestLedere.find((leder) => leder.orgnummer === virksomhetsnummer);
+  };
+
   return {
-    ledere,
+    getCurrentNarmesteLeder,
+    currentLedere,
     hentingLedereForsokt,
     hentingLedereFeilet,
   };

--- a/src/utils/ledereUtils.ts
+++ b/src/utils/ledereUtils.ts
@@ -71,7 +71,7 @@ const isNewerLeader = (ledere: Leder[], givenLeder: Leder): boolean => {
   );
 };
 
-const newestLederForEachVirksomhet = (ledere: Leder[]): Leder[] => {
+export const newestLederForEachVirksomhet = (ledere: Leder[]): Leder[] => {
   return ledere.filter((leder) => {
     return !isNewerLeader(ledere, leder);
   });
@@ -201,7 +201,9 @@ export const formerLedere = (ledere: Leder[]): Leder[] => {
   return ledere.filter((leder) => leder.aktivTom !== null);
 };
 
-export const ledereSortertPaaNavnOgOrganisasjonsnavn = (ledere: Leder[]) =>
+export const ledereSortertPaaNavnOgOrganisasjonsnavn = (
+  ledere: Leder[]
+): Leder[] =>
   ledere
     .sort((a, b) => {
       if (a.navn > b.navn) {

--- a/test/containers/MotebookingContainerTest.js
+++ b/test/containers/MotebookingContainerTest.js
@@ -119,7 +119,7 @@ describe("MotebookingContainer", () => {
           navn: "BEKK",
         },
         ledere: {
-          data: [],
+          currentLedere: [],
           hentingFeilet: false,
           henter: false,
         },

--- a/test/containers/MotelandingssideContainerTest.js
+++ b/test/containers/MotelandingssideContainerTest.js
@@ -66,7 +66,7 @@ describe("MotelandingssideContainer", () => {
         ledere: {
           hentet: true,
           hentingForsokt: true,
-          data: [
+          currentLedere: [
             {
               navn: "Tatten Tattover",
               id: 2,

--- a/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjemaTest.tsx
@@ -76,7 +76,7 @@ const mockState = {
     personident: arbeidstakerFnr,
   },
   ledere: {
-    data: [
+    currentLedere: [
       {
         navn: "Tatten Tattover",
         aktoerId: "1902690001009",

--- a/test/dialogmote/MotehistorikkTest.tsx
+++ b/test/dialogmote/MotehistorikkTest.tsx
@@ -43,8 +43,6 @@ const mockState = {
         arbeidsgiver: {
           uuid: 4,
           virksomhetsnummer: "912345678",
-          lederNavn: "He-man",
-          lederEpost: null,
           type: "ARBEIDSGIVER",
           varselList: [
             {
@@ -87,8 +85,6 @@ const mockState = {
         arbeidsgiver: {
           uuid: 41,
           virksomhetsnummer: "912345678",
-          lederNavn: "He-man",
-          lederEpost: null,
           type: "ARBEIDSGIVER",
           varselList: [
             {

--- a/test/dialogmote/ReferatTest.tsx
+++ b/test/dialogmote/ReferatTest.tsx
@@ -51,7 +51,6 @@ const mote: DialogmoteDTO = {
     virksomhetsnummer: "912345678",
     type: "ARBEIDSGIVER",
     varselList: [],
-    lederNavn: lederNavn,
   },
   arbeidstaker: {
     personIdent: arbeidstakerPersonIdent,
@@ -91,6 +90,20 @@ const mockState = {
   },
   valgtbruker: {
     personident: arbeidstakerPersonIdent,
+  },
+  ledere: {
+    currentLedere: [
+      {
+        navn: lederNavn,
+        aktiv: true,
+        orgnummer: "912345678",
+      },
+      {
+        navn: "Annen Leder",
+        aktiv: true,
+        orgnummer: "89829812",
+      },
+    ],
   },
 };
 

--- a/test/mote/containers/MotebookingSkjemaContainerTest.js
+++ b/test/mote/containers/MotebookingSkjemaContainerTest.js
@@ -12,7 +12,7 @@ describe("MotebookingSkjemaContainer", () => {
       };
       state = {
         ledere: {
-          data: [
+          currentLedere: [
             {
               navn: "Ole",
               erOppgitt: true,
@@ -48,14 +48,14 @@ describe("MotebookingSkjemaContainer", () => {
     });
 
     it("Skal returnere hentingFeilet når henting av ledere feiler", () => {
-      state.ledere.data = [];
+      state.ledere.currentLedere = [];
       state.ledere.hentingFeilet = true;
       const props = mapStateToProps(state, ownProps);
       expect(props.hentLedereFeiletBool).to.be.equal(true);
     });
 
     it("Skal returnere hentingFeilet når henting av ledere ikke feiler", () => {
-      state.ledere.data = [];
+      state.ledere.currentLedere = [];
       state.ledere.hentingFeilet = false;
       const props = mapStateToProps(state, ownProps);
       expect(props.hentLedereFeiletBool).to.be.equal(false);

--- a/test/reducers/ledereReducerTest.js
+++ b/test/reducers/ledereReducerTest.js
@@ -34,7 +34,7 @@ describe("ledere", () => {
       hentet: true,
       hentingFeilet: false,
       hentingForsokt: true,
-      data: [
+      currentLedere: [
         {
           navn: "Kurt Nilsen",
           aktivTom: null,
@@ -61,7 +61,7 @@ describe("ledere", () => {
     const action = { type: HENTER_LEDERE };
     const nextState = ledere(initialState, action);
     expect(nextState).to.deep.equal({
-      data: [],
+      currentLedere: [],
       formerLedere: [],
       allLedere: [],
       henter: true,
@@ -82,7 +82,7 @@ describe("ledere", () => {
       hentet: false,
       hentingFeilet: true,
       hentingForsokt: true,
-      data: [],
+      currentLedere: [],
       formerLedere: [],
       allLedere: [],
     });

--- a/test/utils/ledereUtilsTest.js
+++ b/test/utils/ledereUtilsTest.js
@@ -9,6 +9,7 @@ import {
   ledereWithActiveLedereFirst,
   virksomheterWithoutLeder,
   ledereSortertPaaNavnOgOrganisasjonsnavn,
+  newestLederForEachVirksomhet,
 } from "../../src/utils/ledereUtils";
 import { ANTALL_MS_DAG } from "../../src/utils/datoUtils";
 import {
@@ -582,6 +583,32 @@ describe("ledereUtils", () => {
       expect(ledereSortert[0]).to.deep.equal(leder3);
       expect(ledereSortert[1]).to.deep.equal(leder2);
       expect(ledereSortert[2]).to.deep.equal(leder1);
+    });
+  });
+
+  describe("newestLederForEachVirksomhet", () => {
+    it("returns newest leder for each virksomhet (orgnummer)", () => {
+      const lederFor123Old = {
+        orgnummer: "123",
+        aktoerId: "1",
+        fomDato: "2020-01-01",
+      };
+      const lederFor123New = {
+        orgnummer: "123",
+        aktoerId: "2",
+        fomDato: "2020-09-30",
+      };
+      const lederFor999 = {
+        orgnummer: "999",
+        aktoerId: "3",
+        fomDato: "2020-01-01",
+      };
+      const ledere = [lederFor123Old, lederFor123New, lederFor999];
+
+      const newestLedere = newestLederForEachVirksomhet(ledere);
+      expect(newestLedere.length).to.equal(2);
+      expect(newestLedere[0]).to.deep.equal(lederFor123New);
+      expect(newestLedere[1]).to.deep.equal(lederFor999);
     });
   });
 });


### PR DESCRIPTION
- henter ledernavn fra nyeste nærmeste leder på virksomheten og viser dette i lest-status og nærmeste leder-felt på referatet.
- forbedret typer på ledere-reducer, actions og saga og renamet data til currentLedere.