### PR TITLE
Align behandler search result to the left

### DIFF
--- a/src/components/dialogmote/innkalling/BehandlerSearchResult.tsx
+++ b/src/components/dialogmote/innkalling/BehandlerSearchResult.tsx
@@ -8,6 +8,7 @@ const StyledButton = styled(Button)`
   width: 100%;
   display: flex;
   justify-content: start;
+  text-align: start;
   color: #262626;
 `;
 


### PR DESCRIPTION
Nå ligger teksten til venstre selv når den går over flere linjer.

Co-authored-by: Eirik Dahlen <eirik.dahlen@nav.no>