### PR TITLE
Show årsak for aktivitetskravvurderinger in historikk

### DIFF
--- a/src/components/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
+++ b/src/components/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import {
   AktivitetskravStatus,
   AktivitetskravVurderingDTO,
+  VurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { FlexColumn, FlexRow, PaddingSize } from "@/components/Layout";
 import { Innholdstittel, Normaltekst } from "nav-frontend-typografi";
@@ -11,11 +12,18 @@ import { capitalizeWord } from "@/utils/stringUtils";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
+import {
+  oppfyltVurderingArsakTexts,
+  unntakVurderingArsakTexts,
+} from "@/data/aktivitetskrav/aktivitetskravTexts";
+import styled from "styled-components";
 
 const texts = {
   header: "Historikk",
   subHeader:
     "Tidligere behandling av aktivitetskravet som ble gjennomført i Modia.",
+  arsakTitle: "Årsak",
+  beskrivelseTitle: "Beskrivelse",
 };
 
 const isRelevantForHistorikk = (vurdering: AktivitetskravVurderingDTO) =>
@@ -72,22 +80,56 @@ const headerPrefix = (status: AktivitetskravStatus): string => {
   }
 };
 
+const getArsakText = (arsak: VurderingArsak) => {
+  return (
+    oppfyltVurderingArsakTexts[arsak] ||
+    unntakVurderingArsakTexts[arsak] ||
+    arsak
+  );
+};
+
 const HistorikkElement = ({ vurdering }: HistorikkElementProps) => {
   const { data: veilederinfo } = useVeilederInfoQuery(vurdering.createdBy);
   const header = `${headerPrefix(vurdering.status)} - ${tilDatoMedManedNavn(
     vurdering.createdAt
   )}`;
+  const arsak = vurdering.arsaker[0];
 
   return (
     <Accordion>
       <Accordion.Item>
         <Accordion.Header>{header}</Accordion.Header>
         <Accordion.Content>
-          <Normaltekst>{vurdering.beskrivelse}</Normaltekst>
-          <br />
+          {!!arsak && (
+            <Paragraph title={texts.arsakTitle} body={getArsakText(arsak)} />
+          )}
+          {!!vurdering.beskrivelse && (
+            <Paragraph
+              title={texts.beskrivelseTitle}
+              body={vurdering.beskrivelse}
+            />
+          )}
           {veilederinfo?.navn}
         </Accordion.Content>
       </Accordion.Item>
     </Accordion>
+  );
+};
+
+interface ParagraphProps {
+  title: string;
+  body: string;
+}
+
+const ParagraphWrapper = styled.div`
+  padding-bottom: 1em;
+`;
+
+const Paragraph = ({ title, body }: ParagraphProps) => {
+  return (
+    <ParagraphWrapper>
+      <b>{title}</b>
+      <Normaltekst>{body}</Normaltekst>
+    </ParagraphWrapper>
   );
 };

--- a/test/testDataUtils.ts
+++ b/test/testDataUtils.ts
@@ -43,7 +43,7 @@ export const createAktivitetskrav = (
 export const createAktivitetskravVurdering = (
   status: AktivitetskravStatus,
   arsaker: VurderingArsak[],
-  beskrivelse = "",
+  beskrivelse: string | undefined = "",
   createdAt = new Date()
 ): AktivitetskravVurderingDTO => {
   return {


### PR DESCRIPTION
AVVENT is the only status that can have more than one årsak, but it won't show up in history. So we only care about the first årsak in the array, or no årsak if status is IKKE_OPPFYLT.