### PR TITLE
Tillater vurdering av aktivitetskrav for siste oppfolgingstilfelle (uavhengig av om det er aktivt) - tilsvarende logikk for dm-kandidat og innkalling

### DIFF
--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -22,13 +22,11 @@ const gjelderOppfolgingstilfelle = (
 };
 
 export const AktivitetskravSide = () => {
-  const { hasActiveOppfolgingstilfelle, latestOppfolgingstilfelle } =
-    useOppfolgingstilfellePersonQuery();
+  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
   const { data } = useAktivitetskravQuery();
 
   const aktivitetskravForOppfolgingstilfelle = data.filter(
     (aktivitetskrav) =>
-      hasActiveOppfolgingstilfelle &&
       latestOppfolgingstilfelle &&
       gjelderOppfolgingstilfelle(aktivitetskrav, latestOppfolgingstilfelle)
   );

--- a/test/aktivitetskrav/AktivitetskravHistorikkTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravHistorikkTest.tsx
@@ -12,10 +12,6 @@ import {
   OppfyltVurderingArsak,
   UnntakVurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import {
-  createAktivitetskrav,
-  createAktivitetskravVurdering,
-} from "./testDataUtils";
 import { expect } from "chai";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import { daysFromToday, getButton } from "../testUtils";
@@ -27,6 +23,10 @@ import {
 } from "../../mock/common/mockConstants";
 import { veilederinfoQueryKeys } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
+import {
+  createAktivitetskrav,
+  createAktivitetskravVurdering,
+} from "../testDataUtils";
 
 let queryClient: QueryClient;
 

--- a/test/aktivitetskrav/AktivitetskravSideTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravSideTest.tsx
@@ -17,10 +17,10 @@ import {
   avventVurdering,
   createAktivitetskrav,
   createAktivitetskravVurdering,
-  createOppfolgingstilfelle,
+  generateOppfolgingstilfelle,
   oppfyltVurdering,
   unntakVurdering,
-} from "./testDataUtils";
+} from "../testDataUtils";
 import {
   AktivitetskravDTO,
   AktivitetskravStatus,
@@ -52,7 +52,10 @@ const mockAktivitetskrav = (aktivitetskrav: AktivitetskravDTO[]) => {
   );
 };
 
-const activeOppfolgingstilfelle = createOppfolgingstilfelle(daysFromToday(30));
+const activeOppfolgingstilfelle = generateOppfolgingstilfelle(
+  daysFromToday(-30),
+  daysFromToday(30)
+);
 
 const renderAktivitetskravSide = () => {
   render(
@@ -79,10 +82,8 @@ describe("AktivitetskravSide", () => {
   });
 
   describe("Vurder aktivitetskravet", () => {
-    it("Vises når aktivt oppfølgingstilfelle med aktivitetskrav", () => {
-      mockOppfolgingstilfellePerson([
-        createOppfolgingstilfelle(daysFromToday(30)),
-      ]);
+    it("Vises når siste oppfølgingstilfelle har aktivitetskrav (NY)", () => {
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([
         createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.NY),
       ]);
@@ -92,10 +93,21 @@ describe("AktivitetskravSide", () => {
       expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
         .to.exist;
     });
-    it("Vises ikke når aktivt oppfølgingstilfelle, men aktivitetskrav automatisk oppfylt", () => {
+    it("Vises når siste oppfølgingstilfelle er inaktivt med aktivitetskrav (NY)", () => {
       mockOppfolgingstilfellePerson([
-        createOppfolgingstilfelle(daysFromToday(30)),
+        generateOppfolgingstilfelle(daysFromToday(-30), daysFromToday(-20)),
       ]);
+      mockAktivitetskrav([
+        createAktivitetskrav(daysFromToday(-25), AktivitetskravStatus.NY),
+      ]);
+
+      renderAktivitetskravSide();
+
+      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
+        .to.exist;
+    });
+    it("Vises ikke når siste oppfølgingstilfelle har aktivitetskrav automatisk oppfylt", () => {
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([
         createAktivitetskrav(
           daysFromToday(20),
@@ -109,10 +121,8 @@ describe("AktivitetskravSide", () => {
         screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
       ).to.not.exist;
     });
-    it("Vises ikke når aktivt oppfølgingstilfelle, men aktivitetskrav gjelder ikke tilfelle", () => {
-      mockOppfolgingstilfellePerson([
-        createOppfolgingstilfelle(daysFromToday(30)),
-      ]);
+    it("Vises ikke når aktivitetskrav gjelder tidligere tilfelle", () => {
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([
         createAktivitetskrav(daysFromToday(70), AktivitetskravStatus.NY),
       ]);
@@ -123,22 +133,9 @@ describe("AktivitetskravSide", () => {
         screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
       ).to.not.exist;
     });
-    it("Vises ikke når aktivt oppfølgingstilfelle uten aktivitetskrav", () => {
-      mockOppfolgingstilfellePerson([
-        createOppfolgingstilfelle(daysFromToday(30)),
-      ]);
+    it("Vises ikke når siste oppfølgingstilfelle uten aktivitetskrav", () => {
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([]);
-
-      renderAktivitetskravSide();
-
-      expect(
-        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
-      ).to.not.exist;
-    });
-    it("Vises ikke når inaktivt oppfølgingstilfelle", () => {
-      mockOppfolgingstilfellePerson([
-        createOppfolgingstilfelle(daysFromToday(-20)),
-      ]);
 
       renderAktivitetskravSide();
 

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -5,7 +5,7 @@ import { navEnhet } from "../dialogmote/testData";
 import React from "react";
 import { VurderAktivitetskrav } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskrav";
 import { queryClientWithMockData } from "../testQueryClient";
-import { createAktivitetskrav } from "./testDataUtils";
+import { createAktivitetskrav } from "../testDataUtils";
 import {
   changeTextInput,
   clickButton,

--- a/test/testDataUtils.ts
+++ b/test/testDataUtils.ts
@@ -2,8 +2,7 @@ import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/
 import {
   VEILEDER_IDENT_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
-} from "../../mock/common/mockConstants";
-import { daysFromToday } from "../testUtils";
+} from "../mock/common/mockConstants";
 import {
   AktivitetskravDTO,
   AktivitetskravStatus,
@@ -14,17 +13,6 @@ import {
   VurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { generateUUID } from "@/utils/uuidUtils";
-
-export const createOppfolgingstilfelle = (
-  end: Date
-): OppfolgingstilfelleDTO => {
-  return {
-    virksomhetsnummerList: [VIRKSOMHET_PONTYPANDY.virksomhetsnummer],
-    arbeidstakerAtTilfelleEnd: true,
-    end,
-    start: daysFromToday(-30),
-  };
-};
 
 export const generateOppfolgingstilfelle = (
   start: Date,

--- a/test/utils/oppfolgingstilfelleUtilsTest.ts
+++ b/test/utils/oppfolgingstilfelleUtilsTest.ts
@@ -3,7 +3,7 @@ import {
   isGjentakendeSykefravar,
   sortByDescendingStart,
 } from "@/utils/oppfolgingstilfelleUtils";
-import { generateOppfolgingstilfelle } from "../aktivitetskrav/testDataUtils";
+import { generateOppfolgingstilfelle } from "../testDataUtils";
 import { daysFromToday } from "../testUtils";
 import { THREE_YEARS_AGO_IN_MONTHS } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import dayjs from "dayjs";


### PR DESCRIPTION
Moved testdataUtils and removed redundant method.