### PR TITLE
Show sykmeldinger as old if 3 or more months old

### DIFF
--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -364,4 +364,4 @@ export const skalVisesSomTidligereSykmelding = (sykmld: SykmeldingOldFormat) =>
   manederMellomDatoer(
     senesteTom(sykmld.mulighetForArbeid.perioder),
     new Date()
-  ) > 3;
+  ) >= 3;


### PR DESCRIPTION
Dette skal fikse en feil hvor noen sykmeldinger havnet mellom to stoler: De har status "NY", men er akkurat 3 måneder gamle (på måneden).