### PR TITLE
Change behandlerdialog-svar tag to "Nytt svar"

### DIFF
--- a/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -16,7 +16,7 @@ import { FlexRow } from "@/components/Layout";
 
 const texts = {
   fjernOppgave:
-    "Marker nye meldinger som lest. Oppgaven vil da fjernes fra oversikten.",
+    "Marker nye svar som lest. Oppgaven vil da fjernes fra oversikten.",
 };
 
 const sortDateByTidspunkt = (d1: Date | null, d2: Date | null) => {

--- a/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
@@ -15,7 +15,7 @@ import {
 import { PaminnelseWarningIcon } from "@/components/behandlerdialog/paminnelse/PaminnelseWarningIcon";
 
 const texts = {
-  ny: "Ny",
+  nyttSvar: "Nytt svar",
   venterSvar: "Venter på svar",
   avvist: "Melding ikke levert",
   paminnelseSendt: "Påminnelse sendt",
@@ -40,7 +40,7 @@ const SamtaleTag = (props: ComponentProps<typeof Tag>) => (
 );
 
 type SamtaleTagStatus =
-  | "NY"
+  | "NYTT_SVAR"
   | "AVVIST"
   | "PAMINNELSE_SENDT"
   | "VURDER_PAMINNELSE"
@@ -91,7 +91,7 @@ const getSamtaleTagStatus = (
   if (harAvvistMelding) {
     return "AVVIST";
   } else if (harMeldingMedUbehandletSvarOppgave) {
-    return "NY";
+    return "NYTT_SVAR";
   } else if (harMeldingMedUbehandletPaminnelseOppgave) {
     return "VURDER_PAMINNELSE";
   } else if (manglerSvarFraBehandler && harPaminnelseMelding) {
@@ -108,8 +108,8 @@ export const SamtaleTags = ({ meldinger }: SamtaleTagsProps) => {
   const samtaleTagStatus = getSamtaleTagStatus(meldinger, oppgaver);
 
   switch (samtaleTagStatus) {
-    case "NY": {
-      return <SamtaleTag variant="info">{texts.ny}</SamtaleTag>;
+    case "NYTT_SVAR": {
+      return <SamtaleTag variant="info">{texts.nyttSvar}</SamtaleTag>;
     }
     case "AVVIST": {
       return <SamtaleTag variant="error">{texts.avvist}</SamtaleTag>;

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -1,5 +1,8 @@
 import React from "react";
-import { PersonOppgave } from "@/data/personoppgave/types/PersonOppgave";
+import {
+  PersonOppgave,
+  PersonOppgaveType,
+} from "@/data/personoppgave/types/PersonOppgave";
 import { toDatePrettyPrint } from "@/utils/datoUtils";
 import { Checkbox, Panel } from "@navikt/ds-react";
 import styled from "styled-components";
@@ -9,10 +12,23 @@ const CheckboxPanel = styled(Panel)`
   border: 1px solid ${navFarger.navGra20};
 `;
 
-const ferdigbehandletText = (personOppgave: PersonOppgave) =>
-  `Ferdigbehandlet av ${
+const getFerdigbehandletPrefixText = (personoppgaveType: PersonOppgaveType) => {
+  switch (personoppgaveType) {
+    case PersonOppgaveType.BEHANDLERDIALOG_SVAR:
+      return "Siste svar lest av";
+    default:
+      return "Ferdigbehandlet av";
+  }
+};
+
+const getFerdigbehandletText = (personOppgave: PersonOppgave) => {
+  const ferdigbehandletPrefixText = getFerdigbehandletPrefixText(
+    personOppgave.type
+  );
+  return `${ferdigbehandletPrefixText} ${
     personOppgave.behandletVeilederIdent
   } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`;
+};
 
 interface BehandlePersonoppgaveKnappProps {
   personOppgave: PersonOppgave | undefined;
@@ -31,7 +47,7 @@ const BehandlePersonOppgaveKnapp = ({
 }: BehandlePersonoppgaveKnappProps) => {
   const oppgaveKnappText =
     isBehandlet && personOppgave
-      ? ferdigbehandletText(personOppgave)
+      ? getFerdigbehandletText(personOppgave)
       : behandleOppgaveText;
 
   return (

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -243,6 +243,8 @@ describe("Meldinger panel", () => {
   });
 
   describe("Behandling av personoppgave", () => {
+    const ubehandletCheckboxTekst =
+      "Marker nye svar som lest. Oppgaven vil da fjernes fra oversikten.";
     it("Viser ubehandlet personoppgave for behandlerdialog svar", () => {
       queryClient.setQueryData(
         personoppgaverQueryKeys.personoppgaver(
@@ -257,9 +259,8 @@ describe("Meldinger panel", () => {
       );
 
       renderMeldinger();
-      const checkboxTekst =
-        "Marker nye meldinger som lest. Oppgaven vil da fjernes fra oversikten.";
-      expect(screen.getByText(checkboxTekst)).to.exist;
+
+      expect(screen.getByText(ubehandletCheckboxTekst)).to.exist;
     });
 
     it("Viser behandlet personoppgave for behandlerdialog svar", () => {
@@ -275,7 +276,7 @@ describe("Meldinger panel", () => {
       );
       renderMeldinger();
 
-      expect(screen.getByText("Ferdigbehandlet", { exact: false })).to.exist;
+      expect(screen.getByText("Siste svar lest av", { exact: false })).to.exist;
     });
 
     it("Viser siste ferdigbehandlede personoppgave for behandlerdialog svar når alle oppgaver behandlet", () => {
@@ -298,7 +299,7 @@ describe("Meldinger panel", () => {
       );
       renderMeldinger();
 
-      const expectedFerdigbehandledText = `Ferdigbehandlet av Z991100 ${twoDaysAgo.format(
+      const expectedFerdigbehandledText = `Siste svar lest av Z991100 ${twoDaysAgo.format(
         "DD.MM.YYYY"
       )}`;
       expect(screen.getByText(expectedFerdigbehandledText)).to.exist;
@@ -314,11 +315,10 @@ describe("Meldinger panel", () => {
 
       renderMeldinger();
 
-      expect(screen.queryByText("Ferdigbehandlet", { exact: false })).to.not
+      expect(screen.queryByText("Siste svar lest av", { exact: false })).to.not
         .exist;
-      expect(
-        screen.queryByText("Marker nye meldinger som lest", { exact: false })
-      ).to.not.exist;
+      expect(screen.queryByText(ubehandletCheckboxTekst, { exact: false })).to
+        .not.exist;
     });
 
     it("Viser ingen oppgave når ingen oppgaver", () => {
@@ -331,11 +331,10 @@ describe("Meldinger panel", () => {
 
       renderMeldinger();
 
-      expect(screen.queryByText("Ferdigbehandlet", { exact: false })).to.not
+      expect(screen.queryByText("Siste svar lest av", { exact: false })).to.not
         .exist;
-      expect(
-        screen.queryByText("Marker nye meldinger som lest", { exact: false })
-      ).to.not.exist;
+      expect(screen.queryByText(ubehandletCheckboxTekst, { exact: false })).to
+        .not.exist;
     });
   });
 });

--- a/test/behandlerdialog/SamtalerTagsTest.tsx
+++ b/test/behandlerdialog/SamtalerTagsTest.tsx
@@ -45,7 +45,13 @@ describe("Samtaletags", () => {
   });
 
   describe("Visning av tags på samtaler", () => {
-    it("Viser ny-tag på samtale hvis det er en ny melding i samtalen", () => {
+    const nyttSvarTagText = "Nytt svar";
+    const venterPaSvarTagText = "Venter på svar";
+    const paminnelseSendtTagText = "Påminnelse sendt";
+    const vurderPaminnelseTagText = "Vurder påminnelse";
+    const meldingStatusFeiletTagText = "Melding ikke levert";
+
+    it("Viser nytt-svar-tag på samtale hvis det er en ny melding i samtalen", () => {
       const innkommendeMeldingUuid = "456uio";
       const meldingResponse = meldingTilOgFraBehandler(innkommendeMeldingUuid);
       queryClient.setQueryData(
@@ -70,7 +76,7 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.getByText("Ny")).to.exist;
+      expect(screen.getByText(nyttSvarTagText)).to.exist;
     });
 
     it("Viser venter svar-tag på samtale hvis det mangler melding fra behandler og ingen ubesvart melding-oppgave", () => {
@@ -85,8 +91,8 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.getByText("Venter på svar")).to.exist;
-      expect(screen.queryByText("Påminnelse sendt")).to.not.exist;
+      expect(screen.getByText(venterPaSvarTagText)).to.exist;
+      expect(screen.queryByText(paminnelseSendtTagText)).to.not.exist;
     });
 
     it("Viser påminnelse sendt-tag på samtale hvis påminnelse sendt og det mangler melding fra behandler", () => {
@@ -101,8 +107,8 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.getByText("Påminnelse sendt")).to.exist;
-      expect(screen.queryByText("Venter på svar")).to.not.exist;
+      expect(screen.getByText(paminnelseSendtTagText)).to.exist;
+      expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
     });
 
     it("Viser ingen tags på samtale hvis det er melding til og fra behandler uten oppgave for ny melding", () => {
@@ -124,9 +130,9 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.queryByText("Ny")).to.not.exist;
-      expect(screen.queryByText("Påminnelse sendt")).to.not.exist;
-      expect(screen.queryByText("Venter på svar")).to.not.exist;
+      expect(screen.queryByText(nyttSvarTagText)).to.not.exist;
+      expect(screen.queryByText(paminnelseSendtTagText)).to.not.exist;
+      expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
     });
 
     it("Viser ingen tags på samtale hvis det er melding til og fra behandler (inkl påminnelse) uten oppgave for ny melding", () => {
@@ -148,9 +154,9 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.queryByText("Ny")).to.not.exist;
-      expect(screen.queryByText("Påminnelse sendt")).to.not.exist;
-      expect(screen.queryByText("Venter på svar")).to.not.exist;
+      expect(screen.queryByText(nyttSvarTagText)).to.not.exist;
+      expect(screen.queryByText(paminnelseSendtTagText)).to.not.exist;
+      expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
     });
 
     it("Viser 'Melding ikke levert'-tag på samtale hvis status for melding er avvist", () => {
@@ -168,7 +174,7 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.getByText("Melding ikke levert")).to.exist;
+      expect(screen.getByText(meldingStatusFeiletTagText)).to.exist;
     });
 
     it("Viser alert under melding dersom man har statusTekst for melding som er avvist", () => {
@@ -214,8 +220,8 @@ describe("Samtaletags", () => {
       const accordions = screen.getAllByRole("button");
       accordions.forEach((accordion) => userEvent.click(accordion));
 
-      expect(screen.queryByText("Venter på svar")).to.not.exist;
-      expect(screen.queryByText("Ny")).to.not.exist;
+      expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
+      expect(screen.queryByText(nyttSvarTagText)).to.not.exist;
     });
 
     it("Viser vurder påminnelse tag når man har en ubehandlet ubesvart melding oppgave", () => {
@@ -228,7 +234,7 @@ describe("Samtaletags", () => {
 
       renderSamtaler();
 
-      expect(screen.getByText("Vurder påminnelse")).to.exist;
+      expect(screen.getByText(vurderPaminnelseTagText)).to.exist;
     });
 
     it("Viser ingen tags på samtale hvis det mangler melding fra behandler, ingen påminnelse sendt og ubesvart melding-oppgave behandlet", () => {
@@ -252,10 +258,10 @@ describe("Samtaletags", () => {
 
       renderSamtaler();
 
-      expect(screen.queryByText("Ny")).to.not.exist;
-      expect(screen.queryByText("Påminnelse sendt")).to.not.exist;
-      expect(screen.queryByText("Venter på svar")).to.not.exist;
-      expect(screen.queryByText("Vurder påminnelse")).to.not.exist;
+      expect(screen.queryByText(nyttSvarTagText)).to.not.exist;
+      expect(screen.queryByText(paminnelseSendtTagText)).to.not.exist;
+      expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
+      expect(screen.queryByText(vurderPaminnelseTagText)).to.not.exist;
     });
   });
 });


### PR DESCRIPTION
Etter litt tilbakemelding på demo med PO Helse og diskusjon i `#syfo_dialogmeldinger` så ønsket vi å endre litt på tagen for når man har fått et nytt svar.

![image](https://github.com/navikt/syfomodiaperson/assets/37441744/060f6fc7-e386-4259-a0ab-96ce2ad36061)
![image](https://github.com/navikt/syfomodiaperson/assets/37441744/ec6dcbd2-aa64-419c-a445-ef9af272f596)
