### PR TITLE
Improve and move aktivitetskrav toggle check to container

### DIFF
--- a/src/components/aktivitetskrav/AktivitetskravContainer.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravContainer.tsx
@@ -7,12 +7,19 @@ import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/pe
 import SideLaster from "@/components/SideLaster";
 import { AktivitetskravSide } from "@/components/aktivitetskrav/AktivitetskravSide";
 import { useOppfolgingsplanerQuery } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
+import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
+import { ToggleNames } from "@/data/unleash/unleash_types";
+import Feilmelding from "@/components/Feilmelding";
 
 const texts = {
   title: "Aktivitetskrav",
+  noAccess: "Du har ikke tilgang til denne tjenesten",
 };
 
 export const AktivitetskravContainer = (): ReactElement => {
+  const { isFeatureEnabled, isFetched } = useFeatureToggles();
+  const manglerTilgangAktivitetskrav =
+    isFetched && !isFeatureEnabled(ToggleNames.aktivitetskrav);
   const {
     isInitialLoading: henterAktivitetskrav,
     isError: hentAktivitetskravFeilet,
@@ -34,6 +41,10 @@ export const AktivitetskravContainer = (): ReactElement => {
     hentAktivitetskravFeilet ||
     hentOppfolgingstilfellerFeilet ||
     hentOppfolgingsplanerFeilet;
+
+  if (manglerTilgangAktivitetskrav) {
+    return <Feilmelding tittel={texts.noAccess} melding={""} />;
+  }
 
   return (
     <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.AKTIVITETSKRAV}>

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -21,8 +21,6 @@ import { useAktivBruker } from "@/data/modiacontext/modiacontextQueryHooks";
 import DialogmoteEndreReferatContainer from "@/components/dialogmote/referat/DialogmoteEndreReferatContainer";
 import DialogmoteunntakSkjemaContainer from "@/components/dialogmoteunntak/DialogmoteunntakSkjemaContainer";
 import { PersonsokSide } from "@/components/PersonsokSide";
-import { ToggleNames } from "@/data/unleash/unleash_types";
-import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { AktivitetskravContainer } from "@/components/aktivitetskrav/AktivitetskravContainer";
 
 export const appRoutePath = "/sykefravaer";
@@ -32,9 +30,6 @@ export const dialogmoteUnntakRoutePath = `${appRoutePath}/dialogmoteunntak`;
 export const moteoversiktRoutePath = `${appRoutePath}/moteoversikt`;
 
 const AktivBrukerRouter = (): ReactElement => {
-  const { isFeatureEnabled } = useFeatureToggles();
-  const aktivitetskravEnabled = isFeatureEnabled(ToggleNames.aktivitetskrav);
-
   return (
     <AktivBrukerTilgangLaster>
       <BrowserRouter>
@@ -45,12 +40,10 @@ const AktivBrukerRouter = (): ReactElement => {
             path={`${appRoutePath}/nokkelinformasjon`}
             element={<NokkelinformasjonContainer />}
           />
-          {aktivitetskravEnabled && (
-            <Route
-              path={`${appRoutePath}/aktivitetskrav`}
-              element={<AktivitetskravContainer />}
-            />
-          )}
+          <Route
+            path={`${appRoutePath}/aktivitetskrav`}
+            element={<AktivitetskravContainer />}
+          />
           <Route
             path={`${appRoutePath}/logg`}
             element={<HistorikkContainer />}


### PR DESCRIPTION
Toggle sjekkes også for å vise menypunktet og hente aktivitetskrav-data så dette er bare en ekstra sjekk for å hindre at man kan få opp siden ved å gå til `/aktivitetskrav`-routen.