### PR TITLE
Redesign visning av svar fra møtedeltakere (Arbeidstaker og arbeidsgiver)

### DIFF
--- a/src/components/dialogmote/DeltakereSvarInfo.tsx
+++ b/src/components/dialogmote/DeltakereSvarInfo.tsx
@@ -1,0 +1,143 @@
+import {
+  DialogmotedeltakerArbeidsgiverVarselDTO,
+  DialogmotedeltakerArbeidstakerVarselDTO,
+  DialogmoteDTO,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { useLedere } from "@/hooks/useLedere";
+import { FlexColumn, FlexRow } from "@/components/Layout";
+import { MinusCircleFilled } from "@navikt/ds-icons";
+import navFarger from "nav-frontend-core";
+import React from "react";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import styled from "styled-components";
+import { Element, Normaltekst } from "nav-frontend-typografi";
+import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
+
+const texts = {
+  naermesteLeder: "Nærmeste leder:",
+  arbeidstaker: "Arbeidstakeren:",
+  harAapnetInnkalling: "åpnet innkallingen",
+  harIkkeAapnetInnkalling: "har ikke åpnet innkallingen",
+  harAapnetEndring: "åpnet endringen",
+  harIkkeAapnetEndring: "har ikke åpnet endringen",
+  harIkkeSvar: "Har ikke gitt svar",
+  harIkkeSvarDetaljer: "Ingen detaljer er tilgjengelig.",
+};
+
+const getHarAapnetTekst = (
+  latestVarsel?: Pick<
+    DialogmotedeltakerArbeidsgiverVarselDTO,
+    "varselType" | "lestDato"
+  >
+): string => {
+  const aapnetDatoTekst = latestVarsel?.lestDato
+    ? `${tilLesbarDatoMedArUtenManedNavn(latestVarsel.lestDato)}`
+    : "";
+
+  if (latestVarsel?.varselType === MotedeltakerVarselType.INNKALT) {
+    return latestVarsel?.lestDato
+      ? `${texts.harAapnetInnkalling} ${aapnetDatoTekst} - ${texts.harIkkeSvar}`
+      : texts.harIkkeAapnetInnkalling;
+  } else if (
+    latestVarsel?.varselType === MotedeltakerVarselType.NYTT_TID_STED
+  ) {
+    return latestVarsel?.lestDato
+      ? `${texts.harAapnetEndring} ${aapnetDatoTekst} - ${texts.harIkkeSvar}`
+      : texts.harIkkeAapnetEndring;
+  } else {
+    return "";
+  }
+};
+
+const DeltakerSvarIcon = () => {
+  // TODO: Avhengig av svar
+  return (
+    <MinusCircleFilled
+      color={navFarger.navGra40}
+      aria-label="Minus sirkel"
+      role="img"
+      focusable="false"
+    />
+  );
+};
+
+const DeltakerLabel = styled(Element)`
+  margin-left: 0.5em;
+`;
+
+const TittelTekst = styled(Normaltekst)`
+  margin-left: 0.5em;
+`;
+
+const DetaljerTekst = styled.div`
+  margin-top: 1em;
+`;
+
+const StyledEkspanderbartpanel = styled(Ekspanderbartpanel)`
+  margin-bottom: 1em;
+  border: 1px solid ${navFarger.navGra60};
+`;
+
+interface DeltakerSvarPanelProps {
+  deltakerLabel: string;
+  deltakerNavn: string;
+  varsler: (
+    | DialogmotedeltakerArbeidstakerVarselDTO
+    | DialogmotedeltakerArbeidsgiverVarselDTO
+  )[];
+}
+
+const DeltakerSvarPanel = ({
+  varsler,
+  deltakerLabel,
+  deltakerNavn,
+}: DeltakerSvarPanelProps) => {
+  const harAapnetTekst = getHarAapnetTekst(varsler[0]);
+
+  return (
+    <StyledEkspanderbartpanel
+      tittel={
+        <FlexRow>
+          <DeltakerSvarIcon />
+          <DeltakerLabel>{deltakerLabel}</DeltakerLabel>
+          <TittelTekst>{`${deltakerNavn}, ${harAapnetTekst}`}</TittelTekst>
+        </FlexRow>
+      }
+    >
+      <DetaljerTekst>{texts.harIkkeSvarDetaljer}</DetaljerTekst>
+    </StyledEkspanderbartpanel>
+  );
+};
+
+const StyledColumn = styled(FlexColumn)`
+  width: 100%;
+`;
+
+interface DeltakereSvarInfoProps {
+  dialogmote: DialogmoteDTO;
+}
+
+export const DeltakereSvarInfo = ({ dialogmote }: DeltakereSvarInfoProps) => {
+  const bruker = useNavBrukerData();
+  const { getCurrentNarmesteLeder } = useLedere();
+  const narmesteLederNavn = getCurrentNarmesteLeder(
+    dialogmote.arbeidsgiver.virksomhetsnummer
+  )?.narmesteLederNavn;
+
+  return (
+    <StyledColumn>
+      <DeltakerSvarPanel
+        deltakerLabel={texts.naermesteLeder}
+        deltakerNavn={narmesteLederNavn ?? ""}
+        varsler={dialogmote.arbeidsgiver.varselList}
+      />
+      <DeltakerSvarPanel
+        deltakerLabel={texts.arbeidstaker}
+        deltakerNavn={bruker.navn}
+        varsler={dialogmote.arbeidstaker.varselList}
+      />
+    </StyledColumn>
+  );
+};

--- a/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -1,41 +1,28 @@
-import {
-  MotebehovIkkeSvartImage,
-  MotebehovKanImage,
-  MoteIkonBlaaImage,
-} from "../../../../../img/ImageComponents";
+import { MoteIkonBlaaImage } from "../../../../../img/ImageComponents";
 import { DialogmotePanel } from "../DialogmotePanel";
-import React, { ReactElement, ReactNode } from "react";
-import Alertstripe from "nav-frontend-alertstriper";
-import { FlexColumn, FlexRow, PaddingSize } from "../../../Layout";
-import { InfoRow } from "../../../InfoRow";
+import React, { ReactNode } from "react";
+import { FlexRow, PaddingSize } from "../../../Layout";
 import {
-  DialogmotedeltakerArbeidsgiverVarselDTO,
-  DialogmotedeltakerArbeidstakerVarselDTO,
   DialogmoteDTO,
-  MotedeltakerVarselType,
+  DialogmoteStatus,
 } from "@/data/dialogmote/types/dialogmoteTypes";
-import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
-import { Brukerinfo } from "@/data/navbruker/types/Brukerinfo";
 import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { Link } from "react-router-dom";
 import { TrackedKnapp } from "../../../buttons/TrackedKnapp";
 import { TrackedHovedknapp } from "../../../buttons/TrackedHovedknapp";
-import { useLedere } from "@/hooks/useLedere";
 import { dialogmoteRoutePath } from "@/routers/AppRouter";
 import { Normaltekst } from "nav-frontend-typografi";
+import { DeltakereSvarInfo } from "@/components/dialogmote/DeltakereSvarInfo";
 
 const texts = {
   innkallingSendtTrackingContext: "Møtelandingsside: Sendt innkalling",
-  header: "Innkallingen er sendt",
+  headerInnkalling: "Innkallingen er sendt",
+  headerEndring: "Endringen er sendt",
   infoMessage:
     "Du har brukt den nye løsningen i Modia. Her kan du også avlyse, endre tidspunktet, og skrive referat.",
   endreMote: "Endre møtet",
   avlysMote: "Avlys møtet",
   skrivReferat: "Skriv referat",
-  naermesteLeder: "Nærmeste leder:",
-  denSykmeldte: "Den sykmeldte:",
-  harLestInnkalling: " har åpnet innkallingen",
-  harIkkeLestInnkalling: " har ikke åpnet innkallingen",
   moteTid: "Møtetidspunkt",
   moteSted: "Sted",
 };
@@ -51,91 +38,27 @@ const Subtitle = (dialogmote: DialogmoteDTO): ReactNode => {
   );
 };
 
