### PR TITLE
Cancel auto save debounce on manual save

### DIFF
--- a/src/components/dialogmote/referat/Referat.tsx
+++ b/src/components/dialogmote/referat/Referat.tsx
@@ -269,6 +269,11 @@ const Referat = ({
     { maxWait: 20000 }
   );
 
+  const handleLagreClick = (values: ReferatSkjemaValues) => {
+    debouncedAutoSave.cancel();
+    mellomlagre(values);
+  };
+
   const handleSendClick = () => {
     debouncedAutoSave.cancel();
     resetFeilUtbedret();
@@ -355,7 +360,7 @@ const Referat = ({
             )}
             <ReferatButtons
               pageTitle={pageTitle}
-              onSaveClick={() => mellomlagre(values)}
+              onSaveClick={() => handleLagreClick(values)}
               onSendClick={handleSendClick}
               showSaveSpinner={mellomlagreReferat.isLoading}
               showSendSpinner={


### PR DESCRIPTION
No need to save twice, and this might possibly cause some problems when the user exits the form right after saving.