### PR TITLE
Make Cypress work with Docker Compose

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,12 +34,22 @@ jobs:
       - name: Run unit tests
         run: |
           npm run test
-#      - name: Run Cypress tests
-#        uses: cypress-io/github-action@v2
-#        with:
-#          start: npm start
-#          wait-on: 'http://localhost:8080/sykefravaer'
-#          headless: true
+      - name: Login to Github Package Registry
+        env:
+          DOCKER_USERNAME: x-access-token
+          DOCKER_PASSWORD: ${{ secrets.GITHUB_ACCESS_TOKEN }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
+      - name: Docker compose
+        run: docker-compose up -d
+      - name: read environment file
+        run: cat .env.template >>${GITHUB_ENV}
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          start: npm start
+          wait-on: 'http://localhost:8080/sykefravaer'
+          headless: true
       - name: Upload screenshots if Cypress tests failed
         uses: actions/upload-artifact@v1
         if: failure()
@@ -55,12 +65,6 @@ jobs:
       - name: Prune
         run: |
           npm prune --production
-      - name: Login to Github Package Registry
-        env:
-          DOCKER_USERNAME: x-access-token
-          DOCKER_PASSWORD: ${{ secrets.GITHUB_ACCESS_TOKEN }}
-        run: |
-          echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin docker.pkg.github.com
       - name: Build and publish Docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
   "baseUrl": "http://localhost:8080",
-  "video": false
+  "video": false,
+  "chromeWebSecurity": false
 }

--- a/cypress/integration/dialogmoter/avlys-dialogmoter.spec.ts
+++ b/cypress/integration/dialogmoter/avlys-dialogmoter.spec.ts
@@ -10,6 +10,7 @@ context("Avlys dialogmøte", () => {
   beforeEach(() => {
     cy.stubMoter(MoteState.INNKALT_DIALOGMOTE);
     cy.visit("/sykefravaer/moteoversikt");
+    cy.OAuth2Login();
   });
 
   it("Tester feilhåndtering for manglende begrunnelse", () => {

--- a/cypress/integration/dialogmoter/ferdigstill-dialogmote.spec.ts
+++ b/cypress/integration/dialogmoter/ferdigstill-dialogmote.spec.ts
@@ -12,6 +12,7 @@ context("Ferdigstill dialogmøte", () => {
   beforeEach(() => {
     cy.stubMoter(MoteState.INNKALT_DIALOGMOTE);
     cy.visit("/sykefravaer/moteoversikt");
+    cy.OAuth2Login();
   });
 
   it("Går til skriv referat, sjekker forhåndsvisning og avbryter", () => {

--- a/cypress/integration/dialogmoter/motelandingsside.spec.ts
+++ b/cypress/integration/dialogmoter/motelandingsside.spec.ts
@@ -4,6 +4,7 @@ import { selectors } from "../../support/constants";
 context("Møtelandingsside actions", () => {
   beforeEach(() => {
     cy.visit("/sykefravaer/moteoversikt");
+    cy.OAuth2Login();
   });
 
   it("Oppretter nytt møte der behandler skal være med", () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -26,3 +26,11 @@
 Cypress.Commands.add("dataCy", (value) => {
   return cy.get(`[data-cy=${value}]`);
 });
+
+Cypress.Commands.add("OAuth2Login", () => {
+  cy.get('input[name="username"]').type("La den rette komme inn!");
+
+  cy.get('input[name="acr"]').type(`Sesam sesam`);
+
+  cy.get("input[value=Sign-in]").click();
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -22,6 +22,8 @@ declare global {
       dataCy(value: string): Chainable<Element>;
 
       stubMoter(state: MoteState): Chainable<Element>;
+
+      OAuth2Login(): Chainable<Element>;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "syfomodiaperson",
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
@@ -20,7 +19,7 @@
         "@types/express-session": "1.17.3",
         "@types/passport": "1.0.5",
         "@types/passport-jwt": "3.0.3",
-        "@types/react": "^17.0.19",
+        "@types/react": "17.0.19",
         "@types/react-dom": "17.0.5",
         "@types/react-modal": "3.12.0",
         "@types/styled-components": "5.1.11",


### PR DESCRIPTION
Godta Cross Origin-kall for at man skal kunne redirecte til MockOAuth2.
Legg til Command i Cypress som logger inn i MockOAuth2, bruk den i "before each" i alle testene.
Legg til Docker Compose i GitHub Actions workflow-filen.
Flytt innlogging i Docker lenger opp i workflow, for at man skal få tak i oauth2-pakken i docker compose.
Skriv .env.template-filen til `GITHUB_ENV`, så de er tilgjengelige når Cypress kjører.