-const getHarLestIcon = (harLest: boolean): string => {
-  return harLest ? MotebehovKanImage : MotebehovIkkeSvartImage;
-};
-
-const getHarLestText = (harLest: boolean): string => {
-  return harLest ? texts.harLestInnkalling : texts.harIkkeLestInnkalling;
-};
-
-function isLestInnkalling(
-  varselList:
-    | DialogmotedeltakerArbeidstakerVarselDTO[]
-    | DialogmotedeltakerArbeidsgiverVarselDTO[]
-): boolean {
-  return varselList.some(
-    (varsel) =>
-      varsel.varselType === MotedeltakerVarselType.INNKALT && !!varsel.lestDato
-  );
-}
-
-interface ParticipantProps {
-  dialogmote: DialogmoteDTO;
-  bruker: Brukerinfo;
-}
-
-const ParticipantInfo = ({
-  dialogmote,
-  bruker,
-}: ParticipantProps): ReactElement => {
-  const arbeidstakerHarLestInnkallingen = isLestInnkalling(
-    dialogmote.arbeidstaker.varselList
-  );
-  const arbeidsgiverHarLestInnkallingen = isLestInnkalling(
-    dialogmote.arbeidsgiver.varselList
-  );
-
-  const { getCurrentNarmesteLeder } = useLedere();
-  const narmesteLederNavn = getCurrentNarmesteLeder(
-    dialogmote.arbeidsgiver.virksomhetsnummer
-  )?.narmesteLederNavn;
-
-  return (
-    <FlexColumn>
-      <InfoRow
-        icon={getHarLestIcon(arbeidsgiverHarLestInnkallingen)}
-        title={
-          <span>
-            <b>{texts.naermesteLeder}</b> {narmesteLederNavn ?? ""},
-            {getHarLestText(arbeidsgiverHarLestInnkallingen)}
-          </span>
-        }
-      />
-      <InfoRow
-        icon={getHarLestIcon(arbeidstakerHarLestInnkallingen)}
-        title={
-          <span>
-            <b>{texts.denSykmeldte}</b> {bruker.navn},
-            {getHarLestText(arbeidstakerHarLestInnkallingen)}
-          </span>
-        }
-        topPadding={PaddingSize.SM}
-      />
-    </FlexColumn>
-  );
-};
-
 interface Props {
   dialogmote: DialogmoteDTO;
 }
 
 export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
