### PR TITLE
Rename DTO from Syfomotebehov and add opprettetAvNavn

### DIFF
--- a/mock/data/motebehovMock.ts
+++ b/mock/data/motebehovMock.ts
@@ -5,6 +5,7 @@ const motebehovArbeidstakerUbehandletMock = {
   opprettetDato: "2021-12-08T13:53:57.047+01:00",
   aktorId: "1",
   opprettetAv: "1",
+  opprettetAvNavn: "Sygve Sykmeldt",
   virksomhetsnummer: "110110110",
   motebehovSvar: {
     harMotebehov: true,
@@ -24,6 +25,7 @@ const motebehovArbeidstakerBehandletMock = {
   opprettetDato: "2019-01-08T13:53:57.047+01:00",
   aktorId: "1",
   opprettetAv: "1",
+  opprettetAvNavn: "Sygve Sykmeldt",
   virksomhetsnummer: "000999000",
   motebehovSvar: {
     harMotebehov: true,
@@ -43,6 +45,7 @@ const motebehovArbeidsgiverMock = {
   opprettetDato: "2021-12-08T13:53:57.047+01:00",
   aktorId: "1",
   opprettetAv: "1902690001009",
+  opprettetAvNavn: "Are Arbeidsgiver",
   virksomhetsnummer: "110110110",
   motebehovSvar: {
     harMotebehov: false,

--- a/src/components/motebehov/BehandleMotebehovKnapp.tsx
+++ b/src/components/motebehov/BehandleMotebehovKnapp.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/utils/motebehovUtils";
 import { toDatePrettyPrint } from "@/utils/datoUtils";
 import { behandleMotebehov } from "@/data/motebehov/behandlemotebehov_actions";
-import { MotebehovDTO } from "@/data/motebehov/types/motebehovTypes";
+import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { useTrackOnClick } from "@/data/logging/loggingHooks";
 
@@ -20,7 +20,7 @@ const texts = {
 
 const behandleMotebehovKnappLabel = (
   erBehandlet: boolean,
-  sistBehandletMotebehov?: MotebehovDTO
+  sistBehandletMotebehov?: MotebehovVeilederDTO
 ): string => {
   return erBehandlet
     ? `Ferdigbehandlet av ${
@@ -30,7 +30,7 @@ const behandleMotebehovKnappLabel = (
 };
 
 interface BehandleMotebehovKnappProps {
-  motebehovData: MotebehovDTO[];
+  motebehovData: MotebehovVeilederDTO[];
   veilederinfo?: VeilederinfoDTO;
 }
 

--- a/src/components/motebehov/DialogmoteOnskePanel.tsx
+++ b/src/components/motebehov/DialogmoteOnskePanel.tsx
@@ -4,7 +4,7 @@ import { FlexRow, PaddingSize } from "../Layout";
 import BehandleMotebehovKnapp from "./BehandleMotebehovKnapp";
 import { DialogmotePanel } from "../mote/components/DialogmotePanel";
 import React from "react";
-import { MotebehovDTO } from "@/data/motebehov/types/motebehovTypes";
+import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { Leder } from "@/data/leder/ledere";
 import { OppfolgingstilfelleperioderMapState } from "@/data/oppfolgingstilfelle/oppfolgingstilfelleperioder";
 import { Brukerinfo } from "@/data/navbruker/types/Brukerinfo";
@@ -15,7 +15,7 @@ const texts = {
 };
 
 interface Props {
-  motebehovData: MotebehovDTO[];
+  motebehovData: MotebehovVeilederDTO[];
   ledereData: Leder[];
   oppfolgingstilfelleperioder: OppfolgingstilfelleperioderMapState;
   sykmeldt?: Brukerinfo;

--- a/src/components/motebehov/MotebehovKvittering.tsx
+++ b/src/components/motebehov/MotebehovKvittering.tsx
@@ -6,7 +6,7 @@ import {
   sorterMotebehovDataEtterDato,
 } from "@/utils/motebehovUtils";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
-import { MotebehovDTO } from "@/data/motebehov/types/motebehovTypes";
+import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { Brukerinfo } from "@/data/navbruker/types/Brukerinfo";
 import {
   MotebehovIkkeSvartImage,
@@ -18,14 +18,8 @@ import { InfoRow } from "../InfoRow";
 import { PaddingSize } from "../Layout";
 import { ledereUtenMotebehovsvar } from "@/utils/ledereUtils";
 
-export const lederMedGittAktorId = (aktorId: string, ledere: Leder[]) => {
-  return ledere.find((leder) => {
-    return leder.aktoerId === aktorId;
-  });
-};
-
-export const arbeidsgiverNavnEllerTomStreng = (leder?: Leder) => {
-  return leder && leder.navn ? `${leder.navn}` : "";
+export const arbeidsgiverNavnEllerTomStreng = (lederNavn?: string) => {
+  return lederNavn ? `${lederNavn}` : "";
 };
 
 export const setSvarIkon = (deltakerOnskerMote?: boolean): string => {
@@ -70,7 +64,7 @@ const ikonAlternativTekst = (deltakerOnskerMote?: boolean) => {
   }
 };
 
-export const bareArbeidsgiversMotebehov = (motebehov: MotebehovDTO) => {
+export const bareArbeidsgiversMotebehov = (motebehov: MotebehovVeilederDTO) => {
   return motebehov.opprettetAv !== motebehov.aktorId;
 };
 
@@ -95,7 +89,7 @@ const composePersonSvarText = (
 interface MotebehovKvitteringInnholdProps {
   deltakerOnskerMote?: boolean;
   ikonAltTekst: string;
-  motebehov?: MotebehovDTO;
+  motebehov?: MotebehovVeilederDTO;
   tekst: ReactElement;
   topPadding?: PaddingSize;
 }
@@ -119,7 +113,7 @@ export const MotebehovKvitteringInnhold = ({
 };
 
 interface MotebehovKvitteringInnholdArbeidstakerProps {
-  arbeidstakersMotebehov?: MotebehovDTO;
+  arbeidstakersMotebehov?: MotebehovVeilederDTO;
   sykmeldt?: Brukerinfo;
 }
 
@@ -152,18 +146,17 @@ export const MotebehovKvitteringInnholdArbeidstaker = ({
 };
 
 interface MotebehovKvitteringInnholdArbeidsgiverProps {
-  motebehovListeMedBareArbeidsgiversMotebehov: MotebehovDTO[];
-  ledereData: Leder[];
+  motebehovListeMedBareArbeidsgiversMotebehov: MotebehovVeilederDTO[];
 }
 
 export const composeArbeidsgiverSvarText = (
-  leder?: Leder,
+  lederNavn?: string,
   harMotebehov?: boolean,
   svarOpprettetDato?: Date
 ) => {
   return composePersonSvarText(
     "Nærmeste leder: ",
-    arbeidsgiverNavnEllerTomStreng(leder),
+    arbeidsgiverNavnEllerTomStreng(lederNavn),
     harMotebehov,
     svarOpprettetDato
   );
@@ -171,17 +164,12 @@ export const composeArbeidsgiverSvarText = (
 
 export const MotebehovKvitteringInnholdArbeidsgiver = ({
   motebehovListeMedBareArbeidsgiversMotebehov,
-  ledereData,
 }: MotebehovKvitteringInnholdArbeidsgiverProps) => (
   <>
     {motebehovListeMedBareArbeidsgiversMotebehov.map((motebehov, index) => {
       const arbeidsgiverOnskerMote = motebehov.motebehovSvar?.harMotebehov;
-      const riktigLeder = lederMedGittAktorId(
-        motebehov.opprettetAv,
-        ledereData
-      );
       const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverNavnEllerTomStreng(
-        riktigLeder
+        motebehov.opprettetAvNavn
       )} ${ikonAlternativTekst(arbeidsgiverOnskerMote)}`;
 
       return (
@@ -191,7 +179,7 @@ export const MotebehovKvitteringInnholdArbeidsgiver = ({
           ikonAltTekst={ikonAltTekst}
           motebehov={motebehov}
           tekst={composeArbeidsgiverSvarText(
-            riktigLeder,
+            motebehov.opprettetAvNavn,
             arbeidsgiverOnskerMote,
             motebehov.opprettetDato
           )}
@@ -212,13 +200,13 @@ export const MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov = ({
   <>
     {ledereUtenInnsendtMotebehov.map((leder: Leder, index: number) => {
       const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverNavnEllerTomStreng(
-        leder
+        leder.navn
       )} ${ikonAlternativTekst(undefined)}`;
       return (
         <MotebehovKvitteringInnhold
           key={index}
           ikonAltTekst={ikonAltTekst}
-          tekst={composeArbeidsgiverSvarText(leder)}
+          tekst={composeArbeidsgiverSvarText(leder.navn)}
           topPadding={PaddingSize.SM}
         />
       );
@@ -227,7 +215,7 @@ export const MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov = ({
 );
 
 interface MotebehovKvitteringProps {
-  motebehovData: MotebehovDTO[];
+  motebehovData: MotebehovVeilederDTO[];
   ledereData: Leder[];
   oppfolgingstilfelleperioder: OppfolgingstilfelleperioderMapState;
   sykmeldt?: Brukerinfo;
@@ -262,7 +250,6 @@ const MotebehovKvittering = ({
         motebehovListeMedBareArbeidsgiversMotebehov={aktiveMotebehovSvar.filter(
           bareArbeidsgiversMotebehov
         )}
-        ledereData={ledereData}
       />
       <MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov
         ledereUtenInnsendtMotebehov={ledereUtenInnsendtMotebehov}

--- a/src/data/motebehov/motebehov.ts
+++ b/src/data/motebehov/motebehov.ts
@@ -10,10 +10,13 @@ import {
   BEHANDLE_MOTEBEHOV_BEHANDLET,
   BehandleMotebehovBehandletAction,
 } from "./behandlemotebehov_actions";
-import { MotebehovDTO } from "./types/motebehovTypes";
+import { MotebehovVeilederDTO } from "./types/motebehovTypes";
 import { Tilgang } from "../tilgang/tilgang";
 
-export const sorterEtterDato = (a: MotebehovDTO, b: MotebehovDTO): number => {
+export const sorterEtterDato = (
+  a: MotebehovVeilederDTO,
+  b: MotebehovVeilederDTO
+): number => {
   return b.opprettetDato === a.opprettetDato
     ? 0
     : b.opprettetDato > a.opprettetDato
@@ -26,7 +29,7 @@ export interface MotebehovState {
   hentet: boolean;
   hentingFeilet: boolean;
   hentingForsokt: boolean;
-  data: MotebehovDTO[];
+  data: MotebehovVeilederDTO[];
   tilgang?: Tilgang;
 }
 

--- a/src/data/motebehov/motebehovSagas.ts
+++ b/src/data/motebehov/motebehovSagas.ts
@@ -5,7 +5,7 @@ import { HentMotebehovAction } from "./motebehov_actions";
 import * as behandleActions from "./behandlemotebehov_actions";
 import { BehandleMotebehovAction } from "./behandlemotebehov_actions";
 import { RootState } from "../rootState";
-import { MotebehovDTO } from "./types/motebehovTypes";
+import { MotebehovVeilederDTO } from "./types/motebehovTypes";
 import { SYFOMOTEBEHOV_ROOT } from "@/apiConstants";
 
 export const skalHenteMotebehov = (state: RootState) => {
@@ -21,7 +21,7 @@ export function* hentMotebehovHvisIkkeHentet(action: HentMotebehovAction) {
 
     const path = `${SYFOMOTEBEHOV_ROOT}/motebehov?fnr=${fnr}`;
     try {
-      const data: MotebehovDTO[] = yield call(get, path);
+      const data: MotebehovVeilederDTO[] = yield call(get, path);
       yield put(actions.motebehovHentet(data));
     } catch (e) {
       //TODO: Add error to reducer and errorboundary to components

--- a/src/data/motebehov/motebehov_actions.ts
+++ b/src/data/motebehov/motebehov_actions.ts
@@ -1,4 +1,4 @@
-import { MotebehovDTO } from "./types/motebehovTypes";
+import { MotebehovVeilederDTO } from "./types/motebehovTypes";
 
 export const HENT_MOTEBEHOV_FORESPURT = "HENT_MOTEBEHOV_FORESPURT";
 export const HENT_MOTEBEHOV_HENTER = "HENT_MOTEBEHOV_HENTER";
@@ -17,7 +17,7 @@ export interface HenterMotebehovAction {
 
 export interface MotebehovHentetAction {
   type: typeof HENT_MOTEBEHOV_HENTET;
-  data: MotebehovDTO[];
+  data: MotebehovVeilederDTO[];
 }
 
 export interface HentMotebehovFeiletAction {
@@ -46,7 +46,7 @@ export const henterMotebehov = (): HenterMotebehovAction => ({
 });
 
 export const motebehovHentet = (
-  data: MotebehovDTO[]
+  data: MotebehovVeilederDTO[]
 ): MotebehovHentetAction => ({
   type: HENT_MOTEBEHOV_HENTET,
   data,

--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -1,16 +1,17 @@
-export interface MotebehovSvar {
+export interface MotebehovSvarVeilederDTO {
   harMotebehov: boolean;
   forklaring?: string;
 }
 
-export interface MotebehovDTO {
+export interface MotebehovVeilederDTO {
   id: string;
   opprettetDato: Date;
   aktorId: string;
   opprettetAv: string;
+  opprettetAvNavn?: string;
   arbeidstakerFnr: string;
   virksomhetsnummer: string;
-  motebehovSvar?: MotebehovSvar;
+  motebehovSvar?: MotebehovSvarVeilederDTO;
   tildeltEnhet?: string;
   behandletTidspunkt?: string | Date;
   behandletVeilederIdent?: string;

--- a/src/utils/ledereUtils.ts
+++ b/src/utils/ledereUtils.ts
@@ -7,12 +7,12 @@ import {
 } from "./motebehovUtils";
 import { activeSykmeldingerSentToArbeidsgiver } from "./sykmeldinger/sykmeldingUtils";
 import { OppfolgingstilfelleperioderMapState } from "@/data/oppfolgingstilfelle/oppfolgingstilfelleperioder";
-import { MotebehovDTO } from "@/data/motebehov/types/motebehovTypes";
+import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat";
 
 export const ledereIVirksomheterMedMotebehovsvarFraArbeidstaker = (
   ledereData: Leder[],
-  motebehovData: MotebehovDTO[]
+  motebehovData: MotebehovVeilederDTO[]
 ): Leder[] => {
   return ledereData.filter((leder: Leder) =>
     motebehovData.some(
@@ -25,7 +25,7 @@ export const ledereIVirksomheterMedMotebehovsvarFraArbeidstaker = (
 
 export const ledereIVirksomheterDerIngenLederHarSvartPaMotebehov = (
   ledereListe: Leder[],
-  motebehovData: MotebehovDTO[]
+  motebehovData: MotebehovVeilederDTO[]
 ): Leder[] => {
   return ledereListe.filter(
     (leder) =>
@@ -79,7 +79,7 @@ export const newestLederForEachVirksomhet = (ledere: Leder[]): Leder[] => {
 
 export const ledereUtenMotebehovsvar = (
   ledereData: Leder[],
-  motebehovData: MotebehovDTO[],
+  motebehovData: MotebehovVeilederDTO[],
   oppfolgingstilfelleperioder: OppfolgingstilfelleperioderMapState
 ): Leder[] => {
   const arbeidstakerHarSvartPaaMotebehov =

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -1,11 +1,11 @@
 import { dagerMellomDatoer } from "./datoUtils";
 import { startDateFromLatestActiveTilfelle } from "./periodeUtils";
-import { MotebehovDTO } from "@/data/motebehov/types/motebehovTypes";
+import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { OppfolgingstilfelleperioderMapState } from "@/data/oppfolgingstilfelle/oppfolgingstilfelleperioder";
 
 export const sorterMotebehovDataEtterDato = (
-  a: MotebehovDTO,
-  b: MotebehovDTO
+  a: MotebehovVeilederDTO,
+  b: MotebehovVeilederDTO
 ): number => {
   return b.opprettetDato === a.opprettetDato
     ? 0
@@ -15,8 +15,8 @@ export const sorterMotebehovDataEtterDato = (
 };
 
 export const finnNyesteMotebehovsvarFraHverDeltaker = (
-  sortertMotebehovListe: MotebehovDTO[]
-): MotebehovDTO[] => {
+  sortertMotebehovListe: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO[] => {
   return sortertMotebehovListe.filter((motebehov1, index) => {
     return (
       sortertMotebehovListe.findIndex((motebehov2) => {
@@ -27,8 +27,8 @@ export const finnNyesteMotebehovsvarFraHverDeltaker = (
 };
 
 export const finnArbeidstakerMotebehovSvar = (
-  motebehovListe: MotebehovDTO[]
-): MotebehovDTO | undefined => {
+  motebehovListe: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO | undefined => {
   return motebehovListe.find(
     (motebehov) => motebehov.opprettetAv === motebehov.aktorId
   );
@@ -70,14 +70,14 @@ export const erOppfolgingstilfelleSluttDatoPassert = (
 };
 
 export const harArbeidstakerSvartPaaMotebehov = (
-  motebehovData: MotebehovDTO[]
+  motebehovData: MotebehovVeilederDTO[]
 ): boolean => {
   return !!finnArbeidstakerMotebehovSvar(motebehovData);
 };
 
 export const motebehovUbehandlet = (
-  motebehovListe: MotebehovDTO[]
-): MotebehovDTO[] => {
+  motebehovListe: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO[] => {
   return motebehovListe.filter(
     (motebehov) =>
       motebehov.motebehovSvar &&
@@ -87,39 +87,41 @@ export const motebehovUbehandlet = (
 };
 
 const erAlleMotebehovSvarBehandlet = (
-  motebehovListe: MotebehovDTO[]
+  motebehovListe: MotebehovVeilederDTO[]
 ): boolean => {
   return motebehovUbehandlet(motebehovListe).length === 0;
 };
 
 export const erMotebehovBehandlet = (
-  motebehovListe: MotebehovDTO[]
+  motebehovListe: MotebehovVeilederDTO[]
 ): boolean => {
   return erAlleMotebehovSvarBehandlet(motebehovListe);
 };
 
 export const harUbehandletMotebehov = (
-  motebehovListe: MotebehovDTO[]
+  motebehovListe: MotebehovVeilederDTO[]
 ): boolean => {
   return !erAlleMotebehovSvarBehandlet(motebehovListe);
 };
 
 export const hentSistBehandletMotebehov = (
-  motebehovListe: MotebehovDTO[]
-): MotebehovDTO | undefined =>
-  [...motebehovListe].sort((mb1: MotebehovDTO, mb2: MotebehovDTO) => {
-    if (mb2.behandletTidspunkt === mb1.behandletTidspunkt) {
-      return 0;
+  motebehovListe: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO | undefined =>
+  [...motebehovListe].sort(
+    (mb1: MotebehovVeilederDTO, mb2: MotebehovVeilederDTO) => {
+      if (mb2.behandletTidspunkt === mb1.behandletTidspunkt) {
+        return 0;
+      }
+      if ((mb2.behandletTidspunkt ?? "") > (mb1.behandletTidspunkt ?? "")) {
+        return 1;
+      }
+      return -1;
     }
-    if ((mb2.behandletTidspunkt ?? "") > (mb1.behandletTidspunkt ?? "")) {
-      return 1;
-    }
-    return -1;
-  })[0];
+  )[0];
 
 export const motebehovlisteMedKunJaSvar = (
-  motebehovliste: MotebehovDTO[]
-): MotebehovDTO[] => {
+  motebehovliste: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO[] => {
   return motebehovliste.filter(
     (motebehov) =>
       motebehov.motebehovSvar && motebehov.motebehovSvar.harMotebehov
@@ -127,9 +129,9 @@ export const motebehovlisteMedKunJaSvar = (
 };
 
 export const motebehovFromLatestActiveTilfelle = (
-  sortertMotebehovListe: MotebehovDTO[],
+  sortertMotebehovListe: MotebehovVeilederDTO[],
   oppfolgingstilfelleperioder: OppfolgingstilfelleperioderMapState
-): MotebehovDTO[] => {
+): MotebehovVeilederDTO[] => {
   const startDateNewestActiveTilfelle = startDateFromLatestActiveTilfelle(
     oppfolgingstilfelleperioder
   );


### PR DESCRIPTION
Syfomotebehov now exposes the name of the person who sent in a Motebehov.  The comparison between of aktorId in Motebehov and NarmesteLeder is therefore no longer needed to get the name of the NarmesteLeder who sent in a Motebehov.