### PR TITLE
Show infotext if selected date is too far into the future

### DIFF
--- a/src/components/dialogmote/DialogmoteTidOgSted.tsx
+++ b/src/components/dialogmote/DialogmoteTidOgSted.tsx
@@ -7,6 +7,9 @@ import DialogmoteInnkallingSkjemaSeksjon from "./innkalling/DialogmoteInnkalling
 import styled from "styled-components";
 import { FlexColumn, FlexRow, PaddingSize } from "../Layout";
 import { Innholdstittel } from "nav-frontend-typografi";
+import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";
+import { useVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 
 const texts = {
   title: "Tid og sted",
@@ -17,6 +20,8 @@ const texts = {
   tidLabel: "Klokkeslett",
   videoLabel: "Lenke til videomøte (valgfritt)",
   videoPlaceholder: "https://",
+  alertText:
+    "Tips: Nå som innkallingen ikke sendes med post, kan du kalle inn til dialogmøter tidligere enn tre uker frem i tid.",
 };
 
 const DatoColumn = styled(FlexColumn)`
@@ -27,11 +32,26 @@ const TidOgStedTittel = styled(Innholdstittel)`
   margin-bottom: 1em;
 `;
 
-const DialogmoteTidOgSted = (): ReactElement => {
+const AlertstripeFullbreddeStyled = styled(AlertstripeFullbredde)`
+  margin-bottom: 2em;
+`;
+
+interface DialogmoteTidOgStedProps {
+  isFuturisticMeeting?: boolean;
+}
+
+const DialogmoteTidOgSted = ({
+  isFuturisticMeeting,
+}: DialogmoteTidOgStedProps): ReactElement => {
   const datoField = "dato";
   const klokkeslettField = "klokkeslett";
   const stedField = "sted";
   const videoLinkField = "videoLink";
+  const { data: veilederinfo } = useVeilederinfoQuery();
+  const ABTestHit = Number(veilederinfo?.ident.slice(-1)) >= 5;
+  const { brukerKanVarslesDigitalt } = useBrukerinfoQuery();
+  const showFuturisticWarning =
+    !!isFuturisticMeeting && ABTestHit && brukerKanVarslesDigitalt;
   return (
     <DialogmoteInnkallingSkjemaSeksjon>
       <TidOgStedTittel>{texts.title}</TidOgStedTittel>
@@ -52,6 +72,11 @@ const DialogmoteTidOgSted = (): ReactElement => {
           />
         </FlexColumn>
       </FlexRow>
+      {showFuturisticWarning && (
+        <AlertstripeFullbreddeStyled type="info">
+          <p>{texts.alertText}</p>
+        </AlertstripeFullbreddeStyled>
+      )}
       <FlexRow bottomPadding={PaddingSize.MD}>
         <FlexColumn flex={1}>
           <Field<string> name={stedField}>

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -38,6 +38,7 @@ import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { ToggleNames } from "@/data/unleash/unleash_types";
 import { Flatknapp, Hovedknapp } from "nav-frontend-knapper";
+import dayjs from "dayjs";
 
 interface DialogmoteInnkallingSkjemaTekster {
   fritekstArbeidsgiver: string;
@@ -110,6 +111,13 @@ const toInnkalling = (
   return innkalling;
 };
 
+const isDateFuturistic = (date?: string) => {
+  const today = dayjs(new Date());
+  const selectedDate = dayjs(date);
+
+  return selectedDate.isAfter(today.add(21, "days"), "date");
+};
+
 const DialogmoteInnkallingSkjema = () => {
   const initialValues: Partial<DialogmoteInnkallingSkjemaValues> = {};
   const fnr = useValgtPersonident();
@@ -139,6 +147,9 @@ const DialogmoteInnkallingSkjema = () => {
   const { toTidStedDto } = useSkjemaValuesToDto();
   const opprettInnkalling = useOpprettInnkallingDialogmote(fnr);
 
+  const [isFuturisticMeeting, setIsFuturisticMeeting] =
+    useState<boolean>(false);
+
   const validate = (
     values: Partial<DialogmoteInnkallingSkjemaValues>
   ): DialogmoteInnkallingSkjemaFeil => {
@@ -161,6 +172,8 @@ const DialogmoteInnkallingSkjema = () => {
             }
           : {}),
       });
+
+    setIsFuturisticMeeting(isDateFuturistic(values.dato));
 
     const feilmeldinger: DialogmoteInnkallingSkjemaFeil = {
       arbeidsgiver: validerArbeidsgiver(values.arbeidsgiver),
@@ -202,7 +215,7 @@ const DialogmoteInnkallingSkjema = () => {
             <DialogmoteInnkallingBehandler
               setSelectedBehandler={setSelectedBehandler}
             />
-            <DialogmoteTidOgSted />
+            <DialogmoteTidOgSted isFuturisticMeeting={isFuturisticMeeting} />
             <DialogmoteInnkallingTekster
               selectedBehandler={selectedBehandler}
               visAlternativTekst={visAlternativBehandlertekst}


### PR DESCRIPTION
AB tested functionality: show text for veiledere with idents ending in 5 or
higher.

Only show futuristic warning if innbygger can receive digital communication

Co-authored-by: John Martin Lindseth <john.martin.lindseth@nav.no>