### PR TITLE
Add new brevtekster for legeerklaring

### DIFF
--- a/src/data/behandlerdialog/behandlerMeldingTexts.ts
+++ b/src/data/behandlerdialog/behandlerMeldingTexts.ts
@@ -24,3 +24,19 @@ export const paminnelseTexts = {
   text2:
     "Hvis opplysningene er sendt oss i løpet av de siste dagene, kan du se bort fra denne meldingen.",
 };
+
+export const legeerklaringTexts = {
+  header: "Forespørsel om «Legeerklæring ved arbeidsuførhet»",
+  intro:
+    "Som et ledd i NAVs videre oppfølging av pasienten din har vi behov for informasjon fra deg.",
+  opplysninger:
+    "Opplysninger som etter din vurdering faller utenfor formålet, kan du utelate i oversendelsen til NAV.",
+  takst:
+    "«Legeerklæring ved arbeidsuførhet» leveres på blankett NAV 08-07.08, og honoreres med takst L40.",
+  lovhjemmel: {
+    title: "Lovhjemmel",
+    text: "Folketrygdloven § 21-4 andre ledd gir NAV rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd.",
+  },
+  klage:
+    "Pålegget om utlevering av opplysninger kan påklages etter forvaltningsloven § 14. Klageadgangen gjelder kun lovligheten av pålegget. Fristen for å klage er tre dager etter at pålegget er mottatt. Klagen kan fremsettes muntlig eller skriftlig.",
+};

--- a/src/hooks/behandlerdialog/document/useMeldingTilBehandlerDocument.ts
+++ b/src/hooks/behandlerdialog/document/useMeldingTilBehandlerDocument.ts
@@ -7,6 +7,7 @@ import {
   createParagraphWithTitle,
 } from "@/utils/documentComponentUtils";
 import {
+  legeerklaringTexts,
   paminnelseTexts,
   tilleggsOpplysningerPasientTexts,
 } from "@/data/behandlerdialog/behandlerMeldingTexts";
@@ -20,6 +21,9 @@ export const useMeldingTilBehandlerDocument = (): {
     values: Partial<MeldingTilBehandlerSkjemaValues>
   ): DocumentComponentDto[];
   getPaminnelseDocument(opprinneligMelding: MeldingDTO): DocumentComponentDto[];
+  getLegeerklaringDocument(
+    values: Partial<MeldingTilBehandlerSkjemaValues>
+  ): DocumentComponentDto[];
 } => {
   const navBruker = useNavBrukerData();
   const personident = useValgtPersonident();
@@ -69,8 +73,36 @@ export const useMeldingTilBehandlerDocument = (): {
     ];
   };
 
+  const getLegeerklaringDocument = (
+    values: Partial<MeldingTilBehandlerSkjemaValues>
+  ) => {
+    const documentComponents = [
+      createHeaderH1(legeerklaringTexts.header),
+      createParagraph(`Gjelder pasient: ${navBruker.navn}, ${personident}.`),
+      createParagraph(legeerklaringTexts.intro),
+    ];
+
+    if (values.meldingTekst) {
+      documentComponents.push(createParagraph(values.meldingTekst));
+    }
+
+    documentComponents.push(
+      createParagraph(legeerklaringTexts.opplysninger),
+      createParagraph(legeerklaringTexts.takst),
+      createParagraphWithTitle(
+        legeerklaringTexts.lovhjemmel.title,
+        legeerklaringTexts.lovhjemmel.text
+      ),
+      createParagraph(legeerklaringTexts.klage),
+      getHilsen()
+    );
+
+    return documentComponents;
+  };
+
   return {
     getTilleggsOpplysningerPasientDocument,
     getPaminnelseDocument,
+    getLegeerklaringDocument,
   };
 };

