### PR TITLE
Fetch vedlegg on click via direct link to pdf-url

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosRequestHeaders, ResponseType } from "axios";
+import axios, { AxiosError, AxiosRequestHeaders } from "axios";
 import {
   accessDeniedError,
   ApiErrorException,
@@ -15,12 +15,10 @@ export const NAV_PERSONIDENT_HEADER = "nav-personident";
 
 export const defaultRequestHeaders = (
   personIdent?: string,
-  addHeader?: { [p: string]: string | boolean | number },
-  responseType?: ResponseType,
-  contentType?: string
+  addHeader?: { [p: string]: string | boolean | number }
 ): AxiosRequestHeaders => {
   const headers = {
-    "Content-Type": !!contentType ? contentType : "application/json",
+    "Content-Type": "application/json",
     [NAV_CONSUMER_ID_HEADER]: NAV_CONSUMER_ID,
     [NAV_CALL_ID_HEADER]: `${NAV_CONSUMER_ID}-${generateUUID()}`,
   };
@@ -71,19 +69,11 @@ const handleAxiosError = (error: AxiosError) => {
 export const get = <ResponseData>(
   url: string,
   personIdent?: string,
-  addHeader?: { [p: string]: string | boolean | number },
-  responseType?: ResponseType,
-  contentType?: string
+  addHeader?: { [p: string]: string | boolean | number }
 ): Promise<ResponseData> => {
   return axios
     .get(url, {
-      headers: defaultRequestHeaders(
-        personIdent,
-        addHeader,
-        responseType,
-        contentType
-      ),
-      responseType: !!responseType ? responseType : "json",
+      headers: defaultRequestHeaders(personIdent, addHeader),
     })
     .then((response) => response.data)
     .catch((error) => {

--- a/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
@@ -46,13 +46,9 @@ const VedleggDetails = styled.div`
 
 interface MeldingInnholdPanelProps {
   melding: Melding;
-  skalHenteVedlegg: boolean;
 }
 
-export const MeldingInnholdPanel = ({
-  melding,
-  skalHenteVedlegg,
-}: MeldingInnholdPanelProps) => {
+export const MeldingInnholdPanel = ({ melding }: MeldingInnholdPanelProps) => {
   const behandlerNavn = melding.behandlerNavn;
   return (
     <StyledPanel border>
@@ -64,7 +60,6 @@ export const MeldingInnholdPanel = ({
             <PdfVedleggLink
               meldingUuid={melding.uuid}
               vedleggNumber={index}
-              skalHenteVedlegg={skalHenteVedlegg}
               key={index}
             />
           ))}

--- a/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
@@ -29,32 +29,23 @@ const StyledMeldingInnhold = styled.div<{ innkommende?: boolean }>`
 
 interface MeldingInnholdProps {
   melding: Melding;
-  skalHenteVedlegg: boolean;
 }
 
-const MeldingFraBehandler = ({
-  melding,
-  skalHenteVedlegg,
-}: MeldingInnholdProps) => {
+const MeldingFraBehandler = ({ melding }: MeldingInnholdProps) => {
   return (
     <StyledMeldingInnhold innkommende>
       <StyledImageWrapper innkommende>
         <img src={StetoskopIkonBakgrunn} alt="Stetoskopikon for behandler" />
       </StyledImageWrapper>
-      <MeldingInnholdPanel
-        melding={melding}
-        skalHenteVedlegg={skalHenteVedlegg}
-      />
+      <MeldingInnholdPanel melding={melding} />
     </StyledMeldingInnhold>
   );
 };
 
-const MeldingTilBehandler = ({
-  melding,
-}: Pick<MeldingInnholdProps, "melding">) => {
+const MeldingTilBehandler = ({ melding }: MeldingInnholdProps) => {
   return (
     <StyledMeldingInnhold>
-      <MeldingInnholdPanel melding={melding} skalHenteVedlegg={false} />
+      <MeldingInnholdPanel melding={melding} />
       <StyledImageWrapper>
         <img src={NavLogoRod} alt="Rød NAV-logo" />
       </StyledImageWrapper>
@@ -64,22 +55,14 @@ const MeldingTilBehandler = ({
 
 interface MeldingerISamtaleProps {
   meldinger: Melding[];
-  skalHenteVedlegg: boolean;
 }
 
-export const MeldingerISamtale = ({
-  meldinger,
-  skalHenteVedlegg,
-}: MeldingerISamtaleProps) => {
+export const MeldingerISamtale = ({ meldinger }: MeldingerISamtaleProps) => {
   return (
     <StyledWrapper>
       {meldinger.map((melding: Melding, index: number) => {
         return melding.innkommende ? (
-          <MeldingFraBehandler
-            melding={melding}
-            skalHenteVedlegg={skalHenteVedlegg}
-            key={index}
-          />
+          <MeldingFraBehandler melding={melding} key={index} />
         ) : (
           <MeldingTilBehandler melding={melding} key={index} />
         );

--- a/src/components/behandlerdialog/meldinger/PdfVedleggLink.tsx
+++ b/src/components/behandlerdialog/meldinger/PdfVedleggLink.tsx
@@ -1,15 +1,7 @@
 import React from "react";
-import { Link, Loader } from "@navikt/ds-react";
-import { useBehandlerdialogVedleggQuery } from "@/data/behandlerdialog/behandlerdialogQueryHooks";
+import { Link } from "@navikt/ds-react";
 import styled from "styled-components";
-
-const createPdfBlob = (data: ArrayBuffer | undefined) => {
-  return !!data
-    ? new Blob([data], {
-        type: "application/pdf",
-      })
-    : new Blob();
-};
+import { ISBEHANDLERDIALOG_ROOT } from "@/apiConstants";
 
 const StyledLink = styled(Link)`
   padding-right: 0.25em;
@@ -18,33 +10,15 @@ const StyledLink = styled(Link)`
 interface PdfVedleggProps {
   meldingUuid: string;
   vedleggNumber: number;
-  skalHenteVedlegg: boolean;
 }
 
-const PdfVedleggLink = ({
-  meldingUuid,
-  vedleggNumber,
-  skalHenteVedlegg,
-}: PdfVedleggProps) => {
-  const { data, isFetching } = useBehandlerdialogVedleggQuery(
-    meldingUuid,
-    vedleggNumber,
-    skalHenteVedlegg
-  );
-
-  const blob = createPdfBlob(data);
-  const pdfUrl = data?.byteLength ? URL.createObjectURL(blob) : undefined;
+const PdfVedleggLink = ({ meldingUuid, vedleggNumber }: PdfVedleggProps) => {
+  const pdfUrl = `${ISBEHANDLERDIALOG_ROOT}/melding/${meldingUuid}/${vedleggNumber}/pdf`;
   const oneIndexedVedleggNumber = vedleggNumber + 1;
   return (
-    <>
-      {isFetching ? (
-        <Loader size="small" />
-      ) : (
-        <StyledLink href={pdfUrl} target="_blank" rel="noreferrer">
-          Vedlegg {oneIndexedVedleggNumber}
-        </StyledLink>
-      )}
-    </>
+    <StyledLink href={pdfUrl} target="_blank" rel="noreferrer">
+      Vedlegg {oneIndexedVedleggNumber}
+    </StyledLink>
   );
 };
 

--- a/src/components/behandlerdialog/meldinger/SamtaleAccordion.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { tilDatoMedManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { Accordion } from "@navikt/ds-react";
@@ -18,19 +18,16 @@ interface SamtalerAccordionListProps {
 }
 
 export const SamtaleAccordion = ({ meldinger }: SamtalerAccordionListProps) => {
-  const [isOpen, setIsOpen] = useState<boolean>(false);
   const behandlerNavn = useBehandlerNavn(meldinger[0].behandlerRef);
   const newestMelding = meldinger.slice(-1)[0];
   const dateAndTimeForNewestMelding = `${tilDatoMedManedNavnOgKlokkeslett(
     newestMelding.tidspunkt
   )}`;
 
-  const toggleIsOpen = () => setIsOpen(!isOpen);
-
   return (
     <Accordion>
-      <Accordion.Item open={isOpen}>
-        <Accordion.Header onClick={toggleIsOpen}>
+      <Accordion.Item>
+        <Accordion.Header>
           <FlexRow>
             <StyledImage
               src={StetoskopIkon}
@@ -41,7 +38,7 @@ export const SamtaleAccordion = ({ meldinger }: SamtalerAccordionListProps) => {
           </FlexRow>
         </Accordion.Header>
         <Accordion.Content>
-          <MeldingerISamtale meldinger={meldinger} skalHenteVedlegg={isOpen} />
+          <MeldingerISamtale meldinger={meldinger} />
         </Accordion.Content>
       </Accordion.Item>
     </Accordion>

--- a/src/data/behandlerdialog/behandlerdialogQueryHooks.ts
+++ b/src/data/behandlerdialog/behandlerdialogQueryHooks.ts
@@ -6,11 +6,6 @@ import { MeldingResponseDTO } from "@/data/behandlerdialog/behandlerdialogTypes"
 
 export const behandlerdialogQueryKeys = {
   behandlerdialog: (personident: string) => ["behandlerdialog", personident],
-  vedlegg: (meldingUuid: string, vedleggNumber: number) => [
-    "vedlegg",
-    meldingUuid,
-    vedleggNumber,
-  ],
 };
 
 export const useBehandlerdialogQuery = () => {
@@ -27,32 +22,5 @@ export const useBehandlerdialogQuery = () => {
   return {
     ...query,
     data: query.data,
-  };
-};
-
-export const useBehandlerdialogVedleggQuery = (
-  meldingUuid: string,
-  vedleggNumber: number,
-  skalHenteVedlegg: boolean
-) => {
-  const personident = useValgtPersonident();
-  const path = `${ISBEHANDLERDIALOG_ROOT}/melding/${meldingUuid}/${vedleggNumber}/pdf`;
-  const fetchBehandlerdialogVedlegg = () =>
-    get<ArrayBuffer>(
-      path,
-      personident,
-      undefined,
-      "arraybuffer",
-      "application/pdf"
-    );
-
-  const query = useQuery({
-    queryKey: behandlerdialogQueryKeys.vedlegg(meldingUuid, vedleggNumber),
-    queryFn: fetchBehandlerdialogVedlegg,
-    enabled: skalHenteVedlegg,
-  });
-
-  return {
-    ...query,
   };
 };

--- a/test/behandlerdialog/BehandlerdialogSideTest.tsx
+++ b/test/behandlerdialog/BehandlerdialogSideTest.tsx
@@ -24,9 +24,6 @@ const renderBehandlerdialogSide = () => {
 describe("BehandlerdialogSide", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
-    global.URL.createObjectURL = function () {
-      return "";
-    };
   });
 
   it("Viser behandlerdialogSide", () => {

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -10,7 +10,6 @@ import { behandlerdialogQueryKeys } from "@/data/behandlerdialog/behandlerdialog
 import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
 import {
   behandlerdialogMockEmpty,
-  behandlerdialogVedleggMock,
   defaultMelding,
 } from "../../mock/isbehandlerdialog/behandlerdialogMock";
 import { MeldingResponseDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
@@ -52,9 +51,6 @@ const meldingTilOgFraBehandler = (meldingFraBehandlerUuid: string) => [
 describe("Meldinger panel", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
-    global.URL.createObjectURL = function () {
-      return "";
-    };
   });
 
   it("Viser meldinger", () => {
@@ -289,11 +285,6 @@ describe("Meldinger panel", () => {
       meldinger.filter(
         (melding) => melding.innkommende && melding.antallVedlegg > 0
       )
-    );
-
-    queryClient.setQueryData(
-      behandlerdialogQueryKeys.vedlegg(meldingerMedVedlegg[0].uuid, 0),
-      () => behandlerdialogVedleggMock[0]
     );
 
     renderMeldinger();


### PR DESCRIPTION
Her er variant som henter vedlegg-pdf direkte fra API ved klikk på lenke. For at dette skal fungere må vi endre på veileder-tilgangsjekken i APIet i isbehandlerdialog siden vi nå ikke sender med `personIdent` i request-header: https://github.com/navikt/isbehandlerdialog/compare/master...vedlegg-api-alt2 - lager PR her også hvis vi går for denne løsningen.