### PR TITLE
Fixed spacing around warning label

### DIFF
--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandler.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandler.tsx
@@ -6,13 +6,16 @@ import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { ToggleNames } from "@/data/unleash/unleash_types";
 import AppSpinner from "@/components/AppSpinner";
 
-export const texts = {
+const texts = {
   header: "Skriv til behandler",
-  alert:
+  tilleggsopplysningerInfo:
     "Her kan du kun be om tilleggsopplysninger med takst L8. Dialogmeldingen skal bare benyttes i sykefraværsoppfølgingen.",
 };
 
 const MeldingTilBehandlerAlert = styled(Alert)`
+  max-width: fit-content;
+  margin-bottom: 1.5em;
+
   .navds-alert__wrapper {
     max-width: fit-content;
   }
@@ -35,7 +38,7 @@ export const MeldingTilBehandler = () => {
         <>
           {!isBehandlerdialogLegeerklaringEnabled && (
             <MeldingTilBehandlerAlert variant="warning" size="small">
-              {texts.alert}
+              {texts.tilleggsopplysningerInfo}
             </MeldingTilBehandlerAlert>
           )}
           <MeldingTilBehandlerSkjema

--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../../../img/ImageComponents";
 import { BodyShort } from "@navikt/ds-react";
 
-const text = {
+const texts = {
   tilleggsopplysinger:
     "Tilleggsopplysninger vedrørende pasienten. Behandleren honoreres med takst L8.",
   legeerklaring:
@@ -35,14 +35,14 @@ export const MeldingsTypeInfo = ({ meldingType }: Props) => {
         return (
           <>
             <Icon src={BlyantImage} />
-            <BodyShort size={"small"}>{text.tilleggsopplysinger}</BodyShort>
+            <BodyShort size={"small"}>{texts.tilleggsopplysinger}</BodyShort>
           </>
         );
       case MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING:
         return (
           <>
             <Icon src={BlueDocumentImage} />
-            <BodyShort size={"small"}>{text.legeerklaring}</BodyShort>
+            <BodyShort size={"small"}>{texts.legeerklaring}</BodyShort>
           </>
         );
       case MeldingType.FORESPORSEL_PASIENT_PAMINNELSE:


### PR DESCRIPTION
- Fikset spacing rundt warning label om info rundt tilleggsopplysninger i dialog med behandler. 
- Fikset også at alerten ikke er full bredde, men er like bred som innholdet.

### Screenshots📸
#### Før
![Screenshot 2023-07-14 at 09 13 36](https://github.com/navikt/syfomodiaperson/assets/11747383/5aeb6951-04a5-4b98-b17a-a0211b32004a)


#### Etter
![Screenshot 2023-07-14 at 09 10 59](https://github.com/navikt/syfomodiaperson/assets/11747383/e2bfb49f-9ce8-4f48-9428-e237c2b5bd62)
