### PR TITLE
Bruke nytt designsystem for skjema-input i aktivitetskravet

### DIFF
--- a/src/components/aktivitetskrav/vurdering/AvventArsakerCheckboxGruppe.tsx
+++ b/src/components/aktivitetskrav/vurdering/AvventArsakerCheckboxGruppe.tsx
@@ -1,7 +1,7 @@
-import { Checkbox, CheckboxGruppe } from "nav-frontend-skjema";
 import React from "react";
 import { Field, useFormState } from "react-final-form";
 import { avventVurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
+import { Checkbox, CheckboxGroup } from "@navikt/ds-react";
 
 const texts = {
   arsakLegend: "Årsak (obligatorisk)",
@@ -13,9 +13,10 @@ export const AvventArsakerCheckboxGruppe = () => {
   const { submitFailed, errors } = useFormState();
 
   return (
-    <CheckboxGruppe
+    <CheckboxGroup
+      size="small"
       legend={texts.arsakLegend}
-      feil={
+      error={
         submitFailed && errors && errors[vurderAktivitetskravArsakerFieldName]
       }
     >
@@ -26,9 +27,13 @@ export const AvventArsakerCheckboxGruppe = () => {
           type="checkbox"
           value={arsak}
         >
-          {({ input }) => <Checkbox {...input} label={text} />}
+          {({ input }) => (
+            <Checkbox value={input.value} onChange={input.onChange}>
+              {text}
+            </Checkbox>
+          )}
         </Field>
       ))}
-    </CheckboxGruppe>
+    </CheckboxGroup>
   );
 };

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravArsakRadioGruppe.tsx
@@ -1,7 +1,7 @@
-import { Radio, RadioGruppe } from "nav-frontend-skjema";
 import React from "react";
 import { Field, useFormState } from "react-final-form";
 import { VurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
+import { Radio, RadioGroup } from "@navikt/ds-react";
 
 const texts = {
   arsakLegend: "Årsak (obligatorisk)",
@@ -19,9 +19,10 @@ export const VurderAktivitetskravArsakRadioGruppe = ({
   const { submitFailed, errors } = useFormState();
 
   return (
-    <RadioGruppe
+    <RadioGroup
+      size="small"
       legend={texts.arsakLegend}
-      feil={
+      error={
         submitFailed && errors && errors[vurderAktivitetskravArsakFieldName]
       }
     >
@@ -32,9 +33,9 @@ export const VurderAktivitetskravArsakRadioGruppe = ({
           value={arsak}
           type="radio"
         >
-          {({ input }) => <Radio {...input} label={text} />}
+          {({ input }) => <Radio {...input}>{text}</Radio>}
         </Field>
       ))}
-    </RadioGruppe>
+    </RadioGroup>
   );
 };

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravBeskrivelse.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravBeskrivelse.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Field } from "react-final-form";
-import Fritekst from "@/components/Fritekst";
 import { FlexColumn } from "@/components/Layout";
+import { Textarea } from "@navikt/ds-react";
 
 export const vurderAktivitetskravBeskrivelseMaxLength = 1000;
 export const vurderAktivitetskravBeskrivelseFieldName = "beskrivelse";
@@ -17,12 +17,13 @@ export const VurderAktivitetskravBeskrivelse = ({
     <FlexColumn flex={1}>
       <Field<string> name={vurderAktivitetskravBeskrivelseFieldName}>
         {({ input, meta }) => (
-          <Fritekst
-            size="stor"
-            maxLength={vurderAktivitetskravBeskrivelseMaxLength}
+          <Textarea
+            size="small"
             label={label}
-            feil={meta.submitFailed && meta.error}
+            maxLength={vurderAktivitetskravBeskrivelseMaxLength}
+            error={meta.submitFailed && meta.error}
             id={vurderAktivitetskravBeskrivelseFieldName}
+            minRows={6}
             {...input}
           />
         )}


### PR DESCRIPTION
Sånn at feltene og valideringsmeldingene får lik styling som det nye dato-input-feltet som kommer på Avventer. Eks:
Nytt:
![image](https://user-images.githubusercontent.com/79838644/227226556-c692e5b4-97e6-413c-8c88-0fcc090a9a8d.png)
Gammelt:
![image](https://user-images.githubusercontent.com/79838644/227227183-7c1f0842-f885-463b-8037-38374570b3f6.png)

