### PR TITLE
Increase stale times

### DIFF
--- a/src/data/behandlendeenhet/behandlendeEnhetQueryHooks.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhetQueryHooks.ts
@@ -3,6 +3,7 @@ import { get } from "@/api/axios";
 import { BehandlendeEnhet } from "@/data/behandlendeenhet/types/BehandlendeEnhet";
 import { useQuery } from "react-query";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 export const behandlendeEnhetQueryKeys = {
   behandlendeEnhet: (fnr: string) => ["behandlendeenhet", fnr],
@@ -15,6 +16,6 @@ export const useBehandlendeEnhetQuery = () => {
   return useQuery(
     behandlendeEnhetQueryKeys.behandlendeEnhet(fnr),
     fetchBehandlendeEnhet,
-    { enabled: !!fnr }
+    { enabled: !!fnr, staleTime: minutesToMillis(60 * 12) }
   );
 };

--- a/src/data/diskresjonskode/diskresjonskodeQueryHooks.ts
+++ b/src/data/diskresjonskode/diskresjonskodeQueryHooks.ts
@@ -2,6 +2,7 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { SYFOPERSON_ROOT } from "@/apiConstants";
 import { get } from "@/api/axios";
 import { useQuery } from "react-query";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 const diskresjonskodeQueryKeys = {
   diskresjonskode: (fnr: string) => ["diskresjonskode", fnr],
@@ -14,6 +15,10 @@ export const useDiskresjonskodeQuery = () => {
   return useQuery(
     diskresjonskodeQueryKeys.diskresjonskode(fnr),
     fetchDiskresjonskode,
-    { enabled: !!fnr, select: (diskresjonskode) => diskresjonskode.toString() }
+    {
+      enabled: !!fnr,
+      staleTime: minutesToMillis(60 * 12),
+      select: (diskresjonskode) => diskresjonskode.toString(),
+    }
   );
 };

--- a/src/data/egenansatt/egenansattQueryHooks.ts
+++ b/src/data/egenansatt/egenansattQueryHooks.ts
@@ -2,6 +2,7 @@ import { get } from "@/api/axios";
 import { SYFOPERSON_ROOT } from "@/apiConstants";
 import { useQuery } from "react-query";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 const egenansattQueryKeys = {
   egenansatt: (fnr: string) => ["egenansatt", fnr],
@@ -13,5 +14,6 @@ export const useEgenansattQuery = () => {
   const fetchEgenansatt = () => get<boolean>(path, fnr);
   return useQuery(egenansattQueryKeys.egenansatt(fnr), fetchEgenansatt, {
     enabled: !!fnr,
+    staleTime: minutesToMillis(60 * 12),
   });
 };

--- a/src/data/fastlege/fastlegerQueryHooks.ts
+++ b/src/data/fastlege/fastlegerQueryHooks.ts
@@ -4,6 +4,7 @@ import { Fastlege } from "@/data/fastlege/types/Fastlege";
 import { useQuery } from "react-query";
 import { useMemo } from "react";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 export const fastlegerQueryKeys = {
   fastleger: (fnr: string) => ["fastleger", fnr],
@@ -15,6 +16,7 @@ export const useFastlegerQuery = () => {
   const fetchFastleger = () => get<Fastlege[]>(path);
   const query = useQuery(fastlegerQueryKeys.fastleger(fnr), fetchFastleger, {
     enabled: !!fnr,
+    staleTime: minutesToMillis(60 * 12),
   });
   return {
     ...query,

--- a/src/data/personinfo/personAdresseQueryHooks.ts
+++ b/src/data/personinfo/personAdresseQueryHooks.ts
@@ -3,6 +3,7 @@ import { SYFOPERSON_ROOT } from "@/apiConstants";
 import { PersonAdresse } from "@/data/personinfo/types/PersonAdresse";
 import { get } from "@/api/axios";
 import { useQuery } from "react-query";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 const personinfoQueryKeys = {
   personadresse: (fnr: string) => ["personadresse", fnr],
@@ -14,5 +15,6 @@ export const usePersonAdresseQuery = () => {
   const fetchPersonAdresse = () => get<PersonAdresse>(path, fnr);
   return useQuery(personinfoQueryKeys.personadresse(fnr), fetchPersonAdresse, {
     enabled: !!fnr,
+    staleTime: minutesToMillis(60 * 12),
   });
 };

--- a/src/data/vedtak/vedtakQueryHooks.ts
+++ b/src/data/vedtak/vedtakQueryHooks.ts
@@ -3,6 +3,7 @@ import { VEDTAK_ROOT } from "@/apiConstants";
 import { useQuery } from "react-query";
 import { VedtakDTO } from "./vedtakTypes";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 const vedtakQueryKeys = {
   vedtak: (fnr: string) => ["vedtak", fnr],
@@ -14,5 +15,6 @@ export const useVedtakQuery = () => {
   const fetchVedtak = () => get<VedtakDTO[]>(path);
   return useQuery(vedtakQueryKeys.vedtak(fnr), fetchVedtak, {
     enabled: !!fnr,
+    staleTime: minutesToMillis(60 * 12),
   });
 };

--- a/src/data/virksomhet/virksomhetQueryHooks.ts
+++ b/src/data/virksomhet/virksomhetQueryHooks.ts
@@ -2,6 +2,7 @@ import { SYFOMOTEADMIN_ROOT } from "@/apiConstants";
 import { get } from "@/api/axios";
 import { Virksomhet } from "@/data/virksomhet/types/Virksomhet";
 import { useQuery } from "react-query";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 const virksomhetQueryKeys = {
   virksomhet: (orgnummer: string | undefined) => ["virksomhet", orgnummer],
@@ -12,5 +13,6 @@ export const useVirksomhetQuery = (orgnummer: string | undefined) => {
   const fetchVirksomhet = () => get<Virksomhet>(path);
   return useQuery(virksomhetQueryKeys.virksomhet(orgnummer), fetchVirksomhet, {
     enabled: !!orgnummer,
+    staleTime: minutesToMillis(60 * 12),
   });
 };

--- a/test/components/personkort/PersonkortLegeTest.tsx
+++ b/test/components/personkort/PersonkortLegeTest.tsx
@@ -11,32 +11,12 @@ import React from "react";
 import { createStore } from "redux";
 import { rootReducer } from "@/data/rootState";
 import configureStore from "redux-mock-store";
-import { apiMock } from "../../stubs/stubApi";
-import { stubFastlegerApi } from "../../stubs/stubFastlegeRest";
+import { fastlegerMock } from "../../../mock/fastlegerest/fastlegerMock";
 
 let queryClient;
-let apiMockScope;
 
-const aktivFastlege = {
-  pasientforhold: {
-    fom: "2021-10-01",
-    tom: "9999-12-31",
-  },
-};
-const tidligereFastleger = [
-  {
-    pasientforhold: {
-      fom: "2019-10-01",
-      tom: "2020-10-01",
-    },
-  },
-  {
-    pasientforhold: {
-      fom: "2020-10-01",
-      tom: "2021-10-01",
-    },
-  },
-];
+const aktivFastlege = fastlegerMock[0];
+const tidligereFastleger = [fastlegerMock[1]];
 const realState = createStore(rootReducer).getState();
 const store = configureStore([]);
 const mockState = {
@@ -57,8 +37,6 @@ const renderPersonkortLege = () =>
 describe("PersonkortLege", () => {
   beforeEach(() => {
     queryClient = new QueryClient();
-    apiMockScope = apiMock();
-    stubFastlegerApi(apiMockScope, arbeidstaker.personident);
   });
 
   it("Skal vise feilmelding, fastleger ikke ble funnet, når ingen fastleger", async () => {
@@ -116,8 +94,7 @@ describe("PersonkortLege", () => {
       expect(screen.getAllByRole("listitem")).to.have.length(
         tidligereFastleger.length
       );
-      expect(screen.getByText(/1. oktober 2019 - 1. oktober 2020/)).to.exist;
-      expect(screen.getByText(/1. oktober 2020 - 1. oktober 2021/)).to.exist;
+      expect(screen.getByText(/1. oktober 2011 - 1. oktober 2021/)).to.exist;
     });
   });
 });


### PR DESCRIPTION
Øker `staleTime` til 12t for data man ikke trenger re-fetche fra API så ofte
(og hvor vi tidligere, med redux-saga, ikke hentet på nytt dersom data allerede var hentet).