### PR TITLE
Show veiledernavn for utgående melding

### DIFF
--- a/mock/common/mockConstants.ts
+++ b/mock/common/mockConstants.ts
@@ -44,6 +44,8 @@ export const VEILEDER_IDENT_DEFAULT = "Z990000";
 export const VEILEDER_DEFAULT = {
   ident: VEILEDER_IDENT_DEFAULT,
   navn: "Vetle Veileder",
+  fornavn: "Vetle",
+  etternavn: "Veileder",
   epost: "vetle.veileder@nav.no",
   telefonnummer: "12345678",
 };

--- a/mock/isbehandlerdialog/behandlerdialogMock.ts
+++ b/mock/isbehandlerdialog/behandlerdialogMock.ts
@@ -9,6 +9,7 @@ import {
   ARBEIDSTAKER_DEFAULT,
   ARBEIDSTAKER_DEFAULT_FULL_NAME,
   VEILEDER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
 } from "../common/mockConstants";
 import {
   paminnelseTexts,
@@ -107,6 +108,7 @@ export const defaultMelding = {
   document: meldingtilBehandlerDocument,
   antallVedlegg: 0,
   status: defaultStatus,
+  veilederIdent: VEILEDER_IDENT_DEFAULT,
 };
 
 export const paminnelseMelding = {
@@ -138,6 +140,7 @@ const meldinger = [
     tidspunkt: "2023-01-02T12:00:00.000+01:00",
     antallVedlegg: 5,
     document: [],
+    veilederIdent: null,
   },
   {
     ...defaultMelding,
@@ -147,6 +150,7 @@ const meldinger = [
     tidspunkt: "2023-01-03T12:00:00.000+01:00",
     antallVedlegg: 1,
     document: [],
+    veilederIdent: null,
   },
   {
     ...defaultMelding,

--- a/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
@@ -12,6 +12,7 @@ import PdfVedleggLink from "@/components/behandlerdialog/meldinger/PdfVedleggLin
 import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
 import { PaminnelseWarningIcon } from "@/components/behandlerdialog/paminnelse/PaminnelseWarningIcon";
 import { getHeaderText } from "@/utils/documentComponentUtils";
+import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 
 const MeldingTekstWrapper = styled(BodyLong)`
   white-space: pre-wrap;
@@ -21,6 +22,7 @@ const MeldingDetails = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: start;
+  align-items: center;
 
   > * {
     &:not(:last-child) {
@@ -77,12 +79,26 @@ const MeldingTekst = ({ melding }: MeldingTekstProps): ReactElement => {
   }
 };
 
+interface AvsenderInfoProps {
+  melding: MeldingDTO;
+}
+
+const AvsenderInfo = ({ melding }: AvsenderInfoProps) => {
+  const { data: veilederInfo } = useVeilederInfoQuery(
+    melding.veilederIdent ?? ""
+  );
+  const avsender = melding.innkommende
+    ? melding.behandlerNavn
+    : veilederInfo?.navn;
+
+  return <>{avsender && <Detail>{`Skrevet av ${avsender}`}</Detail>}</>;
+};
+
 interface MeldingInnholdPanelProps {
   melding: MeldingDTO;
 }
 
 export const MeldingInnholdPanel = ({ melding }: MeldingInnholdPanelProps) => {
-  const behandlerNavn = melding.behandlerNavn;
   return (
     <Panel border>
       <MeldingTekstContainer>
@@ -104,9 +120,7 @@ export const MeldingInnholdPanel = ({ melding }: MeldingInnholdPanelProps) => {
         <MeldingTidspunkt>
           {tilDatoMedManedNavnOgKlokkeslett(melding.tidspunkt)}
         </MeldingTidspunkt>
-        {melding.innkommende && behandlerNavn && (
-          <Detail>{`Skrevet av ${behandlerNavn}`}</Detail>
-        )}
+        <AvsenderInfo melding={melding} />
         {!melding.innkommende && <VisMelding melding={melding} />}
       </MeldingDetails>
     </Panel>

--- a/src/data/behandlerdialog/behandlerdialogTypes.ts
+++ b/src/data/behandlerdialog/behandlerdialogTypes.ts
@@ -31,6 +31,7 @@ export interface MeldingDTO {
   document: DocumentComponentDto[];
   antallVedlegg: number;
   status?: MeldingStatusDTO;
+  veilederIdent: string | null;
 }
 
 interface MeldingStatusDTO {

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -96,7 +96,7 @@ describe("Meldinger panel", () => {
     });
   });
 
-  describe("Visning av behandlernavn", () => {
+  describe("Visning av avsender", () => {
     it("Viser riktig behandlerNavn for behandlere", () => {
       renderMeldinger();
 
@@ -119,6 +119,14 @@ describe("Meldinger panel", () => {
       renderMeldinger();
 
       expect(screen.queryByText("Skrevet av", { exact: false })).to.not.exist;
+    });
+
+    it("Skal vise veileders navn på utgåene meldinger", () => {
+      renderMeldinger();
+
+      expect(screen.getAllByText("Skrevet av Vetle Veileder")).to.have.length(
+        7
+      );
     });
   });
 

--- a/test/testQueryClient.ts
+++ b/test/testQueryClient.ts
@@ -62,6 +62,10 @@ export const queryClientWithMockData = (): QueryClient => {
     () => VEILEDER_DEFAULT
   );
   queryClient.setQueryData(
+    veilederinfoQueryKeys.veilederinfoByIdent(VEILEDER_IDENT_DEFAULT),
+    () => VEILEDER_DEFAULT
+  );
+  queryClient.setQueryData(
     behandlendeEnhetQueryKeys.behandlendeEnhet(
       ARBEIDSTAKER_DEFAULT.personIdent
     ),


### PR DESCRIPTION
Viser veiledernavn på samme måte som vi viser behandlernavn.
<img width="1010" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/92357b4e-ce49-4a3f-8592-04b860870885">
