### PR TITLE
Added tags for talesprak and tegnsprak

### DIFF
--- a/mock/syfoperson/brukerinfoMock.ts
+++ b/mock/syfoperson/brukerinfoMock.ts
@@ -13,8 +13,5 @@ export const brukerinfoMock = {
   },
   arbeidssituasjon: "ARBEIDSTAKER",
   dodsdato: null,
-  tilrettelagtKommunikasjon: {
-    talesprakTolk: { value: "NO" },
-    tegnsprakTolk: null,
-  },
+  tilrettelagtKommunikasjon: null,
 };

--- a/mock/syfoperson/brukerinfoMock.ts
+++ b/mock/syfoperson/brukerinfoMock.ts
@@ -13,4 +13,8 @@ export const brukerinfoMock = {
   },
   arbeidssituasjon: "ARBEIDSTAKER",
   dodsdato: null,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: { value: "NO" },
+    tegnsprakTolk: null,
+  },
 };

--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -14,6 +14,8 @@ const texts = {
   kode6: "Kode 6",
   kode7: "Kode 7",
   egenansatt: "Egenansatt",
+  talesprakTolk: "Behov for talespråktolk",
+  tegnsprakTolk: "Behov for tegnspråktolk",
 };
 
 export const PersonkortHeaderTags = () => {
@@ -25,6 +27,10 @@ export const PersonkortHeaderTags = () => {
   const dateOfDeath = tilLesbarDatoMedArUtenManedNavn(navbruker.dodsdato);
   const isKode6 = diskresjonskode === "6";
   const isKode7 = diskresjonskode === "7";
+  const isTalesprakTolkBehov =
+    !!navbruker.tilrettelagtKommunikasjon.talesprakTolk?.value;
+  const isTegnsprakTolkBehov =
+    !!navbruker.tilrettelagtKommunikasjon.tegnsprakTolk?.value;
   const visEtiketter = isKode6 || isKode7 || isEgenAnsatt || isDead;
 
   return (
@@ -50,6 +56,16 @@ export const PersonkortHeaderTags = () => {
             {isEgenAnsatt && (
               <Tag variant="warning" size="small">
                 {texts.egenansatt}
+              </Tag>
+            )}
+            {isTalesprakTolkBehov && (
+              <Tag variant="warning" size="small">
+                {texts.talesprakTolk}
+              </Tag>
+            )}
+            {isTegnsprakTolkBehov && (
+              <Tag variant="warning" size="small">
+                {texts.tegnsprakTolk}
               </Tag>
             )}
             {isDead && (

--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -27,17 +27,17 @@ export const PersonkortHeaderTags = () => {
   const dateOfDeath = tilLesbarDatoMedArUtenManedNavn(navbruker.dodsdato);
   const isKode6 = diskresjonskode === "6";
   const isKode7 = diskresjonskode === "7";
-  const isTalesprakTolkBehov =
+  const hasTalesprakTolkBehov =
     !!navbruker.tilrettelagtKommunikasjon?.talesprakTolk?.value;
-  const isTegnsprakTolkBehov =
+  const hasTegnsprakTolkBehov =
     !!navbruker.tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
   const visEtiketter =
     isKode6 ||
     isKode7 ||
     isEgenAnsatt ||
     isDead ||
-    isTalesprakTolkBehov ||
-    isTegnsprakTolkBehov;
+    hasTalesprakTolkBehov ||
+    hasTegnsprakTolkBehov;
 
   return (
     <>
@@ -64,12 +64,12 @@ export const PersonkortHeaderTags = () => {
                 {texts.egenansatt}
               </Tag>
             )}
-            {isTalesprakTolkBehov && (
+            {hasTalesprakTolkBehov && (
               <Tag variant="warning" size="small">
                 {texts.talesprakTolk}
               </Tag>
             )}
-            {isTegnsprakTolkBehov && (
+            {hasTegnsprakTolkBehov && (
               <Tag variant="warning" size="small">
                 {texts.tegnsprakTolk}
               </Tag>

--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -27,17 +27,17 @@ export const PersonkortHeaderTags = () => {
   const dateOfDeath = tilLesbarDatoMedArUtenManedNavn(navbruker.dodsdato);
   const isKode6 = diskresjonskode === "6";
   const isKode7 = diskresjonskode === "7";
-  const hasTalesprakTolkBehov =
-    !!navbruker.tilrettelagtKommunikasjon?.talesprakTolk?.value;
-  const hasTegnsprakTolkBehov =
-    !!navbruker.tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
+  const talesprakTolkSprakkode =
+    navbruker.tilrettelagtKommunikasjon?.talesprakTolk?.value;
+  const tegnsprakTolkSprakkode =
+    navbruker.tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
   const visEtiketter =
     isKode6 ||
     isKode7 ||
     isEgenAnsatt ||
     isDead ||
-    hasTalesprakTolkBehov ||
-    hasTegnsprakTolkBehov;
+    !!talesprakTolkSprakkode ||
+    !!tegnsprakTolkSprakkode;
 
   return (
     <>
@@ -64,14 +64,14 @@ export const PersonkortHeaderTags = () => {
                 {texts.egenansatt}
               </Tag>
             )}
-            {hasTalesprakTolkBehov && (
+            {talesprakTolkSprakkode && (
               <Tag variant="warning" size="small">
-                {texts.talesprakTolk}
+                {texts.talesprakTolk}: {talesprakTolkSprakkode}
               </Tag>
             )}
-            {hasTegnsprakTolkBehov && (
+            {tegnsprakTolkSprakkode && (
               <Tag variant="warning" size="small">
-                {texts.tegnsprakTolk}
+                {texts.tegnsprakTolk}: {tegnsprakTolkSprakkode}
               </Tag>
             )}
             {isDead && (

--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -14,8 +14,8 @@ const texts = {
   kode6: "Kode 6",
   kode7: "Kode 7",
   egenansatt: "Egenansatt",
-  talesprakTolk: "Behov for talespråktolk",
-  tegnsprakTolk: "Behov for tegnspråktolk",
+  talesprakTolk: "Talespråktolk",
+  tegnsprakTolk: "Tegnspråktolk",
 };
 
 export const PersonkortHeaderTags = () => {

--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -28,10 +28,16 @@ export const PersonkortHeaderTags = () => {
   const isKode6 = diskresjonskode === "6";
   const isKode7 = diskresjonskode === "7";
   const isTalesprakTolkBehov =
-    !!navbruker.tilrettelagtKommunikasjon.talesprakTolk?.value;
+    !!navbruker.tilrettelagtKommunikasjon?.talesprakTolk?.value;
   const isTegnsprakTolkBehov =
-    !!navbruker.tilrettelagtKommunikasjon.tegnsprakTolk?.value;
-  const visEtiketter = isKode6 || isKode7 || isEgenAnsatt || isDead;
+    !!navbruker.tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
+  const visEtiketter =
+    isKode6 ||
+    isKode7 ||
+    isEgenAnsatt ||
+    isDead ||
+    isTalesprakTolkBehov ||
+    isTegnsprakTolkBehov;
 
   return (
     <>

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -26,6 +26,10 @@ export const useBrukerinfoQuery = () => {
     kontaktinfo: undefined,
     arbeidssituasjon: "ARBEIDSTAKER",
     dodsdato: null,
+    tilrettelagtKommunikasjon: {
+      talesprakTolk: null,
+      tegnsprakTolk: null,
+    },
   };
 
   return {

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -9,4 +9,14 @@ export interface BrukerinfoDTO {
   kontaktinfo?: KontaktinfoDTO;
   arbeidssituasjon: string;
   dodsdato: string | null;
+  tilrettelagtKommunikasjon: TilrettelagtKommunikasjon;
+}
+
+interface TilrettelagtKommunikasjon {
+  talesprakTolk: Sprak | null;
+  tegnsprakTolk: Sprak | null;
+}
+
+interface Sprak {
+  value: string | null;
 }

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -9,7 +9,7 @@ export interface BrukerinfoDTO {
   kontaktinfo?: KontaktinfoDTO;
   arbeidssituasjon: string;
   dodsdato: string | null;
-  tilrettelagtKommunikasjon: TilrettelagtKommunikasjon;
+  tilrettelagtKommunikasjon: TilrettelagtKommunikasjon | null;
 }
 
 interface TilrettelagtKommunikasjon {

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -77,6 +77,24 @@ describe("PersonkortHeader", () => {
     expect(screen.queryByText("Kode")).not.to.exist;
   });
 
+  it("viser ikke tegnspråktolk når denne tegnspråktolk er tom fra API", async () => {
+    stubEgenansattApi(apiMockScope, true);
+    stubDiskresjonskodeApi(apiMockScope);
+    renderPersonkortHeader();
+    await screen.findByText("Egenansatt");
+
+    expect(screen.queryByText("Kode")).not.to.exist;
+  });
+
+  it("viser tegnspråktolk når denne tegnspråktolk har verdi fra API", async () => {
+    stubEgenansattApi(apiMockScope, true);
+    stubDiskresjonskodeApi(apiMockScope);
+    renderPersonkortHeader();
+    await screen.findByText("Egenansatt");
+
+    expect(screen.queryByText("Kode")).not.to.exist;
+  });
+
   it("viser dødsdato når dato finnes i brukerinfo", async () => {
     stubPersoninfoApi(apiMockScope, "2023-02-01");
     renderPersonkortHeader();

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -6,7 +6,7 @@ import {
 import { apiMock } from "../../stubs/stubApi";
 import { QueryClientProvider } from "@tanstack/react-query";
 import nock from "nock";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import React from "react";
 import PersonkortHeader from "@/components/personkort/PersonkortHeader/PersonkortHeader";
 import { expect } from "chai";
@@ -75,11 +75,11 @@ describe("PersonkortHeader", () => {
       talesprakTolk: null,
       tegnsprakTolk: null,
     };
-    stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
+    await stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
     renderPersonkortHeader();
 
-    expect(screen.queryByText("Talespråktolk")).not.to.exist;
-    expect(screen.queryByText("Tegnspråktolk")).not.to.exist;
+    expect(screen.queryByText("Talespråktolk")).to.not.exist;
+    expect(screen.queryByText("Tegnspråktolk")).to.not.exist;
   });
 
   it("viser talespråktolk, men ikke tegnspråktolk", async () => {
@@ -89,10 +89,10 @@ describe("PersonkortHeader", () => {
       },
       tegnsprakTolk: null,
     };
-    stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
+    await stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
     renderPersonkortHeader();
 
-    await waitFor(() => expect(screen.queryByText("Talespråktolk")).to.exist);
+    expect(await screen.findByText("Talespråktolk")).to.exist;
     expect(screen.queryByText("Tegnspråktolk")).to.not.exist;
   });
 
@@ -108,8 +108,8 @@ describe("PersonkortHeader", () => {
     stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
     renderPersonkortHeader();
 
-    await waitFor(() => expect(screen.queryByText("Talespråktolk")).to.exist);
-    await waitFor(() => expect(screen.queryByText("Tegnspråktolk")).to.exist);
+    expect(await screen.findByText("Talespråktolk")).to.exist;
+    expect(await screen.findByText("Tegnspråktolk")).to.exist;
   });
 
   it("viser dødsdato når dato finnes i brukerinfo", async () => {

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -92,7 +92,7 @@ describe("PersonkortHeader", () => {
     await stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
     renderPersonkortHeader();
 
-    expect(await screen.findByText("Talespråktolk")).to.exist;
+    expect(await screen.findByText("Talespråktolk: NO")).to.exist;
     expect(screen.queryByText("Tegnspråktolk")).to.not.exist;
   });
 
@@ -108,8 +108,8 @@ describe("PersonkortHeader", () => {
     stubPersoninfoApi(apiMockScope, "", tilrettelagtKommunikasjon);
     renderPersonkortHeader();
 
-    expect(await screen.findByText("Talespråktolk")).to.exist;
-    expect(await screen.findByText("Tegnspråktolk")).to.exist;
+    expect(await screen.findByText("Talespråktolk: NO")).to.exist;
+    expect(await screen.findByText("Tegnspråktolk: EN")).to.exist;
   });
 
   it("viser dødsdato når dato finnes i brukerinfo", async () => {

--- a/test/stubs/stubSyfoperson.ts
+++ b/test/stubs/stubSyfoperson.ts
@@ -21,10 +21,20 @@ export const stubPersonadresseApi = (scope: nock.Scope) =>
     .get(`${SYFOPERSON_ROOT}/person/adresse`)
     .reply(200, () => personAdresseMock);
 
-export const stubPersoninfoApi = (scope: nock.Scope, dodsdato?: string) => {
+interface TilrettelagtKommunikasjon {
+  talesprakTolk: { value: string | null } | null;
+  tegnsprakTolk: { value: string | null } | null;
+}
+
+export const stubPersoninfoApi = (
+  scope: nock.Scope,
+  dodsdato?: string,
+  tilrettelagtKommunikasjon?: TilrettelagtKommunikasjon
+) => {
   const brukerinfo = {
     ...brukerinfoMock,
     dodsdato: dodsdato || null,
+    tilrettelagtKommunikasjon: tilrettelagtKommunikasjon || null,
   };
   scope
     .get(`${SYFOPERSON_ROOT}/person/brukerinfo`)


### PR DESCRIPTION
Legger til tags for tilrettelagt kommunikasjon på `PersonKort`. For en person kan det enten være behov for tilrettelagt kommunikasjon i form av talespråk eller tegnspråk.

Avklaringer:
- [ ] Høre med PDL om man som person skal kunne ha behov for begge tilretteleggelagte kommunikasjonsformer

Relatert til [PR i syfoperson](https://github.com/navikt/syfoperson/pull/144)