### PR TITLE
Referat bugfix: Legg til overskrift bare når man har krysset av for noen standardtekster

### DIFF
--- a/src/hooks/dialogmote/useForhandsvisReferat.ts
+++ b/src/hooks/dialogmote/useForhandsvisReferat.ts
@@ -139,7 +139,7 @@ const standardTekster = (
   values: Partial<ReferatSkjemaValues>
 ): DocumentComponentDto[] => {
   const documentComponents: DocumentComponentDto[] = [];
-  if (values.standardtekster) {
+  if (values.standardtekster && values.standardtekster.length > 0) {
     documentComponents.push(
       createHeader(referatTexts.standardTeksterHeader),
       ...values.standardtekster.map((standardtekst) =>


### PR DESCRIPTION
Dersom man krysset av for noen standardtekster og deretter fjernet avkrysningene ble overskrift værende i brevet.