### PR TITLE
unleashRoutes isEnabled should return false for falsy values

### DIFF
--- a/server/routes/unleashRoutes.js
+++ b/server/routes/unleashRoutes.js
@@ -11,6 +11,9 @@ class ByEnhetAndEnvironment extends Strategy {
     if (process.env.NAIS_CONTEXT === "dev") {
       return true;
     }
+    if (!context.valgtEnhet) {
+      return false;
+    }
 
     const valgtEnhetMatches =
       parameters.valgtEnhet.indexOf(context.valgtEnhet) !== -1;
@@ -26,7 +29,11 @@ class ByUserId extends Strategy {
   }
 
   isEnabled(parameters, context) {
-    return context.user && parameters.user.indexOf(context.user) !== -1;
+    if (!context.user) {
+      return false;
+    }
+
+    return parameters.user.indexOf(context.user) !== -1;
   }
 }
 


### PR DESCRIPTION
valgtEnhet ser ut til å være default tom streng.
dvs `isEnabled` returnerte true dersom man ikke får hentet enhet i Modia - (`parameters.valgtEnhet.indexOf("") === 0` og `valgtEnhetMatches` blir true). Endrer til å returnere false dersom valgtEnhet er falsy (f.eks. tom streng). Endrer også tilsvarende i sjekk på user.