### PR TITLE
Add wildcard app route

### DIFF
--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -121,6 +121,7 @@ const AktivBrukerRouter = ({ fnr }: { fnr: string }): ReactElement => {
             path={`${appRoutePath}/vedtak`}
             element={<VedtakContainer />}
           />
+          <Route path="*" element={<Navigate to={appRoutePath} />} />
         </Routes>
       </BrowserRouter>
     </AktivBrukerTilgangLaster>


### PR DESCRIPTION
When no matching route is found, redirect route to route /sykefravaer. This will prevent the user from coming to a blank page, if a wrong url is given as input.