### PR TITLE
Only add fnr-header for ispengestopp if not post request

### DIFF
--- a/server/proxy.js
+++ b/server/proxy.js
@@ -22,7 +22,7 @@ const proxyExternalHost = (
         options.headers["Authorization"] = `Bearer ${token}`;
       }
       if (
-        host === Config.auth.ispengestopp.host ||
+        (host === Config.auth.ispengestopp.host && !parseReqBody) ||
         host === Config.auth.flexInternGateway.host ||
         host === Config.auth.syfosmregister.host
       ) {


### PR DESCRIPTION
Når vi gjør post-kall blir fnr undefined, og da fungerer ikke kallet, og ingen får stoppet penger.
Bruk "parseReqBody" for å sjekke om det er post-kall eller ikke.