### PR TITLE
Remove behandlerRef query param to unleash

### DIFF
--- a/src/data/unleash/unleashQueryHooks.ts
+++ b/src/data/unleash/unleashQueryHooks.ts
@@ -6,28 +6,28 @@ import { ToggleNames, Toggles } from "@/data/unleash/unleash_types";
 import { useQuery } from "@tanstack/react-query";
 
 export const unleashQueryKeys = {
-  toggles: (
-    valgtEnhet: string,
-    veilederIdent: string,
-    behandlerRef?: string
-  ) => ["toggles", valgtEnhet, veilederIdent, behandlerRef],
+  toggles: (valgtEnhet: string, veilederIdent: string) => [
+    "toggles",
+    valgtEnhet,
+    veilederIdent,
+  ],
 };
 
-export const useFeatureToggles = (behandlerRef?: string) => {
+export const useFeatureToggles = () => {
   const { data: veilederInfo } = useAktivVeilederinfoQuery();
   const { valgtEnhet } = useValgtEnhet();
   const veilederIdent = veilederInfo?.ident || "";
   const path = `${UNLEASH_ROOT}/toggles?valgtEnhet=${valgtEnhet}${
     veilederIdent ? `&userId=${veilederIdent}` : ""
-  }${behandlerRef ? `&behandlerRef=${behandlerRef}` : ""}`;
+  }`;
   const fetchToggles = () =>
     post<Toggles>(path, {
       toggles: Object.values(ToggleNames),
     });
   const query = useQuery({
-    queryKey: unleashQueryKeys.toggles(valgtEnhet, veilederIdent, behandlerRef),
+    queryKey: unleashQueryKeys.toggles(valgtEnhet, veilederIdent),
     queryFn: fetchToggles,
-    enabled: !!valgtEnhet || !!veilederIdent || !!behandlerRef,
+    enabled: !!valgtEnhet || !!veilederIdent,
   });
   const isFeatureEnabled = (toggle: ToggleNames): boolean => {
     return query.data ? query.data[toggle] : false;

--- a/test/testQueryClient.ts
+++ b/test/testQueryClient.ts
@@ -17,7 +17,6 @@ import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/p
 import { oppfolgingstilfellePersonMock } from "../mock/isoppfolgingstilfelle/oppfolgingstilfellePersonMock";
 import { unleashQueryKeys } from "@/data/unleash/unleashQueryHooks";
 import { unleashMock } from "../mock/unleash/unleashMock";
-import { behandlerDeltaker } from "./dialogmote/testData";
 import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { behandlereQueryKeys } from "@/data/behandler/behandlereQueryHooks";
 import {
@@ -128,8 +127,7 @@ export const queryClientWithMockData = (): QueryClient => {
   queryClient.setQueryData(
     unleashQueryKeys.toggles(
       BEHANDLENDE_ENHET_DEFAULT.enhetId,
-      VEILEDER_IDENT_DEFAULT,
-      behandlerDeltaker.behandlerRef
+      VEILEDER_IDENT_DEFAULT
     ),
     () => unleashMock
   );


### PR DESCRIPTION
Fjernet `behandlerRef` query param i kallet vårt til unleash ettersom det ikke er i bruk. 

- Klarer heller ikke egentlig å se at `userId` er i bruk i unleash🤔 Ser vi har en strategi som heter `byUserId`, men inne på beskrivelsen av denne ser det ut som query parameteret er `user`🧐