### PR TITLE
Redirect to møteoversikt i innkalling-skjema dersom man har aktivt møte eller ikke tilgang til dm2-pilot

### DIFF
--- a/cypress/integration/dialogmoter/motelandingsside.spec.ts
+++ b/cypress/integration/dialogmoter/motelandingsside.spec.ts
@@ -57,4 +57,37 @@ context("Møtelandingsside actions", () => {
 
     cy.url().should("include", "/sykefravaer/mote");
   });
+
+  it("Har ikke tilgang til DM2 og ingen aktive møter, blir sendt til møte-landingsside når man forsøker gå direkte til ny løsning for innkalling", () => {
+    cy.stubMoter(MoteState.INGEN_MOTER);
+    cy.intercept(
+      {
+        method: "POST",
+        url: "/isenabled/dm2*",
+      },
+      {
+        "syfo.syfomodiaperson.dm2": false,
+      }
+    );
+
+    cy.visit("/sykefravaer/dialogmote");
+
+    cy.url().should("include", "/sykefravaer/mote");
+  });
+
+  it("Har tilgang til DM2 og aktiv dialogmøte-innkalling, blir sendt til møte-landingsside når man forsøker gå direkte til ny løsning for innkalling", () => {
+    cy.stubMoter(MoteState.INNKALT_DIALOGMOTE);
+
+    cy.visit("/sykefravaer/dialogmote");
+
+    cy.url().should("include", "/sykefravaer/mote");
+  });
+
+  it("Har tilgang til DM2 og ikke aktiv dialogmøte-innkalling, kan gå direkte til ny løsning for innkalling", () => {
+    cy.stubMoter(MoteState.INGEN_MOTER);
+
+    cy.visit("/sykefravaer/dialogmote");
+
+    cy.url().should("include", "/sykefravaer/dialogmote");
+  });
 });

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingContainer.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingContainer.tsx
@@ -11,6 +11,9 @@ import { AlertstripeFullbredde } from "../../AlertstripeFullbredde";
 import { BrukerKanIkkeVarslesPapirpostAdvarsel } from "@/components/dialogmote/BrukerKanIkkeVarslesPapirpostAdvarsel";
 import { useDM2FeatureToggles } from "@/data/unleash/unleash_hooks";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
