### PR TITLE
Simplify debugging of components using Styled-components

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "plugins": [
+    "babel-plugin-styled-components",
     "@babel/plugin-proposal-class-properties",
     [
       "module-resolver",

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,7 @@
         "axios-mock-adapter": "1.20.0",
         "babel-loader": "8.1.0",
         "babel-plugin-module-resolver": "4.1.0",
+        "babel-plugin-styled-components": "^2.0.7",
         "chai": "4.3.6",
         "chai-datetime": "1.8.0",
         "chai-enzyme": "1.0.0-beta.0",
@@ -4916,14 +4917,15 @@
       }
     },
     "node_modules/babel-plugin-styled-components": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz",
-      "integrity": "sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       },
       "peerDependencies": {
         "styled-components": ">= 2"
@@ -13896,7 +13898,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -23265,14 +23266,15 @@
       }
     },
     "babel-plugin-styled-components": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz",
-      "integrity": "sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.7.tgz",
+      "integrity": "sha512-i7YhvPgVqRKfoQ66toiZ06jPNA3p6ierpfUuEWxNF+fV27Uv5gxBkf8KZLHUCc1nFA9j6+80pYoIpqCeyW3/bA==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.0.0",
-        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
       }
     },
     "babel-plugin-syntax-jsx": {
@@ -30026,8 +30028,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pidtree": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "axios-mock-adapter": "1.20.0",
     "babel-loader": "8.1.0",
     "babel-plugin-module-resolver": "4.1.0",
+    "babel-plugin-styled-components": "2.0.7",
     "chai": "4.3.6",
     "chai-datetime": "1.8.0",
     "chai-enzyme": "1.0.0-beta.0",


### PR DESCRIPTION
Add babel-plugin-styled-components to make is easier to debug html elements and css rendered from componennts using styled-components. This package adds automatic annoations of styled components with a unique and readable html class name.