### PR TITLE
Show error if user attempts to add an existing tidspunkt

### DIFF
--- a/src/utils/moteplanleggerUtils.ts
+++ b/src/utils/moteplanleggerUtils.ts
@@ -1,4 +1,6 @@
 import { BRUKER, MULIGE_SVAR } from "@/konstanter";
+import { genererDato } from "@/components/mote/utils";
+import { MoteDTO } from "@/data/mote/types/moteTypes";
 
 export const brukerHarSvart = (svartidspunkt: any, created: any) => {
   if (!svartidspunkt) {
@@ -21,5 +23,16 @@ export const getTidligereAlternativer = (mote: any, deltakertype = BRUKER) => {
   })[0];
   return mote.alternativer.filter((alternativ: any) => {
     return alternativ.created < innloggetBruker.svartidspunkt;
+  });
+};
+
+export const alternativAlreadyExists = (mote: MoteDTO, alternativ: any) => {
+  const newTidspunkt = genererDato(alternativ.dato, alternativ.klokkeslett);
+
+  return mote.alternativer.find((existingAlternativ) => {
+    return (
+      new Date(existingAlternativ.tid).getTime() ===
+      new Date(newTidspunkt).getTime()
+    );
   });
 };


### PR DESCRIPTION
Da slipper vi forhåpentligvis feilen der veileder ikke får til å tidligere tidspunkt fordi de ikke eksisterer i databasen.
Nå vises en feilmelding hvis man forsøker å sende inn et nytt tidspunkt som er likt et eksisterende tidspunkt, både de "aktive" og de som ligger under tidligere tidspunkt.
Man får feilmelding så lenge minst ett av de nye foreslåtte tidspunktene matcher et eksisterende.