### PR TITLE
Remove infobox for vurdering per arbeidsforhold/sykefravær

### DIFF
--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -14,8 +14,6 @@ import {
 import { AktivitetskravAlertstripe } from "@/components/aktivitetskrav/AktivitetskravAlertstripe";
 
 const texts = {
-  vurderArbeidsforhold:
-    "Aktivitetskravvurderingen skal gjøres per sykefravær. Eksempel: Hvis personen er 100% sykmeldt fra to arbeidsforhold, må det gjøres to individuelle vurderinger.",
   noTilfelle:
     "Vi finner ingen aktiv sykmelding på denne personen. Du kan likevel vurdere aktivitetskravet hvis det er behov for det.",
 };
@@ -44,9 +42,6 @@ export const AktivitetskravSide = () => {
 
   return (
     <>
-      <AktivitetskravAlertstripe type="info">
-        {texts.vurderArbeidsforhold}
-      </AktivitetskravAlertstripe>
       {!hasActiveOppfolgingstilfelle && (
         <AktivitetskravAlertstripe type="advarsel">
           {texts.noTilfelle}

--- a/test/aktivitetskrav/AktivitetskravSideTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravSideTest.tsx
@@ -87,14 +87,6 @@ describe("AktivitetskravSide", () => {
     expect(screen.getByRole("heading", { name: "Utdrag fra sykefraværet" })).to
       .exist;
   });
-  it("Viser info om å vurdere alle arbeidsforhold", () => {
-    renderAktivitetskravSide();
-
-    expect(screen.getByRole("img", { name: "info-ikon" })).to.exist;
-    expect(
-      screen.getByText(/Aktivitetskravvurderingen skal gjøres per sykefravær/)
-    ).to.exist;
-  });
 
   describe("Vurder aktivitetskravet", () => {
     it("Vises når person har oppfølgingstilfelle med aktivitetskrav (NY)", () => {


### PR DESCRIPTION
Nå er det uten den blå infoboksen:
<img width="1294" alt="image" src="https://user-images.githubusercontent.com/37441744/222147461-fe2e8210-c1f6-42d4-a74e-3522aee8bcd5.png">

Hvordan det så ut før (fra designskisser):
<img width="747" alt="image" src="https://user-images.githubusercontent.com/37441744/222147620-82e23f38-f79a-4e1a-89cd-c166ea388ef9.png">
