### PR TITLE
Show tag for avvist melding

### DIFF
--- a/mock/isbehandlerdialog/behandlerdialogMock.ts
+++ b/mock/isbehandlerdialog/behandlerdialogMock.ts
@@ -11,6 +11,7 @@ import {
   VEILEDER_DEFAULT,
 } from "../common/mockConstants";
 import { tilleggsOpplysningerPasientTexts } from "../../src/data/behandlerdialog/behandlerMeldingTexts";
+import { MeldingStatusType } from "../../src/data/behandlerdialog/behandlerdialogTypes";
 
 const defaultMeldingTekst = "Dette er en melding";
 const meldingtilBehandlerDocument = [
@@ -54,6 +55,11 @@ const meldingtilBehandlerDocument = [
   },
 ];
 
+const defaultStatus = {
+  type: MeldingStatusType.OK,
+  tekst: null,
+};
+
 export const defaultMelding = {
   uuid: "5f1e2629-062b-443d-ac1f-3b08e9574cd5",
   behandlerRef: behandlerRefDoktorLegesen,
@@ -63,6 +69,7 @@ export const defaultMelding = {
   innkommende: false,
   document: meldingtilBehandlerDocument,
   antallVedlegg: 0,
+  status: defaultStatus,
 };
 
 const longMelding =
@@ -88,6 +95,24 @@ const meldinger = [
     tidspunkt: "2023-01-03T12:00:00.000+01:00",
     antallVedlegg: 1,
     document: [],
+  },
+  {
+    ...defaultMelding,
+    uuid: "9f1e2639-061b-243d-ac1f-3b08e9574cd5",
+    tidspunkt: "2023-01-04T12:00:00.000+01:00",
+    status: {
+      type: MeldingStatusType.AVVIST,
+      tekst: "Mottaker ikke funnet",
+    },
+  },
+  {
+    ...defaultMelding,
+    uuid: "2f1e2639-061b-243d-ac1f-3b08e9574cd5",
+    tidspunkt: "2023-01-05T12:00:00.000+01:00",
+    status: {
+      ...defaultStatus,
+      type: MeldingStatusType.AVVIST,
+    },
   },
 ];
 

--- a/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
@@ -1,15 +1,11 @@
 import React from "react";
