### PR TITLE
Include behandlernavn in ferdigstillelse av oppgave text

### DIFF
--- a/mock/ispersonoppgave/personoppgaveMock.ts
+++ b/mock/ispersonoppgave/personoppgaveMock.ts
@@ -1,5 +1,6 @@
 import {
   ARBEIDSTAKER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
 import dayjs from "dayjs";
@@ -36,7 +37,7 @@ export const personOppgaveBehandletBehandlerdialogSvar = {
   behandletTidspunkt: new Date(
     dayjs().subtract(1, "days").toJSON()
   ).toDateString(),
-  behandletVeilederIdent: "Z991100",
+  behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
 };
 
 export const personOppgaveUbehandletBehandlerdialogUbesvartMelding = {
@@ -53,7 +54,7 @@ export const personOppgaveBehandletBehandlerdialogUbesvartMelding = {
   behandletTidspunkt: new Date(
     dayjs().subtract(1, "days").toJSON()
   ).toDateString(),
-  behandletVeilederIdent: "Z991100",
+  behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
 };
 
 const personOppgaveBehandletOppfolgingsplanLPS = {
@@ -63,7 +64,7 @@ const personOppgaveBehandletOppfolgingsplanLPS = {
   behandletTidspunkt: new Date(
     dayjs().subtract(1, "days").toJSON()
   ).toDateString(),
-  behandletVeilederIdent: "Z991100",
+  behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
   opprettet: new Date(dayjs().subtract(10, "days").toJSON()).toDateString(),
 };
 
@@ -74,7 +75,7 @@ export const personOppgaveBehandletDialogmotesvar = {
   behandletTidspunkt: new Date(
     dayjs().subtract(1, "days").toJSON()
   ).toDateString(),
-  behandletVeilederIdent: "Z991100",
+  behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
   opprettet: new Date(dayjs().subtract(10, "days").toJSON()).toDateString(),
 };
 
@@ -84,7 +85,7 @@ export const makePersonOppgaveBehandlet = (ubehandletPersonOppgave) => {
     behandletTidspunkt: new Date(
       dayjs().subtract(1, "days").toJSON()
     ).toDateString(),
-    behandletVeilederIdent: "Z991100",
+    behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
     opprettet: new Date(dayjs().subtract(10, "days").toJSON()).toDateString(),
   };
 };

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -32,7 +32,6 @@ const getFerdigbehandletText = (
   return `
     ${ferdigbehandletPrefixText} 
     ${veilederNavn} 
-    (${personOppgave.behandletVeilederIdent}) 
     ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}
   `;
 };

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -7,6 +7,7 @@ import { toDatePrettyPrint } from "@/utils/datoUtils";
 import { Checkbox, Panel } from "@navikt/ds-react";
 import styled from "styled-components";
 import navFarger from "nav-frontend-core";
+import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 
 const CheckboxPanel = styled(Panel)`
   border: 1px solid ${navFarger.navGra20};
@@ -21,13 +22,19 @@ const getFerdigbehandletPrefixText = (personoppgaveType: PersonOppgaveType) => {
   }
 };
 
-const getFerdigbehandletText = (personOppgave: PersonOppgave) => {
+const getFerdigbehandletText = (
+  personOppgave: PersonOppgave,
+  veilederNavn: string | undefined
+) => {
   const ferdigbehandletPrefixText = getFerdigbehandletPrefixText(
     personOppgave.type
   );
-  return `${ferdigbehandletPrefixText} ${
-    personOppgave.behandletVeilederIdent
-  } ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}`;
+  return `
+    ${ferdigbehandletPrefixText} 
+    ${veilederNavn} 
+    (${personOppgave.behandletVeilederIdent}) 
+    ${toDatePrettyPrint(personOppgave.behandletTidspunkt)}
+  `;
 };
 
 interface BehandlePersonoppgaveKnappProps {
@@ -45,9 +52,12 @@ const BehandlePersonOppgaveKnapp = ({
   isBehandleOppgaveLoading,
   behandleOppgaveText,
 }: BehandlePersonoppgaveKnappProps) => {
+  const { data: veilederInfo } = useVeilederInfoQuery(
+    personOppgave?.behandletVeilederIdent ?? ""
+  );
   const oppgaveKnappText =
     isBehandlet && personOppgave
-      ? getFerdigbehandletText(personOppgave)
+      ? getFerdigbehandletText(personOppgave, veilederInfo?.navn)
       : behandleOppgaveText;
 
   return (

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -7,7 +7,11 @@ import { queryClientWithMockData } from "../testQueryClient";
 import { expect } from "chai";
 import { Meldinger } from "@/components/behandlerdialog/meldinger/Meldinger";
 import { behandlerdialogQueryKeys } from "@/data/behandlerdialog/behandlerdialogQueryHooks";
-import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  VEILEDER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
+} from "../../mock/common/mockConstants";
 import { behandlerdialogMockEmpty } from "../../mock/isbehandlerdialog/behandlerdialogMock";
 import { MeldingResponseDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 import userEvent from "@testing-library/user-event";
@@ -299,9 +303,9 @@ describe("Meldinger panel", () => {
       );
       renderMeldinger();
 
-      const expectedFerdigbehandledText = `Siste svar lest av Z991100 ${twoDaysAgo.format(
-        "DD.MM.YYYY"
-      )}`;
+      const expectedFerdigbehandledText = `Siste svar lest av ${
+        VEILEDER_DEFAULT.navn
+      } (${VEILEDER_IDENT_DEFAULT}) ${twoDaysAgo.format("DD.MM.YYYY")}`;
       expect(screen.getByText(expectedFerdigbehandledText)).to.exist;
     });
 

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -10,7 +10,6 @@ import { behandlerdialogQueryKeys } from "@/data/behandlerdialog/behandlerdialog
 import {
   ARBEIDSTAKER_DEFAULT,
   VEILEDER_DEFAULT,
-  VEILEDER_IDENT_DEFAULT,
 } from "../../mock/common/mockConstants";
 import { behandlerdialogMockEmpty } from "../../mock/isbehandlerdialog/behandlerdialogMock";
 import { MeldingResponseDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
@@ -305,7 +304,7 @@ describe("Meldinger panel", () => {
 
       const expectedFerdigbehandledText = `Siste svar lest av ${
         VEILEDER_DEFAULT.navn
-      } (${VEILEDER_IDENT_DEFAULT}) ${twoDaysAgo.format("DD.MM.YYYY")}`;
+      } ${twoDaysAgo.format("DD.MM.YYYY")}`;
       expect(screen.getByText(expectedFerdigbehandledText)).to.exist;
     });
 


### PR DESCRIPTION
Det har blitt nevnt at veiledere ikke har noe særlig forhold til veilederident, og at derfor burde vi også vise navn i disse tilfellene. Er ingen skisser på det, så her er et forslag.

![image](https://github.com/navikt/syfomodiaperson/assets/37441744/a8b0ac88-b18c-44b1-aba5-5ccb989e6f54)
