### PR TITLE
Use different text when changing to geografisk enhet in personkort

### DIFF
--- a/src/components/personkort/PersonkortChangeEnhet.tsx
+++ b/src/components/personkort/PersonkortChangeEnhet.tsx
@@ -7,10 +7,18 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 
 const texts = {
   endre: "Endre til",
-  contentModal1:
-    "Hvis du ikke har tilgang til NAV utland, vil du miste tilgangen til denne personen når enheten endres.",
-  contentModal2:
-    "Veiledere med tilgang til NAV utland kan senere flytte personen tilbake til geografisk enhet.",
+  toUtland: {
+    contentModal1:
+      "Hvis du ikke har tilgang til NAV utland, vil du miste tilgangen til denne personen når enheten endres.",
+    contentModal2:
+      "Veiledere med tilgang til NAV utland kan senere flytte personen tilbake til geografisk enhet.",
+  },
+  toGeografisk: {
+    contentModal1:
+      "Hvis du ikke har tilgang til den geografiske enheten, vil du miste tilgangen til denne personen når enheten endres.",
+    contentModal2:
+      "Veiledere med tilgang til geografisk enhet kan senere flytte personen tilbake til NAV Utland.",
+  },
 };
 
 const NAV_UTLAND = "0393";
@@ -41,6 +49,13 @@ const PersonkortChangeEnhet = ({
     isCurrentlyNavUtland ? "geografisk enhet" : "NAV utland"
   }`;
 
+  const modalText1 = isCurrentlyNavUtland
+    ? texts.toGeografisk.contentModal1
+    : texts.toUtland.contentModal1;
+  const modalText2 = isCurrentlyNavUtland
+    ? texts.toGeografisk.contentModal2
+    : texts.toUtland.contentModal2;
+
   const updateEnhet = () => {
     changeEnhet.mutate({
       personident: fnr,
@@ -66,8 +81,8 @@ const PersonkortChangeEnhet = ({
             {heading}
           </Heading>
           <BodyLong as={"div"} spacing={true}>
-            <p>{texts.contentModal1}</p>
-            <p>{texts.contentModal2}</p>
+            <p>{modalText1}</p>
+            <p>{modalText2}</p>
           </BodyLong>
           <ButtonGroup>
             <Button variant="danger" onClick={updateEnhet}>

--- a/test/components/personkort/PersonkortEnhetTest.tsx
+++ b/test/components/personkort/PersonkortEnhetTest.tsx
@@ -64,4 +64,13 @@ describe("PersonkortEnhet", () => {
 
     expect(await screen.findByText("Endre til NAV utland")).to.exist;
   });
+
+  it("viser endre enhet til geografisk enhet hvis allerede NAV utland", async () => {
+    const utlandEnhet = { enhetId: "0393", navn: "NAV Utland" };
+    stubBehandlendeEnhetApi(apiMockScope, utlandEnhet);
+    stubChangeEnhetApi(apiMockScope, person);
+    renderPersonkortEnhet();
+
+    expect(await screen.findByText("Endre til geografisk enhet")).to.exist;
+  });
 });


### PR DESCRIPTION
Før:
![image](https://user-images.githubusercontent.com/40055758/229491942-d8a86d0c-79d5-455f-a0cd-7b085c6bb741.png)


Etter:
![image](https://user-images.githubusercontent.com/40055758/229491991-8ce1b03e-a6f4-4da5-b39e-4ff6794c3ce6.png)
