### PR TITLE
Add correct suffix to svartyper

### DIFF
--- a/mock/sykepengesoknad/soknaderMock.ts
+++ b/mock/sykepengesoknad/soknaderMock.ts
@@ -1297,7 +1297,7 @@ export const soknaderMock = [
         max: null,
         pavirkerAndreSporsmal: false,
         kriterieForVisningAvUndersporsmal: "JA",
-        svar: [{ verdi: "NEI" }],
+        svar: [{ verdi: "JA" }],
         undersporsmal: [
           {
             id: "25452",
@@ -1310,6 +1310,20 @@ export const soknaderMock = [
             pavirkerAndreSporsmal: false,
             kriterieForVisningAvUndersporsmal: null,
             svar: [],
+            undersporsmal: [],
+          },
+          {
+            id: "17000",
+            tag: "HVOR_MANGE_TIMER_PER_UKE_0",
+            sporsmalstekst:
+              "Hvor mange timer i uken jobber du vanligvis når du er frisk? Varierer det, kan du oppgi gjennomsnittet.",
+            undertekst: null,
+            svartype: "TALL",
+            min: "1",
+            max: "150",
+            pavirkerAndreSporsmal: false,
+            kriterieForVisningAvUndersporsmal: null,
+            svar: [{ verdi: "37,5" }],
             undersporsmal: [],
           },
         ],

--- a/src/components/speiling/sykepengsoknader/soknad-felles-oppsummering/OppsummeringTall.tsx
+++ b/src/components/speiling/sykepengsoknader/soknad-felles-oppsummering/OppsummeringTall.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/data/sykepengesoknad/types/SykepengesoknadDTO";
 
 const texts = {
-  timerTot: "timer totalt",
+  timerTotalt: "timer totalt",
   prosent: "prosent",
 };
 
@@ -23,6 +23,17 @@ const verdiAdjustedIfBelop = (
   return svar.verdi as string;
 };
 
+const getSvartypeText = (svartype: SvarTypeDTO | undefined): string => {
+  switch (svartype) {
+    case SvarTypeDTO.TIMER:
+      return texts.timerTotalt;
+    case SvarTypeDTO.PROSENT:
+      return texts.prosent;
+    default:
+      return "";
+  }
+};
+
 const OppsummeringTall = ({
   svar,
   sporsmalstekst,
@@ -31,7 +42,7 @@ const OppsummeringTall = ({
   svartype,
   undertekst,
 }: OppsummeringSporsmalProps): ReactElement => {
-  const text = svartype === SvarTypeDTO.TIMER ? texts.timerTot : texts.prosent;
+  const text = getSvartypeText(svartype);
   const label = undertekst || text;
   return (
     <OppsummeringSporsmalscontainer tag={tag}>


### PR DESCRIPTION
Dataen kan i noen tilfeller henvise til timer i spørsmålet, men være av svartype = Tall. Tidligere løsningen ville da defaulte til prosent, mens nå setter vi heller ingen verdi enn å skrive feil. Vi har sagt ifra til team Flex om at det ville gitt mer mening om dataen vi får fra de hadde Svartype.TIMER når spørsmålet spør om timer, men det er utenfor vår kontroll å rette opp i.

Tidligere:
![image](https://user-images.githubusercontent.com/37441744/191941627-31babeb9-979c-4ad2-86be-d10028f783d7.png)


Nå (det er kun stringbasert mockdata, derfor er det forskjell på `37.50` og `37,5`):
<img width="758" alt="image" src="https://user-images.githubusercontent.com/37441744/191941558-4c9c12a3-1584-4106-b44b-24da8937e5ac.png">
