### PR TITLE
Remove unused text about DM2 in Arena

### DIFF
--- a/src/components/mote/components/innkalling/InnkallingDialogmotePanel.tsx
+++ b/src/components/mote/components/innkalling/InnkallingDialogmotePanel.tsx
@@ -20,8 +20,6 @@ export const texts = {
   ingenMoterPlanlagt: "Ingen møter planlagt",
   dialogMote: "Dialogmøte",
   moteforesporselSendt: "Møteforespørsel sendt",
-  arenaDialogmoteInnkalling:
-    "Dialogmøter med denne innbyggeren må fortsatt kalles inn via Arena.",
 };
 
 const dialogmotePanelHeaderText = (isKandidat: boolean): string => {


### PR DESCRIPTION
Denne henger igjen fra før DM2-innkalling var tilgjengelig for alle, og har ikke vært i bruk på lenge.