### PR TITLE
Henter unleash feature toggles selv om veilederIdent er undefined

### DIFF
--- a/server/routes/unleashRoutes.js
+++ b/server/routes/unleashRoutes.js
@@ -25,7 +25,7 @@ class ByUserId extends Strategy {
   }
 
   isEnabled(parameters, context) {
-    return parameters.user.indexOf(context.user) !== -1;
+    return context.user && parameters.user.indexOf(context.user) !== -1;
   }
 }
 

--- a/src/data/unleash/unleashSagas.ts
+++ b/src/data/unleash/unleashSagas.ts
@@ -11,7 +11,11 @@ import { ToggleNames, Toggles } from "@/data/unleash/unleash_types";
 
 //Common saga for all toggles
 function* fetchToggles(action: FetchUnleashTogglesAction) {
-  const dm2Path = `${UNLEASH_ROOT}/dm2?valgtEnhet=${action.valgtEnhet}&userId=${action.userId}`;
+  const { valgtEnhet, userId } = action;
+  let dm2Path = `${UNLEASH_ROOT}/dm2?valgtEnhet=${valgtEnhet}`;
+  if (userId) {
+    dm2Path += `&userId=${userId}`;
+  }
   try {
     const data: Toggles = yield call(post, dm2Path, {
       toggles: Object.values(ToggleNames),

--- a/src/data/unleash/unleash_actions.ts
+++ b/src/data/unleash/unleash_actions.ts
@@ -9,7 +9,7 @@ export enum UnleashActionTypes {
 export interface FetchUnleashTogglesAction {
   type: UnleashActionTypes.FETCH_UNLEASH_TOGGLES;
   valgtEnhet: string;
-  userId: string;
+  userId: string | undefined;
 }
 
 export interface FetchUnleashTogglesFailedAction {
@@ -23,7 +23,7 @@ export interface FetchUnleashTogglesSuccessAction {
 
 export const fetchUnleashToggles = (
   valgtEnhet: string,
-  userId: string
+  userId: string | undefined
 ): FetchUnleashTogglesAction => ({
   type: UnleashActionTypes.FETCH_UNLEASH_TOGGLES,
   valgtEnhet,

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -156,15 +156,17 @@ const AktivBrukerLoader = () => {
 const AppRouter = () => {
   const fnrFromParam = getFnrFromParams();
   const userProperties = useUserProperties();
-  const userId = useAppSelector((state) => state.veilederinfo.data?.ident);
+  const veilederIdent = useAppSelector(
+    (state) => state.veilederinfo.data?.ident
+  );
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (userProperties.valgtEnhet && userId) {
-      dispatch(fetchUnleashToggles(userProperties.valgtEnhet, userId));
+    if (userProperties.valgtEnhet || veilederIdent) {
+      dispatch(fetchUnleashToggles(userProperties.valgtEnhet, veilederIdent));
       setAmplitudeUserProperties(userProperties);
     }
-  }, [dispatch, userProperties, userId]);
+  }, [dispatch, userProperties, veilederIdent]);
 
   useEffect(() => {
     if (erGyldigFodselsnummer(fnrFromParam)) {


### PR DESCRIPTION
Dersom kall til syfoveileder for å hente veielederIdent feilet hentet vi ikke feature toggles fra unleash. 
Vi bør hente disse uansett slik at veiledere som tilhører kontor hvor MVP er enabled får denne uavhengig av om vi klarer hente veileder fra syfoveileder.