### PR TITLE
Only show behandle oppgave-checbox if behandlerdialog-svar-oppgaver

### DIFF
--- a/mock/ispersonoppgave/personoppgaveMock.ts
+++ b/mock/ispersonoppgave/personoppgaveMock.ts
@@ -67,7 +67,7 @@ const personOppgaveBehandletOppfolgingsplanLPS = {
   opprettet: new Date(dayjs().subtract(10, "days").toJSON()).toDateString(),
 };
 
-const personOppgaveBehandletDialogmotesvar = {
+export const personOppgaveBehandletDialogmotesvar = {
   ...personOppgaveUbehandletDialogmotesvar,
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd3",
   referanseUuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd7",

--- a/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -38,6 +38,10 @@ const getSisteBehandledeBehandlerdialogSvarOppgave = (
 
 const BehandleBehandlerdialogSvarOppgaveKnapp = () => {
   const { data: personOppgaver } = usePersonoppgaverQuery();
+  // TODO: Sjekke på BEHANDLERDIALOG_MELDING_UBESVART her også?
+  const hasBehandlerDialogSvarOppgaver = personOppgaver.some(
+    (p) => p.type === PersonOppgaveType.BEHANDLERDIALOG_SVAR
+  );
   const fnr = useValgtPersonident();
   const behandleAllPersonoppgaver = useBehandleAllPersonoppgaver();
   const isBehandlet = !hasUbehandletPersonoppgave(
@@ -53,7 +57,7 @@ const BehandleBehandlerdialogSvarOppgaveKnapp = () => {
 
   return (
     <FlexRow>
-      {personOppgaver.length > 0 && (
+      {hasBehandlerDialogSvarOppgaver && (
         <BehandlePersonOppgaveKnapp
           personOppgave={sisteBehandledeOppgave}
           isBehandlet={isBehandlet}

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -17,6 +17,7 @@ import userEvent from "@testing-library/user-event";
 import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
 import {
   personOppgaveBehandletBehandlerdialogSvar,
+  personOppgaveBehandletDialogmotesvar,
   personOppgaveUbehandletBehandlerdialogSvar,
 } from "../../mock/ispersonoppgave/personoppgaveMock";
 import dayjs from "dayjs";
@@ -368,6 +369,23 @@ describe("Meldinger panel", () => {
     });
 
     it("Viser ingen oppgave når ingen behandlerdialog-oppgaver", () => {
+      queryClient.setQueryData(
+        personoppgaverQueryKeys.personoppgaver(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => [{ ...personOppgaveBehandletDialogmotesvar }]
+      );
+
+      renderMeldinger();
+
+      expect(screen.queryByText("Ferdigbehandlet", { exact: false })).to.not
+        .exist;
+      expect(
+        screen.queryByText("Marker nye meldinger som lest", { exact: false })
+      ).to.not.exist;
+    });
+
+    it("Viser ingen oppgave når ingen oppgaver", () => {
       queryClient.setQueryData(
         personoppgaverQueryKeys.personoppgaver(
           ARBEIDSTAKER_DEFAULT.personIdent


### PR DESCRIPTION
Fikser bug https://trello.com/c/D0mwLEEn/1484-behandlerdialog-feil-tekst-marker-nye-meldinger-som-lest-osv-ved-inaktiv-checkbox hvor det ble vist disabled checkbox med tekst for å markere oppgaven som behandlet.