### PR TITLE
Use all sykmeldinger in graf regardless of virksomhet

### DIFF
--- a/src/components/sykmeldingsgrad/Sykmeldingsgrad.tsx
+++ b/src/components/sykmeldingsgrad/Sykmeldingsgrad.tsx
@@ -5,7 +5,7 @@ import { Normaltekst, Systemtittel } from "nav-frontend-typografi";
 import Panel from "nav-frontend-paneler";
 import {
   sykmeldingerInnenforOppfolgingstilfelle,
-  sykmeldingerMedStatusSendt,
+  sendtAndBekreftetSykmeldinger,
 } from "@/utils/sykmeldinger/sykmeldingUtils";
 import {
   dagerMellomDatoer,
@@ -43,10 +43,10 @@ export const Sykmeldingsgrad = () => {
   const { isFeatureEnabled } = useFeatureToggles();
   const showTilfelleList = isFeatureEnabled(ToggleNames.gjentakendesykefravar);
 
-  const innsendteSykmeldinger = sykmeldingerMedStatusSendt(sykmeldinger);
+  const usedSykmeldinger = sendtAndBekreftetSykmeldinger(sykmeldinger);
   const sykmeldingerIOppfolgingstilfellet =
     sykmeldingerInnenforOppfolgingstilfelle(
-      innsendteSykmeldinger,
+      usedSykmeldinger,
       selectedOppfolgingstilfelle
     );
 

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -201,6 +201,17 @@ export const getSykmeldingStartdato = (
   return new Date(sykmeldingperioderSortertEldstTilNyest(perioder)[0].fom);
 };
 
+export const sendtAndBekreftetSykmeldinger = (
+  sykmeldinger: SykmeldingOldFormat[]
+) => {
+  return sykmeldinger.filter((sykmelding) => {
+    return (
+      sykmelding.status === SykmeldingStatus.BEKREFTET ||
+      sykmelding.status === SykmeldingStatus.SENDT
+    );
+  });
+};
+
 export const sykmeldingerInnenforOppfolgingstilfelle = (
   sykmeldinger: SykmeldingOldFormat[],
   oppfolgingstilfelle?: OppfolgingstilfelleDTO
@@ -209,18 +220,6 @@ export const sykmeldingerInnenforOppfolgingstilfelle = (
     return [];
   }
   return sykmeldinger.filter((sykmelding) => {
-    if (!erSykmeldingUtenArbeidsgiver(sykmelding)) {
-      const sykmeldingOrgnummer = sykmelding.orgnummer;
-      if (!sykmeldingOrgnummer) {
-        return false;
-      }
-      if (
-        !oppfolgingstilfelle.virksomhetsnummerList.includes(sykmeldingOrgnummer)
-      ) {
-        return false;
-      }
-    }
-
     const sykmeldingStart = dayjs(getSykmeldingStartdato(sykmelding));
     const oppfolgingstilfelleStart = dayjs(oppfolgingstilfelle.start);
     const oppfolgingstilfelleEnd = dayjs(oppfolgingstilfelle.end);


### PR DESCRIPTION
This also affects UtdragFraSykefravaret, since that also uses the sykmeldingerInnenforOppfolgingstilfelle method.
Now it's up to the user of the util method to decide the limitations on which sykmeldinger should count, since it only checks dates as the method name implies.
Also add test, it didn't actually verify the filtering by virksomhet.