### PR TITLE
Viser avkryssede årsaker til Avvent i alert

### DIFF
--- a/mock/isaktivitetskrav/aktivitetskravMock.ts
+++ b/mock/isaktivitetskrav/aktivitetskravMock.ts
@@ -1,4 +1,8 @@
-import { AktivitetskravStatus } from "../../src/data/aktivitetskrav/aktivitetskravTypes";
+import {
+  AktivitetskravStatus,
+  AvventVurderingArsak,
+  OppfyltVurderingArsak,
+} from "../../src/data/aktivitetskrav/aktivitetskravTypes";
 import { generateUUID } from "../../src/utils/uuidUtils";
 import { VEILEDER_DEFAULT } from "../common/mockConstants";
 import { daysFromToday } from "../../test/testUtils";
@@ -25,6 +29,7 @@ const aktivitetskravOppfylt = {
       createdBy: VEILEDER_DEFAULT.ident,
       status: AktivitetskravStatus.OPPFYLT,
       beskrivelse: "Oppfylt",
+      arsaker: [OppfyltVurderingArsak.FRISKMELDT],
     },
     {
       uuid: generateUUID(),
@@ -32,6 +37,10 @@ const aktivitetskravOppfylt = {
       createdBy: VEILEDER_DEFAULT.ident,
       status: AktivitetskravStatus.AVVENT,
       beskrivelse: "Avventer info",
+      arsaker: [
+        AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER,
+        AvventVurderingArsak.INFORMASJON_BEHANDLER,
+      ],
     },
   ],
 };

--- a/src/components/aktivitetskrav/vurdering/AktivitetskravVurderingAlert.tsx
+++ b/src/components/aktivitetskrav/vurdering/AktivitetskravVurderingAlert.tsx
@@ -12,6 +12,7 @@ import { FlexRow, PaddingSize } from "@/components/Layout";
 import { Element, Normaltekst } from "nav-frontend-typografi";
 import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";
 import styled from "styled-components";
