### PR TITLE
Add SYKMELDER to BehandlerDTO

### DIFF
--- a/src/data/behandler/BehandlerDTO.ts
+++ b/src/data/behandler/BehandlerDTO.ts
@@ -15,4 +15,5 @@ export interface BehandlerDTO {
 
 export enum BehandlerType {
   FASTLEGE = "FASTLEGE",
+  SYKMELDER = "SYKMELDER",
 }


### PR DESCRIPTION
Etter fika i går så fant vi ut at dette ikke var på plass i frontend. Visningen blir derimot rett dersom vi sender inn SYKMELDER fra backend, siden det i realiteten er en string når det parses. Men det er likevel fint å ha riktige verdier på enumen i frontend, selv om den stort sett (til nå) kun har blitt brukt i mock- og testdata.