### PR TITLE
DocumentComponent-stuff should not depend on dialogmote

### DIFF
--- a/mock/isdialogmote/dialogmoterMock.ts
+++ b/mock/isdialogmote/dialogmoterMock.ts
@@ -1,7 +1,6 @@
 import {
   DialogmotedeltakerBehandlerDTO,
   DialogmoteStatus,
-  DocumentComponentType,
   MotedeltakerVarselType,
   SvarType,
 } from "../../src/data/dialogmote/types/dialogmoteTypes";
@@ -15,6 +14,7 @@ import {
 import { ReferatDTO } from "../../src/data/dialogmote/types/dialogmoteReferatTypes";
 import { referatTexts } from "../../src/data/dialogmote/dialogmoteTexts";
 import dayjs from "dayjs";
+import { DocumentComponentType } from "../../src/data/documentcomponent/documentComponentTypes";
 
 export const createDialogmote = (
   uuid: string,

--- a/src/components/Forhandsvisning.tsx
+++ b/src/components/Forhandsvisning.tsx
@@ -4,7 +4,7 @@ import {
   JustifyContentType,
   ModalContentContainer,
   PaddingSize,
-} from "../Layout";
+} from "./Layout";
 import {
   Element,
   Innholdstittel,
@@ -13,13 +13,13 @@ import {
   Systemtittel,
 } from "nav-frontend-typografi";
 import React, { ReactElement } from "react";
-import {
-  DocumentComponentDto,
-  DocumentComponentType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
 import styled from "styled-components";
 import Lenke from "nav-frontend-lenker";
 import { Hovedknapp } from "nav-frontend-knapper";
+import {
+  DocumentComponentDto,
+  DocumentComponentType,
+} from "@/data/documentcomponent/documentComponentTypes";
 
 const texts = {
   close: "Lukk",

--- a/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
+++ b/src/components/dialogmote/avlys/AvlysDialogmoteSkjema.tsx
@@ -14,7 +14,7 @@ import { SkjemaFeiloppsummering } from "../../SkjemaFeiloppsummering";
 import { useFeilUtbedret } from "@/hooks/useFeilUtbedret";
 import { validerBegrunnelser } from "@/utils/valideringUtils";
 import { useAvlysningDocument } from "@/hooks/dialogmote/document/useAvlysningDocument";
-import { Forhandsvisning } from "../Forhandsvisning";
+import { Forhandsvisning } from "../../Forhandsvisning";
 import { moteoversiktRoutePath } from "@/routers/AppRouter";
 import { useAvlysDialogmote } from "@/data/dialogmote/useAvlysDialogmote";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";

--- a/src/components/dialogmote/endre/EndreDialogmoteTekster.tsx
+++ b/src/components/dialogmote/endre/EndreDialogmoteTekster.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useFormState } from "react-final-form";
-import { Forhandsvisning } from "../Forhandsvisning";
+import { Forhandsvisning } from "../../Forhandsvisning";
 import { EndreTidStedSkjemaValues } from "./EndreDialogmoteSkjema";
 import { useTidStedDocument } from "@/hooks/dialogmote/document/useTidStedDocument";
 import FritekstSeksjon from "@/components/dialogmote/FritekstSeksjon";

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { Innholdstittel } from "nav-frontend-typografi";
 import { DialogmoteInnkallingSkjemaValues } from "./DialogmoteInnkallingSkjema";
 import { useInnkallingDocument } from "@/hooks/dialogmote/document/useInnkallingDocument";
-import { Forhandsvisning } from "../Forhandsvisning";
+import { Forhandsvisning } from "../../Forhandsvisning";
 import FritekstSeksjon from "../FritekstSeksjon";
 import { BehandlerDTO } from "@/data/behandler/BehandlerDTO";
 import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";

--- a/src/components/dialogmote/motehistorikk/MoteHistorikkUnntak.tsx
+++ b/src/components/dialogmote/motehistorikk/MoteHistorikkUnntak.tsx
@@ -2,11 +2,12 @@ import React, { ReactElement } from "react";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import { ForhandsvisDocumentButtonRow } from "@/components/dialogmote/motehistorikk/MotehistorikkPanel";
+
+import { unntakArsakTexts } from "@/components/dialogmoteunntak/DialogmoteunntakSkjemaArsakVelger";
 import {
   DocumentComponentDto,
   DocumentComponentType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
-import { unntakArsakTexts } from "@/components/dialogmoteunntak/DialogmoteunntakSkjemaArsakVelger";
+} from "@/data/documentcomponent/documentComponentTypes";
 
 const texts = {
   unntakTitle: "Unntak fra dialogmøte",

--- a/src/components/dialogmote/motehistorikk/MotehistorikkPanel.tsx
+++ b/src/components/dialogmote/motehistorikk/MotehistorikkPanel.tsx
@@ -5,16 +5,16 @@ import React, { ReactElement, useState } from "react";
 import {
   DialogmoteDTO,
   DialogmoteStatus,
-  DocumentComponentDto,
   MotedeltakerVarselType,
 } from "@/data/dialogmote/types/dialogmoteTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { Forhandsvisning } from "../Forhandsvisning";
+import { Forhandsvisning } from "../../Forhandsvisning";
 import { useDialogmoteReferat } from "@/hooks/dialogmote/useDialogmoteReferat";
 import styled from "styled-components";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { MoteHistorikkUnntak } from "@/components/dialogmote/motehistorikk/MoteHistorikkUnntak";
 import { Flatknapp } from "nav-frontend-knapper";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 const texts = {
   header: "Møtehistorikk",

--- a/src/components/dialogmote/referat/Referat.tsx
+++ b/src/components/dialogmote/referat/Referat.tsx
@@ -8,10 +8,7 @@ import {
 } from "@/utils/datoUtils";
 import Deltakere from "./Deltakere";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
-import {
-  DialogmoteDTO,
-  DocumentComponentDto,
-} from "@/data/dialogmote/types/dialogmoteTypes";
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { AlertstripeFullbredde } from "../../AlertstripeFullbredde";
 import ReferatButtons from "./ReferatButtons";
 import { Innholdstittel } from "nav-frontend-typografi";
@@ -23,7 +20,7 @@ import {
 import { useFeilUtbedret } from "@/hooks/useFeilUtbedret";
 import { SkjemaFeiloppsummering } from "../../SkjemaFeiloppsummering";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
-import { Forhandsvisning } from "../Forhandsvisning";
+import { Forhandsvisning } from "../../Forhandsvisning";
 import { useReferatDocument } from "@/hooks/dialogmote/document/useReferatDocument";
 import { StandardTekst } from "@/data/dialogmote/dialogmoteTexts";
 import {
@@ -55,6 +52,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { useDebouncedCallback } from "use-debounce";
 import { SaveFile } from "../../../../img/ImageComponents";
 import { FormState } from "final-form";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 export const texts = {
   digitalReferat:

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -96,7 +96,6 @@ export const commonTexts = {
   moteTidTitle: "Møtetidspunkt",
   moteStedTitle: "Møtested",
   videoLinkTitle: "Lenke til videomøte",
-  hilsen: "Vennlig hilsen",
   arbeidsgiverTlfLabel: "Arbeidsgivertelefonen",
   arbeidsgiverTlf: "55 55 33 36",
 };

--- a/src/data/dialogmote/types/dialogmoteReferatTypes.ts
+++ b/src/data/dialogmote/types/dialogmoteReferatTypes.ts
@@ -1,4 +1,4 @@
-import { DocumentComponentDto } from "./dialogmoteTypes";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 export interface ReferatDTO {
   readonly uuid: string;

--- a/src/data/dialogmote/types/dialogmoteTypes.ts
+++ b/src/data/dialogmote/types/dialogmoteTypes.ts
@@ -1,5 +1,6 @@
 import { ReferatDTO } from "./dialogmoteReferatTypes";
 import { BehandlerType } from "@/data/behandler/BehandlerDTO";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 export enum MotedeltakerVarselType {
   AVLYST = "AVLYST",
@@ -50,21 +51,6 @@ export enum SvarType {
   KOMMER = "KOMMER",
   NYTT_TID_STED = "NYTT_TID_STED",
   KOMMER_IKKE = "KOMMER_IKKE",
-}
-
-export enum DocumentComponentType {
-  HEADER = "HEADER",
-  HEADER_H1 = "HEADER_H1",
-  HEADER_H2 = "HEADER_H2",
-  PARAGRAPH = "PARAGRAPH",
-  LINK = "LINK",
-}
-
-export interface DocumentComponentDto {
-  readonly type: DocumentComponentType;
-  readonly key?: string;
-  readonly title?: string;
-  readonly texts: string[];
 }
 
 export enum DialogmoteStatus {

--- a/src/data/documentcomponent/documentComponentTypes.ts
+++ b/src/data/documentcomponent/documentComponentTypes.ts
@@ -1,0 +1,14 @@
+export enum DocumentComponentType {
+  HEADER = "HEADER",
+  HEADER_H1 = "HEADER_H1",
+  HEADER_H2 = "HEADER_H2",
+  PARAGRAPH = "PARAGRAPH",
+  LINK = "LINK",
+}
+
+export interface DocumentComponentDto {
+  readonly type: DocumentComponentType;
+  readonly key?: string;
+  readonly title?: string;
+  readonly texts: string[];
+}

--- a/src/hooks/dialogmote/document/useAvlysningDocument.ts
+++ b/src/hooks/dialogmote/document/useAvlysningDocument.ts
@@ -1,7 +1,4 @@
-import {
-  DialogmoteDTO,
-  DocumentComponentDto,
-} from "@/data/dialogmote/types/dialogmoteTypes";
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { AvlysDialogmoteSkjemaValues } from "@/components/dialogmote/avlys/AvlysDialogmoteSkjema";
 import { avlysningTexts } from "@/data/dialogmote/dialogmoteTexts";
 import { tilDatoMedManedNavnOgKlokkeslettWithComma } from "@/utils/datoUtils";
@@ -9,7 +6,8 @@ import {
   createHeaderH1,
   createParagraph,
 } from "@/utils/documentComponentUtils";
-import { useDocumentComponents } from "@/hooks/dialogmote/document/useDocumentComponents";
+import { useDialogmoteDocumentComponents } from "@/hooks/dialogmote/document/useDialogmoteDocumentComponents";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 export interface IAvlysningDocument {
   getAvlysningDocumentArbeidstaker(
@@ -29,7 +27,7 @@ export const useAvlysningDocument = (
   dialogmote: DialogmoteDTO
 ): IAvlysningDocument => {
   const { getHilsen, getIntroHei, getIntroGjelder, getVirksomhetsnavn } =
-    useDocumentComponents();
+    useDialogmoteDocumentComponents();
 
   const sendt = createParagraph(
     `Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`

--- a/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
+++ b/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
@@ -1,21 +1,17 @@
-import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import {
   createLink,
-  createParagraph,
   createParagraphWithTitle,
 } from "@/utils/documentComponentUtils";
 import { commonTexts } from "@/data/dialogmote/dialogmoteTexts";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
-import { DocumentComponentDto } from "@/data/dialogmote/types/dialogmoteTypes";
 import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { genererDato } from "@/components/mote/utils";
-import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
-import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
+import { useDocumentComponents } from "@/hooks/useDocumentComponents";
 
-export const useDocumentComponents = () => {
-  const navBruker = useNavBrukerData();
-  const { data: veilederinfo } = useAktivVeilederinfoQuery();
+export const useDialogmoteDocumentComponents = () => {
+  const { getHilsen, getIntroGjelder, getIntroHei } = useDocumentComponents();
   const { getCurrentNarmesteLeder } = useLedereQuery();
 
   const getVirksomhetsnavn = (
@@ -60,15 +56,11 @@ export const useDocumentComponents = () => {
     return components;
   };
 
-  const personident = useValgtPersonident();
-
   return {
-    getHilsen: () =>
-      createParagraph(commonTexts.hilsen, veilederinfo?.navn || "", "NAV"),
+    getHilsen,
     getVirksomhetsnavn,
     getMoteInfo,
-    getIntroHei: () => createParagraph(`Hei, ${navBruker.navn}`),
-    getIntroGjelder: () =>
-      createParagraph(`Gjelder ${navBruker.navn}, f.nr. ${personident}`),
+    getIntroHei,
+    getIntroGjelder,
   };
 };

--- a/src/hooks/dialogmote/document/useInnkallingDocument.ts
+++ b/src/hooks/dialogmote/document/useInnkallingDocument.ts
@@ -1,5 +1,4 @@
 import { DialogmoteInnkallingSkjemaValues } from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjema";
-import { DocumentComponentDto } from "@/data/dialogmote/types/dialogmoteTypes";
 import { tilDatoMedManedNavnOgKlokkeslettWithComma } from "@/utils/datoUtils";
 import {
   commonTexts,
@@ -13,7 +12,8 @@ import {
 import { BehandlerDTO } from "@/data/behandler/BehandlerDTO";
 import { capitalizeWord } from "@/utils/stringUtils";
 import { behandlerNavn } from "@/utils/behandlerUtils";
-import { useDocumentComponents } from "@/hooks/dialogmote/document/useDocumentComponents";
+import { useDialogmoteDocumentComponents } from "@/hooks/dialogmote/document/useDialogmoteDocumentComponents";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 export interface IInnkallingDocument {
   getInnkallingDocumentArbeidstaker(
@@ -39,7 +39,7 @@ export const useInnkallingDocument = (): IInnkallingDocument => {
     ),
   ];
   const { getHilsen, getMoteInfo, getIntroHei, getIntroGjelder } =
-    useDocumentComponents();
+    useDialogmoteDocumentComponents();
 
   const getInnkallingDocumentArbeidstaker = (
     values: Partial<DialogmoteInnkallingSkjemaValues>,

--- a/src/hooks/dialogmote/document/useReferatDocument.ts
+++ b/src/hooks/dialogmote/document/useReferatDocument.ts
@@ -2,10 +2,7 @@ import {
   ReferatMode,
   ReferatSkjemaValues,
 } from "@/components/dialogmote/referat/Referat";
-import {
-  DialogmoteDTO,
-  DocumentComponentDto,
-} from "@/data/dialogmote/types/dialogmoteTypes";
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 import {
   tilDatoMedManedNavnOgKlokkeslettWithComma,
@@ -16,15 +13,18 @@ import {
   createHeaderH2,
   createParagraph,
   createParagraphWithTitle,
-  createStandardtekstParagraph,
 } from "@/utils/documentComponentUtils";
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { VeilederinfoDTO } from "@/data/veilederinfo/types/VeilederinfoDTO";
 import { commonTexts, referatTexts } from "@/data/dialogmote/dialogmoteTexts";
 import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { behandlerDeltokTekst } from "@/utils/behandlerUtils";
-import { useDocumentComponents } from "@/hooks/dialogmote/document/useDocumentComponents";
+import { useDialogmoteDocumentComponents } from "@/hooks/dialogmote/document/useDialogmoteDocumentComponents";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import {
+  DocumentComponentDto,
+  DocumentComponentType,
+} from "@/data/documentcomponent/documentComponentTypes";
 
 export interface IReferatDocument {
   getReferatDocument(
@@ -39,7 +39,7 @@ export const useReferatDocument = (
   const navbruker = useNavBrukerData();
   const { data: veilederinfo } = useAktivVeilederinfoQuery();
   const isEndringAvReferat = mode === ReferatMode.ENDRET;
-  const { getVirksomhetsnavn, getHilsen } = useDocumentComponents();
+  const { getVirksomhetsnavn, getHilsen } = useDialogmoteDocumentComponents();
 
   const personident = useValgtPersonident();
 
@@ -187,9 +187,12 @@ const standardTekster = (
   if (values.standardtekster && values.standardtekster.length > 0) {
     documentComponents.push(
       createHeaderH2(referatTexts.standardTeksterHeader),
-      ...values.standardtekster.map((standardtekst) =>
-        createStandardtekstParagraph(standardtekst)
-      )
+      ...values.standardtekster.map((standardtekst) => ({
+        type: DocumentComponentType.PARAGRAPH,
+        key: standardtekst.key,
+        title: standardtekst.label,
+        texts: [standardtekst.text],
+      }))
     );
   }
   return documentComponents;

--- a/src/hooks/dialogmote/document/useTidStedDocument.ts
+++ b/src/hooks/dialogmote/document/useTidStedDocument.ts
@@ -12,10 +12,10 @@ import {
 import {
   DialogmotedeltakerBehandlerDTO,
   DialogmoteDTO,
-  DocumentComponentDto,
 } from "@/data/dialogmote/types/dialogmoteTypes";
 import { behandlerDeltakerTekst } from "@/utils/behandlerUtils";
-import { useDocumentComponents } from "@/hooks/dialogmote/document/useDocumentComponents";
+import { useDialogmoteDocumentComponents } from "@/hooks/dialogmote/document/useDialogmoteDocumentComponents";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 export interface ITidStedDocument {
   getTidStedDocumentArbeidsgiver(
@@ -37,7 +37,7 @@ export const useTidStedDocument = (
   const { tid, arbeidsgiver, behandler } = dialogmote;
 
   const { getHilsen, getMoteInfo, getIntroHei, getIntroGjelder } =
-    useDocumentComponents();
+    useDialogmoteDocumentComponents();
 
   const sendtDato = createParagraph(
     `Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`

--- a/src/hooks/useDocumentComponents.ts
+++ b/src/hooks/useDocumentComponents.ts
@@ -1,0 +1,18 @@
+import { createParagraph } from "@/utils/documentComponentUtils";
+import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { useValgtPersonident } from "@/hooks/useValgtBruker";
+
+export const useDocumentComponents = () => {
+  const navBruker = useNavBrukerData();
+  const personident = useValgtPersonident();
+  const { data: veilederinfo } = useAktivVeilederinfoQuery();
+
+  return {
+    getHilsen: () =>
+      createParagraph("Vennlig hilsen", veilederinfo?.navn || "", "NAV"),
+    getIntroHei: () => createParagraph(`Hei, ${navBruker.navn}`),
+    getIntroGjelder: () =>
+      createParagraph(`Gjelder ${navBruker.navn}, f.nr. ${personident}`),
+  };
+};

--- a/src/utils/documentComponentUtils.ts
+++ b/src/utils/documentComponentUtils.ts
@@ -1,8 +1,7 @@
 import {
   DocumentComponentDto,
   DocumentComponentType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
-import { StandardTekst } from "@/data/dialogmote/dialogmoteTexts";
+} from "@/data/documentcomponent/documentComponentTypes";
 
 export const createLink = (
   title: string,
@@ -24,15 +23,6 @@ export const createParagraph = (...texts: string[]): DocumentComponentDto => ({
   type: DocumentComponentType.PARAGRAPH,
   texts,
 });
-export const createStandardtekstParagraph = (
-  standardTekst: StandardTekst
-): DocumentComponentDto => ({
-  type: DocumentComponentType.PARAGRAPH,
-  key: standardTekst.key,
-  title: standardTekst.label,
-  texts: [standardTekst.text],
-});
-
 export const createHeaderH1 = (text: string): DocumentComponentDto => ({
   type: DocumentComponentType.HEADER_H1,
   texts: [text],

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
@@ -21,13 +21,11 @@ import sinon from "sinon";
 import { queryClientWithMockData } from "../../testQueryClient";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { VIRKSOMHET_UTEN_NARMESTE_LEDER } from "../../../mock/common/mockConstants";
-import {
-  DialogmoteInnkallingDTO,
-  DocumentComponentType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
+import { DialogmoteInnkallingDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { renderWithRouter } from "../../testRouterUtils";
 import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { OppfolgingstilfellePersonDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
 
 let queryClient: any;
 

--- a/test/dialogmote/EndreDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/EndreDialogmoteSkjemaTest.tsx
@@ -25,7 +25,6 @@ import {
 } from "./testData";
 import {
   DialogmoteDTO,
-  DocumentComponentType,
   EndreTidStedDialogmoteDTO,
 } from "@/data/dialogmote/types/dialogmoteTypes";
 import { fireEvent, screen, within } from "@testing-library/react";
@@ -38,6 +37,7 @@ import { renderWithRouter } from "../testRouterUtils";
 import { stubFeatureTogglesApi } from "../stubs/stubUnleash";
 import { stubAktivVeilederinfoApi } from "../stubs/stubSyfoveileder";
 import { queryClientWithMockData } from "../testQueryClient";
+import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
 
 let queryClient: any;
 let apiMockScope;

--- a/test/dialogmote/ForhandsvisningTest.tsx
+++ b/test/dialogmote/ForhandsvisningTest.tsx
@@ -1,11 +1,11 @@
 import React from "react";
-import { Forhandsvisning } from "@/components/dialogmote/Forhandsvisning";
+import { Forhandsvisning } from "@/components/Forhandsvisning";
 import { expect } from "chai";
+import { render, screen } from "@testing-library/react";
 import {
   DocumentComponentDto,
   DocumentComponentType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
-import { render, screen } from "@testing-library/react";
+} from "@/data/documentcomponent/documentComponentTypes";
 
 const doNothing = () => {
   /* do nothing */

--- a/test/dialogmote/testData.ts
+++ b/test/dialogmote/testData.ts
@@ -5,7 +5,6 @@ import {
   DialogmotedeltakerBehandlerDTO,
   DialogmoteDTO,
   DialogmoteStatus,
-  DocumentComponentType,
   MotedeltakerVarselType,
   VarselSvarDTO,
 } from "@/data/dialogmote/types/dialogmoteTypes";
@@ -24,6 +23,7 @@ import { capitalizeWord } from "@/utils/stringUtils";
 import { behandlerNavn } from "@/utils/behandlerUtils";
 import { referatTexts } from "@/data/dialogmote/dialogmoteTexts";
 import { BehandlerDTO, BehandlerType } from "@/data/behandler/BehandlerDTO";
+import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
 
 export const arbeidstaker = {
   navn: ARBEIDSTAKER_DEFAULT_FULL_NAME,

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -1,8 +1,4 @@
 import {
-  DocumentComponentDto,
-  DocumentComponentType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
-import {
   annenDeltakerFunksjon,
   annenDeltakerNavn,
   arbeidstaker,
@@ -29,6 +25,10 @@ import {
 import { genererDato } from "@/components/mote/utils";
 import { capitalizeWord } from "@/utils/stringUtils";
 import { behandlerNavn } from "@/utils/behandlerUtils";
+import {
+  DocumentComponentDto,
+  DocumentComponentType,
+} from "@/data/documentcomponent/documentComponentTypes";
 
 const behandlerTypeNavnText = `${capitalizeWord(
   behandler.type.toLowerCase()
@@ -111,7 +111,7 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -185,7 +185,7 @@ const expectedArbeidsgiverInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -245,7 +245,7 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -335,7 +335,7 @@ const expectedArbeidsgiverEndringsdokument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -429,7 +429,7 @@ const expectedArbeidstakerEndringsdokument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -496,7 +496,7 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -532,7 +532,7 @@ const expectedAvlysningArbeidsgiver = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -568,7 +568,7 @@ const expectedAvlysningArbeidstaker = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -604,7 +604,7 @@ const expectedAvlysningBehandler = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -695,7 +695,7 @@ export const expectedReferatDocument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -788,7 +788,7 @@ export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.hilsen, veileder.navn ?? "", "NAV"],
+    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];


### PR DESCRIPTION
Flyttet Forhandsvisning-komponent og all generell document-component-kode ut av dialogmote-pakker slik at det også kan tas i bruk til behandlerdialog.