### PR TITLE
Behandle all personoppgaver for behandlerdialog svar

### DIFF
--- a/mock/ispersonoppgave/mockIspersonoppgave.ts
+++ b/mock/ispersonoppgave/mockIspersonoppgave.ts
@@ -7,6 +7,7 @@ import {
   makePersonOppgaveBehandlet,
   personoppgaverMock,
 } from "./personoppgaveMock";
+import { BehandlePersonoppgaveRequestDTO } from "@/data/personoppgave/types/BehandlePersonoppgaveRequestDTO";
 
 let personOppgaver = personoppgaverMock();
 
@@ -38,6 +39,30 @@ export const mockIspersonoppgave = (server: any) => {
           ...personOppgaver.filter((oppgave) => oppgave.uuid !== uuid),
         ];
       }
+      res.sendStatus(200);
+    }
+  );
+
+  server.post(
+    `${ISPERSONOPPGAVE_ROOT}/personoppgave/behandle`,
+    Auth.ensureAuthenticated(),
+    (req: express.Request, res: express.Response) => {
+      const body = req.body as BehandlePersonoppgaveRequestDTO;
+      const oppgaverForType = personOppgaver.filter(
+        (oppgave) => oppgave.type === body.personOppgaveType
+      );
+      const behandledeOppgaver = oppgaverForType.map((oppgave) =>
+        makePersonOppgaveBehandlet(oppgave)
+      );
+      const behandledeOppgaverUuid = behandledeOppgaver.map(
+        (oppgave) => oppgave.uuid
+      );
+      personOppgaver = [
+        ...behandledeOppgaver,
+        ...personOppgaver.filter(
+          (oppgave) => !behandledeOppgaverUuid.includes(oppgave.uuid)
+        ),
+      ];
       res.sendStatus(200);
     }
   );

--- a/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -56,13 +56,11 @@ const BehandleBehandlerdialogSvarOppgaveKnapp = () => {
         <BehandlePersonOppgaveKnapp
           personOppgave={sisteBehandledeOppgave}
           isBehandlet={isBehandlet}
-          behandlePersonOppgaveMutation={() =>
+          handleBehandleOppgave={() =>
             behandleAllPersonoppgaver.mutate(behandlePersonOppgaveRequestDTO)
           }
-          behandlePersonOppgaveMutationIsLoading={
-            behandleAllPersonoppgaver.isLoading
-          }
-          behandlePersonOppgaveText={texts.fjernOppgave}
+          isBehandleOppgaveLoading={behandleAllPersonoppgaver.isLoading}
+          behandleOppgaveText={texts.fjernOppgave}
         />
       )}
     </FlexRow>

