### PR TITLE
Update alert text for no virksomhet

### DIFF
--- a/src/components/dialogmote/innkalling/virksomhet/DialogmoteInnkallingVelgVirksomhet.tsx
+++ b/src/components/dialogmote/innkalling/virksomhet/DialogmoteInnkallingVelgVirksomhet.tsx
@@ -59,7 +59,7 @@ const DialogmoteInnkallingVelgVirksomhet = () => {
                 {meta.submitFailed && meta.error}
               </SkjemaelementFeilmelding>
               {narmesteLeder && (
-                <FlexRow topPadding={PaddingSize.MD}>
+                <FlexRow topPadding={PaddingSize.SM}>
                   <LederNavnColumn flex={0.2}>
                     <Input
                       bredde="L"
@@ -78,9 +78,9 @@ const DialogmoteInnkallingVelgVirksomhet = () => {
                   </FlexColumn>
                 </FlexRow>
               )}
-              {isVirksomhetChosen && noNarmesteLeder && (
-                <NoNarmesteLederAlert />
-              )}
+              {isVirksomhetChosen &&
+                noNarmesteLeder &&
+                virksomheter.length > 0 && <NoNarmesteLederAlert />}
             </>
           );
         }}

--- a/src/components/dialogmote/innkalling/virksomhet/VirksomhetChooser.tsx
+++ b/src/components/dialogmote/innkalling/virksomhet/VirksomhetChooser.tsx
@@ -4,12 +4,14 @@ import { VirksomhetInput } from "@/components/dialogmote/innkalling/virksomhet/V
 import { VirksomhetRadioGruppe } from "@/components/dialogmote/innkalling/virksomhet/VirksomhetRadioGruppe";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { ToggleNames } from "@/data/unleash/unleash_types";
+import styled from "styled-components";
 
 const texts = {
   chooseArbeidsgiver: "Velg arbeidsgiver",
-  noArbeidsgiver:
-    "Det er ikke registrert en virksomhet på denne arbeidstakeren. " +
-    "Hvis du mener det er feil, meld sak i Porten",
+  noArbeidsgiver: "Det er ikke registrert en virksomhet på denne personen.",
+  unemployed:
+    "Hvis personen er arbeidsledig, kan du kalle inn til samarbeidsmøte fra aktivitetsplanen.",
+  report_error: "Hvis du mener det er feil, meld sak i Porten.",
 };
 
 interface VirksomhetRadioGruppeProps {
@@ -19,6 +21,11 @@ interface VirksomhetRadioGruppeProps {
   label: string;
   name: string;
 }
+
+const NoVirksomhetAlert = styled(AlertstripeFullbredde)`
+  padding_top: 2em;
+  margin-bottom: 2em;
+`;
 
 export const VirksomhetChooser = ({
   velgVirksomhet,
@@ -47,9 +54,13 @@ export const VirksomhetChooser = ({
       {showInput && <VirksomhetInput velgVirksomhet={velgVirksomhet} />}
 
       {virksomheter.length === 0 && !hasAccessToVirksomhetInput && (
-        <AlertstripeFullbredde type="advarsel">
+        <NoVirksomhetAlert type="advarsel">
           {texts.noArbeidsgiver}
-        </AlertstripeFullbredde>
+          <ul>
+            <li>{texts.unemployed}</li>
+            <li>{texts.report_error}</li>
+          </ul>
+        </NoVirksomhetAlert>
       )}
     </>
   );

--- a/src/components/dialogmote/innkalling/virksomhet/VirksomhetInput.tsx
+++ b/src/components/dialogmote/innkalling/virksomhet/VirksomhetInput.tsx
@@ -9,6 +9,7 @@ const texts = {
 
 const StyledInput = styled(Input)`
   margin-top: 1em;
+  margin-bottom: 2em;
 `;
 
 interface VirksomhetInputProps {

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
@@ -181,7 +181,7 @@ describe("DialogmoteInnkallingSkjema", () => {
     changeTextInput(virksomhetInput, "123456789");
 
     expect(screen.queryByText(/Det er ikke registrert en nærmeste leder/i)).to
-      .exist;
+      .not.exist;
     expect(screen.queryByLabelText("Nærmeste leder")).to.not.exist;
     expect(screen.queryByLabelText("Epost")).to.not.exist;
   });


### PR DESCRIPTION
Due to many jira-cases where the veileder haven't checked if the AT is unemployed we add information on this in the alert text.

Also made sure the two alerts don't show at the same time, and added some space.