### PR TITLE
Refactor UtdragFraSykefravaeret and DialogmotePanel

### DIFF
--- a/src/components/IconHeader.tsx
+++ b/src/components/IconHeader.tsx
@@ -1,0 +1,38 @@
+import {
+  FlexColumn,
+  FlexRow,
+  H2NoMargins,
+  JustifyContentType,
+  PaddingSize,
+} from "@/components/Layout";
+import React, { ReactNode } from "react";
+import styled from "styled-components";
+
+const Icon = styled.img`
+  margin-right: 1em;
+  width: 3em;
+`;
+
+interface IconHeaderProps {
+  icon: string;
+  altIcon: string;
+  header: string;
+  subtitle?: ReactNode;
+}
+
+export const IconHeader = ({
+  icon,
+  altIcon,
+  header,
+  subtitle,
+}: IconHeaderProps) => {
+  return (
+    <FlexRow bottomPadding={PaddingSize.MD}>
+      <Icon src={icon} alt={altIcon} />
+      <FlexColumn justifyContent={JustifyContentType.CENTER}>
+        <H2NoMargins>{header}</H2NoMargins>
+        {typeof subtitle === "string" ? <p>{subtitle}</p> : subtitle}
+      </FlexColumn>
+    </FlexRow>
+  );
+};

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Panel from "nav-frontend-paneler";
 
 export enum JustifyContentType {
   CENTER = "center",
@@ -64,4 +65,11 @@ export const FlexRow = styled.div<RowProps>`
 
 export const H2NoMargins = styled.h2`
   margin: 0;
+`;
+
+export const FlexPanel = styled(Panel)`
+  display: flex;
+  flex-direction: column;
+  margin-bottom: ${PaddingSize.MD};
+  padding: 2em;
 `;

--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -10,6 +10,7 @@ import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/
 import { AktivitetskravVurderingAlert } from "@/components/aktivitetskrav/vurdering/AktivitetskravVurderingAlert";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import { AktivitetskravHistorikk } from "@/components/aktivitetskrav/historikk/AktivitetskravHistorikk";
+import { AktivitetskravPanel } from "@/components/aktivitetskrav/AktivitetskravPanel";
 
 const gjelderOppfolgingstilfelle = (
   aktivitetskrav: AktivitetskravDTO,
@@ -46,7 +47,9 @@ export const AktivitetskravSide = () => {
       {aktivitetskravTilVurdering && (
         <VurderAktivitetskrav aktivitetskrav={aktivitetskravTilVurdering} />
       )}
-      <UtdragFraSykefravaeret />
+      <AktivitetskravPanel>
+        <UtdragFraSykefravaeret />
+      </AktivitetskravPanel>
       <AktivitetskravHistorikk />
     </>
   );

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
@@ -29,21 +29,19 @@ export const VurderAktivitetskrav = ({
   };
 
   return (
-    <>
-      <AktivitetskravPanel>
-        <FlexRow bottomPadding={PaddingSize.MD}>
-          <Innholdstittel>{texts.header}</Innholdstittel>
-        </FlexRow>
-        <VurderAktivitetskravButtons
-          onButtonClick={visVurderingAktivitetskravModalForType}
-        />
-        <VurderAktivitetskravModal
-          isOpen={visVurderAktivitetskravModal}
-          setModalOpen={setVisVurderAktivitetskravModal}
-          modalType={modalType}
-          aktivitetskravUuid={aktivitetskrav.uuid}
-        />
-      </AktivitetskravPanel>
-    </>
+    <AktivitetskravPanel>
+      <FlexRow bottomPadding={PaddingSize.MD}>
+        <Innholdstittel>{texts.header}</Innholdstittel>
+      </FlexRow>
+      <VurderAktivitetskravButtons
+        onButtonClick={visVurderingAktivitetskravModalForType}
+      />
+      <VurderAktivitetskravModal
+        isOpen={visVurderAktivitetskravModal}
+        setModalOpen={setVisVurderAktivitetskravModal}
+        modalType={modalType}
+        aktivitetskravUuid={aktivitetskrav.uuid}
+      />
+    </AktivitetskravPanel>
   );
 };

--- a/src/components/mote/components/DialogmotePanel.tsx
+++ b/src/components/mote/components/DialogmotePanel.tsx
@@ -1,59 +1,19 @@
 import React, { ReactElement, ReactNode } from "react";
-import styled from "styled-components";
-import Panel from "nav-frontend-paneler";
-import {
-  FlexColumn,
-  FlexRow,
-  H2NoMargins,
-  JustifyContentType,
-  PaddingSize,
-} from "../../Layout";
+import { IconHeader } from "@/components/IconHeader";
+import { FlexPanel } from "@/components/Layout";
 
 interface Props {
   icon: string;
   header: string;
   subtitle?: ReactNode;
-  topRightElement?: ReactElement;
   children: ReactNode;
 }
 
-const StyledPanel = styled(Panel)`
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 2em;
-  padding: 2em;
-`;
-
-const Icon = styled.img`
-  margin-right: 1em;
-  width: 3em;
-`;
-
-const DivRightAligned = styled.div`
-  margin-left: auto;
-`;
-
-export const DialogmotePanel = ({
-  icon,
-  header,
-  subtitle,
-  topRightElement,
-  children,
-}: Props): ReactElement => {
+export const DialogmotePanel = ({ children, ...rest }: Props): ReactElement => {
   return (
-    <StyledPanel>
-      <FlexRow bottomPadding={PaddingSize.MD}>
-        <Icon src={icon} alt="moteikon" />
-        <FlexColumn justifyContent={JustifyContentType.CENTER}>
-          <H2NoMargins>{header}</H2NoMargins>
-          {typeof subtitle === "string" ? <p>{subtitle}</p> : subtitle}
-        </FlexColumn>
-        {topRightElement && (
-          <DivRightAligned>{topRightElement}</DivRightAligned>
-        )}
-      </FlexRow>
-
+    <FlexPanel>
+      <IconHeader altIcon="moteikon" {...rest} />
       <>{children}</>
-    </StyledPanel>
+    </FlexPanel>
   );
 };

--- a/src/components/mote/components/Motelandingsside.tsx
+++ b/src/components/mote/components/Motelandingsside.tsx
@@ -13,6 +13,7 @@ import { DialogmoteFerdigstilteReferatPanel } from "@/components/dialogmote/Dial
 import { DialogmoteStatus } from "@/data/dialogmote/types/dialogmoteTypes";
 import { useDialogmoteunntakQuery } from "@/data/dialogmotekandidat/dialogmoteunntakQueryHooks";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { FlexPanel } from "@/components/Layout";
 
 const texts = {
   dialogmoter: "Dialogmøter",
@@ -71,7 +72,9 @@ export const Motelandingsside = () => {
           (mote) => mote.status === DialogmoteStatus.FERDIGSTILT
         )}
       />
-      <UtdragFraSykefravaeretPanel />
+      <FlexPanel>
+        <UtdragFraSykefravaeretPanel />
+      </FlexPanel>
       <MotehistorikkPanel
         historiskeMoter={historiskeDialogmoter}
         dialogmoteunntak={dialogmoteunntak}

--- a/src/components/nokkelinformasjon/Nokkelinformasjon.tsx
+++ b/src/components/nokkelinformasjon/Nokkelinformasjon.tsx
@@ -4,6 +4,7 @@ import UtdragFraSykefravaeret from "../utdragFraSykefravaeret/UtdragFraSykefrava
 import { Sykmeldingsgrad } from "@/components/sykmeldingsgrad/Sykmeldingsgrad";
 import { ToggleNames } from "@/data/unleash/unleash_types";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
+import { FlexPanel } from "@/components/Layout";
 
 interface NokkelinformasjonProps {
   pageTitle: string;
@@ -19,7 +20,9 @@ const Nokkelinformasjon = ({ pageTitle }: NokkelinformasjonProps) => {
 
       {visSykmeldingsgrad && <Sykmeldingsgrad />}
 
-      <UtdragFraSykefravaeret />
+      <FlexPanel>
+        <UtdragFraSykefravaeret />
+      </FlexPanel>
     </div>
   );
 };

--- a/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
@@ -23,7 +23,6 @@ import {
   MerInformasjonImage,
 } from "../../../img/ImageComponents";
 import { UtdragOppfolgingsplaner } from "./UtdragOppfolgingsplaner";
-import { DialogmotePanel } from "../mote/components/DialogmotePanel";
 import { Undertittel } from "nav-frontend-typografi";
 import { SpinnsynLenke } from "@/components/vedtak/SpinnsynLenke";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
@@ -31,6 +30,7 @@ import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/pe
 import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
 import Ekspanderbartpanel from "nav-frontend-ekspanderbartpanel";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { IconHeader } from "@/components/IconHeader";
 
 const tekster = {
   header: "Utdrag fra sykefraværet",
@@ -229,7 +229,12 @@ const UtdragFraSykefravaeret = () => {
   const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
 
   return (
-    <DialogmotePanel icon={GultDokumentImage} header={tekster.header}>
+    <>
+      <IconHeader
+        icon={GultDokumentImage}
+        altIcon="Gult dokument"
+        header={tekster.header}
+      />
       <div className="utdragFraSykefravaeret">
         <UtdragOppfolgingsplaner />
 
@@ -247,7 +252,7 @@ const UtdragFraSykefravaeret = () => {
         <Undertittel tag={"h3"}>{tekster.vedtak.header}</Undertittel>
         <SpinnsynLenke />
       </div>
-    </DialogmotePanel>
+    </>
   );
 };
 


### PR DESCRIPTION
For å slippe avhengighet til DialogmotePanel fra UtdragFraSykefravaeret og kunne bruke AktivitetskravPanel til å vise UtdragFraSykefravaeret på aktivitetskrav-siden.