### PR TITLE
Use nav-personident and fnr header when getting pengestopp status

### DIFF
--- a/src/data/pengestopp/flaggPersonSagas.ts
+++ b/src/data/pengestopp/flaggPersonSagas.ts
@@ -17,7 +17,7 @@ export function* hentStatusHvisIkkeHentet(action: any) {
     yield put(actions.henterStatus());
 
     const path = `${ISPENGESTOPP_ROOT}/person/status?fnr=${action.fnr}`;
-    const result: Result<StatusEndring[]> = yield call(get, path);
+    const result: Result<StatusEndring[]> = yield call(get, path, action.fnr);
 
     if (result instanceof Success) {
       yield put(actions.statusHentet(result.data || [], action.fnr));


### PR DESCRIPTION
Dette er en midlertidig løsning for å kunne bytte til ny header "nav-personident" i ispengestopp.
Nå sender vi begge headere samtidig, så vi trygt kan bytte i ispengestopp uten at noe feiler. Når vi har prodsatt ny versjon av pengestopp, kan vi fjerne "fnr" header fra proxy.js.