### PR TITLE
Knapp for å mellomlagre referat

### DIFF
--- a/mock/data/dialogmoterMock.ts
+++ b/mock/data/dialogmoterMock.ts
@@ -1,6 +1,7 @@
 import {
   DialogmotedeltakerBehandlerDTO,
   DialogmoteStatus,
+  DocumentComponentType,
   MotedeltakerVarselType,
 } from "../../src/data/dialogmote/types/dialogmoteTypes";
 import { BehandlerType } from "../../src/data/behandlerdialogmelding/BehandlerDialogmeldingDTO";
@@ -10,6 +11,8 @@ import {
   VEILEDER_IDENT_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
+import { ReferatDTO } from "../../src/data/dialogmote/types/dialogmoteReferatTypes";
+import { referatTexts } from "../../src/data/dialogmote/dialogmoteTexts";
 
 const createDialogmote = (
   uuid: string,
@@ -109,45 +112,48 @@ const createDialogmote = (
   if (moteStatus === DialogmoteStatus.FERDIGSTILT) {
     return {
       ...dialogMote,
-      referat: {
-        uuid: "520239a6-a973-42f6-a4e7-9fe7d27d2f93",
-        createdAt: "2021-06-08T09:23:26.162354",
-        updatedAt: "2021-06-08T09:23:26.162354",
-        digitalt: true,
-        situasjon: "Dette er en beskrivelse av situasjonen",
-        konklusjon: "Dette er en beskrivelse av konklusjon",
-        arbeidstakerOppgave: "Dette er en beskrivelse av arbeidstakerOppgave",
-        arbeidsgiverOppgave: "Dette er en beskrivelse av arbeidsgiverOppgave",
-        veilederOppgave: "Dette er en beskrivelse av veilederOppgave",
-        document: [
-          {
-            type: "HEADER",
-            title: "Tittel referat",
-            texts: [],
-          },
-          {
-            type: "PARAGRAPH",
-            title: null,
-            texts: ["Brødtekst"],
-          },
-        ],
-        pdf: "Lic=",
-        lestDatoArbeidstaker: null,
-        lestDatoArbeidsgiver: null,
-        andreDeltakere: [
-          {
-            uuid: "0c72f8ec-452f-4606-b47e-6da5a408a9f7",
-            createdAt: "2021-06-08T09:23:26.162354",
-            updatedAt: "2021-06-08T09:23:26.162354",
-            funksjon: "Verneombud",
-            navn: "Tøff Pyjamas",
-          },
-        ],
-      },
+      referat: createReferat(true),
     };
   }
 
   return dialogMote;
+};
+
+const createReferat = (ferdigstilt: boolean): ReferatDTO => {
+  const standardTekst = referatTexts.standardTekster[0];
+  return {
+    uuid: "520239a6-a973-42f6-a4e7-9fe7d27d2f93",
+    ferdigstilt,
+    narmesteLederNavn: "Tatten Tattover",
+    situasjon: "Dette er en beskrivelse av situasjonen",
+    konklusjon: "Dette er en beskrivelse av konklusjon",
+    arbeidstakerOppgave: "Dette er en beskrivelse av arbeidstakerOppgave",
+    arbeidsgiverOppgave: "Dette er en beskrivelse av arbeidsgiverOppgave",
+    veilederOppgave: "Dette er en beskrivelse av veilederOppgave",
+    document: [
+      {
+        type: DocumentComponentType.HEADER,
+        title: "Tittel referat",
+        texts: [],
+      },
+      {
+        type: DocumentComponentType.PARAGRAPH,
+        texts: ["Brødtekst"],
+      },
+      {
+        type: DocumentComponentType.PARAGRAPH,
+        key: standardTekst.key,
+        title: standardTekst.label,
+        texts: [standardTekst.text],
+      },
+    ],
+    andreDeltakere: [
+      {
+        funksjon: "Verneombud",
+        navn: "Tøff Pyjamas",
+      },
+    ],
+  };
 };
 
 const behandler = (uuid: string) => {

--- a/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
+++ b/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
@@ -75,7 +75,7 @@ const AvlysDialogmoteSkjema = ({
   const fnr = useValgtPersonident();
   const avlysDialogmote = useAvlysDialogmote(fnr, dialogmote.uuid);
   const {
-    feilUtbedret,
+    harIkkeUtbedretFeil,
     resetFeilUtbedret,
     updateFeilUtbedret,
   } = useFeilUtbedret();
@@ -206,7 +206,7 @@ const AvlysDialogmoteSkjema = ({
             <AvlysningAlertStripe type="advarsel">
               {texts.alert}
             </AvlysningAlertStripe>
-            {submitFailed && !feilUtbedret && (
+            {submitFailed && harIkkeUtbedretFeil && (
               <SkjemaFeiloppsummering errors={errors} />
             )}
             <FlexRow>

--- a/src/components/dialogmote/endre/EndreDialogmoteSkjema.tsx
+++ b/src/components/dialogmote/endre/EndreDialogmoteSkjema.tsx
@@ -93,7 +93,7 @@ const EndreDialogmoteSkjema = ({ dialogmote, pageTitle }: Props) => {
   );
 
   const {
-    feilUtbedret,
+    harIkkeUtbedretFeil,
     resetFeilUtbedret,
     updateFeilUtbedret,
   } = useFeilUtbedret();
@@ -172,7 +172,7 @@ const EndreDialogmoteSkjema = ({ dialogmote, pageTitle }: Props) => {
             {endreTidStedDialogmote.isError && (
               <SkjemaInnsendingFeil error={endreTidStedDialogmote.error} />
             )}
-            {submitFailed && !feilUtbedret && (
+            {submitFailed && harIkkeUtbedretFeil && (
               <SkjemaFeiloppsummering errors={errors} />
             )}
             <FlexRow>

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -128,7 +128,7 @@ const DialogmoteInnkallingSkjema = ({
   const fnr = useValgtPersonident();
   const navEnhet = useNavEnhet();
   const {
-    feilUtbedret,
+    harIkkeUtbedretFeil,
     resetFeilUtbedret,
     updateFeilUtbedret,
   } = useFeilUtbedret();
@@ -213,7 +213,7 @@ const DialogmoteInnkallingSkjema = ({
             {opprettInnkalling.isError && (
               <SkjemaInnsendingFeil error={opprettInnkalling.error} />
             )}
-            {submitFailed && !feilUtbedret && (
+            {submitFailed && harIkkeUtbedretFeil && (
               <SkjemaFeiloppsummering errors={errors} />
             )}
             <FlexRow>

--- a/src/components/dialogmote/referat/Referat.tsx
+++ b/src/components/dialogmote/referat/Referat.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement, useState } from "react";
-import { Form } from "react-final-form";
+import { Form, FormSpy } from "react-final-form";
 import arrayMutators from "final-form-arrays";
 import Panel from "nav-frontend-paneler";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
@@ -125,6 +125,9 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
   const fnr = useValgtPersonident();
   const ferdigstillDialogmote = useFerdigstillDialogmote(fnr, dialogmote.uuid);
   const mellomlagreReferat = useMellomlagreReferat(fnr, dialogmote.uuid);
+  const [uendretSidenMellomlagring, setUendretSidenMellomlagring] = useState<
+    boolean | undefined
+  >();
 
   const navbruker = useNavBrukerData();
   const [displayReferatPreview, setDisplayReferatPreview] = useState(false);
@@ -193,7 +196,8 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
 
   const mellomlagre = (values: ReferatSkjemaValues) => {
     mellomlagreReferat.mutate(
-      toNewReferat(dialogmote, values, generateReferatDocument)
+      toNewReferat(dialogmote, values, generateReferatDocument),
+      { onSuccess: () => setUendretSidenMellomlagring(true) }
     );
   };
 
@@ -213,6 +217,14 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
       >
         {({ handleSubmit, submitFailed, errors, values }) => (
           <form onSubmit={handleSubmit}>
+            <FormSpy
+              subscription={{ values: true }}
+              onChange={() => {
+                if (uendretSidenMellomlagring) {
+                  setUendretSidenMellomlagring(false);
+                }
+              }}
+            />
             <ReferatTittel>{header}</ReferatTittel>
             <ReferatWarningAlert type="advarsel">
               {texts.digitalReferat}
@@ -245,7 +257,7 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
             {submitFailed && harIkkeUtbedretFeil && (
               <SkjemaFeiloppsummering errors={errors} />
             )}
-            {mellomlagreReferat.isSuccess && (
+            {mellomlagreReferat.isSuccess && uendretSidenMellomlagring && (
               <AlertstripeFullbredde type="suksess">
                 {texts.referatSaved}
               </AlertstripeFullbredde>

--- a/src/components/dialogmote/referat/Referat.tsx
+++ b/src/components/dialogmote/referat/Referat.tsx
@@ -5,7 +5,10 @@ import Panel from "nav-frontend-paneler";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import Deltakere from "./Deltakere";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
-import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
+import {
+  DialogmoteDTO,
+  DocumentComponentDto,
+} from "@/data/dialogmote/types/dialogmoteTypes";
 import { AlertstripeFullbredde } from "../../AlertstripeFullbredde";
 import ReferatButtons from "./ReferatButtons";
 import { Innholdstittel } from "nav-frontend-typografi";
@@ -35,8 +38,10 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { Forhandsvisning } from "../Forhandsvisning";
 import { useForhandsvisReferat } from "@/hooks/dialogmote/useForhandsvisReferat";
 import { StandardTekst } from "@/data/dialogmote/dialogmoteTexts";
-import { NewDialogmotedeltakerAnnenDTO } from "@/data/dialogmote/types/dialogmoteReferatTypes";
-import { useLedere } from "@/hooks/useLedere";
+import {
+  NewDialogmotedeltakerAnnenDTO,
+  NewDialogmoteReferatDTO,
+} from "@/data/dialogmote/types/dialogmoteReferatTypes";
 import { useFerdigstillDialogmote } from "@/data/dialogmote/useFerdigstillDialogmote";
 import { Redirect } from "react-router-dom";
 import { moteoversiktRoutePath } from "@/routers/AppRouter";
@@ -45,6 +50,10 @@ import {
   BehandlersOppgave,
   MAX_LENGTH_BEHANDLERS_OPPGAVE,
 } from "@/components/dialogmote/referat/BehandlersOppgave";
+import { useMellomlagreReferat } from "@/data/dialogmote/useMellomlagreReferat";
+import { FlexRow, PaddingSize } from "@/components/Layout";
+import { Knapp } from "nav-frontend-knapper";
+import { useInitialValuesReferat } from "@/hooks/dialogmote/useInitialValuesReferat";
 
 export const texts = {
   digitalReferat:
@@ -53,6 +62,8 @@ export const texts = {
     "Du må aldri skrive sensitive opplysninger om helse, diagnose, behandling, og prognose. Dette gjelder også hvis arbeidstakeren er åpen om helsen og snakket om den i møtet.",
   forhandsvisningTitle: "Referat fra dialogmøte",
   forhandsvisningContentLabel: "Forhåndsvis referat fra dialogmøte",
+  preview: "Se forhåndsvisning",
+  referatSaved: "Referatet er lagret",
 };
 
 export const valideringsTexts = {
@@ -90,19 +101,39 @@ interface ReferatProps {
   pageTitle: string;
 }
 
+const toNewReferat = (
+  dialogmote: DialogmoteDTO,
+  values: Partial<ReferatSkjemaValues>,
+  generateDocument: (
+    values: Partial<ReferatSkjemaValues>
+  ) => DocumentComponentDto[]
+): NewDialogmoteReferatDTO => ({
+  narmesteLederNavn: values.naermesteLeder ?? "",
+  situasjon: values.situasjon ?? "",
+  konklusjon: values.konklusjon ?? "",
+  arbeidsgiverOppgave: values.arbeidsgiversOppgave ?? "",
+  arbeidstakerOppgave: values.arbeidstakersOppgave ?? "",
+  ...(dialogmote.behandler
+    ? { behandlerOppgave: values.behandlersOppgave }
+    : {}),
+  veilederOppgave: values.veiledersOppgave,
+  document: generateDocument(values),
+  andreDeltakere: values.andreDeltakere || [],
+});
+
 const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
   const fnr = useValgtPersonident();
   const ferdigstillDialogmote = useFerdigstillDialogmote(fnr, dialogmote.uuid);
+  const mellomlagreReferat = useMellomlagreReferat(fnr, dialogmote.uuid);
 
   const navbruker = useNavBrukerData();
-  const { getCurrentNarmesteLeder } = useLedere();
   const [displayReferatPreview, setDisplayReferatPreview] = useState(false);
 
   const dateAndTimeForMeeting = tilDatoMedManedNavn(dialogmote.tid);
   const header = `${navbruker?.navn}, ${dateAndTimeForMeeting}, ${dialogmote.sted}`;
 
   const {
-    feilUtbedret,
+    harIkkeUtbedretFeil,
     resetFeilUtbedret,
     updateFeilUtbedret,
   } = useFeilUtbedret();
@@ -155,26 +186,18 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
   };
 
   const submit = (values: ReferatSkjemaValues) => {
-    ferdigstillDialogmote.mutate({
-      narmesteLederNavn: values.naermesteLeder,
-      situasjon: values.situasjon,
-      konklusjon: values.konklusjon,
-      arbeidsgiverOppgave: values.arbeidsgiversOppgave,
-      arbeidstakerOppgave: values.arbeidstakersOppgave,
-      ...(dialogmote.behandler
-        ? { behandlerOppgave: values.behandlersOppgave }
-        : {}),
-      veilederOppgave: values.veiledersOppgave,
-      document: generateReferatDocument(values),
-      andreDeltakere: values.andreDeltakere || [],
-    });
+    ferdigstillDialogmote.mutate(
+      toNewReferat(dialogmote, values, generateReferatDocument)
+    );
   };
 
-  const initialValues: Partial<ReferatSkjemaValues> = {
-    naermesteLeder: getCurrentNarmesteLeder(
-      dialogmote.arbeidsgiver.virksomhetsnummer
-    )?.narmesteLederNavn,
+  const mellomlagre = (values: ReferatSkjemaValues) => {
+    mellomlagreReferat.mutate(
+      toNewReferat(dialogmote, values, generateReferatDocument)
+    );
   };
+
+  const initialValues = useInitialValuesReferat(dialogmote);
 
   if (ferdigstillDialogmote.isSuccess) {
     return <Redirect to={moteoversiktRoutePath} />;
@@ -205,16 +228,33 @@ const Referat = ({ dialogmote, pageTitle }: ReferatProps): ReactElement => {
             {dialogmote.behandler && <BehandlersOppgave />}
             <VeiledersOppgave />
             <StandardTekster />
+            <FlexRow topPadding={PaddingSize.SM} bottomPadding={PaddingSize.MD}>
+              <Knapp
+                htmlType="button"
+                onClick={() => setDisplayReferatPreview(true)}
+              >
+                {texts.preview}
+              </Knapp>
+            </FlexRow>
             {ferdigstillDialogmote.isError && (
               <SkjemaInnsendingFeil error={ferdigstillDialogmote.error} />
             )}
-            {submitFailed && !feilUtbedret && (
+            {mellomlagreReferat.isError && (
+              <SkjemaInnsendingFeil error={mellomlagreReferat.error} />
+            )}
+            {submitFailed && harIkkeUtbedretFeil && (
               <SkjemaFeiloppsummering errors={errors} />
+            )}
+            {mellomlagreReferat.isSuccess && (
+              <AlertstripeFullbredde type="suksess">
+                {texts.referatSaved}
+              </AlertstripeFullbredde>
             )}
             <ReferatButtons
               pageTitle={pageTitle}
+              onSaveClick={() => mellomlagre(values)}
               onSendClick={resetFeilUtbedret}
-              onPreviewClick={() => setDisplayReferatPreview(true)}
+              showSaveSpinner={mellomlagreReferat.isLoading}
               showSendSpinner={ferdigstillDialogmote.isLoading}
             />
             <Forhandsvisning

--- a/src/components/dialogmote/referat/ReferatButtons.tsx
+++ b/src/components/dialogmote/referat/ReferatButtons.tsx
@@ -1,43 +1,53 @@
 import React, { ReactElement } from "react";
-import { Knapp } from "nav-frontend-knapper";
 import { FlexRow, PaddingSize } from "../../Layout";
 import styled from "styled-components";
 import { TrackedHovedknapp } from "../../buttons/TrackedHovedknapp";
 import { Link } from "react-router-dom";
 import { TrackedFlatknapp } from "../../buttons/TrackedFlatknapp";
 import { moteoversiktRoutePath } from "@/routers/AppRouter";
+import { TrackedKnapp } from "@/components/buttons/TrackedKnapp";
 
 const texts = {
+  save: "Lagre",
   send: "Lagre og send",
-  preview: "Se forhåndsvisning",
   abort: "Avbryt",
 };
 
 interface ReferatButtonsProps {
+  onSaveClick: () => void;
   onSendClick: () => void;
-  onPreviewClick: () => void;
   pageTitle: string;
+  showSaveSpinner: boolean;
   showSendSpinner: boolean;
 }
 
-const HovedKnappRightMargin = styled(TrackedHovedknapp)`
-  margin-right: 2em;
+const HovedKnapp = styled(TrackedHovedknapp)`
+  margin-right: 1em;
+  transform: none;
+`;
+const LagreKnapp = styled(TrackedKnapp)`
+  margin-right: 1em;
 `;
 
 const ReferatButtons = ({
+  onSaveClick,
   onSendClick,
-  onPreviewClick,
   pageTitle,
+  showSaveSpinner,
   showSendSpinner,
 }: ReferatButtonsProps): ReactElement => (
   <>
-    <FlexRow topPadding={PaddingSize.MD}>
-      <Knapp htmlType="button" onClick={onPreviewClick}>
-        {texts.preview}
-      </Knapp>
-    </FlexRow>
     <FlexRow topPadding={PaddingSize.LG}>
-      <HovedKnappRightMargin
+      <LagreKnapp
+        context={pageTitle}
+        htmlType="button"
+        onClick={onSaveClick}
+        autoDisableVedSpinner
+        spinner={showSaveSpinner}
+      >
+        {texts.save}
+      </LagreKnapp>
+      <HovedKnapp
         context={pageTitle}
         htmlType="submit"
         onClick={onSendClick}
@@ -45,7 +55,7 @@ const ReferatButtons = ({
         spinner={showSendSpinner}
       >
         {texts.send}
-      </HovedKnappRightMargin>
+      </HovedKnapp>
       <Link to={moteoversiktRoutePath}>
         <TrackedFlatknapp context={pageTitle} htmlType="button">
           {texts.abort}

--- a/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -13,16 +13,19 @@ import { TrackedHovedknapp } from "../../../buttons/TrackedHovedknapp";
 import { dialogmoteRoutePath } from "@/routers/AppRouter";
 import { Normaltekst } from "nav-frontend-typografi";
 import { DeltakereSvarInfo } from "@/components/dialogmote/DeltakereSvarInfo";
+import dayjs from "dayjs";
 
 const texts = {
   innkallingSendtTrackingContext: "Møtelandingsside: Sendt innkalling",
   headerInnkalling: "Innkallingen er sendt",
   headerEndring: "Endringen er sendt",
+  headerMotedatoPassert: "Møtedato er passert",
   infoMessage:
     "Du har brukt den nye løsningen i Modia. Her kan du også avlyse, endre tidspunktet, og skrive referat.",
   endreMote: "Endre møtet",
   avlysMote: "Avlys møtet",
   skrivReferat: "Skriv referat",
+  fortsettReferat: "Fortsett på referatet",
   moteTid: "Møtetidspunkt",
   moteSted: "Sted",
 };
@@ -38,21 +41,33 @@ const Subtitle = (dialogmote: DialogmoteDTO): ReactNode => {
   );
 };
 
+const headerText = (dialogmote: DialogmoteDTO): string => {
+  const moteDatoTid = dayjs(dialogmote.tid);
+  const today = dayjs(new Date());
+  if (moteDatoTid.isBefore(today, "date")) {
+    return texts.headerMotedatoPassert;
+  }
+
+  return dialogmote.status === DialogmoteStatus.NYTT_TID_STED
+    ? texts.headerEndring
+    : texts.headerInnkalling;
+};
+
 interface Props {
   dialogmote: DialogmoteDTO;
 }
 
 export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
-  const headerText =
-    dialogmote.status == DialogmoteStatus.NYTT_TID_STED
-      ? texts.headerEndring
-      : texts.headerInnkalling;
+  const referatKnappText =
+    dialogmote.referat?.ferdigstilt === false
+      ? texts.fortsettReferat
+      : texts.skrivReferat;
 
   return (
     <DialogmotePanel
       icon={MoteIkonBlaaImage}
       subtitle={Subtitle(dialogmote)}
-      header={headerText}
+      header={headerText(dialogmote)}
     >
       <FlexRow>
         <DeltakereSvarInfo dialogmote={dialogmote} />
@@ -82,7 +97,7 @@ export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
             data-cy="skrivReferatKnapp"
             context={texts.innkallingSendtTrackingContext}
           >
-            {texts.skrivReferat}
+            {referatKnappText}
           </TrackedHovedknapp>
         </Link>
       </FlexRow>

--- a/src/data/dialogmote/types/dialogmoteReferatTypes.ts
+++ b/src/data/dialogmote/types/dialogmoteReferatTypes.ts
@@ -2,24 +2,19 @@ import { DocumentComponentDto } from "./dialogmoteTypes";
 
 export interface ReferatDTO {
   readonly uuid: string;
-  readonly createdAt: string;
-  readonly updatedAt: string;
-  readonly digitalt: boolean;
+  readonly ferdigstilt: boolean;
+  readonly narmesteLederNavn: string;
   readonly situasjon: string;
   readonly konklusjon: string;
   readonly arbeidstakerOppgave: string;
   readonly arbeidsgiverOppgave: string;
   readonly veilederOppgave?: string;
+  readonly behandlerOppgave?: string;
   readonly document: DocumentComponentDto[];
-  readonly lestDatoArbeidstaker?: string;
-  readonly lestDatoArbeidsgiver?: string;
   readonly andreDeltakere: DialogmotedeltakerAnnenDTO[];
 }
 
 export interface DialogmotedeltakerAnnenDTO {
-  readonly uuid: string;
-  readonly createdAt: string;
-  readonly updatedAt: string;
   readonly funksjon: string;
   readonly navn: string;
 }

--- a/src/data/dialogmote/useMellomlagreReferat.ts
+++ b/src/data/dialogmote/useMellomlagreReferat.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "react-query";
+import { ISDIALOGMOTE_ROOT } from "@/apiConstants";
+import { NewDialogmoteReferatDTO } from "@/data/dialogmote/types/dialogmoteReferatTypes";
+import { post } from "@/api/axios";
+import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
+
+export const useMellomlagreReferat = (fnr: string, dialogmoteUuid: string) => {
+  const queryClient = useQueryClient();
+  const path = `${ISDIALOGMOTE_ROOT}/dialogmote/${dialogmoteUuid}/mellomlagre`;
+  const postMellomlagreReferat = (referat: NewDialogmoteReferatDTO) =>
+    post(path, referat);
+
+  return useMutation(postMellomlagreReferat, {
+    onSettled: () =>
+      queryClient.invalidateQueries(dialogmoterQueryKeys.dialogmoter(fnr), {
+        refetchActive: false,
+      }),
+  });
+};

--- a/src/hooks/dialogmote/useInitialValuesReferat.ts
+++ b/src/hooks/dialogmote/useInitialValuesReferat.ts
@@ -1,0 +1,42 @@
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
+import { useLedere } from "@/hooks/useLedere";
+import { ReferatSkjemaValues } from "@/components/dialogmote/referat/Referat";
+import { referatTexts } from "@/data/dialogmote/dialogmoteTexts";
+import { useMemo } from "react";
+
+export const useInitialValuesReferat = (
+  dialogmote: DialogmoteDTO
+): Partial<ReferatSkjemaValues> => {
+  const { getCurrentNarmesteLeder } = useLedere();
+  const {
+    referat,
+    arbeidsgiver: { virksomhetsnummer },
+  } = dialogmote;
+  const currentNarmesteLederNavn = getCurrentNarmesteLeder(virksomhetsnummer)
+    ?.narmesteLederNavn;
+
+  return useMemo(() => {
+    if (!referat) {
+      return {
+        naermesteLeder: currentNarmesteLederNavn,
+      };
+    } else {
+      return {
+        naermesteLeder: referat.narmesteLederNavn,
+        konklusjon: referat.konklusjon,
+        situasjon: referat.situasjon,
+        arbeidstakersOppgave: referat.arbeidstakerOppgave,
+        arbeidsgiversOppgave: referat.arbeidsgiverOppgave,
+        veiledersOppgave: referat.veilederOppgave,
+        behandlersOppgave: referat.behandlerOppgave,
+        andreDeltakere: referat.andreDeltakere.map(({ navn, funksjon }) => ({
+          navn,
+          funksjon,
+        })),
+        standardtekster: referatTexts.standardTekster.filter((standardtekst) =>
+          referat.document.some(({ key }) => key === standardtekst.key)
+        ),
+      };
+    }
+  }, [currentNarmesteLederNavn, referat]);
+};

--- a/src/hooks/useFeilUtbedret.ts
+++ b/src/hooks/useFeilUtbedret.ts
@@ -2,15 +2,17 @@ import { useState } from "react";
 import { harFeilmeldinger, SkjemaFeil } from "@/utils/valideringUtils";
 
 export const useFeilUtbedret = () => {
-  const [feilUtbedret, setFeilUtbedret] = useState(false);
+  const [feilUtbedret, setFeilUtbedret] = useState<boolean | undefined>();
+  const harIkkeUtbedretFeil = feilUtbedret === false;
   const resetFeilUtbedret = () => setFeilUtbedret(false);
   const updateFeilUtbedret = (feil: Partial<SkjemaFeil>) => {
-    if (!harFeilmeldinger(feil)) {
+    if (harIkkeUtbedretFeil && !harFeilmeldinger(feil)) {
       setFeilUtbedret(true);
     }
   };
+
   return {
-    feilUtbedret,
+    harIkkeUtbedretFeil,
     resetFeilUtbedret,
     updateFeilUtbedret,
   };

--- a/test/dialogmote/DialogmoteMoteStatusPanelTest.tsx
+++ b/test/dialogmote/DialogmoteMoteStatusPanelTest.tsx
@@ -1,0 +1,117 @@
+import {
+  DialogmoteDTO,
+  DialogmoteStatus,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { DialogmoteMoteStatusPanel } from "@/components/mote/components/innkalling/DialogmoteMoteStatusPanel";
+import { dialogmote, dialogmoteMedReferat } from "./testData";
+import { createStore } from "redux";
+import { rootReducer } from "@/data/rootState";
+import configureStore from "redux-mock-store";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { expect } from "chai";
+
+const queryClient = new QueryClient();
+const realState = createStore(rootReducer).getState();
+const store = configureStore([]);
+
+const daysFromToday = (days: number): Date => {
+  const nyDato = new Date();
+  nyDato.setDate(nyDato.getDate() + days);
+  return new Date(nyDato);
+};
+
+const renderDialogmoteMoteStatusPanel = (dialogmote: DialogmoteDTO) =>
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store({ ...realState })}>
+          <DialogmoteMoteStatusPanel dialogmote={dialogmote} />
+        </Provider>
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+
+describe("DialogmoteMoteStatusPanel", () => {
+  it("Viser knapp 'Skriv referat' når dialogmøte uten påbegynt referat", () => {
+    renderDialogmoteMoteStatusPanel(dialogmote);
+
+    expect(screen.getByRole("button", { name: "Skriv referat" })).to.exist;
+    expect(screen.queryByRole("button", { name: "Fortsett på referatet" })).to
+      .not.exist;
+  });
+  it("Viser knapp 'Fortsett på referat' når dialogmøte med påbegynt referat", () => {
+    renderDialogmoteMoteStatusPanel(dialogmoteMedReferat);
+
+    expect(screen.getByRole("button", { name: "Fortsett på referatet" })).to
+      .exist;
+    expect(screen.queryByRole("button", { name: "Skriv referat" })).to.not
+      .exist;
+  });
+  it("Viser overskrift 'Innkallingen er sendt' for innkalt dialogmøte i morgen", () => {
+    const innkaltDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      tid: daysFromToday(1).toISOString(),
+    };
+    renderDialogmoteMoteStatusPanel(innkaltDialogmote);
+
+    expect(screen.getByRole("heading", { name: "Innkallingen er sendt" })).to
+      .exist;
+  });
+  it("Viser overskrift 'Endringen er sendt' for endret dialogmøte i morgen", () => {
+    const endretDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      status: DialogmoteStatus.NYTT_TID_STED,
+      tid: daysFromToday(1).toISOString(),
+    };
+    renderDialogmoteMoteStatusPanel(endretDialogmote);
+
+    expect(screen.getByRole("heading", { name: "Endringen er sendt" })).to
+      .exist;
+  });
+  it("Viser overskrift 'Møtedato er passert' for innkalt dialogmøte i går", () => {
+    const innkaltDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      tid: daysFromToday(-1).toISOString(),
+    };
+    renderDialogmoteMoteStatusPanel(innkaltDialogmote);
+
+    expect(screen.getByRole("heading", { name: "Møtedato er passert" })).to
+      .exist;
+  });
+  it("Viser overskrift 'Møtedato er passert' for endret dialogmøte i går", () => {
+    const endretDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      status: DialogmoteStatus.NYTT_TID_STED,
+      tid: daysFromToday(-1).toISOString(),
+    };
+    renderDialogmoteMoteStatusPanel(endretDialogmote);
+
+    expect(screen.getByRole("heading", { name: "Møtedato er passert" })).to
+      .exist;
+  });
+  it("Viser overskrift 'Innkallingen er sendt' for innkalt dialogmøte i dag", () => {
+    const innkaltDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      tid: new Date().toISOString(),
+    };
+    renderDialogmoteMoteStatusPanel(innkaltDialogmote);
+
+    expect(screen.getByRole("heading", { name: "Innkallingen er sendt" })).to
+      .exist;
+  });
+  it("Viser overskrift 'Endringen er sendt' for endret dialogmøte i dag", () => {
+    const endretDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      status: DialogmoteStatus.NYTT_TID_STED,
+      tid: new Date().toISOString(),
+    };
+    renderDialogmoteMoteStatusPanel(endretDialogmote);
+
+    expect(screen.getByRole("heading", { name: "Endringen er sendt" })).to
+      .exist;
+  });
+});

--- a/test/dialogmote/ReferatMellomlagreTest.tsx
+++ b/test/dialogmote/ReferatMellomlagreTest.tsx
@@ -1,0 +1,173 @@
+import { MemoryRouter, Route } from "react-router-dom";
+import { Provider } from "react-redux";
+import React from "react";
+import Referat from "../../src/components/dialogmote/referat/Referat";
+import { createStore } from "redux";
+import { rootReducer } from "@/data/rootState";
+import configureStore from "redux-mock-store";
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
+import { expect } from "chai";
+import { changeTextInput, clickButton, getTextInput } from "../testUtils";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { veilederinfoQueryKeys } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { dialogmoteRoutePath } from "@/routers/AppRouter";
+import {
+  annenDeltakerFunksjon,
+  annenDeltakerNavn,
+  arbeidstaker,
+  behandlendeEnhet,
+  dialogmoteMedBehandler,
+  dialogmoteMedReferat,
+  lederNavn,
+  moteTekster,
+  referatStandardTekst,
+  veileder,
+} from "./testData";
+import { NarmesteLederRelasjonStatus } from "@/data/leder/ledere";
+import { behandlendeEnhetQueryKeys } from "@/data/behandlendeenhet/behandlendeEnhetQueryHooks";
+import { VIRKSOMHET_PONTYPANDY } from "../../mock/common/mockConstants";
+import { render, screen } from "@testing-library/react";
+import { expectedReferatDocument } from "./testDataDocuments";
+import sinon from "sinon";
+import userEvent from "@testing-library/user-event";
+import { stubMellomlagreApi } from "../stubs/stubIsdialogmote";
+import { apiMock } from "../stubs/stubApi";
+
+const realState = createStore(rootReducer).getState();
+const store = configureStore([]);
+
+const mockState = {
+  navbruker: {
+    data: {
+      navn: arbeidstaker.navn,
+      kontaktinfo: {
+        fnr: arbeidstaker.personident,
+      },
+    },
+  },
+  valgtbruker: {
+    personident: arbeidstaker.personident,
+  },
+  ledere: {
+    currentLedere: [
+      {
+        narmesteLederNavn: lederNavn,
+        status: NarmesteLederRelasjonStatus.INNMELDT_AKTIV,
+        virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+        virksomhetsnavn: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
+      },
+      {
+        narmesteLederNavn: "Annen Leder",
+        status: NarmesteLederRelasjonStatus.INNMELDT_AKTIV,
+        virksomhetsnummer: "89829812",
+      },
+    ],
+  },
+};
+
+let queryClient;
+
+describe("ReferatMellomlagreTest", () => {
+  let clock;
+  const today = new Date(Date.now());
+
+  beforeEach(() => {
+    queryClient = new QueryClient();
+    queryClient.setQueryData(
+      veilederinfoQueryKeys.veilederinfo,
+      () => veileder
+    );
+    queryClient.setQueryData(
+      behandlendeEnhetQueryKeys.behandlendeEnhet(arbeidstaker.personident),
+      () => behandlendeEnhet
+    );
+
+    clock = sinon.useFakeTimers(today.getTime());
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it("lagrer referat med verdier fra skjema", () => {
+    stubMellomlagreApi(apiMock(), dialogmoteMedBehandler.uuid);
+    renderReferat(dialogmoteMedBehandler);
+    passSkjemaTekstInput();
+    clickButton("Lagre");
+
+    const mellomlagreMutation = queryClient.getMutationCache().getAll()[0];
+    const expectedReferat = {
+      narmesteLederNavn: lederNavn,
+      situasjon: moteTekster.situasjonTekst,
+      konklusjon: moteTekster.konklusjonTekst,
+      arbeidsgiverOppgave: moteTekster.arbeidsgiversOppgave,
+      arbeidstakerOppgave: moteTekster.arbeidstakersOppgave,
+      behandlerOppgave: moteTekster.behandlersOppgave,
+      veilederOppgave: moteTekster.veiledersOppgave,
+      document: expectedReferatDocument,
+      andreDeltakere: [
+        { funksjon: annenDeltakerFunksjon, navn: annenDeltakerNavn },
+      ],
+    };
+    expect(mellomlagreMutation.options.variables).to.deep.equal(
+      expectedReferat
+    );
+  });
+
+  it("preutfyller referat-skjema fra dialogmote med mellomlagret referat", () => {
+    renderReferat(dialogmoteMedReferat);
+
+    expect(screen.getByDisplayValue(lederNavn)).to.exist;
+    expect(screen.getByDisplayValue(moteTekster.situasjonTekst)).to.exist;
+    expect(screen.getByDisplayValue(moteTekster.arbeidsgiversOppgave)).to.exist;
+    expect(screen.getByDisplayValue(moteTekster.arbeidstakersOppgave)).to.exist;
+    expect(screen.getByDisplayValue(moteTekster.konklusjonTekst)).to.exist;
+    expect(screen.getByDisplayValue(annenDeltakerNavn)).to.exist;
+    expect(screen.getByDisplayValue(annenDeltakerFunksjon)).to.exist;
+    const checkedStandardtekst = screen.getByRole("checkbox", {
+      checked: true,
+      name: referatStandardTekst.label,
+    });
+    expect(checkedStandardtekst).to.exist;
+  });
+});
+
+const renderReferat = (dialogmoteDTO: DialogmoteDTO) => {
+  return render(
+    <MemoryRouter
+      initialEntries={[`${dialogmoteRoutePath}/${dialogmoteDTO.uuid}/referat`]}
+    >
+      <Route path={`${dialogmoteRoutePath}/:dialogmoteUuid/referat`}>
+        <QueryClientProvider client={queryClient}>
+          <Provider store={store({ ...realState, ...mockState })}>
+            <Referat dialogmote={dialogmoteDTO} pageTitle="Test" />
+          </Provider>
+        </QueryClientProvider>
+      </Route>
+    </MemoryRouter>
+  );
+};
+
+const passSkjemaTekstInput = () => {
+  const situasjonInput = getTextInput("Situasjon og muligheter");
+  const konklusjonInput = getTextInput("Konklusjon");
+  const arbeidstakerInput = getTextInput("Arbeidstakerens oppgave:");
+  const arbeidsgiverInput = getTextInput("Arbeidsgiverens oppgave:");
+  const behandlerInput = getTextInput("Behandlerens oppgave (valgfri):");
+  const veilederInput = getTextInput("Veilederens oppgave (valgfri):");
+  const addDeltakerButton = screen.getByRole("button", {
+    name: "Pluss ikon Legg til en deltaker",
+  });
+  userEvent.click(addDeltakerButton);
+  const annenDeltakerNavnInput = getTextInput("Navn");
+  const annenDeltakerFunksjonInput = getTextInput("Funksjon");
+
+  changeTextInput(annenDeltakerNavnInput, annenDeltakerNavn);
+  changeTextInput(annenDeltakerFunksjonInput, annenDeltakerFunksjon);
+  changeTextInput(situasjonInput, moteTekster.situasjonTekst);
+  changeTextInput(konklusjonInput, moteTekster.konklusjonTekst);
+  changeTextInput(arbeidstakerInput, moteTekster.arbeidstakersOppgave);
+  changeTextInput(arbeidsgiverInput, moteTekster.arbeidsgiversOppgave);
+  changeTextInput(behandlerInput, moteTekster.behandlersOppgave);
+  changeTextInput(veilederInput, moteTekster.veiledersOppgave);
+};

--- a/test/dialogmote/testData.ts
+++ b/test/dialogmote/testData.ts
@@ -4,6 +4,7 @@ import {
   DialogmotedeltakerBehandlerDTO,
   DialogmoteDTO,
   DialogmoteStatus,
+  DocumentComponentType,
   MotedeltakerVarselType,
   VarselSvarDTO,
 } from "@/data/dialogmote/types/dialogmoteTypes";
@@ -22,6 +23,7 @@ import {
 } from "../../mock/common/mockConstants";
 import { capitalizeWord } from "@/utils/stringUtils";
 import { behandlerNavn } from "@/utils/behandlerUtils";
+import { referatTexts } from "@/data/dialogmote/dialogmoteTexts";
 
 export const arbeidstaker = {
   navn: "Arne Arbeidstaker",
@@ -239,4 +241,30 @@ export const moteTekster = {
   arbeidstakersOppgave,
   veiledersOppgave,
   behandlersOppgave,
+};
+
+export const referatStandardTekst = referatTexts.standardTekster[3];
+
+export const dialogmoteMedReferat: DialogmoteDTO = {
+  ...dialogmote,
+  referat: {
+    uuid: "123abc",
+    situasjon: situasjonTekst,
+    arbeidsgiverOppgave: arbeidsgiversOppgave,
+    arbeidstakerOppgave: arbeidstakersOppgave,
+    narmesteLederNavn: lederNavn,
+    konklusjon: konklusjonTekst,
+    document: [
+      {
+        key: referatStandardTekst.key,
+        title: referatStandardTekst.label,
+        texts: [referatStandardTekst.text],
+        type: DocumentComponentType.PARAGRAPH,
+      },
+    ],
+    ferdigstilt: false,
+    andreDeltakere: [
+      { navn: annenDeltakerNavn, funksjon: annenDeltakerFunksjon },
+    ],
+  },
 };

--- a/test/stubs/stubIsdialogmote.ts
+++ b/test/stubs/stubIsdialogmote.ts
@@ -32,3 +32,12 @@ export const stubFerdigstillApi = (
     .post(`${ISDIALOGMOTE_ROOT}/dialogmote/${dialogmoteUuid}/ferdigstill`)
     .reply(200);
 };
+
+export const stubMellomlagreApi = (
+  scope: nock.Scope,
+  dialogmoteUuid: string
+) => {
+  return scope
+    .post(`${ISDIALOGMOTE_ROOT}/dialogmote/${dialogmoteUuid}/mellomlagre`)
+    .reply(200);
+};


### PR DESCRIPTION
- Endret tekst på knapp "Skriv referat" på landdingsside når det finnes mellomlagret referat. Og endret header hvis møtedato passert.
- Knapp for "manuell" lagring av referatet i skjema
- Fyller skjema med verdier fra mellomlagret referat
- Flyttet forhåndsvisning-knapp over feilmeldinger/alerts i skjema.