### PR TITLE
try catch errors in sagas

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import { hentLoginUrl, hentRedirectBaseUrl } from "@/utils/miljoUtil";
 import {
   accessDeniedError,
@@ -24,7 +24,7 @@ export const defaultRequestHeaders = (personIdent?: string): HeadersInit => {
   return headers;
 };
 
-function handleError(error) {
+function handleAxiosError(error: AxiosError) {
   if (error.response) {
     switch (error.response.status) {
       case 401: {
@@ -65,7 +65,11 @@ export const get = <ResponseData>(
     })
     .then((response) => response.data)
     .catch(function (error) {
-      handleError(error);
+      if (axios.isAxiosError(error)) {
+        handleAxiosError(error);
+      } else {
+        throw new ApiErrorException(generalError(error.message), error.code);
+      }
     });
 };
 
@@ -80,6 +84,10 @@ export const post = <ResponseData>(
     })
     .then((response) => response.data)
     .catch(function (error) {
-      handleError(error);
+      if (axios.isAxiosError(error)) {
+        handleAxiosError(error);
+      } else {
+        throw new ApiErrorException(generalError(error.message), error.code);
+      }
     });
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,5 +1,12 @@
 import axios from "axios";
 import { hentLoginUrl, hentRedirectBaseUrl } from "@/utils/miljoUtil";
+import {
+  accessDeniedError,
+  ApiErrorException,
+  generalError,
+  loginRequiredError,
+  networkError,
+} from "@/api/errors";
 
 export const NAV_CONSUMER_ID_HEADER = "nav-consumer-id";
 export const NAV_CONSUMER_ID = "syfomodiaperson";
@@ -17,103 +24,48 @@ export const defaultRequestHeaders = (personIdent?: string): HeadersInit => {
   return headers;
 };
 
-export const defaultErrorTexts = {
-  accessDenied: "Du har ikke tilgang til å utføre denne handlingen.",
-  generalError: "Det skjedde en uventet feil. Vennligst prøv igjen senere.",
-  networkError: "Vi har problemer med nettet, prøv igjen senere.",
-  loginRequired: "Handlingen krever at du logger på.",
-};
-
-export enum ErrorType {
-  ACCESS_DENIED = "ACCESS_DENIED",
-  GENERAL_ERROR = "GENERAL_ERROR",
-  NETWORK_ERROR = "NETWORK_ERROR",
-  LOGIN_REQUIRED = "LOGIN_REQUIRED",
-}
-
-export class Success<ResponseData> {
-  constructor(
-    public readonly data: ResponseData,
-    public readonly code: number
-  ) {}
-}
-
-export class Failure {
-  constructor(public readonly error: ApiError, public readonly code?: number) {}
-}
-
-export interface ApiError {
-  type: ErrorType;
-  message: string;
-  defaultErrorMsg: string;
-}
-
-export type Result<ResponseData> = Success<ResponseData> | Failure;
-
-function handleError(error): Failure {
+function handleError(error) {
   if (error.response) {
     switch (error.response.status) {
       case 401: {
         window.location.href = `${hentLoginUrl()}?redirect=${hentRedirectBaseUrl()}`;
-        return new Failure(
-          {
-            type: ErrorType.LOGIN_REQUIRED,
-            message: error.message,
-            defaultErrorMsg: defaultErrorTexts.loginRequired,
-          },
+        throw new ApiErrorException(
+          loginRequiredError(error.message),
           error.response.status
         );
       }
       case 403: {
         const message =
           error.response.data.begrunnelse || error.response.data.message;
-        return new Failure(
-          {
-            type: ErrorType.ACCESS_DENIED,
-            message: message,
-            defaultErrorMsg: defaultErrorTexts.accessDenied,
-          },
+        throw new ApiErrorException(
+          accessDeniedError(message),
           error.response.status
         );
       }
       default:
-        return new Failure(
-          {
-            type: ErrorType.GENERAL_ERROR,
-            message: error.message,
-            defaultErrorMsg: defaultErrorTexts.generalError,
-          },
+        throw new ApiErrorException(
+          generalError(error.message),
           error.response.status
         );
     }
   } else if (error.request) {
-    return new Failure({
-      type: ErrorType.NETWORK_ERROR,
-      message: error.message,
-      defaultErrorMsg: defaultErrorTexts.networkError,
-    });
+    throw new ApiErrorException(networkError(error.message));
   } else {
-    return new Failure({
-      type: ErrorType.GENERAL_ERROR,
-      message: error.message,
-      defaultErrorMsg: defaultErrorTexts.generalError,
-    });
+    throw new ApiErrorException(generalError(error.message));
   }
 }
 
 export const get = <ResponseData>(
   url: string,
   personIdent?: string
-): Promise<Result<ResponseData>> => {
+): Promise<ResponseData> => {
   return axios
     .get(url, {
       headers: defaultRequestHeaders(personIdent),
     })
-    .then((response) => {
-      return new Success(response.data, response.status);
-    })
+    .then((response) => response.data)
     .catch(function (error) {
-      return handleError(error);
+      handleError(error);
     });
 };
 
@@ -121,15 +73,13 @@ export const post = <ResponseData>(
   url: string,
   data: Record<string, any>,
   personIdent?: string
-): Promise<Result<ResponseData>> => {
+): Promise<ResponseData> => {
   return axios
     .post(url, data, {
       headers: defaultRequestHeaders(personIdent),
     })
-    .then((response) => {
-      return new Success(response.data, response.status);
-    })
+    .then((response) => response.data)
     .catch(function (error) {
-      return handleError(error);
+      handleError(error);
     });
 };

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,0 +1,51 @@
+export const defaultErrorTexts = {
+  accessDenied: "Du har ikke tilgang til å utføre denne handlingen.",
+  generalError: "Det skjedde en uventet feil. Vennligst prøv igjen senere.",
+  networkError: "Vi har problemer med nettet, prøv igjen senere.",
+  loginRequired: "Handlingen krever at du logger på.",
+};
+
+export enum ErrorType {
+  ACCESS_DENIED = "ACCESS_DENIED",
+  GENERAL_ERROR = "GENERAL_ERROR",
+  NETWORK_ERROR = "NETWORK_ERROR",
+  LOGIN_REQUIRED = "LOGIN_REQUIRED",
+}
+
+export class ApiErrorException extends Error {
+  constructor(public readonly error: ApiError, public readonly code?: number) {
+    super(error.message);
+  }
+}
+
+export interface ApiError {
+  type: ErrorType;
+  message: string;
+  defaultErrorMsg: string;
+}
+
+export const generalError = (message: string): ApiError => ({
+  type: ErrorType.GENERAL_ERROR,
+  message,
+  defaultErrorMsg: defaultErrorTexts.generalError,
+});
+
+export const loginRequiredError = (message: string): ApiError => ({
+  type: ErrorType.LOGIN_REQUIRED,
+  message,
+  defaultErrorMsg: defaultErrorTexts.loginRequired,
+});
+
+export const accessDeniedError = (message: string): ApiError => {
+  return {
+    type: ErrorType.ACCESS_DENIED,
+    message,
+    defaultErrorMsg: defaultErrorTexts.accessDenied,
+  };
+};
+
+export const networkError = (message: string): ApiError => ({
+  type: ErrorType.NETWORK_ERROR,
+  message,
+  defaultErrorMsg: defaultErrorTexts.networkError,
+});

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { ApiError, defaultErrorTexts, ErrorType } from "@/api/axios";
 import Alertstripe from "nav-frontend-alertstriper";
 import { Normaltekst } from "nav-frontend-typografi";
 import Lenke from "nav-frontend-lenker";
 import styled from "styled-components";
+import { ApiError, defaultErrorTexts, ErrorType } from "@/api/errors";
 
 const texts = {
   meldFeil: "Meld oss gjerne om feilen her",

--- a/src/data/behandlendeenhet/behandlendeEnhet.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhet.ts
@@ -4,7 +4,7 @@ import {
   BehandlendeEnhetActionTypes,
 } from "./behandlendeEnhet_actions";
 import { BehandlendeEnhet } from "./types/BehandlendeEnhet";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export interface BehandlendeEnhetState {
   henter: boolean;

--- a/src/data/behandlendeenhet/behandlendeEnhetSagas.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhetSagas.ts
@@ -6,18 +6,23 @@ import {
   HentBehandlendeEnhetAction,
   hentBehandlendeEnhetFeilet,
 } from "./behandlendeEnhet_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { BehandlendeEnhet } from "./types/BehandlendeEnhet";
 import { SYFOBEHANDLENDEENHET_ROOT } from "@/apiConstants";
+import { ApiErrorException, generalError } from "@/api/errors";
 
 function* hentBehandlendeEnhetSaga(action: HentBehandlendeEnhetAction) {
   yield put(actions.henterBehandlendeEnhet());
   const path = `${SYFOBEHANDLENDEENHET_ROOT}/personident`;
-  const result: Result<BehandlendeEnhet> = yield call(get, path, action.fnr);
-  if (result instanceof Success) {
-    yield put(behandlendeEnhetHentet(result.data));
-  } else {
-    yield put(hentBehandlendeEnhetFeilet(result.error));
+  try {
+    const data: BehandlendeEnhet = yield call(get, path, action.fnr);
+    yield put(behandlendeEnhetHentet(data));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(hentBehandlendeEnhetFeilet(e.error));
+    } else {
+      yield put(hentBehandlendeEnhetFeilet(generalError(e.message)));
+    }
   }
 }
 

--- a/src/data/behandlendeenhet/behandlendeEnhet_actions.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhet_actions.ts
@@ -1,5 +1,5 @@
 import { BehandlendeEnhet } from "./types/BehandlendeEnhet";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export enum BehandlendeEnhetActionTypes {
   HENT_BEHANDLENDE_ENHET_FORESPURT = "HENT_BEHANDLENDE_ENHET_FORESPURT",

--- a/src/data/dialogmote/dialogmote.ts
+++ b/src/data/dialogmote/dialogmote.ts
@@ -1,7 +1,7 @@
 import { Reducer } from "redux";
 import { DialogmoteActions, DialogmoteActionTypes } from "./dialogmote_actions";
 import { DialogmoteDTO } from "./types/dialogmoteTypes";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export interface DialogmoteState {
   senderInnkalling: boolean;

--- a/src/data/dialogmote/dialogmoteSagas.ts
+++ b/src/data/dialogmote/dialogmoteSagas.ts
@@ -21,92 +21,86 @@ import {
   opprettInnkallingFeilet,
   opprettInnkallingFullfort,
 } from "./dialogmote_actions";
-import { get, post, Result, Success } from "@/api/axios";
-import {
-  AvlysDialogmoteDTO,
-  DialogmoteDTO,
-  DialogmoteInnkallingDTO,
-  EndreTidStedDialogmoteDTO,
-} from "./types/dialogmoteTypes";
-import { NewDialogmoteReferatDTO } from "./types/dialogmoteReferatTypes";
+import { get, post } from "@/api/axios";
+import { DialogmoteDTO } from "./types/dialogmoteTypes";
 import { ISDIALOGMOTE_ROOT } from "@/apiConstants";
+import { ApiErrorException, generalError } from "@/api/errors";
 
 function* opprettInnkalling(action: OpprettInnkallingAction) {
   yield put(oppretterInnkalling());
   const path = `${ISDIALOGMOTE_ROOT}/dialogmote/personident`;
-  const result: Result<DialogmoteInnkallingDTO> = yield call(
-    post,
-    path,
-    action.data,
-    action.fnr
-  );
-
-  if (result instanceof Success) {
+  try {
+    yield call(post, path, action.data, action.fnr);
     yield put(opprettInnkallingFullfort());
     window.location.href = `/sykefravaer/moteoversikt`;
-  } else {
-    yield put(opprettInnkallingFeilet(result.error));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(opprettInnkallingFeilet(e.error));
+    } else {
+      yield put(opprettInnkallingFeilet(generalError(e.message)));
+    }
   }
 }
 
 function* fetchDialogmoteSaga(action: FetchDialogmoteAction) {
   const path = `${ISDIALOGMOTE_ROOT}/dialogmote/personident`;
-  const result: Result<DialogmoteDTO[]> = yield call(get, path, action.fnr);
-  if (result instanceof Success) {
-    yield put(fetchDialogmoteSuccess(result.data));
-  } else {
-    yield put(fetchDialogmoteFailed(result.error));
+  try {
+    const data: DialogmoteDTO[] = yield call(get, path, action.fnr);
+    yield put(fetchDialogmoteSuccess(data));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(fetchDialogmoteFailed(e.error));
+    } else {
+      yield put(fetchDialogmoteFailed(generalError(e.message)));
+    }
   }
 }
 
 function* avlysDialogmote(action: AvlysMoteAction) {
   yield put(avlyserMote());
   const path = `${ISDIALOGMOTE_ROOT}/dialogmote/${action.moteUuid}/avlys`;
-  const result: Result<AvlysDialogmoteDTO> = yield call(
-    post,
-    path,
-    action.data
-  );
-
-  if (result instanceof Success) {
+  try {
+    yield call(post, path, action.data);
     yield put(avlysMoteFullfort());
     window.location.href = `/sykefravaer/moteoversikt`;
-  } else {
-    yield put(avlysMoteFeilet(result.error));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(avlysMoteFeilet(e.error));
+    } else {
+      yield put(avlysMoteFeilet(generalError(e.message)));
+    }
   }
 }
 
 function* endreTidStedDialogmote(action: EndreTidStedAction) {
   yield put(endrerTidSted());
   const path = `${ISDIALOGMOTE_ROOT}/dialogmote/${action.moteUuid}/tidsted`;
-  const result: Result<EndreTidStedDialogmoteDTO> = yield call(
-    post,
-    path,
-    action.data
-  );
-
-  if (result instanceof Success) {
+  try {
+    yield call(post, path, action.data);
     yield put(endreTidStedFullfort());
     window.location.href = `/sykefravaer/moteoversikt`;
-  } else {
-    yield put(endreTidStedFeilet(result.error));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(endreTidStedFeilet(e.error));
+    } else {
+      yield put(endreTidStedFeilet(generalError(e.message)));
+    }
   }
 }
 
 function* ferdigstillDialogmote(action: FerdigstillMoteAction) {
   yield put(ferdigstillerMote());
   const path = `${ISDIALOGMOTE_ROOT}/dialogmote/${action.moteUuid}/ferdigstill`;
-  const result: Result<NewDialogmoteReferatDTO> = yield call(
-    post,
-    path,
-    action.data
-  );
-
-  if (result instanceof Success) {
+  try {
+    yield call(post, path, action.data);
     yield put(ferdigstillMoteFullfort());
     window.location.href = `/sykefravaer/moteoversikt`;
-  } else {
-    yield put(ferdigstillMoteFeilet(result.error));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(ferdigstillMoteFeilet(e.error));
+    } else {
+      yield put(ferdigstillMoteFeilet(generalError(e.message)));
+    }
   }
 }
 

--- a/src/data/dialogmote/dialogmote_actions.ts
+++ b/src/data/dialogmote/dialogmote_actions.ts
@@ -5,7 +5,7 @@ import {
   EndreTidStedDialogmoteDTO,
 } from "./types/dialogmoteTypes";
 import { NewDialogmoteReferatDTO } from "./types/dialogmoteReferatTypes";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export enum DialogmoteActionTypes {
   OPPRETT_INNKALLING_FORESPURT = "OPPRETT_INNKALLING_FORESPURT",

--- a/src/data/diskresjonskode/diskresjonskode.ts
+++ b/src/data/diskresjonskode/diskresjonskode.ts
@@ -1,9 +1,9 @@
+import { ApiError } from "@/api/errors";
 import { Reducer } from "redux";
 import {
   HentDiskresjonskodeActions,
   HentDiskresjonskodeActionTypes,
 } from "./diskresjonskode_actions";
-import { ApiError } from "@/api/axios";
 
 export interface DiskresjonskodeData {
   diskresjonskode: string;

--- a/src/data/diskresjonskode/diskresjonskodeSagas.ts
+++ b/src/data/diskresjonskode/diskresjonskodeSagas.ts
@@ -6,19 +6,23 @@ import {
   hentDiskresjonskodeFeilet,
   henterDiskresjonskode,
 } from "./diskresjonskode_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { RootState } from "../rootState";
 import { SYFOPERSON_ROOT } from "@/apiConstants";
+import { ApiErrorException, generalError } from "@/api/errors";
 
 export function* hentDiskresjonskodeSaga(action: HentDiskresjonskodeAction) {
   yield put(henterDiskresjonskode());
   const path = `${SYFOPERSON_ROOT}/person/diskresjonskode`;
-  const result: Result<string> = yield call(get, path, action.fnr);
-
-  if (result instanceof Success) {
-    yield put(diskresjonskodeHentet(result.data));
-  } else {
-    yield put(hentDiskresjonskodeFeilet(result.error));
+  try {
+    const data: string = yield call(get, path, action.fnr);
+    yield put(diskresjonskodeHentet(data));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(hentDiskresjonskodeFeilet(e.error));
+    } else {
+      yield put(hentDiskresjonskodeFeilet(generalError(e.message)));
+    }
   }
 }
 

--- a/src/data/diskresjonskode/diskresjonskode_actions.ts
+++ b/src/data/diskresjonskode/diskresjonskode_actions.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export enum HentDiskresjonskodeActionTypes {
   HENT_DISKRESJONSKODE_FORESPURT = "HENT_DISKRESJONSKODE_FORESPURT",

--- a/src/data/egenansatt/egenansatt.ts
+++ b/src/data/egenansatt/egenansatt.ts
@@ -3,7 +3,7 @@ import {
   HentEgenAnsattActions,
   HentEgenAnsattActionTypes,
 } from "./egenansatt_actions";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export interface EgenansattState {
   henter: boolean;

--- a/src/data/egenansatt/egenansattSagas.ts
+++ b/src/data/egenansatt/egenansattSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { RootState } from "../rootState";
 import {
   egenansattHentet,
@@ -7,14 +7,19 @@ import {
   hentEgenansattFeilet,
 } from "./egenansatt_actions";
 import { SYFOPERSON_ROOT } from "@/apiConstants";
+import { ApiErrorException, generalError } from "@/api/errors";
 
 export function* hentEgenansattSaga(action: any) {
   const path = `${SYFOPERSON_ROOT}/person/egenansatt`;
-  const result: Result<boolean> = yield call(get, path, action.fnr);
-  if (result instanceof Success) {
-    yield put(egenansattHentet(result.data));
-  } else {
-    yield put(hentEgenansattFeilet(result.error));
+  try {
+    const data: boolean = yield call(get, path, action.fnr);
+    yield put(egenansattHentet(data));
+  } catch (e) {
+    if (e instanceof ApiErrorException) {
+      yield put(hentEgenansattFeilet(e.error));
+    } else {
+      yield put(hentEgenansattFeilet(generalError(e.message)));
+    }
   }
 }
 

--- a/src/data/egenansatt/egenansatt_actions.ts
+++ b/src/data/egenansatt/egenansatt_actions.ts
@@ -1,4 +1,4 @@
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export enum HentEgenAnsattActionTypes {
   HENT_EGENANSATT_FORESPURT = "HENT_EGENANSATT_FORESPURT",

--- a/src/data/fastlege/fastlegerSagas.ts
+++ b/src/data/fastlege/fastlegerSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import * as actions from "./fastleger_actions";
 import { Fastlege } from "./types/Fastlege";
 import { RootState } from "../rootState";
@@ -15,11 +15,10 @@ export function* hentFastlegerHvisIkkeHentet(action: any) {
   if (skalHente) {
     yield put(actions.henterFastleger());
     const path = `${FASTLEGEREST_ROOT}/fastleger?fnr=${action.fnr}`;
-    const result: Result<Fastlege> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(actions.fastlegerHentet(result.data));
-    } else {
+    try {
+      const data: Fastlege = yield call(get, path);
+      yield put(actions.fastlegerHentet(data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentFastlegerFeilet());
     }

--- a/src/data/historikk/historikkSagas.ts
+++ b/src/data/historikk/historikkSagas.ts
@@ -1,6 +1,5 @@
 import { call, put, takeEvery } from "redux-saga/effects";
 import { get } from "@/api/axios";
-import { Result, Success } from "@/api/axios";
 import { HistorikkEvent } from "./types/historikkTypes";
 import {
   SYFOMOTEADMIN_ROOT,
@@ -19,11 +18,10 @@ export function* hentHistorikkOppfoelgingsdialog(action: HentHistorikkAction) {
   yield put(henterHistorikk("OPPFOELGINGSDIALOG"));
 
   const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/v1/oppfolgingsplan/${action.fnr}/historikk`;
-  const result: Result<HistorikkEvent[]> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(historikkHentet(result.data, "OPPFOELGINGSDIALOG"));
-  } else {
+  try {
+    const data: HistorikkEvent[] = yield call(get, path);
+    yield put(historikkHentet(data, "OPPFOELGINGSDIALOG"));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(hentHistorikkFeilet("OPPFOELGINGSDIALOG"));
   }
@@ -33,11 +31,10 @@ export function* hentHistorikkMoter(action: HentHistorikkAction) {
   yield put(henterHistorikk("MOTER"));
 
   const path = `${SYFOMOTEADMIN_ROOT}/historikk?fnr=${action.fnr}`;
-  const result: Result<HistorikkEvent[]> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(historikkHentet(result.data, "MOTER"));
-  } else {
+  try {
+    const data: HistorikkEvent[] = yield call(get, path);
+    yield put(historikkHentet(data, "MOTER"));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(hentHistorikkFeilet("MOTER"));
   }
@@ -47,11 +44,10 @@ export function* hentHistorikkMotebehov(action: HentHistorikkAction) {
   yield put(henterHistorikk("MOTEBEHOV"));
 
   const path = `${SYFOMOTEBEHOV_ROOT}/historikk?fnr=${action.fnr}`;
-  const result: Result<HistorikkEvent[]> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(historikkHentet(result.data, "MOTEBEHOV"));
-  } else {
+  try {
+    const data: HistorikkEvent[] = yield call(get, path);
+    yield put(historikkHentet(data, "MOTEBEHOV"));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(hentHistorikkFeilet("MOTEBEHOV"));
   }

--- a/src/data/leder/ledereSagas.ts
+++ b/src/data/leder/ledereSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import * as actions from "./ledere_actions";
 import { HentLedereAction } from "./ledere_actions";
 import { RootState } from "../rootState";
@@ -17,11 +17,10 @@ export function* hentLedereHvisIkkeHentet(action: HentLedereAction) {
     yield put(actions.henterLedere());
 
     const path = `${MODIASYFOREST_ROOT}/allnaermesteledere?fnr=${action.fnr}`;
-    const result: Result<Leder[]> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(actions.ledereHentet(result.data));
-    } else {
+    try {
+      const data: Leder[] = yield call(get, path);
+      yield put(actions.ledereHentet(data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentLedereFailed());
     }

--- a/src/data/modiacontext/modiacontextSagas.ts
+++ b/src/data/modiacontext/modiacontextSagas.ts
@@ -1,7 +1,6 @@
 import { call, put, takeEvery } from "redux-saga/effects";
 import { get, post } from "@/api/axios";
 import * as actions from "./modiacontext_actions";
-import { Result, Success } from "@/api/axios";
 import { RSContext } from "./modiacontextTypes";
 import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
 
@@ -13,14 +12,13 @@ export function* pushModiacontextSaga(action: actions.PushModiaContextAction) {
   yield put(actions.pusherModiaContext());
 
   const path = `${MODIACONTEXTHOLDER_ROOT}/context`;
-  const result: Result<any> = yield call(post, path, {
-    verdi: action.data.verdi,
-    eventType: action.data.eventType,
-  });
-
-  if (result instanceof Success) {
+  try {
+    yield call(post, path, {
+      verdi: action.data.verdi,
+      eventType: action.data.eventType,
+    });
     redirectWithoutFnrInUrl(action.data.verdi);
-  } else {
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.pushModiaContextFeilet());
   }
@@ -30,11 +28,10 @@ export function* aktivBrukerSaga() {
   yield put(actions.henterAktivBruker());
 
   const path = `${MODIACONTEXTHOLDER_ROOT}/context/aktivbruker`;
-  const result: Result<RSContext> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(actions.aktivBrukerHentet(result.data));
-  } else {
+  try {
+    const data: RSContext = yield call(get, path);
+    yield put(actions.aktivBrukerHentet(data));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.hentAktivBrukerFeilet());
   }
@@ -44,11 +41,10 @@ export function* aktivEnhetSaga(action: any) {
   yield put(actions.henterAktivEnhet());
 
   const path = `${MODIACONTEXTHOLDER_ROOT}/context/aktivenhet`;
-  const result: Result<RSContext> = yield call(get, path);
-
-  if (result instanceof Success) {
-    action.data.callback(result.data.aktivEnhet);
-  } else {
+  try {
+    const data: RSContext = yield call(get, path);
+    action.data.callback(data.aktivEnhet);
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.hentAktivEnhetFeilet());
   }

--- a/src/data/mote/epostinnholdSagas.ts
+++ b/src/data/mote/epostinnholdSagas.ts
@@ -1,7 +1,7 @@
 import { call, put, takeEvery } from "redux-saga/effects";
 import * as actions from "./epostinnhold_actions";
 import * as arbeidsgiveractions from "./arbeidsgiverepostinnhold_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { EpostInnholdDTO } from "./types/EpostInnholdDTO";
 import { SYFOMOTEADMIN_ROOT } from "@/apiConstants";
 
@@ -9,11 +9,10 @@ export function* hentBekreftMoteEpostinnhold(action: any) {
   yield put(actions.henterEpostInnhold());
 
   const path = `${SYFOMOTEADMIN_ROOT}/epostinnhold/BEKREFTET?motedeltakeruuid=${action.motedeltakerUuid}&valgtAlternativId=${action.valgtAlternativId}`;
-  const result: Result<EpostInnholdDTO> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(actions.epostInnholdHentet("BEKREFT_TIDSPUNKT", result.data));
-  } else {
+  try {
+    const data: EpostInnholdDTO = yield call(get, path);
+    yield put(actions.epostInnholdHentet("BEKREFT_TIDSPUNKT", data));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.hentEpostinnholdFeilet());
   }
@@ -23,16 +22,15 @@ export function* hentBekreftMoteArbeidsgiverEpostinnhold(action: any) {
   yield put(arbeidsgiveractions.henterArbeidstakerEpostInnhold());
 
   const path = `${SYFOMOTEADMIN_ROOT}/epostinnhold/BEKREFTET?motedeltakeruuid=${action.motedeltakerUuid}&valgtAlternativId=${action.valgtAlternativId}`;
-  const result: Result<EpostInnholdDTO> = yield call(get, path);
-
-  if (result instanceof Success) {
+  try {
+    const data: EpostInnholdDTO = yield call(get, path);
     yield put(
       arbeidsgiveractions.arbeidsgiverEpostInnholdHentet(
         "BEKREFT_TIDSPUNKT",
-        result.data
+        data
       )
     );
-  } else {
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(arbeidsgiveractions.hentArbeidsgiverEpostinnholdFeilet());
   }
@@ -42,11 +40,10 @@ export function* hentAvbrytMoteEpostinnhold(action: any) {
   yield put(actions.henterEpostInnhold());
 
   const path = `${SYFOMOTEADMIN_ROOT}/epostinnhold/AVBRUTT?motedeltakeruuid=${action.motedeltakerUuid}`;
-  const result: Result<EpostInnholdDTO> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(actions.epostInnholdHentet("AVBRYT_TIDSPUNKT", result.data));
-  } else {
+  try {
+    const data: EpostInnholdDTO = yield call(get, path);
+    yield put(actions.epostInnholdHentet("AVBRYT_TIDSPUNKT", data));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.hentEpostinnholdFeilet());
   }

--- a/src/data/navbruker/navbrukerSagas.ts
+++ b/src/data/navbruker/navbrukerSagas.ts
@@ -5,19 +5,18 @@ import {
   HENTER_NAVBRUKER,
   NAVBRUKER_HENTET,
 } from "./navbruker_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { MODIASYFOREST_ROOT } from "@/apiConstants";
 
 export function* hentNavbruker(action: any) {
   yield put({ type: HENTER_NAVBRUKER });
 
   const path = `${MODIASYFOREST_ROOT}/brukerinfo?fnr=${action.fnr}`;
-  const result: Result<string> = yield call(get, path);
-
-  //TODO: Add proper actions and types
-  if (result instanceof Success) {
-    yield put({ type: NAVBRUKER_HENTET, data: result.data });
-  } else {
+  try {
+    //TODO: Add proper actions and types
+    const data: string = yield call(get, path);
+    yield put({ type: NAVBRUKER_HENTET, data });
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put({ type: HENT_NAVBRUKER_FEILET });
   }

--- a/src/data/oppfolgingsplan/dokumentInfoSagas.ts
+++ b/src/data/oppfolgingsplan/dokumentInfoSagas.ts
@@ -1,6 +1,6 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import * as actions from "./dokumentinfo_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { DokumentinfoDTO } from "./types/DokumentinfoDTO";
 import { RootState } from "../rootState";
 import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
@@ -17,11 +17,10 @@ export function* hentMotebehovHvisIkkeHentet(action: any) {
     yield put(actions.henterDokumentinfo(action.id));
 
     const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/${action.id}/dokumentinfo`;
-    const result: Result<DokumentinfoDTO> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(actions.dokumentinfoHentet(action.id, result.data));
-    } else {
+    try {
+      const data: DokumentinfoDTO = yield call(get, path);
+      yield put(actions.dokumentinfoHentet(action.id, data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentDokumentinfoFeilet(action.id));
     }

--- a/src/data/oppfolgingsplan/oppfoelgingsdialogerSagas.ts
+++ b/src/data/oppfolgingsplan/oppfoelgingsdialogerSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import * as actions from "./oppfoelgingsdialoger_actions";
 import { OppfolgingsplanDTO } from "./oppfoelgingsdialoger";
 import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
@@ -15,11 +15,10 @@ export function* hentOppfolgingsplanerHvisIkkeHentet(action: any) {
     yield put(actions.henterOppfoelgingsdialoger());
 
     const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/v1/oppfolgingsplan/${action.fnr}`;
-    const result: Result<OppfolgingsplanDTO[]> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(actions.hentOppfolgingsdialogerHentet(result.data));
-    } else {
+    try {
+      const data: OppfolgingsplanDTO[] = yield call(get, path);
+      yield put(actions.hentOppfolgingsdialogerHentet(data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentOppfoelgingsdialogerFeilet());
     }

--- a/src/data/oppfolgingsplan/oppfolgingsplanerLPSSagas.ts
+++ b/src/data/oppfolgingsplan/oppfolgingsplanerLPSSagas.ts
@@ -1,7 +1,7 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import * as actions from "./oppfolgingsplanerlps_actions";
 import { PersonOppgave } from "../personoppgave/types/PersonOppgave";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { OppfolgingsplanLPS } from "./types/OppfolgingsplanLPS";
 import { RootState } from "../rootState";
 import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
@@ -13,17 +13,10 @@ export function* hentOppfolgingsplanerLPS(
   yield put(actions.hentOppfolgingsplanerLPSHenter());
 
   const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/lps`;
-  const result: Result<OppfolgingsplanLPS[]> = yield call(
-    get,
-    path,
-    action.fnr
-  );
-
-  if (result instanceof Success) {
-    yield put(
-      actions.hentOppfolgingsplanerLPSHentet(result.data, personOppgaveList)
-    );
-  } else {
+  try {
+    const data: OppfolgingsplanLPS[] = yield call(get, path, action.fnr);
+    yield put(actions.hentOppfolgingsplanerLPSHentet(data, personOppgaveList));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.hentOppfolgingsplanerLPSFeilet());
   }

--- a/src/data/oppfolgingstilfelle/oppfolgingstilfellePersonSagas.ts
+++ b/src/data/oppfolgingstilfelle/oppfolgingstilfellePersonSagas.ts
@@ -1,6 +1,6 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import * as actions from "./oppfolgingstilfellerperson_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { OppfolgingstilfellePerson } from "./types/OppfolgingstilfellePerson";
 import { MODIASYFOREST_ROOT } from "@/apiConstants";
 
@@ -31,13 +31,12 @@ export function* hentOppfolgingstilfellerPersonHvisIkkeHentet(action: any) {
     yield put(actions.hentOppfolgingstilfellerPersonUtenArbeidsiverHenter());
 
     const path = `${MODIASYFOREST_ROOT}/oppfolgingstilfelleperioder/utenarbeidsgiver?fnr=${action.fnr}`;
-    const result: Result<OppfolgingstilfellePerson[]> = yield call(get, path);
-
-    if (result instanceof Success) {
+    try {
+      const data: OppfolgingstilfellePerson[] = yield call(get, path);
       yield put(
-        actions.hentOppfolgingstilfellerPersonUtenArbeidsiverHentet(result.data)
+        actions.hentOppfolgingstilfellerPersonUtenArbeidsiverHentet(data)
       );
-    } else {
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentOppfolgingstilfellerPersonUtenArbeidsiverFeilet());
     }

--- a/src/data/oppfolgingstilfelle/oppfolgingstilfelleperioderSagas.ts
+++ b/src/data/oppfolgingstilfelle/oppfolgingstilfelleperioderSagas.ts
@@ -1,6 +1,6 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import { LedereState } from "../leder/ledere";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { OppfolgingstilfellePersonArbeidsgiver } from "./types/OppfolgingstilfellePersonArbeidsgiver";
 import { RootState } from "../rootState";
 import {
@@ -19,14 +19,10 @@ export function* hentOppfolgingstilfelleperioder(
   yield put(hentOppfolgingstilfelleperioderHenter(orgnummer));
 
   const path = `${MODIASYFOREST_ROOT}/oppfolgingstilfelleperioder?fnr=${action.fnr}&orgnummer=${orgnummer}`;
-  const result: Result<OppfolgingstilfellePersonArbeidsgiver[]> = yield call(
-    get,
-    path
-  );
-
-  if (result instanceof Success) {
-    yield put(hentOppfolgingstilfelleperioderHentet(result.data, orgnummer));
-  } else {
+  try {
+    const data: OppfolgingstilfellePersonArbeidsgiver[] = yield call(get, path);
+    yield put(hentOppfolgingstilfelleperioderHentet(data, orgnummer));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(hentOppfolgingstilfelleperioderFeilet(orgnummer));
   }

--- a/src/data/pengestopp/flaggPersonSagas.ts
+++ b/src/data/pengestopp/flaggPersonSagas.ts
@@ -2,7 +2,7 @@ import { call, put, select, takeEvery } from "redux-saga/effects";
 import * as actions from "./flaggperson_actions";
 import { stoppAutomatikk2StatusEndring } from "@/utils/pengestoppUtils";
 import { FlaggpersonState } from "./flaggperson";
-import { get, post, Result, Success } from "@/api/axios";
+import { get, post } from "@/api/axios";
 import { StatusEndring } from "./types/FlaggPerson";
 import { ISPENGESTOPP_ROOT } from "@/apiConstants";
 
@@ -17,11 +17,10 @@ export function* hentStatusHvisIkkeHentet(action: any) {
     yield put(actions.henterStatus());
 
     const path = `${ISPENGESTOPP_ROOT}/person/status`;
-    const result: Result<StatusEndring[]> = yield call(get, path, action.fnr);
-
-    if (result instanceof Success) {
-      yield put(actions.statusHentet(result.data || [], action.fnr));
-    } else {
+    try {
+      const data: StatusEndring[] = yield call(get, path, action.fnr);
+      yield put(actions.statusHentet(data || [], action.fnr));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentStatusFeilet());
     }
@@ -39,10 +38,8 @@ export function* endreStatusHvisIkkeEndret(action: any) {
     yield put(actions.endrerStatus());
 
     const path = `${ISPENGESTOPP_ROOT}/person/flagg`;
-
-    const result: Result<any> = yield call(post, path, action.stoppAutomatikk);
-
-    if (result instanceof Success) {
+    try {
+      yield call(post, path, action.stoppAutomatikk);
       yield put(actions.statusEndret());
       yield put(
         actions.statusHentet(
@@ -53,7 +50,7 @@ export function* endreStatusHvisIkkeEndret(action: any) {
           action.fnr
         )
       );
-    } else {
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.endreStatusFeilet());
     }

--- a/src/data/personinfo/personInfoSagas.ts
+++ b/src/data/personinfo/personInfoSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import * as actions from "./personInfo_actions";
 import { PersonAdresse } from "./types/PersonAdresse";
 import { SYFOPERSON_ROOT } from "@/apiConstants";
@@ -14,11 +14,10 @@ export function* hentPersonAdresseHvisIkkeHentet(action: any) {
   if (skalHente) {
     yield put(actions.hentPersonAdresseHenter());
     const path = `${SYFOPERSON_ROOT}/person/adresse`;
-    const result: Result<PersonAdresse> = yield call(get, path, action.fnr);
-
-    if (result instanceof Success) {
-      yield put(actions.hentPersonAdresseHentet(result.data));
-    } else {
+    try {
+      const data: PersonAdresse = yield call(get, path, action.fnr);
+      yield put(actions.hentPersonAdresseHentet(data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentPersonAdresseFeilet());
     }

--- a/src/data/personoppgave/personoppgaveSagas.ts
+++ b/src/data/personoppgave/personoppgaveSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, post, Result, Success } from "@/api/axios";
+import { get, post } from "@/api/axios";
 import * as actions from "./personoppgave_actions";
 import { PersonOppgave } from "./types/PersonOppgave";
 import { ISPERSONOPPGAVE_ROOT } from "@/apiConstants";
@@ -13,13 +13,11 @@ export function* hentPersonOppgaverHvisIkkeHentet(action: any) {
   const skalHente = yield select(skalHentePersonOppgaver);
   if (skalHente) {
     yield put(actions.hentPersonOppgaverHenter());
-
     const path = `${ISPERSONOPPGAVE_ROOT}/personoppgave/personident`;
-    const result: Result<PersonOppgave[]> = yield call(get, path, action.fnr);
-
-    if (result instanceof Success) {
-      yield put(actions.hentPersonOppgaverHentet(result.data || []));
-    } else {
+    try {
+      const data: PersonOppgave[] = yield call(get, path, action.fnr);
+      yield put(actions.hentPersonOppgaverHentet(data || []));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentPersonOppgaverFeilet());
     }
@@ -33,15 +31,14 @@ export function* behandlePersonOppgave(action: any) {
   yield put(actions.behandlePersonOppgaveBehandler());
 
   const path = `${ISPERSONOPPGAVE_ROOT}/personoppgave/${uuid}/behandle`;
-  const result: Result<any> = yield call(post, path, []);
-
-  if (result instanceof Success) {
+  try {
+    yield call(post, path, []);
     yield put(
       actions.behandlePersonOppgaveBehandlet(uuid, referanseUuid, veilederIdent)
     );
-  } else {
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
-    if (result.code === 409) {
+    if (e.code === 409) {
       window.location.reload();
       return;
     }

--- a/src/data/prediksjon/prediksjonSagas.ts
+++ b/src/data/prediksjon/prediksjonSagas.ts
@@ -1,7 +1,7 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import * as actions from "./prediksjon_actions";
 import { Prediksjon, PrediksjonState } from "./prediksjon";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { ISPREDIKSJON_ROOT } from "@/apiConstants";
 
 export const skalHentePrediksjon = (state: { prediksjon: PrediksjonState }) => {
@@ -14,11 +14,10 @@ export function* hentPrediksjonHvisIkkeHentet(action: any) {
   if (skalHente) {
     yield put(actions.hentPrediksjonHenter());
     const path = `${ISPREDIKSJON_ROOT}/prediksjon`;
-    const result: Result<Prediksjon> = yield call(get, path, action.fnr);
-
-    if (result instanceof Success) {
-      yield put(actions.hentPrediksjonHentet(result.data, action.fnr));
-    } else {
+    try {
+      const data: Prediksjon = yield call(get, path, action.fnr);
+      yield put(actions.hentPrediksjonHentet(data, action.fnr));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentPrediksjonFeilet());
     }

--- a/src/data/sykepengesoknad/soknaderSagas.ts
+++ b/src/data/sykepengesoknad/soknaderSagas.ts
@@ -1,6 +1,6 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import * as actions from "./soknader_actions";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { SykepengesoknadDTO } from "./types/SykepengesoknadDTO";
 import { SYFOSOKNAD_ROOT } from "@/apiConstants";
 
@@ -15,11 +15,10 @@ export function* hentSoknaderHvisIkkeHentet(action: any) {
     yield put(actions.henterSoknader());
 
     const path = `${SYFOSOKNAD_ROOT}/soknader?fnr=${action.fnr}`;
-    const result: Result<SykepengesoknadDTO[]> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(actions.soknaderHentet(result.data));
-    } else {
+    try {
+      const data: SykepengesoknadDTO[] = yield call(get, path);
+      yield put(actions.soknaderHentet(data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentSoknaderFeilet());
     }

--- a/src/data/sykmelding/sykmeldinger.ts
+++ b/src/data/sykmelding/sykmeldinger.ts
@@ -9,7 +9,7 @@ import {
   SykmeldingerActions,
   SykmeldingerActionTypes,
 } from "./sykmeldinger_actions";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export interface SykmeldingerState {
   henter: boolean;

--- a/src/data/sykmelding/sykmeldinger_actions.ts
+++ b/src/data/sykmelding/sykmeldinger_actions.ts
@@ -1,5 +1,5 @@
 import { SykmeldingNewFormatDTO } from "./types/SykmeldingNewFormatDTO";
-import { ApiError } from "@/api/axios";
+import { ApiError } from "@/api/errors";
 
 export enum SykmeldingerActionTypes {
   HENT_SYKMELDINGER_FEILET = "HENT_SYKMELDINGER_FEILET",

--- a/src/data/tilgang/tilgangSagas.ts
+++ b/src/data/tilgang/tilgangSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import * as actions from "./tilgang_actions";
 import { Tilgang } from "./tilgang";
 import { SYFOTILGANGSKONTROLL_ROOT } from "@/apiConstants";
@@ -8,15 +8,14 @@ export function* sjekkTilgang(action: any) {
   yield put(actions.sjekkerTilgang());
 
   const path = `${SYFOTILGANGSKONTROLL_ROOT}/tilgang/bruker?fnr=${action.fnr}`;
-  const result: Result<Tilgang> = yield call(get, path);
-
-  if (result instanceof Success) {
-    if (result.data.harTilgang) {
+  try {
+    const { harTilgang, begrunnelse }: Tilgang = yield call(get, path);
+    if (harTilgang) {
       yield put(actions.harTilgang());
     } else {
-      yield put(actions.harIkkeTilgang(result.data.begrunnelse));
+      yield put(actions.harIkkeTilgang(begrunnelse));
     }
-  } else {
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(actions.sjekkTilgangFeilet());
   }

--- a/src/data/unleash/unleashSagas.ts
+++ b/src/data/unleash/unleashSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import {
   FetchUnleashTogglesAction,
   fetchUnleashTogglesFailed,
@@ -11,11 +11,10 @@ import { UNLEASH_ROOT } from "@/apiConstants";
 //Common saga for all toggles
 function* fetchToggles(action: FetchUnleashTogglesAction) {
   const dm2Path = `${UNLEASH_ROOT}/dm2/?valgtEnhet=${action.valgtEnhet}&userId=${action.userId}`;
-  const result: Result<boolean> = yield call(get, dm2Path);
-
-  if (result instanceof Success) {
-    yield put(fetchUnleashTogglesSuccess(result.data));
-  } else {
+  try {
+    const data: boolean = yield call(get, dm2Path);
+    yield put(fetchUnleashTogglesSuccess(data));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(fetchUnleashTogglesFailed());
   }

--- a/src/data/vedtak/vedtakSagas.ts
+++ b/src/data/vedtak/vedtakSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { VedtakDTO, VedtakState } from "./vedtak";
 import {
   HENT_VEDTAK_FORESPURT,
@@ -20,11 +20,10 @@ export function* hentVedtakHvisIkkeHentet(action: any) {
     yield put(hentVedtakHenter());
 
     const path = `${VEDTAK_ROOT}?fnr=${action.fnr}`;
-    const result: Result<VedtakDTO> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(hentVedtakHentet(result.data || {}, action.fnr));
-    } else {
+    try {
+      const data: VedtakDTO = yield call(get, path);
+      yield put(hentVedtakHentet(data || {}, action.fnr));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(hentVedtakFeilet());
     }

--- a/src/data/veilederinfo/veilederinfoSagas.ts
+++ b/src/data/veilederinfo/veilederinfoSagas.ts
@@ -1,5 +1,5 @@
 import { call, put, takeEvery } from "redux-saga/effects";
-import { get, Result, Success } from "@/api/axios";
+import { get } from "@/api/axios";
 import { VeilederinfoDTO } from "./types/VeilederinfoDTO";
 import {
   HENT_VEILEDERINFO_FORESPURT,
@@ -13,11 +13,10 @@ export function* hentVeilederinfoSaga() {
   yield put(henterVeilederinfo());
 
   const path = `${SYFOVEILEDER_ROOT}/veileder/self`;
-  const result: Result<VeilederinfoDTO> = yield call(get, path);
-
-  if (result instanceof Success) {
-    yield put(veilederinfoHentet(result.data));
-  } else {
+  try {
+    const data: VeilederinfoDTO = yield call(get, path);
+    yield put(veilederinfoHentet(data));
+  } catch (e) {
     //TODO: Add error to reducer and errorboundary to components
     yield put(hentVeilederinfoFeilet());
   }

--- a/src/data/virksomhet/virksomhetSagas.ts
+++ b/src/data/virksomhet/virksomhetSagas.ts
@@ -1,7 +1,6 @@
 import { call, put, select, takeEvery } from "redux-saga/effects";
 import { get } from "@/api/axios";
 import * as actions from "./virksomhet_actions";
-import { Result, Success } from "@/api/axios";
 import { Virksomhet } from "./types/Virksomhet";
 import { SYFOMOTEADMIN_ROOT } from "@/apiConstants";
 
@@ -18,11 +17,10 @@ export function* hentVirksomhetHvisIkkeHentet(action: any) {
     yield put(actions.henterVirksomhet(orgnummer));
 
     const path = `${SYFOMOTEADMIN_ROOT}/virksomhet/${orgnummer}`;
-    const result: Result<Virksomhet> = yield call(get, path);
-
-    if (result instanceof Success) {
-      yield put(actions.virksomhetHentet(orgnummer, result.data));
-    } else {
+    try {
+      const data: Virksomhet = yield call(get, path);
+      yield put(actions.virksomhetHentet(orgnummer, data));
+    } catch (e) {
       //TODO: Add error to reducer and errorboundary to components
       yield put(actions.hentVirksomhetFeilet(orgnummer));
     }

--- a/test/api/axiosApiTest.ts
+++ b/test/api/axiosApiTest.ts
@@ -1,8 +1,9 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
-import { ErrorType, Failure, get, post, Result, Success } from "@/api/axios";
 import { Tilgang } from "@/data/tilgang/tilgang";
 import { expect } from "chai";
+import { get, post } from "@/api/axios";
+import { ApiErrorException, ErrorType } from "@/api/errors";
 
 describe("Axios API tests", () => {
   let stub: MockAdapter;
@@ -28,56 +29,64 @@ describe("Axios API tests", () => {
 
   describe("Happy case", () => {
     it("returns expected data from http 200", async function () {
-      const result: Result<any> = await get(pathHappyCase);
-      expect(result instanceof Success).to.equal(true);
-
-      const { data, code } = result as Success<any>;
-      expect(code).to.equal(200);
-      expect(data).to.equal(happyCaseMessage);
+      const result = await get(pathHappyCase);
+      expect(result).to.equal(happyCaseMessage);
     });
   });
 
   describe("Access denied tests", () => {
-    it("Returns access denied for http 403, and handles Tilgang-object", async function () {
-      const result: Result<any> = await get(pathAccessDenied);
-      expect(result instanceof Success).to.equal(false);
-      expect(result.code).to.equal(403);
+    it("Throws access denied for http 403, and handles Tilgang-object", async function () {
+      try {
+        await get(pathAccessDenied);
+      } catch (e) {
+        expect(e instanceof ApiErrorException).to.equal(true);
 
-      const { error } = result as Failure;
-      expect(error.type).to.equal(ErrorType.ACCESS_DENIED);
-      expect(error.message).to.equal(tilgangDenied.begrunnelse);
+        const { error, code } = e as ApiErrorException;
+        expect(code).to.equal(403);
+        expect(error.type).to.equal(ErrorType.ACCESS_DENIED);
+        expect(error.message).to.equal(tilgangDenied.begrunnelse);
+      }
     });
 
-    it("Returns access denied for http 403, and handles message", async function () {
-      const result: Result<any> = await post(pathAccessDeniedMessage, {
-        some: "data",
-      });
-      expect(result instanceof Failure).to.equal(true);
-      expect(result.code).to.equal(403);
+    it("Throws access denied for http 403, and handles message", async function () {
+      try {
+        await post(pathAccessDeniedMessage, {
+          some: "data",
+        });
+      } catch (e) {
+        expect(e instanceof ApiErrorException).to.equal(true);
 
-      const { error } = result as Failure;
-      expect(error.type).to.equal(ErrorType.ACCESS_DENIED);
-      expect(error.message).to.equal(tilgangDeniedMessage.message);
+        const { error, code } = e as ApiErrorException;
+        expect(code).to.equal(403);
+        expect(error.type).to.equal(ErrorType.ACCESS_DENIED);
+        expect(error.message).to.equal(tilgangDeniedMessage.message);
+      }
     });
   });
 
   describe("General error tests", () => {
-    it("Returns general error for http 404", async function () {
-      const result: Result<any> = await post(pathNotFound, { some: "data" });
-      expect(result instanceof Failure).to.equal(true);
-      expect(result.code).to.equal(404);
+    it("Throws general error for http 404", async function () {
+      try {
+        await post(pathNotFound, { some: "data" });
+      } catch (e) {
+        expect(e instanceof ApiErrorException).to.equal(true);
 
-      const { error } = result as Failure;
-      expect(error.type).to.equal(ErrorType.GENERAL_ERROR);
+        const { error, code } = e as ApiErrorException;
+        expect(code).to.equal(404);
+        expect(error.type).to.equal(ErrorType.GENERAL_ERROR);
+      }
     });
 
-    it("Returns general error for http 500", async function () {
-      const result: Result<any> = await get(pathInternalServerError);
-      expect(result instanceof Failure).to.equal(true);
-      expect(result.code).to.equal(500);
+    it("Throws general error for http 500", async function () {
+      try {
+        await get(pathInternalServerError);
+      } catch (e) {
+        expect(e instanceof ApiErrorException).to.equal(true);
 
-      const { error } = result as Failure;
-      expect(error.type).to.equal(ErrorType.GENERAL_ERROR);
+        const { error, code } = e as ApiErrorException;
+        expect(code).to.equal(500);
+        expect(error.type).to.equal(ErrorType.GENERAL_ERROR);
+      }
     });
   });
 });

--- a/test/reducers/diskresjonskodeReducerTest.js
+++ b/test/reducers/diskresjonskodeReducerTest.js
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import * as actions from "../../src/data/diskresjonskode/diskresjonskode_actions";
 import { HentDiskresjonskodeActionTypes } from "@/data/diskresjonskode/diskresjonskode_actions";
 import diskresjonskode from "../../src/data/diskresjonskode/diskresjonskode";
-import { defaultErrorTexts, ErrorType } from "@/api/axios";
+import { defaultErrorTexts, ErrorType } from "@/api/errors";
 
 describe("diskresjonskode", () => {
   describe("henter", () => {

--- a/test/reducers/egenansattReducerTest.js
+++ b/test/reducers/egenansattReducerTest.js
@@ -3,7 +3,7 @@ import deepFreeze from "deep-freeze";
 import * as actions from "../../src/data/egenansatt/egenansatt_actions";
 import egenansatt from "../../src/data/egenansatt/egenansatt";
 import { HentEgenAnsattActionTypes } from "@/data/egenansatt/egenansatt_actions";
-import { defaultErrorTexts, ErrorType } from "@/api/axios";
+import { defaultErrorTexts, ErrorType } from "@/api/errors";
 
 describe("egenansatt", () => {
   describe("henter", () => {


### PR DESCRIPTION
Endret til try/catch i sagas slik at disse også håndterer feil utover de som kastes fra axios (f.eks. feil i reducer). Forenkler samtidig axios-feilhåndteringen til å kaste exception eller returnere respons.