### PR TITLE
Clean up texts on motelandingsside

### DIFF
--- a/src/components/mote/NoNarmestLederAlert.tsx
+++ b/src/components/mote/NoNarmestLederAlert.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";
-import styled from "styled-components";
 
 const texts = {
   noNarmesteleder:
@@ -8,12 +7,8 @@ const texts = {
     "til Altinn. Lederen må registrere seg som nærmeste leder i Altinn for å kunne gi svar på Nav.no.",
 };
 
-const NoNarmesteLederWarning = styled(AlertstripeFullbredde)`
-  margin-top: 2em;
-`;
-
 export const NoNarmesteLederAlert = () => (
-  <NoNarmesteLederWarning type="advarsel">
+  <AlertstripeFullbredde type="advarsel">
     <p>{texts.noNarmesteleder}</p>
-  </NoNarmesteLederWarning>
+  </AlertstripeFullbredde>
 );

--- a/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/components/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -27,8 +27,6 @@ const texts = {
   headerInnkalling: "Innkallingen er sendt",
   headerEndring: "Endringen er sendt",
   headerMotedatoPassert: "Møtedato er passert",
-  infoMessage:
-    "Du har brukt den nye løsningen i Modia. Her kan du også avlyse, endre tidspunktet, og skrive referat.",
   endreMote: "Endre møtet",
   avlysMote: "Avlys møtet",
   skrivReferat: "Skriv referat",
@@ -96,17 +94,15 @@ export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
       subtitle={Subtitle(dialogmote)}
       header={headerText(dialogmote)}
     >
-      <FlexRow>
-        <DeltakereSvarInfo dialogmote={dialogmote} />
-      </FlexRow>
-
-      <FlexRow topPadding={PaddingSize.SM}>{texts.infoMessage}</FlexRow>
-
       {noNarmesteLeder && (
-        <FlexRow>
+        <FlexRow bottomPadding={PaddingSize.MD}>
           <NoNarmesteLederAlert />
         </FlexRow>
       )}
+
+      <FlexRow>
+        <DeltakereSvarInfo dialogmote={dialogmote} />
+      </FlexRow>
 
       {skalVurderes && (
         <FlexRow topPadding={PaddingSize.MD}>


### PR DESCRIPTION
Remove superfluous text, and move 'no arbeidsgiver'-alert to the top. This will allow the behandle oppgave box to be closer to the motesvars it refers to.

Co-authored-by: John Martin Lindseth <john.martin.lindseth@nav.no>