+import { Redirect } from "react-router-dom";
+import { moteoversiktRoutePath } from "@/routers/AppRouter";
 
 const texts = {
   title: "Innkalling til dialogmøte",
@@ -25,8 +28,17 @@ const DialogmoteInnkallingWarningAlert = styled(AlertstripeFullbredde)`
 const DialogmoteInnkallingContainer = (): ReactElement => {
   const fnr = useValgtPersonident();
   const { hentingLedereForsokt, hentingLedereFeilet } = useLedere();
-  const { isDm2FysiskBrevEnabled } = useDM2FeatureToggles();
+  const {
+    triedFetchingToggles,
+    isDm2FysiskBrevEnabled,
+    isDm2Enabled,
+  } = useDM2FeatureToggles();
   const { brukerKanIkkeVarslesDigitalt } = useNavBrukerData();
+  const { aktivtDialogmote } = useDialogmoterQuery();
+
+  if ((triedFetchingToggles && !isDm2Enabled) || aktivtDialogmote) {
+    return <Redirect to={moteoversiktRoutePath} />;
+  }
 
   return (
     <Side fnr={fnr} tittel={texts.title} aktivtMenypunkt={MOETEPLANLEGGER}>

--- a/src/components/mote/components/Motelandingsside.tsx
+++ b/src/components/mote/components/Motelandingsside.tsx
@@ -15,7 +15,6 @@ import { useOppfoelgingsDialoger } from "@/hooks/useOppfoelgingsDialoger";
 import { DialogmoteOnskePanel } from "../../motebehov/DialogmoteOnskePanel";
 import { MotehistorikkPanel } from "../../dialogmote/motehistorikk/MotehistorikkPanel";
 import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
-import { DialogmoteStatus } from "@/data/dialogmote/types/dialogmoteTypes";
 
 interface Props {
   fnr: string;
@@ -35,7 +34,8 @@ export const Motelandingsside = ({ fnr }: Props) => {
   const {
     isLoading: henterDialogmoter,
     isError: henterDialogmoterFeilet,
-    data: dialogmoter,
+    aktivtDialogmote,
+    historiskeDialogmoter,
   } = useDialogmoterQuery();
 
   const {
@@ -65,17 +65,6 @@ export const Motelandingsside = ({ fnr }: Props) => {
     ledere.hentingForsokt &&
     moter.hentingForsokt;
 
-  const aktivtDialogmote = dialogmoter?.find(
-    (mote) =>
-      mote.status === DialogmoteStatus.NYTT_TID_STED ||
-      mote.status === DialogmoteStatus.INNKALT
-  );
-  const historiskeMoter = dialogmoter?.filter(
-    (mote) =>
-      mote.status === DialogmoteStatus.FERDIGSTILT ||
-      mote.status === DialogmoteStatus.AVLYST
-  );
-
   return (
     <SideLaster
       henter={!harForsoktHentetAlt || henterDialogmoter}
@@ -99,7 +88,7 @@ export const Motelandingsside = ({ fnr }: Props) => {
         sykmeldinger={sykmeldinger.data}
       />
 
-      <MotehistorikkPanel historiskeMoter={historiskeMoter || []} />
+      <MotehistorikkPanel historiskeMoter={historiskeDialogmoter || []} />
     </SideLaster>
   );
 };

--- a/src/data/unleash/unleash.ts
+++ b/src/data/unleash/unleash.ts
@@ -5,12 +5,14 @@ import { ToggleNames, Toggles } from "@/data/unleash/unleash_types";
 export interface UnleashState {
   fetching: boolean;
   fetchingFailed: boolean;
+  triedFetchingToggles: boolean;
   toggles: Toggles;
 }
 
 export const initialState: UnleashState = {
   fetching: false,
   fetchingFailed: false,
+  triedFetchingToggles: false,
   toggles: {
     [ToggleNames.dm2]: false,
     [ToggleNames.dm2VarselFysiskBrev]: false,
@@ -28,6 +30,7 @@ const unleash: Reducer<UnleashState, UnleashActions> = (
         ...state,
         fetching: true,
         fetchingFailed: false,
+        triedFetchingToggles: false,
       };
     }
     case UnleashActionTypes.FETCH_UNLEASH_TOGGLES_FAILED: {
@@ -35,6 +38,7 @@ const unleash: Reducer<UnleashState, UnleashActions> = (
         ...state,
         fetching: false,
         fetchingFailed: true,
+        triedFetchingToggles: true,
       };
     }
     case UnleashActionTypes.FETCH_UNLEASH_TOGGLES_SUCCESS: {
@@ -42,6 +46,7 @@ const unleash: Reducer<UnleashState, UnleashActions> = (
         ...state,
         fetching: false,
         fetchingFailed: false,
+        triedFetchingToggles: true,
         toggles: action.toggles,
       };
     }

--- a/src/data/unleash/unleash_hooks.ts
+++ b/src/data/unleash/unleash_hooks.ts
@@ -2,12 +2,16 @@ import { useAppSelector } from "@/hooks/hooks";
 import { ToggleNames } from "@/data/unleash/unleash_types";
 
 export const useDM2FeatureToggles: () => {
+  triedFetchingToggles: boolean;
   isDm2Enabled: boolean;
   isDm2FysiskBrevEnabled: boolean;
   isDm2InnkallingFastlegeEnabled: boolean;
 } = () => {
-  const toggles = useAppSelector((state) => state.unleash.toggles);
+  const { toggles, triedFetchingToggles } = useAppSelector(
+    (state) => state.unleash
+  );
   return {
+    triedFetchingToggles,
     isDm2Enabled: toggles[ToggleNames.dm2],
     isDm2FysiskBrevEnabled: toggles[ToggleNames.dm2VarselFysiskBrev],
     isDm2InnkallingFastlegeEnabled: toggles[ToggleNames.dm2InnkallingFastlege],


### PR DESCRIPTION
Dersom man skulle finne på å gå direkte til url for innkalling-skjema (ikke via modaler fra møte-landingssiden)