### PR TITLE
Skal kunne vurdere aktivitetskrav uten at det finnes oppfolgingstilfelle med aktivitetskrav

### DIFF
--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -2,25 +2,16 @@ import React from "react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { VurderAktivitetskrav } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskrav";
 import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
-import {
-  AktivitetskravDTO,
-  AktivitetskravStatus,
-} from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { AktivitetskravVurderingAlert } from "@/components/aktivitetskrav/vurdering/AktivitetskravVurderingAlert";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import { AktivitetskravHistorikk } from "@/components/aktivitetskrav/historikk/AktivitetskravHistorikk";
 import { AktivitetskravPanel } from "@/components/aktivitetskrav/AktivitetskravPanel";
-
-const gjelderOppfolgingstilfelle = (
-  aktivitetskrav: AktivitetskravDTO,
-  oppfolgingstilfelle: OppfolgingstilfelleDTO
-): boolean => {
-  return (
-    aktivitetskrav.stoppunktAt > oppfolgingstilfelle.start &&
-    aktivitetskrav.stoppunktAt <= oppfolgingstilfelle.end
-  );
-};
+import {
+  aktivitetskravVurderingerForOppfolgingstilfelle,
+  oppfolgingstilfelleForAktivitetskrav,
+} from "@/utils/aktivitetskravUtils";
+import { NoOppfolgingstilfelleAktivitetskravAlert } from "@/components/aktivitetskrav/NoOppfolgingstilfelleAktivitetskravAlert";
 
 export const AktivitetskravSide = () => {
   const { tilfellerDescendingStart } = useOppfolgingstilfellePersonQuery();
@@ -32,31 +23,27 @@ export const AktivitetskravSide = () => {
   );
   const oppfolgingstilfelle =
     aktivitetskravTilVurdering &&
-    tilfellerDescendingStart.find((tilfelle) =>
-      gjelderOppfolgingstilfelle(aktivitetskravTilVurdering, tilfelle)
+    oppfolgingstilfelleForAktivitetskrav(
+      aktivitetskravTilVurdering,
+      tilfellerDescendingStart
     );
-  const vurderteAktivitetskravForOppfolgingstilfelle =
-    oppfolgingstilfelle &&
-    data.filter(
-      (aktivitetskrav) =>
-        gjelderOppfolgingstilfelle(aktivitetskrav, oppfolgingstilfelle) &&
-        aktivitetskrav.vurderinger.length > 0
-    );
-  const sisteVurdering = vurderteAktivitetskravForOppfolgingstilfelle?.flatMap(
-    (aktivitetskrav) => aktivitetskrav.vurderinger
-  )[0];
+  const sisteVurdering = oppfolgingstilfelle
+    ? aktivitetskravVurderingerForOppfolgingstilfelle(
+        data,
+        oppfolgingstilfelle
+      )[0]
+    : aktivitetskravTilVurdering?.vurderinger[0];
 
   return (
     <>
+      {!oppfolgingstilfelle && <NoOppfolgingstilfelleAktivitetskravAlert />}
       {sisteVurdering && (
         <AktivitetskravVurderingAlert vurdering={sisteVurdering} />
       )}
-      {aktivitetskravTilVurdering && oppfolgingstilfelle && (
-        <VurderAktivitetskrav
-          aktivitetskrav={aktivitetskravTilVurdering}
-          oppfolgingstilfelle={oppfolgingstilfelle}
-        />
-      )}
+      <VurderAktivitetskrav
+        aktivitetskrav={aktivitetskravTilVurdering}
+        oppfolgingstilfelle={oppfolgingstilfelle}
+      />
       <AktivitetskravPanel>
         <UtdragFraSykefravaeret />
       </AktivitetskravPanel>

--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -14,7 +14,8 @@ import {
 import { NoOppfolgingstilfelleAktivitetskravAlert } from "@/components/aktivitetskrav/NoOppfolgingstilfelleAktivitetskravAlert";
 
 export const AktivitetskravSide = () => {
-  const { tilfellerDescendingStart } = useOppfolgingstilfellePersonQuery();
+  const { tilfellerDescendingStart, hasActiveOppfolgingstilfelle } =
+    useOppfolgingstilfellePersonQuery();
   const { data } = useAktivitetskravQuery();
 
   const aktivitetskravTilVurdering = data.find(
@@ -36,7 +37,9 @@ export const AktivitetskravSide = () => {
 
   return (
     <>
-      {!oppfolgingstilfelle && <NoOppfolgingstilfelleAktivitetskravAlert />}
+      {!hasActiveOppfolgingstilfelle && (
+        <NoOppfolgingstilfelleAktivitetskravAlert />
+      )}
       {sisteVurdering && (
         <AktivitetskravVurderingAlert vurdering={sisteVurdering} />
       )}

--- a/src/components/aktivitetskrav/NoOppfolgingstilfelleAktivitetskravAlert.tsx
+++ b/src/components/aktivitetskrav/NoOppfolgingstilfelleAktivitetskravAlert.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import styled from "styled-components";
+import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";
+
+const texts = {
+  alert:
+    "Vi finner ingen aktiv sykmelding på denne personen. Du kan likevel vurdere aktivitetskravet hvis det er behov for det.",
+};
+
+const StyledAlertstripe = styled(AlertstripeFullbredde)`
+  margin-bottom: 1em;
+`;
+
+export const NoOppfolgingstilfelleAktivitetskravAlert =
+  (): React.ReactElement => {
+    return <StyledAlertstripe type="advarsel">{texts.alert}</StyledAlertstripe>;
+  };

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
@@ -26,8 +26,8 @@ const HjelpetekstColumn = styled(FlexColumn)`
 `;
 
 interface VurderAktivitetskravProps {
-  aktivitetskrav: AktivitetskravDTO;
-  oppfolgingstilfelle: OppfolgingstilfelleDTO;
+  aktivitetskrav: AktivitetskravDTO | undefined;
+  oppfolgingstilfelle: OppfolgingstilfelleDTO | undefined;
 }
 
 export const VurderAktivitetskrav = ({
@@ -53,12 +53,14 @@ export const VurderAktivitetskrav = ({
           </Hjelpetekst>
         </HjelpetekstColumn>
       </FlexRow>
-      <FlexRow>
-        <Normaltekst>{`Gjelder tilfelle ${tilLesbarPeriodeMedArUtenManednavn(
-          oppfolgingstilfelle.start,
-          oppfolgingstilfelle.end
-        )}`}</Normaltekst>
-      </FlexRow>
+      {oppfolgingstilfelle && (
+        <FlexRow>
+          <Normaltekst>{`Gjelder tilfelle ${tilLesbarPeriodeMedArUtenManednavn(
+            oppfolgingstilfelle.start,
+            oppfolgingstilfelle.end
+          )}`}</Normaltekst>
+        </FlexRow>
+      )}
       <VurderAktivitetskravButtons
         onButtonClick={visVurderingAktivitetskravModalForType}
       />
@@ -66,7 +68,7 @@ export const VurderAktivitetskrav = ({
         isOpen={visVurderAktivitetskravModal}
         setModalOpen={setVisVurderAktivitetskravModal}
         modalType={modalType}
-        aktivitetskravUuid={aktivitetskrav.uuid}
+        aktivitetskravUuid={aktivitetskrav?.uuid}
       />
     </AktivitetskravPanel>
   );

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravModal.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravModal.tsx
@@ -21,7 +21,7 @@ interface VurderAktivitetskravModalProps {
   isOpen: boolean;
   setModalOpen: (modalOpen: boolean) => void;
   modalType: ModalType | undefined;
-  aktivitetskravUuid: string;
+  aktivitetskravUuid: string | undefined;
 }
 
 export const VurderAktivitetskravModal = ({
@@ -53,7 +53,7 @@ export const VurderAktivitetskravModal = ({
 interface VurderAktivitetskravModalContentProps {
   setModalOpen: (modalOpen: boolean) => void;
   modalType: ModalType;
-  aktivitetskravUuid: string;
+  aktivitetskravUuid: string | undefined;
 }
 
 export const ModalContent = styled.div`

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravSkjema.tsx
@@ -10,7 +10,7 @@ import { ValidationErrors } from "final-form";
 
 export interface VurderAktivitetskravSkjemaProps {
   setModalOpen: (modalOpen: boolean) => void;
-  aktivitetskravUuid: string;
+  aktivitetskravUuid: string | undefined;
 }
 
 interface Props<SkjemaValues> extends VurderAktivitetskravSkjemaProps {

--- a/src/data/aktivitetskrav/useVurderAktivitetskrav.ts
+++ b/src/data/aktivitetskrav/useVurderAktivitetskrav.ts
@@ -5,10 +5,14 @@ import { post } from "@/api/axios";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 
-export const useVurderAktivitetskrav = (aktivitetskravUuid: string) => {
+export const useVurderAktivitetskrav = (
+  aktivitetskravUuid: string | undefined
+) => {
   const personident = useValgtPersonident();
   const queryClient = useQueryClient();
-  const path = `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav/${aktivitetskravUuid}/vurder`;
+  const path = aktivitetskravUuid
+    ? `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav/${aktivitetskravUuid}/vurder`
+    : `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav/vurder`;
   const postVurderAktivitetskrav = (
     vurdering: CreateAktivitetskravVurderingDTO
   ) => post(path, vurdering, personident);

--- a/src/utils/aktivitetskravUtils.ts
+++ b/src/utils/aktivitetskravUtils.ts
@@ -1,0 +1,35 @@
+import {
+  AktivitetskravDTO,
+  AktivitetskravVurderingDTO,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+
+export const oppfolgingstilfelleForAktivitetskrav = (
+  aktivitetskrav: AktivitetskravDTO,
+  oppfolgingstilfeller: OppfolgingstilfelleDTO[]
+): OppfolgingstilfelleDTO | undefined => {
+  return oppfolgingstilfeller.find((tilfelle) =>
+    gjelderOppfolgingstilfelle(aktivitetskrav, tilfelle)
+  );
+};
+
+export const aktivitetskravVurderingerForOppfolgingstilfelle = (
+  aktivitetskrav: AktivitetskravDTO[],
+  oppfolgingstilfelle: OppfolgingstilfelleDTO
+): AktivitetskravVurderingDTO[] => {
+  return aktivitetskrav
+    .filter((aktivitetskrav) =>
+      gjelderOppfolgingstilfelle(aktivitetskrav, oppfolgingstilfelle)
+    )
+    .flatMap((aktivitetskrav) => aktivitetskrav.vurderinger);
+};
+
+const gjelderOppfolgingstilfelle = (
+  aktivitetskrav: AktivitetskravDTO,
+  oppfolgingstilfelle: OppfolgingstilfelleDTO
+): boolean => {
+  return (
+    aktivitetskrav.stoppunktAt > oppfolgingstilfelle.start &&
+    aktivitetskrav.stoppunktAt <= oppfolgingstilfelle.end
+  );
+};

--- a/test/aktivitetskrav/AktivitetskravSideTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravSideTest.tsx
@@ -32,6 +32,8 @@ import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQue
 let queryClient: QueryClient;
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
+const noOppfolgingstilfelleAktivitetskravText =
+  "Vi finner ingen aktiv sykmelding på denne personen. Du kan likevel vurdere aktivitetskravet hvis det er behov for det.";
 
 const mockOppfolgingstilfellePerson = (
   oppfolgingstilfeller: OppfolgingstilfelleDTO[]
@@ -97,6 +99,9 @@ describe("AktivitetskravSide", () => {
 
       expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
         .to.exist;
+      expect(screen.queryByRole("img", { name: "advarsel-ikon" })).to.not.exist;
+      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
+        .exist;
     });
     it("Vises når person har inaktivt oppfølgingstilfelle med aktivitetskrav (NY)", () => {
       mockOppfolgingstilfellePerson([
@@ -110,8 +115,11 @@ describe("AktivitetskravSide", () => {
 
       expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
         .to.exist;
+      expect(screen.queryByRole("img", { name: "advarsel-ikon" })).to.not.exist;
+      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
+        .exist;
     });
-    it("Vises ikke når person har oppfølgingstilfelle med bare aktivitetskrav (AUTOMATISK_OPPFYLT)", () => {
+    it("Vises med advarsel når person har oppfølgingstilfelle med bare aktivitetskrav (AUTOMATISK_OPPFYLT)", () => {
       mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([
         createAktivitetskrav(
@@ -122,9 +130,11 @@ describe("AktivitetskravSide", () => {
 
       renderAktivitetskravSide();
 
-      expect(
-        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
-      ).to.not.exist;
+      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
+        .to.exist;
+      expect(screen.getByRole("img", { name: "advarsel-ikon" })).to.exist;
+      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
+        .exist;
     });
     it("Vises når aktivitetskrav gjelder tidligere tilfelle", () => {
       mockOppfolgingstilfellePerson([
@@ -139,16 +149,33 @@ describe("AktivitetskravSide", () => {
 
       expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
         .to.exist;
+      expect(screen.queryByRole("img", { name: "advarsel-ikon" })).to.not.exist;
+      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
+        .exist;
     });
-    it("Vises ikke når person har oppfølgingstilfelle uten aktivitetskrav", () => {
+    it("Vises med advarsel når person har oppfølgingstilfelle uten aktivitetskrav", () => {
       mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([]);
 
       renderAktivitetskravSide();
 
-      expect(
-        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
-      ).to.not.exist;
+      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
+        .to.exist;
+      expect(screen.getByRole("img", { name: "advarsel-ikon" })).to.exist;
+      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
+        .exist;
+    });
+    it("Vises med advarsel når person har verken oppfølgingstilfelle eller aktivitetskrav", () => {
+      mockOppfolgingstilfellePerson([]);
+      mockAktivitetskrav([]);
+
+      renderAktivitetskravSide();
+
+      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
+        .to.exist;
+      expect(screen.getByRole("img", { name: "advarsel-ikon" })).to.exist;
+      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
+        .exist;
     });
   });
   describe("Vurdering alert", () => {
@@ -169,6 +196,17 @@ describe("AktivitetskravSide", () => {
       expect(
         screen.getByText(/Det er vurdert at Samuel Sam Jones er i aktivitet/)
       ).to.exist;
+    });
+    it("viser siste aktivitetskrav-vurdering fra aktivitetskrav uten oppfølgingstilfelle", () => {
+      mockAktivitetskrav([
+        createAktivitetskrav(daysFromToday(20), AktivitetskravStatus.UNNTAK, [
+          unntakVurdering,
+        ]),
+      ]);
+      renderAktivitetskravSide();
+
+      expect(screen.getByRole("img", { name: "suksess-ikon" })).to.exist;
+      expect(screen.getByText(/Det er vurdert unntak/)).to.exist;
     });
     it("viser advarsel når siste aktivitetskrav-vurdering er AVVENT", () => {
       mockAktivitetskrav([

--- a/test/aktivitetskrav/AktivitetskravSideTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravSideTest.tsx
@@ -103,7 +103,7 @@ describe("AktivitetskravSide", () => {
       expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
         .exist;
     });
-    it("Vises når person har inaktivt oppfølgingstilfelle med aktivitetskrav (NY)", () => {
+    it("Vises med advarsel når person har inaktivt oppfølgingstilfelle med aktivitetskrav (NY)", () => {
       mockOppfolgingstilfellePerson([
         generateOppfolgingstilfelle(daysFromToday(-30), daysFromToday(-20)),
       ]);
@@ -115,11 +115,11 @@ describe("AktivitetskravSide", () => {
 
       expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
         .to.exist;
-      expect(screen.queryByRole("img", { name: "advarsel-ikon" })).to.not.exist;
-      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
+      expect(screen.getByRole("img", { name: "advarsel-ikon" })).to.exist;
+      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
         .exist;
     });
-    it("Vises med advarsel når person har oppfølgingstilfelle med bare aktivitetskrav (AUTOMATISK_OPPFYLT)", () => {
+    it("Vises når person har oppfølgingstilfelle med bare aktivitetskrav (AUTOMATISK_OPPFYLT)", () => {
       mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
       mockAktivitetskrav([
         createAktivitetskrav(
@@ -132,8 +132,8 @@ describe("AktivitetskravSide", () => {
 
       expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
         .to.exist;
-      expect(screen.getByRole("img", { name: "advarsel-ikon" })).to.exist;
-      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
+      expect(screen.queryByRole("img", { name: "advarsel-ikon" })).to.not.exist;
+      expect(screen.queryByRole(noOppfolgingstilfelleAktivitetskravText)).to.not
         .exist;
     });
     it("Vises når aktivitetskrav gjelder tidligere tilfelle", () => {
@@ -153,8 +153,20 @@ describe("AktivitetskravSide", () => {
       expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
         .exist;
     });
-    it("Vises med advarsel når person har oppfølgingstilfelle uten aktivitetskrav", () => {
+    it("Vises når person har oppfølgingstilfelle uten aktivitetskrav", () => {
       mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
+      mockAktivitetskrav([]);
+
+      renderAktivitetskravSide();
+
+      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
+        .to.exist;
+      expect(screen.queryByRole("img", { name: "advarsel-ikon" })).to.not.exist;
+      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
+        .exist;
+    });
+    it("Vises med advarsel når person har inaktivt oppfølgingstilfelle uten aktivitetskrav", () => {
+      mockOppfolgingstilfellePerson([inactiveOppfolgingstilfelle]);
       mockAktivitetskrav([]);
 
       renderAktivitetskravSide();
@@ -165,6 +177,7 @@ describe("AktivitetskravSide", () => {
       expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
         .exist;
     });
+
     it("Vises med advarsel når person har verken oppfølgingstilfelle eller aktivitetskrav", () => {
       mockOppfolgingstilfellePerson([]);
       mockAktivitetskrav([]);

--- a/test/utils/aktivitetskravUtils.test.ts
+++ b/test/utils/aktivitetskravUtils.test.ts
@@ -1,0 +1,139 @@
+import {
+  aktivitetskravVurderingerForOppfolgingstilfelle,
+  oppfolgingstilfelleForAktivitetskrav,
+} from "@/utils/aktivitetskravUtils";
+import {
+  createAktivitetskrav,
+  createAktivitetskravVurdering,
+  generateOppfolgingstilfelle,
+} from "../testDataUtils";
+import {
+  AktivitetskravStatus,
+  AvventVurderingArsak,
+  OppfyltVurderingArsak,
+  UnntakVurderingArsak,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { daysFromToday } from "../testUtils";
+import { expect } from "chai";
+
+describe("aktivitetskravUtils", () => {
+  describe("aktivitetskravVurderingerForOppfolgingstilfelle", () => {
+    it("returns vurderinger for all aktivitetskrav with stoppunkt after oppfolgingstilfelle start and before oppfolgingstilfelle end", () => {
+      const oppfolgingstilfelle = generateOppfolgingstilfelle(
+        daysFromToday(-100),
+        daysFromToday(100)
+      );
+      const aktivitetskrav = [
+        createAktivitetskrav(daysFromToday(-501), AktivitetskravStatus.UNNTAK, [
+          createAktivitetskravVurdering(AktivitetskravStatus.UNNTAK, [
+            UnntakVurderingArsak.SJOMENN_UTENRIKS,
+          ]),
+        ]),
+        createAktivitetskrav(
+          daysFromToday(-300),
+          AktivitetskravStatus.AUTOMATISK_OPPFYLT
+        ),
+        createAktivitetskrav(new Date(), AktivitetskravStatus.OPPFYLT, [
+          createAktivitetskravVurdering(AktivitetskravStatus.OPPFYLT, [
+            OppfyltVurderingArsak.FRISKMELDT,
+          ]),
+          createAktivitetskravVurdering(AktivitetskravStatus.AVVENT, [
+            AvventVurderingArsak.INFORMASJON_BEHANDLER,
+          ]),
+        ]),
+      ];
+
+      const aktivitetskravVurderinger =
+        aktivitetskravVurderingerForOppfolgingstilfelle(
+          aktivitetskrav,
+          oppfolgingstilfelle
+        );
+      expect(aktivitetskravVurderinger).to.have.length(2);
+      expect(aktivitetskravVurderinger[0].status).to.equal(
+        AktivitetskravStatus.OPPFYLT
+      );
+      expect(aktivitetskravVurderinger[1].status).to.equal(
+        AktivitetskravStatus.AVVENT
+      );
+    });
+    it("returns no vurderinger when no aktivitetskrav with stoppunkt after oppfolgingstilfelle start and before oppfolgingstilfelle end", () => {
+      const oppfolgingstilfelle = generateOppfolgingstilfelle(
+        daysFromToday(-100),
+        daysFromToday(100)
+      );
+      const aktivitetskrav = [
+        createAktivitetskrav(daysFromToday(-501), AktivitetskravStatus.UNNTAK, [
+          createAktivitetskravVurdering(AktivitetskravStatus.UNNTAK, [
+            UnntakVurderingArsak.SJOMENN_UTENRIKS,
+          ]),
+        ]),
+        createAktivitetskrav(
+          daysFromToday(-300),
+          AktivitetskravStatus.AUTOMATISK_OPPFYLT
+        ),
+      ];
+
+      const aktivitetskravVurderinger =
+        aktivitetskravVurderingerForOppfolgingstilfelle(
+          aktivitetskrav,
+          oppfolgingstilfelle
+        );
+      expect(aktivitetskravVurderinger).to.be.empty;
+    });
+  });
+  describe("oppfolgingstilfelleForAktivitetskrav", () => {
+    it("returns oppfolgingstilfelle starting before stoppunkt and ending after stoppunkt for aktivitetskrav", () => {
+      const aktivitetskrav = createAktivitetskrav(
+        new Date(),
+        AktivitetskravStatus.NY
+      );
+      const tilfeller = [
+        generateOppfolgingstilfelle(daysFromToday(-601), daysFromToday(-401)),
+        generateOppfolgingstilfelle(daysFromToday(-400), daysFromToday(-200)),
+        generateOppfolgingstilfelle(daysFromToday(-100), daysFromToday(100)),
+      ];
+
+      const oppfolgingstilfelleDTO = oppfolgingstilfelleForAktivitetskrav(
+        aktivitetskrav,
+        tilfeller
+      );
+      expect(oppfolgingstilfelleDTO).to.not.be.undefined;
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(oppfolgingstilfelleDTO!.start < aktivitetskrav.stoppunktAt).to.be
+        .true;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(oppfolgingstilfelleDTO!.end >= aktivitetskrav.stoppunktAt).to.be
+        .true;
+    });
+    it("returns undefined when no oppfolgingstilfelle starting before stoppunkt and ending after stoppunkt for aktivitetskrav", () => {
+      const aktivitetskrav = createAktivitetskrav(
+        new Date(),
+        AktivitetskravStatus.NY
+      );
+      const tilfeller = [
+        generateOppfolgingstilfelle(daysFromToday(-601), daysFromToday(-401)),
+        generateOppfolgingstilfelle(daysFromToday(-400), daysFromToday(-200)),
+      ];
+
+      const oppfolgingstilfelleDTO = oppfolgingstilfelleForAktivitetskrav(
+        aktivitetskrav,
+        tilfeller
+      );
+      expect(oppfolgingstilfelleDTO).to.be.undefined;
+    });
+    it("returns undefined when no oppfolgingstilfeller", () => {
+      const aktivitetskrav = createAktivitetskrav(
+        new Date(),
+        AktivitetskravStatus.NY
+      );
+      const tilfeller = [];
+
+      const oppfolgingstilfelleDTO = oppfolgingstilfelleForAktivitetskrav(
+        aktivitetskrav,
+        tilfeller
+      );
+      expect(oppfolgingstilfelleDTO).to.be.undefined;
+    });
+  });
+});


### PR DESCRIPTION
Flyttet noe logikk til `aktivitetskravUtils`.
Viser advarsel når vi ikke finner oppfølgingstilfelle.
![image](https://user-images.githubusercontent.com/79838644/215997721-9dd6456a-799e-44d6-a5e7-8740ee629541.png)