### PR TITLE
Fix broken sendtTilArbeidsgiver check in soknad

### DIFF
--- a/src/utils/soknad-felles/hentSoknadStatustekst.js
+++ b/src/utils/soknad-felles/hentSoknadStatustekst.js
@@ -27,9 +27,8 @@ const textSendtTilArbeidsgiver = (
 };
 
 const hentStatustekst = (soknad) => {
-  const soknadSendtTilNav =
-    soknad.sendtTilNAVDato !== null || soknad.innsendtDato !== null;
-  const soknadSendtTilArbeidsgiver = soknad.sendtTilArbeidsgiverDato !== null;
+  const isSoknadSentToNav = !!soknad.sendtTilNAVDato || !!soknad.innsendtDato;
+  const isSoknadSentToArbeidsgiver = !!soknad.sendtTilArbeidsgiverDato;
 
   const arbeidsgiver =
     soknad.arbeidsgiver && soknad.arbeidsgiver.navn
@@ -41,18 +40,18 @@ const hentStatustekst = (soknad) => {
     soknad.arbeidsgiver && soknad.arbeidsgiver.orgnummer
       ? formaterOrgnr(soknad.arbeidsgiver.orgnummer)
       : null;
-  const sendtTilArbeidsgiverDato = soknadSendtTilArbeidsgiver
+  const sendtTilArbeidsgiverDato = isSoknadSentToArbeidsgiver
     ? tilLesbarDatoMedArstall(soknad.sendtTilArbeidsgiverDato)
     : null;
-  const sendtTilNavDato = soknadSendtTilNav
+  const sendtTilNavDato = isSoknadSentToNav
     ? tilLesbarDatoMedArstall(soknad.sendtTilNAVDato || soknad.innsendtDato)
     : null;
 
   return soknad.status === SoknadstatusDTO.KORRIGERT
     ? texts.korrigert
-    : soknadSendtTilNav && soknadSendtTilArbeidsgiver
+    : isSoknadSentToNav && isSoknadSentToArbeidsgiver
     ? textSendtTilArbeidsgiverOgNav(arbeidsgiver, orgnr, sendtTilNavDato)
-    : soknadSendtTilNav && !soknadSendtTilArbeidsgiver
+    : isSoknadSentToNav && !isSoknadSentToArbeidsgiver
     ? textSendtTilNav(sendtTilNavDato)
     : textSendtTilArbeidsgiver(arbeidsgiver, orgnr, sendtTilArbeidsgiverDato);
 };

--- a/test/utils/soknad-felles/hentSoknadStatustekstTest.ts
+++ b/test/utils/soknad-felles/hentSoknadStatustekstTest.ts
@@ -1,0 +1,76 @@
+import { expect } from "chai";
+import hentStatustekst from "@/utils/soknad-felles/hentSoknadStatustekst";
+import { tilLesbarDatoMedArstall } from "@/utils/datoUtils";
+
+describe("hentSoknadStatustekst", () => {
+  describe("hentStatustekst", () => {
+    it("Return correct statustekst when soknad is only sent to NAV, regardless of whether missing values are null or undefined", () => {
+      const sendtTilNavDato = new Date("2022-01-01");
+      const readableDate = tilLesbarDatoMedArstall(sendtTilNavDato);
+      const soknad = {
+        sendtTilNAVDato: "2022-01-01",
+        innsendtDato: null,
+        sendtTilArbeidsgiverDato: undefined,
+      };
+
+      const statustekst = hentStatustekst(soknad);
+
+      expect(statustekst).to.be.equal(`Sendt til NAV: ${readableDate}`);
+    });
+
+    it("Return correct statustekst when soknad only has innsendtDato", () => {
+      const innsendtDato = new Date("2022-01-01");
+      const readableDate = tilLesbarDatoMedArstall(innsendtDato);
+      const soknad = {
+        sendtTilNAVDato: undefined,
+        innsendtDato: innsendtDato,
+        sendtTilArbeidsgiverDato: null,
+      };
+
+      const statustekst = hentStatustekst(soknad);
+
+      expect(statustekst).to.be.equal(`Sendt til NAV: ${readableDate}`);
+    });
+
+    it("Return correct statustekst when soknad is only sent to arbeidsgiver", () => {
+      const sendtTilArbeidsgiverDato = new Date("2022-01-01");
+      const readableDate = tilLesbarDatoMedArstall(sendtTilArbeidsgiverDato);
+      const soknad = {
+        sendtTilNAVDato: null,
+        innsendtDato: undefined,
+        sendtTilArbeidsgiverDato: sendtTilArbeidsgiverDato,
+        arbeidsgiver: {
+          navn: "AG",
+          orgnummer: "123",
+        },
+      };
+
+      const statustekst = hentStatustekst(soknad);
+
+      expect(statustekst).to.be.equal(
+        `Sendt til AG (org. nr. 123): ${readableDate}`
+      );
+    });
+
+    it("Return correct statustekst when soknad is sent to both NAV and arbeidsgiver, using sendtTilNAVDato as date", () => {
+      const sendtTilNAVDato = new Date("2022-01-01");
+      const readableNAVDate = tilLesbarDatoMedArstall(sendtTilNAVDato);
+      const sendtTilArbeidsgiverDato = new Date("2023-02-02");
+      const soknad = {
+        sendtTilNAVDato: sendtTilNAVDato,
+        innsendtDato: undefined,
+        sendtTilArbeidsgiverDato: sendtTilArbeidsgiverDato,
+        arbeidsgiver: {
+          navn: "AG",
+          orgnummer: "123",
+        },
+      };
+
+      const statustekst = hentStatustekst(soknad);
+
+      expect(statustekst).to.be.equal(
+        `Sendt til NAV og AG (org. nr. 123): ${readableNAVDate}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
Erstatter `!== null` med en sjekk av datoens boolske verdi, vha dobbel negasjon.
Dette var feil fordi vi i parsingen av innkommet json gjør om datoer som mangler til `undefined`, noe som blir true når man sjekker ikke lik null.
Ved å konvertere direkte til boolsk verdi, skal både null og undefined gi false.