### PR TITLE
Add behandler details to melding to behandler

### DIFF
--- a/mock/isdialogmelding/behandlereDialogmeldingMock.ts
+++ b/mock/isdialogmelding/behandlereDialogmeldingMock.ts
@@ -3,6 +3,7 @@ export const behandlerRefDoktorLegesen = "behandler-ref-annen-uuid";
 
 export const behandlerLegoLasLegesen = {
   type: "FASTLEGE",
+  fnr: "01010012345",
   behandlerRef: behandlerRefLegoLasLegesen,
   fornavn: "Lego",
   mellomnavn: "Las",
@@ -17,6 +18,7 @@ export const behandlerLegoLasLegesen = {
 
 export const behandlerDoktorLegesen = {
   type: "FASTLEGE",
+  fnr: "01010012346",
   behandlerRef: behandlerRefDoktorLegesen,
   fornavn: "Doktor",
   mellomnavn: undefined,
@@ -34,6 +36,7 @@ export const behandlereDialogmeldingMock = [behandlerLegoLasLegesen];
 export const behandlerSokDialogmeldingMock = [
   {
     type: null,
+    fnr: "01010012347",
     behandlerRef: "behandler-ref-uuid",
     fornavn: "Enda",
     mellomnavn: "Enny",
@@ -47,6 +50,7 @@ export const behandlerSokDialogmeldingMock = [
   },
   {
     type: null,
+    fnr: "01010012348",
     behandlerRef: "behandler-ref-uuid",
     fornavn: "Kake",
     mellomnavn: "Bake",

--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema.tsx
@@ -22,6 +22,7 @@ import { tilDatoMedManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { FormApi } from "final-form";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
 import { useMeldingTilBehandlerDocument } from "@/hooks/behandlerdialog/document/useMeldingTilBehandlerDocument";
+import { behandlerNavn } from "@/utils/behandlerUtils";
 
 const texts = {
   sendKnapp: "Send til behandler",
@@ -97,6 +98,10 @@ export const MeldingTilBehandlerSkjema = () => {
       behandlerRef: values.behandlerRef,
       tekst: values[meldingTekstField],
       document: getTilleggsOpplysningerPasientDocument(values),
+      behandlerIdent: selectedBehandler?.fnr,
+      behandlerNavn: selectedBehandler
+        ? behandlerNavn(selectedBehandler)
+        : undefined,
     };
     meldingTilBehandler.mutate(meldingTilBehandlerDTO, {
       onSuccess: () => form.reset(), // TODO: Reset for radiogruppe fungerer ikke

--- a/src/data/behandlerdialog/behandlerdialogTypes.ts
+++ b/src/data/behandlerdialog/behandlerdialogTypes.ts
@@ -4,6 +4,8 @@ export interface MeldingTilBehandlerDTO {
   behandlerRef: string;
   tekst: string;
   document: DocumentComponentDto[];
+  behandlerIdent?: string;
+  behandlerNavn?: string;
 }
 
 export interface MeldingResponseDTO {

--- a/test/behandlerdialog/MeldingTilBehandlerTest.tsx
+++ b/test/behandlerdialog/MeldingTilBehandlerTest.tsx
@@ -112,6 +112,8 @@ describe("MeldingTilBehandler", () => {
 
   describe("MeldingTilBehandler innsending", () => {
     const meldingTilBehandlerDTO: MeldingTilBehandlerDTO = {
+      behandlerIdent: behandlereDialogmeldingMock[0].fnr,
+      behandlerNavn: `${behandlereDialogmeldingMock[0].fornavn} ${behandlereDialogmeldingMock[0].mellomnavn} ${behandlereDialogmeldingMock[0].etternavn}`,
       behandlerRef: behandlereDialogmeldingMock[0].behandlerRef,
       tekst: enMeldingTekst,
       document: expectedMeldingTilBehandlerDocument(enMeldingTekst),


### PR DESCRIPTION
We need the behandler's details when journalføring meldinger we send to him/her
- full name 
- ident

The name will be displayed in the document list in Gosys, and help identify the pdf version of the melding til behandler.