### PR TITLE
Add optional text input for behandler, generate preview document

### DIFF
--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -39,13 +39,14 @@ export interface DialogmoteInnkallingSkjemaValues {
   videoLink?: string;
   fritekstArbeidsgiver?: string;
   fritekstArbeidstaker?: string;
+  fritekstBehandler?: string;
 }
 
 interface DialogmoteInnkallingSkjemaProps {
   pageTitle: string;
 }
 
-interface DialogmoteInnkallingRouteStateProps {
+export interface DialogmoteInnkallingRouteStateProps {
   valgtBehandler?: BehandlerDialogmeldingDTO;
 }
 

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
@@ -3,11 +3,15 @@ import { useFormState } from "react-final-form";
 import DialogmoteInnkallingSkjemaSeksjon from "./DialogmoteInnkallingSkjemaSeksjon";
 import styled from "styled-components";
 import { Innholdstittel } from "nav-frontend-typografi";
-import { DialogmoteInnkallingSkjemaValues } from "./DialogmoteInnkallingSkjema";
+import {
+  DialogmoteInnkallingRouteStateProps,
+  DialogmoteInnkallingSkjemaValues,
+} from "./DialogmoteInnkallingSkjema";
 import { useForhandsvisInnkalling } from "@/hooks/dialogmote/useForhandsvisInnkalling";
 import { Forhandsvisning } from "../Forhandsvisning";
 import FritekstSeksjon from "../FritekstSeksjon";
 import { DialogmoteInnkallingTeksterAlert } from "./DialogmoteInnkallingTeksterAlert";
+import { useLocation } from "react-router-dom";
 
 export const MAX_LENGTH_INNKALLING_FRITEKST = 2000;
 
@@ -15,6 +19,7 @@ export const texts = {
   title: "Tekster i innkallingen",
   arbeidstakerLabel: "Fritekst til arbeidstakeren (valgfri)",
   arbeidsgiverLabel: "Fritekst til nærmeste leder (valgfri)",
+  behandlerLabel: "Fritekst til behandler (valgfri)",
   forhandsvisningTitle: "Innkalling til dialogmøte",
   forhandsvisningArbeidstakerSubtitle: "(brev til arbeidstakeren)",
   forhandsvisningArbeidstakerContentLabel:
@@ -22,6 +27,9 @@ export const texts = {
   forhandsvisningArbeidsgiverSubtitle: "(brev til nærmeste leder)",
   forhandsvisningArbeidsgiverContentLabel:
     "Forhåndsvis innkalling til dialogmøte arbeidsgiver",
+  forhandsvisningBehandlerSubtitle: "(brev til behandler)",
+  forhandsvisningBehandlerContentLabel:
+    "Forhåndsvis innkalling til dialogmøte behandler",
 };
 
 const TeksterTittel = styled(Innholdstittel)`
@@ -38,10 +46,22 @@ const DialogmoteInnkallingTekster = (): ReactElement => {
     displayInnkallingArbeidsgiverPreview,
     setDisplayInnkallingArbeidsgiverPreview,
   ] = useState(false);
+
+  const [
+    displayInnkallingBehandlerPreview,
+    setDisplayInnkallingBehandlerPreview,
+  ] = useState(false);
+
   const {
     generateArbeidstakerInnkallingDocument,
     generateArbeidsgiverInnkallingDocument,
+    generateBehandlerInnkallingDocument,
   } = useForhandsvisInnkalling();
+
+  const location = useLocation<DialogmoteInnkallingRouteStateProps>();
+
+  const valgtBehandler = location.state?.valgtBehandler;
+
   return (
     <DialogmoteInnkallingSkjemaSeksjon>
       <TeksterTittel>{texts.title}</TeksterTittel>
@@ -59,7 +79,7 @@ const DialogmoteInnkallingTekster = (): ReactElement => {
         isOpen={displayInnkallingArbeidstakerPreview}
         handleClose={() => setDisplayInnkallingArbeidstakerPreview(false)}
         getDocumentComponents={() =>
-          generateArbeidstakerInnkallingDocument(values)
+          generateArbeidstakerInnkallingDocument(values, valgtBehandler)
         }
       />
       <FritekstSeksjon
@@ -75,9 +95,32 @@ const DialogmoteInnkallingTekster = (): ReactElement => {
         isOpen={displayInnkallingArbeidsgiverPreview}
         handleClose={() => setDisplayInnkallingArbeidsgiverPreview(false)}
         getDocumentComponents={() =>
-          generateArbeidsgiverInnkallingDocument(values)
+          generateArbeidsgiverInnkallingDocument(values, valgtBehandler)
         }
       />
+
+      {!!valgtBehandler && (
+        <>
+          <FritekstSeksjon
+            fieldName="fritekstBehandler"
+            label={texts.behandlerLabel}
+            handlePreviewClick={() =>
+              setDisplayInnkallingBehandlerPreview(true)
+            }
+            maxLength={MAX_LENGTH_INNKALLING_FRITEKST}
+          />
+          <Forhandsvisning
+            title={texts.forhandsvisningTitle}
+            subtitle={texts.forhandsvisningBehandlerSubtitle}
+            contentLabel={texts.forhandsvisningBehandlerContentLabel}
+            isOpen={displayInnkallingBehandlerPreview}
+            handleClose={() => setDisplayInnkallingBehandlerPreview(false)}
+            getDocumentComponents={() =>
+              generateBehandlerInnkallingDocument(values)
+            }
+          />
+        </>
+      )}
     </DialogmoteInnkallingSkjemaSeksjon>
   );
 };

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -9,6 +9,8 @@ export const innkallingTexts = {
       "I møtet vil vi høre både hva du og arbeidsgiveren sier om arbeidssituasjonen og mulighetene for å jobbe.",
     outro1:
       "Den som har sykmeldt deg, eller en annen behandler, kan også bli invitert til å delta i møtet. Til dette møtet har vi ikke sett behov for det.",
+    outro1WithBehandler:
+      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å innkalle",
     outro2Title: "Før møtet",
     outro2Text:
       "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
@@ -22,6 +24,19 @@ export const innkallingTexts = {
       "Det er obligatorisk å delta i dialogmøtet. Hvis vårt forslag ikke passer, ber vi om at du tar kontakt. Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS.",
     outro2:
       "NAV kan be fastlegen eller annet helsepersonell om å delta i møtet. Til dette møtet har vi ikke sett behov for det.",
+    outro2MedBehandler:
+      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å innkalle",
+  },
+
+  behandler: {
+    intro1:
+      "Velkommen til dialogmøte i regi av NAV. NAV har ansvar for å innkalle til dialogmøte senest når en sykmelding har vart i seks måneder, eventuelt på et annet tidspunkt hvis noen av partene ser behov for det.",
+    intro2:
+      "I møtet vil vi høre både hva du, arbeidsgiveren og den ansatte sier om arbeidssituasjonen og mulighetene for å jobbe.",
+    outro1:
+      "Det er obligatorisk å delta i dialogmøtet. Hvis vårt forslag ikke passer, ber vi om at du tar kontakt. Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS.",
+    outro2:
+      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å invitere deg.",
   },
 };
 


### PR DESCRIPTION
Lag egne metoder og tekster for behandler, selv om det er litt overlapp med arbeidsgiver.
Endre outro-tekstene for innbygger og arbeidsgiver hvis behandler skal være med.
Ikke ta med behandler i dokumentet som genereres for sending til bakcend, det gjøres i neste oppgave.