+import { avventVurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 
 const prefixTexts = {
   [AktivitetskravStatus.UNNTAK]: "Det er vurdert unntak for",
@@ -51,8 +52,13 @@ export const AktivitetskravVurderingAlert = ({
             <Normaltekst>{vurdering.beskrivelse}</Normaltekst>
           </FlexRow>
           <FlexRow topPadding={PaddingSize.SM}>
-            {/*TODO: Punkter med avkryssede sjekkbokser når det er implementert
-              for vurdering*/}
+            <ul>
+              {vurdering.arsaker.map((arsak, index) => {
+                const avventArsakText =
+                  avventVurderingArsakTexts[arsak] || arsak;
+                return <li key={index}>{avventArsakText}</li>;
+              })}
+            </ul>
           </FlexRow>
         </StyledAlertstripeFullbredde>
       );

--- a/src/components/aktivitetskrav/vurdering/AvventArsakerCheckboxGruppe.tsx
+++ b/src/components/aktivitetskrav/vurdering/AvventArsakerCheckboxGruppe.tsx
@@ -19,8 +19,8 @@ export const AvventArsakerCheckboxGruppe = () => {
         submitFailed && errors && errors[vurderAktivitetskravArsakerFieldName]
       }
     >
-      {avventVurderingArsakTexts.map(({ arsak, text }, index) => (
-        <Field
+      {Object.entries(avventVurderingArsakTexts).map(([arsak, text], index) => (
+        <Field<string>
           key={index}
           name={vurderAktivitetskravArsakerFieldName}
           type="checkbox"

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe.tsx
@@ -1,8 +1,7 @@
 import { Radio, RadioGruppe } from "nav-frontend-skjema";
 import React from "react";
 import { Field, useFormState } from "react-final-form";
-import { VurderingArsak } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { ArsakText } from "@/data/aktivitetskrav/aktivitetskravTexts";
+import { VurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 
 const texts = {
   arsakLegend: "Årsak (obligatorisk)",
@@ -11,7 +10,7 @@ const texts = {
 export const vurderAktivitetskravArsakFieldName = "arsak";
 
 interface VurderAktivitetskravArsakRadioGruppeProps {
-  arsakTexts: ArsakText[];
+  arsakTexts: VurderingArsakTexts;
 }
 
 export const VurderAktivitetskravArsakRadioGruppe = ({
@@ -26,8 +25,8 @@ export const VurderAktivitetskravArsakRadioGruppe = ({
         submitFailed && errors && errors[vurderAktivitetskravArsakFieldName]
       }
     >
-      {arsakTexts.map(({ arsak, text }, index) => (
-        <Field<VurderingArsak>
+      {Object.entries(arsakTexts).map(([arsak, text], index) => (
+        <Field<string>
           key={index}
           name={vurderAktivitetskravArsakFieldName}
           value={arsak}

--- a/src/data/aktivitetskrav/aktivitetskravTexts.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTexts.ts
@@ -5,52 +5,27 @@ import {
   VurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 
-export type ArsakText = {
-  arsak: VurderingArsak;
-  text: string;
+export type VurderingArsakTexts = {
+  [key in VurderingArsak]?: string;
 };
 
-export const oppfyltVurderingArsakTexts: ArsakText[] = [
-  {
-    arsak: OppfyltVurderingArsak.FRISKMELDT,
-    text: "Friskmeldt",
-  },
-  {
-    arsak: OppfyltVurderingArsak.GRADERT,
-    text: "Gradert",
-  },
-  {
-    arsak: OppfyltVurderingArsak.TILTAK,
-    text: "I tiltak",
-  },
-];
+export const oppfyltVurderingArsakTexts: VurderingArsakTexts = {
+  [OppfyltVurderingArsak.FRISKMELDT]: "Friskmeldt",
+  [OppfyltVurderingArsak.GRADERT]: "Gradert",
+  [OppfyltVurderingArsak.TILTAK]: "I tiltak",
+};
 
-export const unntakVurderingArsakTexts: ArsakText[] = [
-  {
-    arsak: UnntakVurderingArsak.MEDISINSKE_GRUNNER,
-    text: "Medisinske grunner",
-  },
-  {
-    arsak: UnntakVurderingArsak.TILRETTELEGGING_IKKE_MULIG,
-    text: "Tilrettelegging ikke mulig",
-  },
-  {
-    arsak: UnntakVurderingArsak.SJOMENN_UTENRIKS,
-    text: "Sjømenn i utenriksfart",
-  },
-];
+export const unntakVurderingArsakTexts: VurderingArsakTexts = {
+  [UnntakVurderingArsak.MEDISINSKE_GRUNNER]: "Medisinske grunner",
+  [UnntakVurderingArsak.TILRETTELEGGING_IKKE_MULIG]:
+    "Tilrettelegging ikke mulig",
+  [UnntakVurderingArsak.SJOMENN_UTENRIKS]: "Sjømenn i utenriksfart",
+};
 
-export const avventVurderingArsakTexts: ArsakText[] = [
-  {
-    arsak: AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER,
-    text: "Har bedt om oppfølgingsplan fra arbeidsgiver",
-  },
-  {
-    arsak: AvventVurderingArsak.INFORMASJON_BEHANDLER,
-    text: "Har bedt om mer informasjon fra behandler",
-  },
-  {
-    arsak: AvventVurderingArsak.ANNET,
-    text: "Annet",
-  },
-];
+export const avventVurderingArsakTexts: VurderingArsakTexts = {
+  [AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER]:
+    "Har bedt om oppfølgingsplan fra arbeidsgiver",
+  [AvventVurderingArsak.INFORMASJON_BEHANDLER]:
+    "Har bedt om mer informasjon fra behandler",
+  [AvventVurderingArsak.ANNET]: "Annet",
+};

--- a/test/aktivitetskrav/AktivitetskravSideTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravSideTest.tsx
@@ -16,6 +16,7 @@ import { expect } from "chai";
 import {
   avventVurdering,
   createAktivitetskrav,
+  createAktivitetskravVurdering,
   createOppfolgingstilfelle,
   oppfyltVurdering,
   unntakVurdering,
@@ -23,6 +24,7 @@ import {
 import {
   AktivitetskravDTO,
   AktivitetskravStatus,
+  AvventVurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
 
@@ -141,7 +143,7 @@ describe("AktivitetskravSide", () => {
   describe("Vurdering alert", () => {
     it("viser advarsel når siste aktivitetskrav-vurdering er AVVENT", () => {
       mockAktivitetskrav([
-        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.NY, [
+        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.AVVENT, [
           avventVurdering,
         ]),
       ]);
@@ -151,9 +153,33 @@ describe("AktivitetskravSide", () => {
       expect(screen.getByRole("img", { name: "advarsel-ikon" })).to.exist;
       expect(screen.getByText(/Avventer - /)).to.exist;
     });
+    it("viser beskrivelse og årsaker når siste aktivitetskrav-vurdering er AVVENT", () => {
+      const beskrivelse = "Avventer litt";
+      const vurdering = createAktivitetskravVurdering(
+        AktivitetskravStatus.AVVENT,
+        [
+          AvventVurderingArsak.OPPFOLGINGSPLAN_ARBEIDSGIVER,
+          AvventVurderingArsak.INFORMASJON_BEHANDLER,
+        ],
+        beskrivelse
+      );
+      mockAktivitetskrav([
+        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.AVVENT, [
+          vurdering,
+        ]),
+      ]);
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
+      renderAktivitetskravSide();
+
+      expect(screen.getByText(beskrivelse)).to.exist;
+      expect(screen.getByText("Har bedt om oppfølgingsplan fra arbeidsgiver"))
+        .to.exist;
+      expect(screen.getByText("Har bedt om mer informasjon fra behandler")).to
+        .exist;
+    });
     it("viser suksess når siste aktivitetskrav-vurdering er OPPFYLT", () => {
       mockAktivitetskrav([
-        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.NY, [
+        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.OPPFYLT, [
           oppfyltVurdering,
           avventVurdering,
         ]),
@@ -166,7 +192,7 @@ describe("AktivitetskravSide", () => {
     });
     it("viser suksess når siste aktivitetskrav-vurdering er UNNTAK", () => {
       mockAktivitetskrav([
-        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.NY, [
+        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.UNNTAK, [
           unntakVurdering,
           avventVurdering,
         ]),

--- a/test/aktivitetskrav/testDataUtils.ts
+++ b/test/aktivitetskrav/testDataUtils.ts
@@ -43,10 +43,11 @@ export const createAktivitetskrav = (
 
 export const createAktivitetskravVurdering = (
   status: AktivitetskravStatus,
-  arsaker: VurderingArsak[]
+  arsaker: VurderingArsak[],
+  beskrivelse = ""
 ): AktivitetskravVurderingDTO => {
   return {
-    beskrivelse: "",
+    beskrivelse,
     createdAt: new Date(),
     createdBy: VEILEDER_IDENT_DEFAULT,
     status,


### PR DESCRIPTION
Samt gjort litt forenkling/refaktorering av årsak-tekstene i src/data/aktivitetskrav/aktivitetskravTexts.ts
![image](https://user-images.githubusercontent.com/79838644/208053050-084ac5c1-a10a-497f-8d92-f8eb660f7577.png)
