### PR TITLE
Vurder aktivitetskrav unntak

### DIFF
--- a/src/components/aktivitetskrav/vurdering/UnntakAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/UnntakAktivitetskravSkjema.tsx
@@ -1,45 +1,45 @@
 import React from "react";
 import {
   AktivitetskravStatus,
-  OppfyltVurderingArsak,
+  UnntakVurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { oppfyltVurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 import { VurderAktivitetskravArsakRadioGruppe } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe";
+import { unntakVurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 import { VurderAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravSkjema";
 import { useAktivitetskravVurderingSkjema } from "@/hooks/aktivitetskrav/useAktivitetskravVurderingSkjema";
 
 const texts = {
-  title: "Aktivitetskravet er oppfylt",
+  title: "Sett unntak fra aktivitetskravet",
 };
 
-interface OppfyltAktivitetskravSkjemaValues {
+interface UnntakAktivitetskravSkjemaValues {
   beskrivelse: string;
-  arsak: OppfyltVurderingArsak;
+  arsak: UnntakVurderingArsak;
 }
 
-interface OppfyltAktivitetskravSkjemaProps {
+interface UnntakAktivitetskravSkjemaProps {
   setModalOpen: (modalOpen: boolean) => void;
   aktivitetskravUuid: string;
 }
 
-export const OppfyltAktivitetskravSkjema = ({
+export const UnntakAktivitetskravSkjema = ({
   setModalOpen,
   aktivitetskravUuid,
-}: OppfyltAktivitetskravSkjemaProps) => {
+}: UnntakAktivitetskravSkjemaProps) => {
   const { createDto, validateArsak, validateBeskrivelse } =
-    useAktivitetskravVurderingSkjema(AktivitetskravStatus.OPPFYLT);
+    useAktivitetskravVurderingSkjema(AktivitetskravStatus.UNNTAK);
 
-  const validate = (values: Partial<OppfyltAktivitetskravSkjemaValues>) => ({
+  const validate = (values: Partial<UnntakAktivitetskravSkjemaValues>) => ({
     ...validateArsak(values.arsak),
     ...validateBeskrivelse(values.beskrivelse, false),
   });
 
   return (
-    <VurderAktivitetskravSkjema<OppfyltAktivitetskravSkjemaValues>
+    <VurderAktivitetskravSkjema<UnntakAktivitetskravSkjemaValues>
       title={texts.title}
       arsakVelger={
         <VurderAktivitetskravArsakRadioGruppe
-          arsakTexts={oppfyltVurderingArsakTexts}
+          arsakTexts={unntakVurderingArsakTexts}
         />
       }
       setModalOpen={setModalOpen}

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe.tsx
@@ -2,17 +2,13 @@ import { Radio, RadioGruppe } from "nav-frontend-skjema";
 import React from "react";
 import { Field, useFormState } from "react-final-form";
 import { VurderingArsak } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { ArsakText } from "@/data/aktivitetskrav/aktivitetskravTexts";
 
 const texts = {
   arsakLegend: "Årsak (obligatorisk)",
 };
 
 export const vurderAktivitetskravArsakFieldName = "arsak";
-
-type ArsakText = {
-  arsak: VurderingArsak;
-  text: string;
-};
 
 interface VurderAktivitetskravArsakRadioGruppeProps {
   arsakTexts: ArsakText[];

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravModal.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravModal.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { OppfyltAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/OppfyltAktivitetskravSkjema";
 import styled from "styled-components";
+import { UnntakAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/UnntakAktivitetskravSkjema";
 
 const texts = {
   modalContentLabel: "Vurder aktivitetskrav",
@@ -68,6 +69,14 @@ const VurderAktivitetskravModalContent = ({
     case "OPPFYLT": {
       return (
         <OppfyltAktivitetskravSkjema
+          setModalOpen={setModalOpen}
+          aktivitetskravUuid={aktivitetskravUuid}
+        />
+      );
+    }
+    case "UNNTAK": {
+      return (
+        <UnntakAktivitetskravSkjema
           setModalOpen={setModalOpen}
           aktivitetskravUuid={aktivitetskravUuid}
         />

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravSkjema.tsx
@@ -1,0 +1,63 @@
+import { FlexRow, PaddingSize } from "@/components/Layout";
+import React, { ReactElement } from "react";
+import { CreateAktivitetskravVurderingDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { Innholdstittel } from "nav-frontend-typografi";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { VurderAktivitetskravSkjemaButtons } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravSkjemaButtons";
+import { Form } from "react-final-form";
+import { useVurderAktivitetskrav } from "@/data/aktivitetskrav/useVurderAktivitetskrav";
+import { VurderAktivitetskravBeskrivelse } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravBeskrivelse";
+import { ValidationErrors } from "final-form";
+
+interface VurderAktivitetskravSkjemaProps<SkjemaValues> {
+  title: string;
+  arsakVelger: ReactElement;
+  setModalOpen: (modalOpen: boolean) => void;
+  aktivitetskravUuid: string;
+
+  toDto(values: SkjemaValues): CreateAktivitetskravVurderingDTO;
+
+  validate(values: Partial<SkjemaValues>): ValidationErrors;
+}
+
+export const VurderAktivitetskravSkjema = <SkjemaValues extends object>({
+  title,
+  arsakVelger,
+  setModalOpen,
+  aktivitetskravUuid,
+  toDto,
+  validate,
+}: VurderAktivitetskravSkjemaProps<SkjemaValues>) => {
+  const vurderAktivitetskrav = useVurderAktivitetskrav(aktivitetskravUuid);
+
+  const submit = (values: SkjemaValues) => {
+    const createAktivitetskravVurderingDTO: CreateAktivitetskravVurderingDTO =
+      toDto(values);
+    vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO, {
+      onSuccess: () => setModalOpen(false),
+    });
+  };
+
+  return (
+    <Form onSubmit={submit} validate={validate}>
+      {({ handleSubmit }) => (
+        <form onSubmit={handleSubmit}>
+          <FlexRow bottomPadding={PaddingSize.MD}>
+            <Innholdstittel>{title}</Innholdstittel>
+          </FlexRow>
+          <FlexRow bottomPadding={PaddingSize.SM}>{arsakVelger}</FlexRow>
+          <FlexRow bottomPadding={PaddingSize.MD}>
+            <VurderAktivitetskravBeskrivelse />
+          </FlexRow>
+          {vurderAktivitetskrav.isError && (
+            <SkjemaInnsendingFeil error={vurderAktivitetskrav.error} />
+          )}
+          <VurderAktivitetskravSkjemaButtons
+            onAvbrytClick={() => setModalOpen(false)}
+            showLagreSpinner={vurderAktivitetskrav.isLoading}
+          />
+        </form>
+      )}
+    </Form>
+  );
+};

--- a/src/data/aktivitetskrav/aktivitetskravTexts.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTexts.ts
@@ -1,11 +1,15 @@
-import { OppfyltVurderingArsak } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import {
+  OppfyltVurderingArsak,
+  UnntakVurderingArsak,
+  VurderingArsak,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
 
-export type OppfyltVurderingArsakText = {
-  arsak: OppfyltVurderingArsak;
+export type ArsakText = {
+  arsak: VurderingArsak;
   text: string;
 };
 
-export const oppfyltVurderingArsakTexts: OppfyltVurderingArsakText[] = [
+export const oppfyltVurderingArsakTexts: ArsakText[] = [
   {
     arsak: OppfyltVurderingArsak.FRISKMELDT,
     text: "Friskmeldt",
@@ -17,5 +21,20 @@ export const oppfyltVurderingArsakTexts: OppfyltVurderingArsakText[] = [
   {
     arsak: OppfyltVurderingArsak.TILTAK,
     text: "I tiltak",
+  },
+];
+
+export const unntakVurderingArsakTexts: ArsakText[] = [
+  {
+    arsak: UnntakVurderingArsak.MEDISINSKE_GRUNNER,
+    text: "Medisinske grunner",
+  },
+  {
+    arsak: UnntakVurderingArsak.TILRETTELEGGING_IKKE_MULIG,
+    text: "Tilrettelegging ikke mulig",
+  },
+  {
+    arsak: UnntakVurderingArsak.SJOMENN_UTENRIKS,
+    text: "Sjømenn i utenriksfart",
   },
 ];

--- a/src/hooks/aktivitetskrav/useAktivitetskravVurderingSkjema.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVurderingSkjema.ts
@@ -1,0 +1,53 @@
+import {
+  AktivitetskravStatus,
+  CreateAktivitetskravVurderingDTO,
+  VurderingArsak,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { vurderAktivitetskravArsakFieldName } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe";
+import {
+  vurderAktivitetskravBeskrivelseFieldName,
+  vurderAktivitetskravBeskrivelseMaxLength,
+} from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravBeskrivelse";
+import { validerTekst } from "@/utils/valideringUtils";
+
+export const useAktivitetskravVurderingSkjema = (
+  status: AktivitetskravStatus
+) => {
+  const createDto = (
+    beskrivelse: string,
+    arsaker: VurderingArsak[]
+  ): CreateAktivitetskravVurderingDTO => {
+    return {
+      status,
+      beskrivelse,
+      arsaker,
+    };
+  };
+  const validateArsak = (arsak: VurderingArsak | undefined) => {
+    return {
+      [vurderAktivitetskravArsakFieldName]: !arsak
+        ? "Vennligst angi årsak"
+        : undefined,
+    };
+  };
+  const validateBeskrivelse = (
+    beskrivelse: string | undefined,
+    required: boolean
+  ) => {
+    return {
+      [vurderAktivitetskravBeskrivelseFieldName]: validerTekst({
+        value: beskrivelse || "",
+        maxLength: vurderAktivitetskravBeskrivelseMaxLength,
+        missingRequiredMessage: required
+          ? "Vennligst angi beskrivelse"
+          : undefined,
+      }),
+    };
+  };
+
+  return {
+    createDto,
+    validateArsak,
+    validateBeskrivelse,
+  };
+};


### PR DESCRIPTION
Refaktorert en del felles kode til `<VurderAktivitetskravSkjema>` og `useAktivitetskravVurderingSkjema` siden det er en del likt i disse skjemaene (UNNTAK/OPPFYLT/AVVENT)
![image](https://user-images.githubusercontent.com/79838644/207282236-29527d45-9adc-4215-a2ae-5f3de26d0a9a.png)