-  const bruker = useNavBrukerData();
+  const headerText =
+    dialogmote.status == DialogmoteStatus.NYTT_TID_STED
+      ? texts.headerEndring
+      : texts.headerInnkalling;
 
   return (
     <DialogmotePanel
       icon={MoteIkonBlaaImage}
-      header={texts.header}
       subtitle={Subtitle(dialogmote)}
+      header={headerText}
     >
       <FlexRow>
-        <ParticipantInfo dialogmote={dialogmote} bruker={bruker} />
+        <DeltakereSvarInfo dialogmote={dialogmote} />
       </FlexRow>
 
-      <FlexRow topPadding={PaddingSize.MD}>
-        <Alertstripe type="advarsel">{texts.infoMessage}</Alertstripe>
-      </FlexRow>
+      <FlexRow topPadding={PaddingSize.MD}>{texts.infoMessage}</FlexRow>
 
       <FlexRow topPadding={PaddingSize.MD}>
         <Link to={`${dialogmoteRoutePath}/${dialogmote.uuid}/endre`}>

--- a/test/dialogmote/DeltakereSvarInfoTest.tsx
+++ b/test/dialogmote/DeltakereSvarInfoTest.tsx
@@ -1,0 +1,197 @@
+import {
+  arbeidsgiver,
+  arbeidstaker,
+  dialogmote,
+  mockState,
+  narmesteLederNavn,
+} from "./testData";
+import { render } from "@testing-library/react";
+import { expect } from "chai";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { Provider } from "react-redux";
+import React from "react";
+import configureStore from "redux-mock-store";
+import { DeltakereSvarInfo } from "@/components/dialogmote/DeltakereSvarInfo";
+import {
+  DialogmotedeltakerArbeidsgiverVarselDTO,
+  DialogmotedeltakerArbeidstakerVarselDTO,
+  DialogmoteDTO,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+
+const store = configureStore([]);
+let queryClient;
+
+const varselArbeidsgiver = (
+  type: MotedeltakerVarselType,
+  lestDato?: string
+) => ({
+  varselType: type,
+  fritekst: "",
+  document: [],
+  createdAt: "",
+  lestDato: lestDato,
+  status: "",
+});
+const varselArbeidstaker = (
+  type: MotedeltakerVarselType,
+  lestDato?: string
+) => ({
+  varselType: type,
+  fritekst: "",
+  document: [],
+  digitalt: true,
+  createdAt: "",
+  lestDato: lestDato,
+});
+
+const dialogmoteMedVarsel = (
+  varselArbeidsgiver: DialogmotedeltakerArbeidsgiverVarselDTO,
+  varselArbeidstaker: DialogmotedeltakerArbeidstakerVarselDTO
+): DialogmoteDTO => ({
+  ...dialogmote,
+  arbeidsgiver: {
+    virksomhetsnummer: arbeidsgiver.orgnr,
+    type: "ARBEIDSGIVER",
+    varselList: [varselArbeidsgiver],
+  },
+  arbeidstaker: {
+    personIdent: arbeidstaker.personident,
+    type: "ARBEIDSTAKER",
+    varselList: [varselArbeidstaker],
+  },
+});
+
+describe("DeltakereSvarInfo", () => {
+  beforeEach(() => {
+    queryClient = new QueryClient();
+  });
+
+  describe("arbeidstaker og arbeidsgiver har åpnet innkalling", () => {
+    const dialogmoteMedLestInnkalling = dialogmoteMedVarsel(
+      varselArbeidsgiver(
+        MotedeltakerVarselType.INNKALT,
+        "2021-12-01T12:56:26.271381"
+      ),
+      varselArbeidstaker(
+        MotedeltakerVarselType.INNKALT,
+        "2021-12-02T12:56:26.271381"
+      )
+    );
+    let wrapper;
+    beforeEach(() => {
+      wrapper = render(
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store(mockState)}>
+            <DeltakereSvarInfo dialogmote={dialogmoteMedLestInnkalling} />
+          </Provider>
+        </QueryClientProvider>
+      );
+    });
+    it("viser nærmeste leder har åpnet innkalling", () => {
+      const expectedText = `${narmesteLederNavn}, åpnet innkallingen 01.12.2021 - Har ikke gitt svar`;
+
+      expect(wrapper.getByText("Nærmeste leder:", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+    it("viser arbeidstaker har åpnet innkalling", () => {
+      const expectedText = `${arbeidstaker.navn}, åpnet innkallingen 02.12.2021 - Har ikke gitt svar`;
+
+      expect(wrapper.getByText("Arbeidstakeren", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+  });
+
+  describe("arbeidstaker og arbeidsgiver har ikke åpnet innkalling", () => {
+    const dialogmoteMedUlestInnkalling = dialogmoteMedVarsel(
+      varselArbeidsgiver(MotedeltakerVarselType.INNKALT),
+      varselArbeidstaker(MotedeltakerVarselType.INNKALT)
+    );
+    let wrapper;
+    beforeEach(() => {
+      wrapper = render(
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store(mockState)}>
+            <DeltakereSvarInfo dialogmote={dialogmoteMedUlestInnkalling} />
+          </Provider>
+        </QueryClientProvider>
+      );
+    });
+    it("viser nærmeste leder har ikke åpnet innkalling", () => {
+      const expectedText = `${narmesteLederNavn}, har ikke åpnet innkallingen`;
+
+      expect(wrapper.getByText("Nærmeste leder:", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+    it("viser arbeidstaker har ikke åpnet innkalling", () => {
+      const expectedText = `${arbeidstaker.navn}, har ikke åpnet innkallingen`;
+
+      expect(wrapper.getByText("Arbeidstakeren", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+  });
+
+  describe("arbeidstaker og arbeidsgiver har åpnet endring", () => {
+    const dialogmoteMedLestEndring = dialogmoteMedVarsel(
+      varselArbeidsgiver(
+        MotedeltakerVarselType.NYTT_TID_STED,
+        "2021-12-03T12:56:26.271381"
+      ),
+      varselArbeidstaker(
+        MotedeltakerVarselType.NYTT_TID_STED,
+        "2021-12-04T12:56:26.271381"
+      )
+    );
+    let wrapper;
+    beforeEach(() => {
+      wrapper = render(
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store(mockState)}>
+            <DeltakereSvarInfo dialogmote={dialogmoteMedLestEndring} />
+          </Provider>
+        </QueryClientProvider>
+      );
+    });
+    it("viser nærmeste leder har åpnet endring", () => {
+      const expectedText = `${narmesteLederNavn}, åpnet endringen 03.12.2021 - Har ikke gitt svar`;
+
+      expect(wrapper.getByText("Nærmeste leder:", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+    it("viser arbeidstaker har åpnet endring", () => {
+      const expectedText = `${arbeidstaker.navn}, åpnet endringen 04.12.2021 - Har ikke gitt svar`;
+
+      expect(wrapper.getByText("Arbeidstakeren", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+  });
+
+  describe("arbeidstaker og arbeidsgiver har ikke åpnet endring", () => {
+    const dialogmoteMedUlestEndring = dialogmoteMedVarsel(
+      varselArbeidsgiver(MotedeltakerVarselType.NYTT_TID_STED),
+      varselArbeidstaker(MotedeltakerVarselType.NYTT_TID_STED)
+    );
+    let wrapper;
+    beforeEach(() => {
+      wrapper = render(
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store(mockState)}>
+            <DeltakereSvarInfo dialogmote={dialogmoteMedUlestEndring} />
+          </Provider>
+        </QueryClientProvider>
+      );
+    });
+    it("viser nærmeste leder har ikke åpnet endring", () => {
+      const expectedText = `${narmesteLederNavn}, har ikke åpnet endringen`;
+
+      expect(wrapper.getByText("Nærmeste leder:", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+    it("viser arbeidstaker har ikke åpnet endring", () => {
+      const expectedText = `${arbeidstaker.navn}, har ikke åpnet endringen`;
+
+      expect(wrapper.getByText("Arbeidstakeren", { exact: false })).to.exist;
+      expect(wrapper.getByText(expectedText, { exact: false })).to.exist;
+    });
+  });
+});

--- a/test/dialogmote/testData.ts
+++ b/test/dialogmote/testData.ts
@@ -41,6 +41,7 @@ export const veileder: Partial<VeilederinfoDTO> = {
   epost: "vetle.veileder@nav.no",
   telefonnummer: "12345678",
 };
+export const narmesteLederNavn = "Tatten Tattover";
 
 export const behandler: BehandlerDialogmeldingDTO = {
   behandlerRef: "behandler-ref-uuid",
@@ -105,12 +106,12 @@ export const mockState = {
       {
         uuid: "3",
         arbeidstakerPersonIdentNumber: "19026900010",
-        virksomhetsnummer: "110110110",
+        virksomhetsnummer: arbeidsgiver.orgnr,
         virksomhetsnavn: "PONTYPANDY FIRE SERVICE",
         narmesteLederPersonIdentNumber: "02690001009",
         narmesteLederTelefonnummer: "12345666",
         narmesteLederEpost: "test3@test.no",
-        narmesteLederNavn: "Tatten Tattover",
+        narmesteLederNavn: narmesteLederNavn,
         aktivFom: new Date(),
         aktivTom: null,
         arbeidsgiverForskutterer: false,
@@ -122,39 +123,7 @@ export const mockState = {
 };
 
 export const mockStateBehandler = {
-  navbruker: {
-    data: {
-      navn: arbeidstaker.navn,
-      kontaktinfo: {
-        fnr: arbeidstaker.personident,
-      },
-    },
-  },
-  enhet: {
-    valgtEnhet: navEnhet,
-  },
-  valgtbruker: {
-    personident: arbeidstaker.personident,
-  },
-  ledere: {
-    currentLedere: [
-      {
-        uuid: "3",
-        arbeidstakerPersonIdentNumber: "19026900010",
-        virksomhetsnummer: "110110110",
-        virksomhetsnavn: "PONTYPANDY FIRE SERVICE",
-        narmesteLederPersonIdentNumber: "02690001009",
-        narmesteLederTelefonnummer: "12345666",
-        narmesteLederEpost: "test3@test.no",
-        narmesteLederNavn: "Tatten Tattover",
-        aktivFom: new Date(),
-        aktivTom: null,
-        arbeidsgiverForskutterer: false,
-        timestamp: "2020-02-06T12:00:00+01:00",
-        status: NarmesteLederRelasjonStatus.INNMELDT_AKTIV,
-      },
-    ],
-  },
+  ...mockState,
   unleash: {
     toggles: {
       [ToggleNames.dm2]: true,


### PR DESCRIPTION
Se https://www.figma.com/file/L6DPvt6dU1XzypeiQoQ54C/MODIA-Person?node-id=5433%3A32695
- Implementert nytt design fra skisser (foreløpig uten behandler og kun har åpnet/ikke åpnet), med ekspanderbart svar. 
- Håndterer at varsel kan være både innkalling og endring i tittel og i svar-panel.
- Tekst om ny løsning skal være vanlig tekst ikke advarsel

![image (1)](https://user-images.githubusercontent.com/79838644/145163311-be26b705-dceb-4b13-9124-1dcc581162c5.png)
