### PR TITLE
Turn off network error logging for react-query in tests. Add some missing stubs.

### DIFF
--- a/test/components/personkort/PersonkortVisningTest.js
+++ b/test/components/personkort/PersonkortVisningTest.js
@@ -23,8 +23,11 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { fastlegerQueryKeys } from "@/data/fastlege/fastlegerQueryHooks";
 import { arbeidstaker } from "../../dialogmote/testData";
 import { behandlendeEnhetQueryKeys } from "@/data/behandlendeenhet/behandlendeEnhetQueryHooks";
+import { apiMock } from "../../stubs/stubApi";
+import { stubFastlegerApi } from "../../stubs/stubFastlegeRest";
 
 const queryClient = new QueryClient();
+let apiMockScope;
 const aktivFastlege = {
   pasientforhold: {
     fom: "2021-10-01",
@@ -68,6 +71,8 @@ describe("PersonkortVisning", () => {
   });
 
   beforeEach(() => {
+    apiMockScope = apiMock();
+    stubFastlegerApi(apiMockScope, arbeidstaker.personident);
     mockState = {
       ledere: [
         {

--- a/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
@@ -173,6 +173,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
     expect(wrapper.find(Feiloppsummering)).to.have.length(1);
   });
   it("validerer maks lengde på begrunnelser", () => {
+    stubAvlysApi(apiMock(), dialogmoteMedBehandler.uuid);
     const tooLongFritekst = getTooLongText(MAX_LENGTH_AVLYS_BEGRUNNELSE);
     const maxLengthErrorMsg = maxLengthErrorMessage(
       MAX_LENGTH_AVLYS_BEGRUNNELSE

--- a/test/dialogmote/ReferatTest.tsx
+++ b/test/dialogmote/ReferatTest.tsx
@@ -242,6 +242,7 @@ describe("ReferatTest", () => {
   });
 
   it("validerer maks lengde på fritekstfelter", () => {
+    stubFerdigstillApi(apiMock(), dialogmoteMedBehandler.uuid);
     const wrapper = mountReferat(dialogmoteMedBehandler);
 
     changeTextAreaValue(wrapper, "situasjon", situasjonTekst);

--- a/test/setup.js
+++ b/test/setup.js
@@ -2,6 +2,7 @@ import Enzyme from "enzyme";
 import Adapter from "@wojtekmaj/enzyme-adapter-react-17";
 import path from "path";
 import MutationObserver from "@sheerun/mutationobserver-shim";
+import { setLogger } from "react-query";
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -15,6 +16,14 @@ const { JSDOM } = require("jsdom");
 
 const jsdom = new JSDOM("<!doctype html><html><body></body></html>");
 const { window } = jsdom;
+
+setLogger({
+  log: console.log,
+  warn: console.warn,
+  error: () => {
+    /*empty*/
+  },
+});
 
 function copyProps(src, target) {
   const props = Object.getOwnPropertyNames(src)


### PR DESCRIPTION
Kjøring av tester spyttet ut nettverks-feil i loggene ved api-kall fra react-query så skrur av dette som beskrevet her https://react-query.tanstack.com/guides/testing#turn-off-network-error-logging