### PR TITLE
Handle that behandler type can be null

### DIFF
--- a/mock/isdialogmelding/behandlereDialogmeldingMock.ts
+++ b/mock/isdialogmelding/behandlereDialogmeldingMock.ts
@@ -1,3 +1,5 @@
+import { BehandlerDTO } from "@/data/behandler/BehandlerDTO";
+
 export const behandlereDialogmeldingMock = [
   {
     type: "FASTLEGE",
@@ -14,7 +16,7 @@ export const behandlereDialogmeldingMock = [
   },
 ];
 
-export const behandlerSokDialogmeldingMock = [
+export const behandlerSokDialogmeldingMock: BehandlerDTO[] = [
   {
     type: null,
     behandlerRef: "behandler-ref-uuid",

--- a/src/components/dialogmote/innkalling/BehandlerRadioGruppe.tsx
+++ b/src/components/dialogmote/innkalling/BehandlerRadioGruppe.tsx
@@ -18,7 +18,8 @@ const behandlerOneliner = (behandler: BehandlerDTO): string => {
   const name = [behandler.fornavn, behandler.mellomnavn, behandler.etternavn]
     .filter(Boolean)
     .join(" ");
-  const typeAndName = `${capitalizeWord(behandler.type)}: ${name}`;
+  const type = !!behandler.type ? `${capitalizeWord(behandler.type)}:` : "";
+  const typeAndName = `${type} ${name}`;
   const office = !!behandler.kontor ? capitalizeWord(behandler.kontor) : "";
   const phone = !!behandler.telefon ? `tlf ${behandler.telefon}` : "";
 

--- a/src/data/behandler/BehandlerDTO.ts
+++ b/src/data/behandler/BehandlerDTO.ts
@@ -1,5 +1,5 @@
 export interface BehandlerDTO {
-  type: BehandlerType;
+  type: BehandlerType | null;
   behandlerRef: string;
   fnr?: string;
   fornavn: string;
@@ -15,4 +15,5 @@ export interface BehandlerDTO {
 
 export enum BehandlerType {
   FASTLEGE = "FASTLEGE",
+  SYKMELDER = "SYKMELDER",
 }


### PR DESCRIPTION
Hvis Behandlertype er `null` (som den vil være hvis du velger noe annet enn fastlegen eller den som sykemelder), vil vi ikke vise dette i denne funksjonen.