--- a/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -26,7 +26,7 @@ const sortDateByTidspunkt = (d1: Date | null, d2: Date | null) => {
 };
 const getSisteBehandledeBehandlerdialogSvarOppgave = (
   personOppgaver: PersonOppgave[]
-): PersonOppgave => {
+): PersonOppgave | undefined => {
   return getAllBehandledePersonOppgaver(
     personOppgaver,
     PersonOppgaveType.BEHANDLERDIALOG_SVAR

--- a/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
+import { useBehandleAllPersonoppgaver } from "@/data/personoppgave/useBehandlePersonoppgave";
+import BehandlePersonOppgaveKnapp from "@/components/personoppgave/BehandlePersonOppgaveKnapp";
+import { BehandlePersonoppgaveRequestDTO } from "@/data/personoppgave/types/BehandlePersonoppgaveRequestDTO";
+import {
+  PersonOppgave,
+  PersonOppgaveType,
+} from "@/data/personoppgave/types/PersonOppgave";
+import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import {
+  getAllBehandledePersonOppgaver,
+  hasUbehandletPersonoppgave,
+} from "@/utils/personOppgaveUtils";
+import { FlexRow } from "@/components/Layout";
+
+const texts = {
+  fjernOppgave:
+    "Marker nye meldinger som lest. Oppgaven vil da fjernes fra oversikten.",
+};
+
+const sortDateByTidspunkt = (d1: Date | null, d2: Date | null) => {
+  if (d1 === null) return 1;
+  if (d2 === null) return -1;
+  return new Date(d2).getTime() - new Date(d1).getTime();
+};
+const getSisteBehandledeBehandlerdialogSvarOppgave = (
+  personOppgaver: PersonOppgave[]
+): PersonOppgave => {
+  return getAllBehandledePersonOppgaver(
+    personOppgaver,
+    PersonOppgaveType.BEHANDLERDIALOG_SVAR
+  ).sort((a, b) =>
+    sortDateByTidspunkt(a.behandletTidspunkt, b.behandletTidspunkt)
+  )[0];
+};
+
+const BehandleBehandlerdialogSvarOppgaveKnapp = () => {
+  const { data: personOppgaver } = usePersonoppgaverQuery();
+  const fnr = useValgtPersonident();
+  const behandleAllPersonoppgaver = useBehandleAllPersonoppgaver();
+  const isBehandlet = !hasUbehandletPersonoppgave(
+    personOppgaver,
+    PersonOppgaveType.BEHANDLERDIALOG_SVAR
+  );
+  const behandlePersonOppgaveRequestDTO: BehandlePersonoppgaveRequestDTO = {
+    personIdent: fnr,
+    personOppgaveType: PersonOppgaveType.BEHANDLERDIALOG_SVAR,
+  };
+  const sisteBehandledeOppgave =
+    getSisteBehandledeBehandlerdialogSvarOppgave(personOppgaver);
+
+  return (
+    <FlexRow>
+      {personOppgaver.length > 0 && (
+        <BehandlePersonOppgaveKnapp
+          personOppgave={sisteBehandledeOppgave}
+          isBehandlet={isBehandlet}
+          behandlePersonOppgaveMutation={() =>
+            behandleAllPersonoppgaver.mutate(behandlePersonOppgaveRequestDTO)
+          }
+          behandlePersonOppgaveMutationIsLoading={
+            behandleAllPersonoppgaver.isLoading
+          }
+          behandlePersonOppgaveText={texts.fjernOppgave}
+        />
+      )}
+    </FlexRow>
+  );
+};
+
+export default BehandleBehandlerdialogSvarOppgaveKnapp;

--- a/src/components/behandlerdialog/meldinger/Meldinger.tsx
+++ b/src/components/behandlerdialog/meldinger/Meldinger.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Heading } from "@navikt/ds-react";
 import { Samtaler } from "@/components/behandlerdialog/meldinger/Samtaler";
+import BehandleBehandlerdialogSvarOppgaveKnapp from "@/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp";
 
 export const texts = {
   header: "Meldinger",
@@ -9,9 +10,10 @@ export const texts = {
 export const Meldinger = () => {
   return (
     <>
-      <Heading level="1" size="large">
+      <Heading level="1" size="large" spacing={true}>
         {texts.header}
       </Heading>
+      <BehandleBehandlerdialogSvarOppgaveKnapp />
       <Samtaler />
     </>
   );

--- a/src/components/behandlerdialog/meldinger/Meldinger.tsx
+++ b/src/components/behandlerdialog/meldinger/Meldinger.tsx
@@ -10,7 +10,7 @@ export const texts = {
 export const Meldinger = () => {
   return (
     <>
-      <Heading level="1" size="large" spacing={true}>
+      <Heading level="1" size="large" spacing>
         {texts.header}
       </Heading>
       <BehandleBehandlerdialogSvarOppgaveKnapp />

--- a/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import styled from "styled-components";
 import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
-import { ubehandledePersonOppgaver } from "@/utils/personOppgaveUtils";
+import { getAllUbehandledePersonOppgaver } from "@/utils/personOppgaveUtils";
 import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
 
 const texts = {
@@ -21,10 +21,11 @@ interface SamtaleTagsProps {
 
 export const SamtaleTags = ({ meldinger }: SamtaleTagsProps) => {
   const { data: oppgaver } = usePersonoppgaverQuery();
-  const ubehandledeBehandlerDialogSvarOppgaver = ubehandledePersonOppgaver(
-    oppgaver,
-    PersonOppgaveType.BEHANDLERDIALOG_SVAR
-  );
+  const ubehandledeBehandlerDialogSvarOppgaver =
+    getAllUbehandledePersonOppgaver(
+      oppgaver,
+      PersonOppgaveType.BEHANDLERDIALOG_SVAR
+    );
   const hasMeldingMedUbehandletOppgave = meldinger.some((melding) =>
     ubehandledeBehandlerDialogSvarOppgaver.some(
       (oppgave) => oppgave.referanseUuid === melding.uuid

--- a/src/components/mote/components/innkalling/VurderOppgaveForDialogmotesvarKnapp.tsx
+++ b/src/components/mote/components/innkalling/VurderOppgaveForDialogmotesvarKnapp.tsx
@@ -1,24 +1,12 @@
 import React from "react";
-import { Checkbox } from "nav-frontend-skjema";
-import { toDatePrettyPrint } from "@/utils/datoUtils";
 import { PersonOppgave } from "@/data/personoppgave/types/PersonOppgave";
 import { useBehandlePersonoppgave } from "@/data/personoppgave/useBehandlePersonoppgave";
 import { isBehandletOppgave } from "@/utils/personOppgaveUtils";
+import BehandlePersonOppgaveKnapp from "@/components/personoppgave/BehandlePersonOppgaveKnapp";
 
 const texts = {
   fjernOppgave:
     "Jeg har vurdert alle møtesvarene. Oppgaven kan fjernes fra oversikten.",
-};
-
-const vurderOppgaveForInnkallingLabel = (
-  isBehandlet: boolean,
-  personOppgave: PersonOppgave
-): string => {
-  return isBehandlet
-    ? `Ferdigbehandlet av ${
-        personOppgave.behandletVeilederIdent
-      } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`
-    : texts.fjernOppgave;
 };
 
 interface VurderTilbakemeldingPaInnkallingKnappProps {
@@ -32,18 +20,15 @@ const VurderOppgaveForDialogmotesvarKnapp = ({
   const behandlePersonOppgave = useBehandlePersonoppgave();
 
   return (
-    <div className="panel vurderBehovKnapp">
-      <div className="skjema__input">
-        <Checkbox
-          label={vurderOppgaveForInnkallingLabel(isBehandlet, personOppgave)}
-          onClick={() => {
-            behandlePersonOppgave.mutate(personOppgave.uuid);
-          }}
-          disabled={isBehandlet || behandlePersonOppgave.isLoading}
-          defaultChecked={isBehandlet}
-        />
-      </div>
-    </div>
+    <BehandlePersonOppgaveKnapp
+      personOppgave={personOppgave}
+      isBehandlet={isBehandlet}
+      behandlePersonOppgaveMutation={() =>
+        behandlePersonOppgave.mutate(personOppgave.uuid)
+      }
+      behandlePersonOppgaveMutationIsLoading={behandlePersonOppgave.isLoading}
+      behandlePersonOppgaveText={texts.fjernOppgave}
+    />
   );
 };
 

--- a/src/components/mote/components/innkalling/VurderOppgaveForDialogmotesvarKnapp.tsx
+++ b/src/components/mote/components/innkalling/VurderOppgaveForDialogmotesvarKnapp.tsx
@@ -23,11 +23,11 @@ const VurderOppgaveForDialogmotesvarKnapp = ({
     <BehandlePersonOppgaveKnapp
       personOppgave={personOppgave}
       isBehandlet={isBehandlet}
-      behandlePersonOppgaveMutation={() =>
+      handleBehandleOppgave={() =>
         behandlePersonOppgave.mutate(personOppgave.uuid)
       }
-      behandlePersonOppgaveMutationIsLoading={behandlePersonOppgave.isLoading}
-      behandlePersonOppgaveText={texts.fjernOppgave}
+      isBehandleOppgaveLoading={behandlePersonOppgave.isLoading}
+      behandleOppgaveText={texts.fjernOppgave}
     />
   );
 };

--- a/src/components/motebehov/BehandleMotebehovKnapp.tsx
+++ b/src/components/motebehov/BehandleMotebehovKnapp.tsx
@@ -9,10 +9,17 @@ import {
 import { toDatePrettyPrint } from "@/utils/datoUtils";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { useBehandleMotebehov } from "@/data/motebehov/useBehandleMotebehov";
+import navFarger from "nav-frontend-core";
+import { Panel } from "@navikt/ds-react";
+import styled from "styled-components";
 
 const texts = {
   fjernOppgave: "Jeg har vurdert behovet. Oppgaven kan fjernes fra oversikten.",
 };
+
+const CheckboxPanel = styled(Panel)`
+  border: 1px solid ${navFarger.navGra20};
+`;
 
 const behandleMotebehovKnappLabel = (
   erBehandlet: boolean,
@@ -38,24 +45,19 @@ const BehandleMotebehovKnapp = ({
   const behandleMotebehov = useBehandleMotebehov();
 
   return motebehovListe.length > 0 ? (
-    <div className="panel checkboxKnappWrapper">
-      <div className="skjema__input">
-        <Checkbox
-          label={behandleMotebehovKnappLabel(
-            erBehandlet,
-            sistBehandletMotebehov
-          )}
-          onClick={() => {
-            if (harUbehandletMotebehov(motebehovListe)) {
-              behandleMotebehov.mutate();
-            }
-          }}
-          id="marker__utfoert"
-          disabled={erBehandlet || behandleMotebehov.isLoading}
-          defaultChecked={erBehandlet}
-        />
-      </div>
-    </div>
+    <CheckboxPanel>
+      <Checkbox
+        label={behandleMotebehovKnappLabel(erBehandlet, sistBehandletMotebehov)}
+        onClick={() => {
+          if (harUbehandletMotebehov(motebehovListe)) {
+            behandleMotebehov.mutate();
+          }
+        }}
+        id="marker__utfoert"
+        disabled={erBehandlet || behandleMotebehov.isLoading}
+        defaultChecked={erBehandlet}
+      />
+    </CheckboxPanel>
   ) : (
     <></>
   );

--- a/src/components/motebehov/BehandleMotebehovKnapp.tsx
+++ b/src/components/motebehov/BehandleMotebehovKnapp.tsx
@@ -38,7 +38,7 @@ const BehandleMotebehovKnapp = ({
   const behandleMotebehov = useBehandleMotebehov();
 
   return motebehovListe.length > 0 ? (
-    <div className="panel vurderBehovKnapp">
+    <div className="panel checkboxKnappWrapper">
       <div className="skjema__input">
         <Checkbox
           label={behandleMotebehovKnappLabel(

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { PersonOppgave } from "@/data/personoppgave/types/PersonOppgave";
 import { toDatePrettyPrint } from "@/utils/datoUtils";
-import { Checkbox } from "@navikt/ds-react";
+import { Checkbox, Panel } from "@navikt/ds-react";
+import styled from "styled-components";
+import navFarger from "nav-frontend-core";
 
 const getBehandlePersonOppgaveKnappLabel = (
   isBehandlet: boolean,
@@ -14,6 +16,10 @@ const getBehandlePersonOppgaveKnappLabel = (
       } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`
     : behandlePersonOppgaveText;
 };
+
+const CheckboxPanel = styled(Panel)`
+  border: 1px solid ${navFarger.navGra20};
+`;
 
 interface BehandlePersonoppgaveKnappProps {
   personOppgave: PersonOppgave;
@@ -30,24 +36,21 @@ const BehandlePersonOppgaveKnapp = ({
   behandlePersonOppgaveMutationIsLoading,
   behandlePersonOppgaveText,
 }: BehandlePersonoppgaveKnappProps) => {
-  // TODO: Skrive oss bort fra less-styling
   return (
-    <div className="panel checkboxKnappWrapper">
-      <div className="skjema__input">
-        <Checkbox
-          onClick={behandlePersonOppgaveMutation}
-          disabled={isBehandlet || behandlePersonOppgaveMutationIsLoading}
-          defaultChecked={isBehandlet}
-          size="small"
-        >
-          {getBehandlePersonOppgaveKnappLabel(
-            isBehandlet,
-            personOppgave,
-            behandlePersonOppgaveText
-          )}
-        </Checkbox>
-      </div>
-    </div>
+    <CheckboxPanel>
+      <Checkbox
+        onClick={behandlePersonOppgaveMutation}
+        disabled={isBehandlet || behandlePersonOppgaveMutationIsLoading}
+        defaultChecked={isBehandlet}
+        size="small"
+      >
+        {getBehandlePersonOppgaveKnappLabel(
+          isBehandlet,
+          personOppgave,
+          behandlePersonOppgaveText
+        )}
+      </Checkbox>
+    </CheckboxPanel>
   );
 };
 

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { PersonOppgave } from "@/data/personoppgave/types/PersonOppgave";
+import { toDatePrettyPrint } from "@/utils/datoUtils";
+import { Checkbox } from "@navikt/ds-react";
+
+const getBehandlePersonOppgaveKnappLabel = (
+  isBehandlet: boolean,
+  personOppgave: PersonOppgave,
+  behandlePersonOppgaveText: string
+): string => {
+  return isBehandlet
+    ? `Ferdigbehandlet av ${
+        personOppgave.behandletVeilederIdent
+      } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`
+    : behandlePersonOppgaveText;
+};
+
+interface BehandlePersonoppgaveKnappProps {
+  personOppgave: PersonOppgave;
+  isBehandlet: boolean;
+  behandlePersonOppgaveMutation: () => void;
+  behandlePersonOppgaveMutationIsLoading: boolean;
+  behandlePersonOppgaveText: string;
+}
+
+const BehandlePersonOppgaveKnapp = ({
+  personOppgave,
+  isBehandlet,
+  behandlePersonOppgaveMutation,
+  behandlePersonOppgaveMutationIsLoading,
+  behandlePersonOppgaveText,
+}: BehandlePersonoppgaveKnappProps) => {
+  // TODO: Skrive oss bort fra less-styling
+  return (
+    <div className="panel checkboxKnappWrapper">
+      <div className="skjema__input">
+        <Checkbox
+          onClick={behandlePersonOppgaveMutation}
+          disabled={isBehandlet || behandlePersonOppgaveMutationIsLoading}
+          defaultChecked={isBehandlet}
+          size="small"
+        >
+          {getBehandlePersonOppgaveKnappLabel(
+            isBehandlet,
+            personOppgave,
+            behandlePersonOppgaveText
+          )}
+        </Checkbox>
+      </div>
+    </div>
+  );
+};
+
+export default BehandlePersonOppgaveKnapp;

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -5,18 +5,6 @@ import { Checkbox, Panel } from "@navikt/ds-react";
 import styled from "styled-components";
 import navFarger from "nav-frontend-core";
 
-const getBehandlePersonOppgaveKnappLabel = (
-  isBehandlet: boolean,
-  personOppgave: PersonOppgave,
-  behandlePersonOppgaveText: string
-): string => {
-  return isBehandlet
-    ? `Ferdigbehandlet av ${
-        personOppgave.behandletVeilederIdent
-      } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`
-    : behandlePersonOppgaveText;
-};
-
 const CheckboxPanel = styled(Panel)`
   border: 1px solid ${navFarger.navGra20};
 `;
@@ -24,31 +12,36 @@ const CheckboxPanel = styled(Panel)`
 interface BehandlePersonoppgaveKnappProps {
   personOppgave: PersonOppgave;
   isBehandlet: boolean;
-  behandlePersonOppgaveMutation: () => void;
-  behandlePersonOppgaveMutationIsLoading: boolean;
-  behandlePersonOppgaveText: string;
+  handleBehandleOppgave: () => void;
+  isBehandleOppgaveLoading: boolean;
+  behandleOppgaveText: string;
 }
+
+const ferdigbehandletText = (personOppgave: PersonOppgave) =>
+  `Ferdigbehandlet av ${
+    personOppgave.behandletVeilederIdent
+  } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`;
 
 const BehandlePersonOppgaveKnapp = ({
   personOppgave,
   isBehandlet,
-  behandlePersonOppgaveMutation,
-  behandlePersonOppgaveMutationIsLoading,
-  behandlePersonOppgaveText,
+  handleBehandleOppgave,
+  isBehandleOppgaveLoading,
+  behandleOppgaveText,
 }: BehandlePersonoppgaveKnappProps) => {
+  const oppgaveKnappText = isBehandlet
+    ? ferdigbehandletText(personOppgave)
+    : behandleOppgaveText;
+
   return (
     <CheckboxPanel>
       <Checkbox
-        onClick={behandlePersonOppgaveMutation}
-        disabled={isBehandlet || behandlePersonOppgaveMutationIsLoading}
+        onClick={handleBehandleOppgave}
+        disabled={isBehandlet || isBehandleOppgaveLoading}
         defaultChecked={isBehandlet}
         size="small"
       >
-        {getBehandlePersonOppgaveKnappLabel(
-          isBehandlet,
-          personOppgave,
-          behandlePersonOppgaveText
-        )}
+        {oppgaveKnappText}
       </Checkbox>
     </CheckboxPanel>
   );

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -9,18 +9,18 @@ const CheckboxPanel = styled(Panel)`
   border: 1px solid ${navFarger.navGra20};
 `;
 
+const ferdigbehandletText = (personOppgave: PersonOppgave) =>
+  `Ferdigbehandlet av ${
+    personOppgave.behandletVeilederIdent
+  } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`;
+
 interface BehandlePersonoppgaveKnappProps {
-  personOppgave: PersonOppgave;
+  personOppgave: PersonOppgave | undefined;
   isBehandlet: boolean;
   handleBehandleOppgave: () => void;
   isBehandleOppgaveLoading: boolean;
   behandleOppgaveText: string;
 }
-
-const ferdigbehandletText = (personOppgave: PersonOppgave) =>
-  `Ferdigbehandlet av ${
-    personOppgave.behandletVeilederIdent
-  } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`;
 
 const BehandlePersonOppgaveKnapp = ({
   personOppgave,
@@ -29,9 +29,10 @@ const BehandlePersonOppgaveKnapp = ({
   isBehandleOppgaveLoading,
   behandleOppgaveText,
 }: BehandlePersonoppgaveKnappProps) => {
-  const oppgaveKnappText = isBehandlet
-    ? ferdigbehandletText(personOppgave)
-    : behandleOppgaveText;
+  const oppgaveKnappText =
+    isBehandlet && personOppgave
+      ? ferdigbehandletText(personOppgave)
+      : behandleOppgaveText;
 
   return (
     <CheckboxPanel>

--- a/src/data/personoppgave/types/BehandlePersonoppgaveRequestDTO.ts
+++ b/src/data/personoppgave/types/BehandlePersonoppgaveRequestDTO.ts
@@ -1,0 +1,6 @@
+import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
+
+export interface BehandlePersonoppgaveRequestDTO {
+  personIdent: string;
+  personOppgaveType: PersonOppgaveType;
+}

--- a/src/data/personoppgave/useBehandlePersonoppgave.ts
+++ b/src/data/personoppgave/useBehandlePersonoppgave.ts
@@ -3,12 +3,31 @@ import { ISPERSONOPPGAVE_ROOT } from "@/apiConstants";
 import { post } from "@/api/axios";
 import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { BehandlePersonoppgaveRequestDTO } from "@/data/personoppgave/types/BehandlePersonoppgaveRequestDTO";
 
 export const useBehandlePersonoppgave = () => {
   const fnr = useValgtPersonident();
   const queryClient = useQueryClient();
   const postBehandlePersonoppgave = (uuid: string) =>
     post(`${ISPERSONOPPGAVE_ROOT}/personoppgave/${uuid}/behandle`, {});
+  const personOppgaverQueryKey = personoppgaverQueryKeys.personoppgaver(fnr);
+
+  return useMutation({
+    mutationFn: postBehandlePersonoppgave,
+    onSettled: () => queryClient.invalidateQueries(personOppgaverQueryKey),
+  });
+};
+
+export const useBehandleAllPersonoppgaver = () => {
+  const fnr = useValgtPersonident();
+  const queryClient = useQueryClient();
+  const postBehandlePersonoppgave = (
+    behandlePersonoppgaverRequestDTO: BehandlePersonoppgaveRequestDTO
+  ) =>
+    post(
+      `${ISPERSONOPPGAVE_ROOT}/personoppgave/behandle`,
+      behandlePersonoppgaverRequestDTO
+    );
   const personOppgaverQueryKey = personoppgaverQueryKeys.personoppgaver(fnr);
 
   return useMutation({

--- a/src/styles/_checkboxKnappWrapper.less
+++ b/src/styles/_checkboxKnappWrapper.less
@@ -1,4 +1,4 @@
-.vurderBehovKnapp {
+.checkboxKnappWrapper {
   border: 1px solid @navGra20;
   .skjemaelement {
     margin: 0;

--- a/src/styles/_checkboxKnappWrapper.less
+++ b/src/styles/_checkboxKnappWrapper.less
@@ -1,6 +1,0 @@
-.checkboxKnappWrapper {
-  border: 1px solid @navGra20;
-  .skjemaelement {
-    margin: 0;
-  }
-}

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -22,7 +22,7 @@
 @import "_knapperad";
 @import "_lightbox";
 @import "_media";
-@import "_vurderBehov";
+@import "_checkboxKnappWrapper";
 @import "_naermesteLedere";
 @import "_navigasjon";
 @import "_navigasjonselement";

--- a/src/styles/styles.less
+++ b/src/styles/styles.less
@@ -22,7 +22,6 @@
 @import "_knapperad";
 @import "_lightbox";
 @import "_media";
-@import "_checkboxKnappWrapper";
 @import "_naermesteLedere";
 @import "_navigasjon";
 @import "_navigasjonselement";

--- a/src/utils/personOppgaveUtils.ts
+++ b/src/utils/personOppgaveUtils.ts
@@ -9,15 +9,24 @@ export const numberOfUbehandledePersonOppgaver = (
   personOppgaver: PersonOppgave[],
   type: string
 ): number => {
-  return ubehandledePersonOppgaver(personOppgaver, type).length;
+  return getAllUbehandledePersonOppgaver(personOppgaver, type).length;
 };
 
-export const ubehandledePersonOppgaver = (
+export const getAllUbehandledePersonOppgaver = (
   personOppgaver: PersonOppgave[],
   type: string
 ): PersonOppgave[] => {
   return personOppgaver.filter((personoppgave) => {
     return personoppgave.type === type && !isBehandletOppgave(personoppgave);
+  });
+};
+
+export const getAllBehandledePersonOppgaver = (
+  personOppgaver: PersonOppgave[],
+  type: string
+): PersonOppgave[] => {
+  return personOppgaver.filter((personoppgave) => {
+    return personoppgave.type === type && isBehandletOppgave(personoppgave);
   });
 };
 

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -20,6 +20,7 @@ import {
   personOppgaveBehandletBehandlerdialogSvar,
   personOppgaveUbehandletBehandlerdialogSvar,
 } from "../../mock/ispersonoppgave/personoppgaveMock";
+import dayjs from "dayjs";
 
 let queryClient: QueryClient;
 
@@ -311,6 +312,7 @@ describe("Meldinger panel", () => {
           ...personOppgaveUbehandletBehandlerdialogSvar,
           referanseUuid: innkommendeMeldingUuid,
         },
+        personOppgaveBehandletBehandlerdialogSvar,
       ]
     );
 
@@ -334,5 +336,39 @@ describe("Meldinger panel", () => {
     renderMeldinger();
 
     expect(screen.getByText("Ferdigbehandlet", { exact: false })).to.exist;
+  });
+
+  it("Viser siste ferdigbehandlede personoppgave for behandlerdialog svar når alle oppgaver behandlet", () => {
+    const twoDaysAgo = dayjs(new Date()).subtract(2, "days");
+    const threeDaysAgo = dayjs(new Date()).subtract(3, "days");
+    queryClient.setQueryData(
+      personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...personOppgaveBehandletBehandlerdialogSvar,
+          behandletTidspunkt: twoDaysAgo.toDate(),
+        },
+        {
+          ...personOppgaveBehandletBehandlerdialogSvar,
+          behandletTidspunkt: threeDaysAgo.toDate(),
+        },
+      ]
+    );
+    renderMeldinger();
+
+    const expectedFerdigbehandledText = `Ferdigbehandlet av Z991100 ${twoDaysAgo.format(
+      "DD.MM.YYYY"
+    )}`;
+    expect(screen.getByText(expectedFerdigbehandledText)).to.exist;
+  });
+
+  it("Viser ingen oppgave når ingen behandlerdialog-oppgaver", () => {
+    renderMeldinger();
+
+    expect(screen.queryByText("Ferdigbehandlet", { exact: false })).to.not
+      .exist;
+    expect(
+      screen.queryByText("Marker nye meldinger som lest", { exact: false })
+    ).to.not.exist;
   });
 });

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -304,13 +304,11 @@ describe("Meldinger panel", () => {
   });
 
   it("Viser ubehandlet personoppgave for behandlerdialog svar", () => {
-    const innkommendeMeldingUuid = "456uio";
     queryClient.setQueryData(
       personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
       () => [
         {
           ...personOppgaveUbehandletBehandlerdialogSvar,
-          referanseUuid: innkommendeMeldingUuid,
         },
         personOppgaveBehandletBehandlerdialogSvar,
       ]
@@ -323,13 +321,11 @@ describe("Meldinger panel", () => {
   });
 
   it("Viser behandlet personoppgave for behandlerdialog svar", () => {
-    const innkommendeMeldingUuid = "456uio";
     queryClient.setQueryData(
       personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
       () => [
         {
           ...personOppgaveBehandletBehandlerdialogSvar,
-          referanseUuid: innkommendeMeldingUuid,
         },
       ]
     );
@@ -363,6 +359,11 @@ describe("Meldinger panel", () => {
   });
 
   it("Viser ingen oppgave når ingen behandlerdialog-oppgaver", () => {
+    queryClient.setQueryData(
+      personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => []
+    );
+
     renderMeldinger();
 
     expect(screen.queryByText("Ferdigbehandlet", { exact: false })).to.not

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -301,4 +301,38 @@ describe("Meldinger panel", () => {
       expect(vedleggTekst).to.exist;
     });
   });
+
+  it("Viser ubehandlet personoppgave for behandlerdialog svar", () => {
+    const innkommendeMeldingUuid = "456uio";
+    queryClient.setQueryData(
+      personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...personOppgaveUbehandletBehandlerdialogSvar,
+          referanseUuid: innkommendeMeldingUuid,
+        },
+      ]
+    );
+
+    renderMeldinger();
+    const checkboxTekst =
+      "Marker nye meldinger som lest. Oppgaven vil da fjernes fra oversikten.";
+    expect(screen.getByText(checkboxTekst)).to.exist;
+  });
+
+  it("Viser behandlet personoppgave for behandlerdialog svar", () => {
+    const innkommendeMeldingUuid = "456uio";
+    queryClient.setQueryData(
+      personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...personOppgaveBehandletBehandlerdialogSvar,
+          referanseUuid: innkommendeMeldingUuid,
+        },
+      ]
+    );
+    renderMeldinger();
+
+    expect(screen.getByText("Ferdigbehandlet", { exact: false })).to.exist;
+  });
 });


### PR DESCRIPTION
1. Flytter ut knappen for å behandle personoppgaver i en egen komponent
2. Tar inn checkbox fra nytt designsystem
     - Litt mer padding på denne enn den forrige, må i så fall override litt styles for å få det likt som den gamle. 

Se bildet. I dag er feks `vurder møtebehov` et annet endepunkt og tok jeg ikke i bruk den nye `behandlePersonoppgave`-knappen her, selv om man fint kunne gjort det. Ville ikke gjøre for mye endringer på en gang, bare 🤔 

<img width="755" alt="image" src="https://user-images.githubusercontent.com/37441744/236201252-3d97ef3f-52b4-4182-a8b1-90e5b988535d.png">
