### PR TITLE
Send med "tom" behandler i endre/avlys hvis møtet har behandler

### DIFF
--- a/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
+++ b/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
@@ -6,7 +6,10 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { FlexRow } from "../../Layout";
 import { Form } from "react-final-form";
 import DialogmoteInfo from "./DialogmoteInfo";
-import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
+import {
+  AvlysDialogmoteDTO,
+  DialogmoteDTO,
+} from "@/data/dialogmote/types/dialogmoteTypes";
 import { SkjemaFeiloppsummering } from "../../SkjemaFeiloppsummering";
 import { useFeilUtbedret } from "@/hooks/useFeilUtbedret";
 import { validerBegrunnelser } from "@/utils/valideringUtils";
@@ -99,7 +102,7 @@ const AvlysDialogmoteSkjema = ({
   };
 
   const submit = (values: AvlysDialogmoteSkjemaValues) => {
-    avlysDialogmote.mutate({
+    const avlysDto: AvlysDialogmoteDTO = {
       arbeidstaker: {
         begrunnelse: values.begrunnelseArbeidstaker,
         avlysning: generateAvlysningArbeidstakerDocument(values),
@@ -108,7 +111,17 @@ const AvlysDialogmoteSkjema = ({
         begrunnelse: values.begrunnelseArbeidsgiver,
         avlysning: generateAvlysningArbeidsgiverDocument(values),
       },
-    });
+    };
+
+    if (dialogmote.behandler) {
+      // TODO: Implementere med verdier fra skjema i egen oppgave
+      avlysDto.behandler = {
+        begrunnelse: "",
+        avlysning: [],
+      };
+    }
+
+    avlysDialogmote.mutate(avlysDto);
   };
 
   if (avlysDialogmote.isSuccess) {

--- a/src/components/dialogmote/endre/EndreDialogmoteSkjema.tsx
+++ b/src/components/dialogmote/endre/EndreDialogmoteSkjema.tsx
@@ -114,25 +114,36 @@ const EndreDialogmoteSkjema = ({ dialogmote, pageTitle }: Props) => {
 
   const toEndreTidSted = (
     values: EndreTidStedSkjemaValues
-  ): EndreTidStedDialogmoteDTO => ({
-    sted: values.sted,
-    tid: genererDato(values.dato, values.klokkeslett),
-    videoLink: values.videoLink,
-    arbeidstaker: {
-      begrunnelse: values.begrunnelseArbeidstaker,
-      endringsdokument: forhandsvisEndreTidStedGenerator.generateArbeidstakerTidStedDocument(
-        values,
-        dialogmote.tid
-      ),
-    },
-    arbeidsgiver: {
-      begrunnelse: values.begrunnelseArbeidsgiver,
-      endringsdokument: forhandsvisEndreTidStedGenerator.generateArbeidsgiverTidStedDocument(
-        values,
-        dialogmote.tid
-      ),
-    },
-  });
+  ): EndreTidStedDialogmoteDTO => {
+    const endreTidStedDto: EndreTidStedDialogmoteDTO = {
+      sted: values.sted,
+      tid: genererDato(values.dato, values.klokkeslett),
+      videoLink: values.videoLink,
+      arbeidstaker: {
+        begrunnelse: values.begrunnelseArbeidstaker,
+        endringsdokument: forhandsvisEndreTidStedGenerator.generateArbeidstakerTidStedDocument(
+          values,
+          dialogmote.tid
+        ),
+      },
+      arbeidsgiver: {
+        begrunnelse: values.begrunnelseArbeidsgiver,
+        endringsdokument: forhandsvisEndreTidStedGenerator.generateArbeidsgiverTidStedDocument(
+          values,
+          dialogmote.tid
+        ),
+      },
+    };
+    if (dialogmote.behandler) {
+      // TODO: Implementere med verdier fra skjema i egen oppgave
+      endreTidStedDto.behandler = {
+        begrunnelse: "",
+        endringsdokument: [],
+      };
+    }
+
+    return endreTidStedDto;
+  };
 
   const submit = (values: EndreTidStedSkjemaValues) => {
     const dialogmoteEndring = toEndreTidSted(values);

--- a/src/data/dialogmote/types/dialogmoteTypes.ts
+++ b/src/data/dialogmote/types/dialogmoteTypes.ts
@@ -114,11 +114,16 @@ export interface EndreTidStedDialogmoteDTO {
     begrunnelse: string;
     endringsdokument: DocumentComponentDto[];
   };
+  behandler?: {
+    begrunnelse: string;
+    endringsdokument: DocumentComponentDto[];
+  };
 }
 
 export interface AvlysDialogmoteDTO {
   arbeidstaker: AvlysningDto;
   arbeidsgiver: AvlysningDto;
+  behandler?: AvlysningDto;
 }
 
 interface AvlysningDto {


### PR DESCRIPTION
API krever at behandler sendes med avlysning/endring dersom innkallingen hadde med behandler. Legger til foreløpig "tom" behandler for at innsending av endring/avlysning av møter med behandler skal fungere. Tekst og dokument til behandler kommer i egne oppgaver.