### PR TITLE
Move defaultvalue from option to select-tag

### DIFF
--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema.tsx
@@ -146,7 +146,7 @@ export const MeldingTilBehandlerSkjema = ({
           )}
           {isBehandlerdialogLegeerklaringEnabled && (
             <MeldingsType>
-              <SelectMeldingType values={values} />
+              <SelectMeldingType />
               {values.type && <MeldingsTypeInfo meldingType={values.type} />}
             </MeldingsType>
           )}

--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
@@ -1,6 +1,6 @@
 import { MeldingType } from "@/data/behandlerdialog/behandlerdialogTypes";
 import styled from "styled-components";
-import React from "react";
+import React, { ReactElement } from "react";
 import {
   BlueDocumentImage,
   BlyantImage,
@@ -28,7 +28,7 @@ interface Props {
   meldingType: MeldingType;
 }
 
-export const MeldingsTypeInfo = ({ meldingType }: Props) => {
+export const MeldingsTypeInfo = ({ meldingType }: Props): ReactElement => {
   const Info = () => {
     switch (meldingType) {
       case MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER:

--- a/src/components/behandlerdialog/meldingtilbehandler/SelectMeldingType.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/SelectMeldingType.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { Select, SkjemaelementFeilmelding } from "nav-frontend-skjema";
 import { MeldingType } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { Field } from "react-final-form";
-import { MeldingTilBehandlerSkjemaValues } from "@/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema";
 
 const text = {
   tilleggsopplysinger: "Tilleggsopplysninger L8",
@@ -11,12 +10,8 @@ const text = {
   defaultOption: "Velg meldingstype",
 };
 
-interface SelectMeldingTypeProps {
-  values: MeldingTilBehandlerSkjemaValues;
-}
-
 const field = "type";
-export const SelectMeldingType = ({ values }: SelectMeldingTypeProps) => {
+export const SelectMeldingType = () => {
   return (
     <Field<string> name={field}>
       {({ input, meta }) => {
@@ -26,10 +21,9 @@ export const SelectMeldingType = ({ values }: SelectMeldingTypeProps) => {
               id={field}
               label={text.label}
               onChange={(e) => input.onChange(e.target.value)}
+              defaultValue={""}
             >
-              <option value="" selected={values.type === undefined}>
-                {text.defaultOption}
-              </option>
+              <option value="">{text.defaultOption}</option>
               <option
                 value={MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER}
               >


### PR DESCRIPTION
Fikk warning i consollen på at man heller burde bruke `defaultValue` fra select-komponenten enn å legge `selected` på `option`-tagene.