### PR TITLE
Add feedback on successfull or erroneous sending of MeldingTilBehandler

### DIFF
--- a/src/components/SkjemaInnsendingFeil.tsx
+++ b/src/components/SkjemaInnsendingFeil.tsx
@@ -5,10 +5,14 @@ import React from "react";
 
 interface SkjemaInnsendingFeilProps {
   error: unknown;
+  bottomPadding?: PaddingSize | null;
 }
 
-export const SkjemaInnsendingFeil = ({ error }: SkjemaInnsendingFeilProps) => (
-  <FlexRow bottomPadding={PaddingSize.MD}>
+export const SkjemaInnsendingFeil = ({
+  error,
+  bottomPadding = PaddingSize.MD,
+}: SkjemaInnsendingFeilProps) => (
+  <FlexRow bottomPadding={bottomPadding ? bottomPadding : undefined}>
     <AlertStripeFeil>
       {error instanceof ApiErrorException
         ? error.error.defaultErrorMsg


### PR DESCRIPTION
Formet blir ikke clearet for radiogruppa - men vi tenker at det er sufficient å cleare meldingsfeltet i første omgang, ettersom at man da får en valideringsfeil hvis man prøver å trykke på "send melding" to ganger eller lignende.

✅ Bekreftet at riktig behandlerRef er satt i dev, selv om formet blir clearet.

Suksess:
<img width="807" alt="image" src="https://user-images.githubusercontent.com/37441744/228193864-66210708-8368-4c8b-a4ff-ab198f260073.png">

Feil:
![image](https://user-images.githubusercontent.com/37441744/228193900-9fa09a77-5377-4f50-9558-be4d8729b510.png)