--- a/test/behandlerdialog/MeldingTilBehandlerTest.tsx
+++ b/test/behandlerdialog/MeldingTilBehandlerTest.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { behandlereDialogmeldingMock } from "../../mock/isdialogmelding/behandlereDialogmeldingMock";
 import userEvent from "@testing-library/user-event";
-import { expectedMeldingTilBehandlerDocument } from "./testDataDocuments";
+import { expectedTilleggsopplysningerDocument } from "./testDataDocuments";
 
 let queryClient: QueryClient;
 
@@ -83,7 +83,7 @@ describe("MeldingTilBehandler", () => {
       });
       expect(previewModal).to.exist;
 
-      const expectedTexts = expectedMeldingTilBehandlerDocument(
+      const expectedTexts = expectedTilleggsopplysningerDocument(
         enMeldingTekst
       ).flatMap((documentComponent) => documentComponent.texts);
       expectedTexts.forEach((text) => {
@@ -120,7 +120,7 @@ describe("MeldingTilBehandler", () => {
       behandlerNavn: `${behandlereDialogmeldingMock[0].fornavn} ${behandlereDialogmeldingMock[0].mellomnavn} ${behandlereDialogmeldingMock[0].etternavn}`,
       behandlerRef: behandlereDialogmeldingMock[0].behandlerRef,
       tekst: enMeldingTekst,
-      document: expectedMeldingTilBehandlerDocument(enMeldingTekst),
+      document: expectedTilleggsopplysningerDocument(enMeldingTekst),
     };
 
     it("Send melding med verdier fra skjema", () => {

--- a/test/behandlerdialog/testDataDocuments.ts
+++ b/test/behandlerdialog/testDataDocuments.ts
@@ -10,7 +10,7 @@ import {
 import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 
-export const expectedMeldingTilBehandlerDocument = (
+export const expectedTilleggsopplysningerDocument = (
   meldingTekst: string
 ): DocumentComponentDto[] => [
   {
@@ -87,6 +87,60 @@ export const expectedPaminnelseDocument = (
   {
     texts: [
       "Hvis opplysningene er sendt oss i løpet av de siste dagene, kan du se bort fra denne meldingen.",
+    ],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+];
+
+export const expectedLegeerklaringDocument = (
+  meldingTekst: string
+): DocumentComponentDto[] => [
+  {
+    texts: ["Forespørsel om «Legeerklæring ved arbeidsuførhet»"],
+    type: DocumentComponentType.HEADER_H1,
+  },
+  {
+    texts: [
+      `Gjelder pasient: ${ARBEIDSTAKER_DEFAULT_FULL_NAME}, ${ARBEIDSTAKER_DEFAULT.personIdent}.`,
+    ],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    texts: [
+      "Som et ledd i NAVs videre oppfølging av pasienten din har vi behov for informasjon fra deg.",
+    ],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    texts: [meldingTekst],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    texts: [
+      "Opplysninger som etter din vurdering faller utenfor formålet, kan du utelate i oversendelsen til NAV.",
+    ],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    texts: [
+      "«Legeerklæring ved arbeidsuførhet» leveres på blankett NAV 08-07.08, og honoreres med takst L40.",
+    ],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    title: "Lovhjemmel",
+    texts: [
+      "Folketrygdloven § 21-4 andre ledd gir NAV rett til å innhente nødvendige opplysninger. Dette gjelder selv om opplysningene er taushetsbelagte, jf. § 21-4 sjette ledd.",
+    ],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
+    texts: [
+      "Pålegget om utlevering av opplysninger kan påklages etter forvaltningsloven § 14. Klageadgangen gjelder kun lovligheten i pålegget. Fristen for å klage er tre dager etter at pålegget er mottatt. Klagen kan fremsettes muntlig eller skriftlig.",
     ],
     type: DocumentComponentType.PARAGRAPH,
   },


### PR DESCRIPTION
Tas ikke i bruk enda, vi må få på plass mulighet til å velge meldingstype først og kunne sende inn en legeerklaring. Tester det når sånt er på plass 👍🏼