### PR TITLE
Add styling to SamtaleTags

### DIFF
--- a/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
@@ -22,6 +22,7 @@ const texts = {
 };
 
 const StyledWrapper = styled.div`
+  display: flex;
   margin-left: 1em;
 `;
 


### PR DESCRIPTION
Var noe alignment-issues på samtaletagsene (Påminnelse var ikke "midt på" i raden sin):
Før:
<img width="630" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/88d66b80-fe0c-431b-b10e-494b30c4f10d">

Etter:
<img width="641" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/22a72d09-8f45-4f25-ac74-ef6e0ebe56b8">