-import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
+import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { BodyLong, Detail, Panel } from "@navikt/ds-react";
 import { PaperclipIcon } from "@navikt/aksel-icons";
 import styled from "styled-components";
 import { tilDatoMedManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { VisMelding } from "@/components/behandlerdialog/meldinger/VisMelding";
 import PdfVedleggLink from "@/components/behandlerdialog/meldinger/PdfVedleggLink";
-
-const StyledPanel = styled(Panel)`
-  width: 80%;
-`;
 
 const MeldingTekst = styled(BodyLong)`
   margin-bottom: 0.75em;
@@ -45,13 +41,13 @@ const VedleggDetails = styled.div`
 `;
 
 interface MeldingInnholdPanelProps {
-  melding: Melding;
+  melding: MeldingDTO;
 }
 
 export const MeldingInnholdPanel = ({ melding }: MeldingInnholdPanelProps) => {
   const behandlerNavn = melding.behandlerNavn;
   return (
-    <StyledPanel border>
+    <Panel border>
       <MeldingTekst>{melding.tekst}</MeldingTekst>
       {melding.innkommende && melding.antallVedlegg > 0 && (
         <VedleggDetails>
@@ -74,6 +70,6 @@ export const MeldingInnholdPanel = ({ melding }: MeldingInnholdPanelProps) => {
         )}
         {!melding.innkommende && <VisMelding melding={melding} />}
       </MeldingDetails>
-    </StyledPanel>
+    </Panel>
   );
 };

--- a/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
+import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { MeldingInnholdPanel } from "@/components/behandlerdialog/meldinger/MeldingInnholdPanel";
 import styled from "styled-components";
 import {
   NavLogoRod,
   StetoskopIkonBakgrunn,
 } from "../../../../img/ImageComponents";
+import { Alert } from "@navikt/ds-react";
 
 const StyledWrapper = styled.div`
   margin: 1em 0;
@@ -21,46 +22,65 @@ const StyledImageWrapper = styled.div<{ innkommende?: boolean }>`
   margin: ${(props) => (props.innkommende ? "0 1em 0 0" : "0 0 0 1em")};
 `;
 
-const StyledMeldingInnhold = styled.div<{ innkommende?: boolean }>`
+const StyledMelding = styled.div<{ innkommende?: boolean }>`
   display: flex;
   flex-direction: row;
   justify-content: ${(props) => (props.innkommende ? "start" : "end")};
 `;
 
+const StyledInnhold = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 80%;
+
+  > * {
+    &:not(:last-child) {
+      margin-bottom: 1em;
+    }
+  }
+`;
+
 interface MeldingInnholdProps {
-  melding: Melding;
+  melding: MeldingDTO;
 }
 
 const MeldingFraBehandler = ({ melding }: MeldingInnholdProps) => {
   return (
-    <StyledMeldingInnhold innkommende>
+    <StyledMelding innkommende>
       <StyledImageWrapper innkommende>
         <img src={StetoskopIkonBakgrunn} alt="Stetoskopikon for behandler" />
       </StyledImageWrapper>
-      <MeldingInnholdPanel melding={melding} />
-    </StyledMeldingInnhold>
+      <StyledInnhold>
+        <MeldingInnholdPanel melding={melding} />
+      </StyledInnhold>
+    </StyledMelding>
   );
 };
 
 const MeldingTilBehandler = ({ melding }: MeldingInnholdProps) => {
   return (
-    <StyledMeldingInnhold>
-      <MeldingInnholdPanel melding={melding} />
+    <StyledMelding>
+      <StyledInnhold>
+        <MeldingInnholdPanel melding={melding} />
+        {melding.status?.tekst && (
+          <Alert variant="error">{melding.status?.tekst}</Alert>
+        )}
+      </StyledInnhold>
       <StyledImageWrapper>
         <img src={NavLogoRod} alt="Rød NAV-logo" />
       </StyledImageWrapper>
-    </StyledMeldingInnhold>
+    </StyledMelding>
   );
 };
 
 interface MeldingerISamtaleProps {
-  meldinger: Melding[];
+  meldinger: MeldingDTO[];
 }
 
 export const MeldingerISamtale = ({ meldinger }: MeldingerISamtaleProps) => {
   return (
     <StyledWrapper>
-      {meldinger.map((melding: Melding, index: number) => {
+      {meldinger.map((melding: MeldingDTO, index: number) => {
         return melding.innkommende ? (
           <MeldingFraBehandler melding={melding} key={index} />
         ) : (

--- a/src/components/behandlerdialog/meldinger/SamtaleAccordion.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleAccordion.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
+import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { tilDatoMedManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { Accordion } from "@navikt/ds-react";
 import { MeldingerISamtale } from "@/components/behandlerdialog/meldinger/MeldingerISamtale";
@@ -14,7 +14,7 @@ const StyledImage = styled.img`
 `;
 
 interface SamtalerAccordionListProps {
-  meldinger: Melding[];
+  meldinger: MeldingDTO[];
 }
 
 export const SamtaleAccordion = ({ meldinger }: SamtalerAccordionListProps) => {

--- a/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
@@ -1,7 +1,10 @@
 import { Tag } from "@navikt/ds-react";
 import React from "react";
 import styled from "styled-components";
-import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
+import {
+  MeldingDTO,
+  MeldingStatusType,
+} from "@/data/behandlerdialog/behandlerdialogTypes";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { getAllUbehandledePersonOppgaver } from "@/utils/personOppgaveUtils";
 import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
@@ -9,6 +12,7 @@ import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
 const texts = {
   ny: "Ny",
   manglerSvar: "Venter på svar fra behandler",
+  avvist: "Melding ikke levert",
 };
 
 const StyledWrapper = styled.div`
@@ -16,7 +20,7 @@ const StyledWrapper = styled.div`
 `;
 
 interface SamtaleTagsProps {
-  meldinger: Melding[];
+  meldinger: MeldingDTO[];
 }
 
 export const SamtaleTags = ({ meldinger }: SamtaleTagsProps) => {
@@ -34,18 +38,29 @@ export const SamtaleTags = ({ meldinger }: SamtaleTagsProps) => {
   const manglerSvarFraBehandler = !meldinger.some(
     (melding) => melding.innkommende
   );
+  const harAvvistMelding = meldinger.some(
+    (melding) => melding.status?.type === MeldingStatusType.AVVIST
+  );
 
   return (
     <StyledWrapper>
-      {hasMeldingMedUbehandletOppgave && (
-        <Tag size="small" variant="info">
-          {texts.ny}
+      {harAvvistMelding ? (
+        <Tag size="small" variant="error">
+          {texts.avvist}
         </Tag>
-      )}
-      {manglerSvarFraBehandler && (
-        <Tag size="small" variant="warning">
-          {texts.manglerSvar}
-        </Tag>
+      ) : (
+        <>
+          {hasMeldingMedUbehandletOppgave && (
+            <Tag size="small" variant="info">
+              {texts.ny}
+            </Tag>
+          )}
+          {manglerSvarFraBehandler && (
+            <Tag size="small" variant="warning">
+              {texts.manglerSvar}
+            </Tag>
+          )}
+        </>
       )}
     </StyledWrapper>
   );

--- a/src/components/behandlerdialog/meldinger/Samtaler.tsx
+++ b/src/components/behandlerdialog/meldinger/Samtaler.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { useBehandlerdialogQuery } from "@/data/behandlerdialog/behandlerdialogQueryHooks";
 import {
   Conversations,
-  Melding,
+  MeldingDTO,
 } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { GuidePanel } from "@navikt/ds-react";
 import styled from "styled-components";
@@ -27,8 +27,8 @@ const StyledGuidePanel = styled(GuidePanel)`
 `;
 
 const sortMeldingerByTidspunkt = (
-  m1: Melding,
-  m2: Melding,
+  m1: MeldingDTO,
+  m2: MeldingDTO,
   order: "asc" | "desc" = "asc"
 ) => {
   return order === "desc"
@@ -38,13 +38,13 @@ const sortMeldingerByTidspunkt = (
 
 export const sortConversations = (
   conversations: Conversations
-): Melding[][] => {
+): MeldingDTO[][] => {
   const conversationRefs: string[] = Object.keys(conversations);
   conversationRefs.sort((a, b) => {
-    const aNewestMelding: Melding = conversations[a]
+    const aNewestMelding: MeldingDTO = conversations[a]
       .sort((m1, m2) => sortMeldingerByTidspunkt(m1, m2))
       .slice(-1)[0];
-    const bNewestMelding: Melding = conversations[b]
+    const bNewestMelding: MeldingDTO = conversations[b]
       .sort((m1, m2) => sortMeldingerByTidspunkt(m1, m2))
       .slice(-1)[0];
     return sortMeldingerByTidspunkt(aNewestMelding, bNewestMelding, "desc");
@@ -56,7 +56,7 @@ export const sortConversations = (
 export const Samtaler = () => {
   const { data, isInitialLoading } = useBehandlerdialogQuery();
 
-  const sortedConversations: Melding[][] = useMemo(() => {
+  const sortedConversations: MeldingDTO[][] = useMemo(() => {
     return data ? sortConversations(data.conversations) : [];
   }, [data]);
 
@@ -66,7 +66,7 @@ export const Samtaler = () => {
         <AppSpinner />
       ) : sortedConversations.length ? (
         <>
-          {sortedConversations.map((meldinger: Melding[], index: number) => (
+          {sortedConversations.map((meldinger: MeldingDTO[], index: number) => (
             <SamtaleAccordion meldinger={meldinger} key={index} />
           ))}
         </>

--- a/src/components/behandlerdialog/meldinger/VisMelding.tsx
+++ b/src/components/behandlerdialog/meldinger/VisMelding.tsx
@@ -2,7 +2,7 @@ import { Button } from "@navikt/ds-react";
 import { EyeWithPupilIcon } from "@navikt/aksel-icons";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
 import React, { useState } from "react";
-import { Melding } from "@/data/behandlerdialog/behandlerdialogTypes";
+import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 import styled from "styled-components";
 
 const texts = {
@@ -11,7 +11,7 @@ const texts = {
 };
 
 interface VisMeldingProps {
-  melding: Melding;
+  melding: MeldingDTO;
 }
 
 const VisMeldingButton = styled(Button)`

--- a/src/data/behandlerdialog/behandlerdialogTypes.ts
+++ b/src/data/behandlerdialog/behandlerdialogTypes.ts
@@ -13,10 +13,10 @@ export interface MeldingResponseDTO {
 }
 
 export interface Conversations {
-  [key: string]: Melding[];
+  [key: string]: MeldingDTO[];
 }
 
-export interface Melding {
+export interface MeldingDTO {
   uuid: string;
   behandlerRef: string;
   behandlerNavn: string | null;
@@ -25,4 +25,17 @@ export interface Melding {
   innkommende: boolean;
   document: DocumentComponentDto[];
   antallVedlegg: number;
+  status?: MeldingStatusDTO;
+}
+
+interface MeldingStatusDTO {
+  type: MeldingStatusType;
+  tekst: string | null;
+}
+
+export enum MeldingStatusType {
+  BESTILT = "BESTILT",
+  SENDT = "SENDT",
+  OK = "OK",
+  AVVIST = "AVVIST",
 }


### PR DESCRIPTION
Ikke nødvendigvis realistisk mock (siden man har svart på en meldingFraBehandler), men legger til tag dersom man har status `AVVIST`. Dersom man har fått `statusTekst` skal man også vise en alert under meldingen.

Har ikke utvidet endepunktet (og responsen) i backend enda, Anders jobber med det 👍🏼 

<img width="893" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/112657f1-b228-41f9-aee7-21c5802dae98">
