### PR TITLE
Disallow whitespace in video url in dm2 forms

### DIFF
--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -5,3 +5,7 @@ export const firstLetterToUpperCase = (ord: string): string => {
 export const capitalizeWord = (word: string): string => {
   return firstLetterToUpperCase(word.toLowerCase());
 };
+
+export const containsWhiteSpace = (string: string) => {
+  return /\s/g.test(string);
+};

--- a/src/utils/valideringUtils.ts
+++ b/src/utils/valideringUtils.ts
@@ -1,6 +1,7 @@
 import { isISODateString } from "nav-datovelger";
 import { ReferatSkjemaValues } from "@/components/dialogmote/referat/Referat";
 import { genererDato } from "@/components/mote/utils";
+import { containsWhiteSpace } from "@/utils/stringUtils";
 
 export interface SkjemaFeil {
   [key: string]: string | undefined;
@@ -36,6 +37,7 @@ export const texts = {
   andreDeltakereMissingFunksjon: "Vennligst angi funksjon på deltaker",
   andreDeltakereMissingNavn: "Vennligst angi navn på deltaker",
   invalidVideoLink: "Lenke må begynne med https://video.nav.no",
+  whiteSpaceInVideoLink: "Lenke kan ikke inneholde mellomrom",
 };
 
 export const harFeilmeldinger = (errors: SkjemaFeil): boolean =>
@@ -97,9 +99,13 @@ export const validerVideoLink = (videoLink?: string): string | undefined => {
   }
 
   try {
-    const url = new URL(videoLink);
+    const trimmedVideoLink = videoLink.trim();
+    const url = new URL(trimmedVideoLink);
     if (url.origin !== "https://video.nav.no") {
       return texts.invalidVideoLink;
+    }
+    if (containsWhiteSpace(trimmedVideoLink)) {
+      return texts.whiteSpaceInVideoLink;
     }
   } catch (err) {
     return texts.invalidVideoLink;

--- a/test/utils/valideringUtilsTest.ts
+++ b/test/utils/valideringUtilsTest.ts
@@ -1,4 +1,8 @@
-import { validerSkjemaTekster } from "@/utils/valideringUtils";
+import {
+  texts,
+  validerSkjemaTekster,
+  validerVideoLink,
+} from "@/utils/valideringUtils";
 import { expect } from "chai";
 import { getTooLongText, maxLengthErrorMessage } from "../testUtils";
 
@@ -69,6 +73,40 @@ describe("valideringUtils", () => {
       expect(feil).to.deep.equal({
         tekst: maxLengthErrorMessage(maxLength),
       });
+    });
+  });
+
+  describe("validerVideoLink", () => {
+    it("validate incorrect url format, returns error message", () => {
+      const validationMessage = validerVideoLink("https://invalid.url");
+
+      expect(validationMessage).to.equal(texts.invalidVideoLink);
+    });
+    it("validate correct url format and no whitespace, doesn't return error message", () => {
+      const validationMessage = validerVideoLink("https://video.nav.no/abc");
+
+      expect(validationMessage).to.be.undefined;
+    });
+    it("validate url with whitespace, returns error message", () => {
+      const validationMessage = validerVideoLink(
+        "https://video.nav.no/abc space"
+      );
+
+      expect(validationMessage).to.equal(texts.whiteSpaceInVideoLink);
+    });
+    it("validate url with whitespace only before and after valid url, doesn't return error message", () => {
+      const validationMessage = validerVideoLink(
+        "   https://video.nav.no/abc  "
+      );
+
+      expect(validationMessage).to.be.undefined;
+    });
+    it("validate url with both wrong format and whitespace, returns format error message", () => {
+      const validationMessage = validerVideoLink(
+        "https://invalid.url/abc  space"
+      );
+
+      expect(validationMessage).to.equal(texts.invalidVideoLink);
     });
   });
 });


### PR DESCRIPTION
For å unngå at veileder legger til ekstra informasjon i feltet som gjør at pdf-generering feiler.
Trim space før og etter for å unngå at det blir med noe ekstra f.eks. ved innliming.