### PR TITLE
Always show melding til NAV in sykmelding if it exists

### DIFF
--- a/mock/syfosmregister/sykmeldingerMock.ts
+++ b/mock/syfosmregister/sykmeldingerMock.ts
@@ -542,9 +542,12 @@ export const sykmeldingerMock = [
     },
     tiltakArbeidsplassen: "Fortsett som sist.",
     tiltakNAV:
-      "Pasienten har plager som er kommet tilbake etter operasjon. Det er nylig tatt MR bildet som viser forandringer i hånd som mulig må opereres. Venter på time. Det er mulig sykemledingen vil vare utover aktuell sm periode. ",
+      "Sende George på kostskole, han har plaget Pontypandy lenge nok nå",
     andreTiltak: null,
-    meldingTilNAV: null,
+    meldingTilNAV: {
+      bistandUmiddelbart: false,
+      beskrivBistand: "Mye røykskader pga jobben",
+    },
     meldingTilArbeidsgiver: null,
     kontaktMedPasient: {
       kontaktDato: null,
@@ -971,11 +974,14 @@ export const sykmeldingerMock = [
         },
       },
     },
-    tiltakArbeidsplassen: "Fortsett som sist.",
-    tiltakNAV:
-      "Pasienten har plager som er kommet tilbake etter operasjon. Det er nylig tatt MR bildet som viser forandringer i hånd som mulig må opereres. Venter på time. Det er mulig sykemledingen vil vare utover aktuell sm periode. ",
+    tiltakArbeidsplassen: "Sette phasers til stun.",
+    tiltakNAV: "Vedlikehold av holodeck",
     andreTiltak: null,
-    meldingTilNAV: null,
+    meldingTilNAV: {
+      bistandUmiddelbart: true,
+      beskrivBistand:
+        "Nav kan vise til egen forskning på faren med phaser blasts",
+    },
     meldingTilArbeidsgiver: null,
     kontaktMedPasient: {
       kontaktDato: null,

--- a/src/components/speiling/sykmeldinger/sykmelding/sykmeldingOpplysninger/flereopplysninger/MeldingTilNAV.tsx
+++ b/src/components/speiling/sykmeldinger/sykmelding/sykmeldingOpplysninger/flereopplysninger/MeldingTilNAV.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat";
 import { SykmeldingCheckboxSelvstendig } from "../SykmeldingCheckbox";
+import { erMeldingTilNavInformasjon } from "@/utils/sykmeldinger/sykmeldingUtils";
 
 const texts = {
   begrunnelse: "Begrunn nærmere",
@@ -14,16 +15,18 @@ interface MeldingTilNAVProps {
 
 const MeldingTilNAV = (meldingTilNAVProps: MeldingTilNAVProps) => {
   const { sykmelding } = meldingTilNAVProps;
-  if (!sykmelding.meldingTilNav.navBoerTaTakISaken) {
+  if (!erMeldingTilNavInformasjon(sykmelding)) {
     return <span />;
   }
   return (
     <div className="sykmeldingSeksjon">
       <h4 className="sykmeldingSeksjon__tittel">{texts.meldingTilNAV}</h4>
-      <SykmeldingCheckboxSelvstendig
-        tekst={texts.bistandNAV}
-        jsClassName="navBoerTaTakISaken"
-      />
+      {!sykmelding.meldingTilNav.navBoerTaTakISaken ? null : (
+        <SykmeldingCheckboxSelvstendig
+          tekst={texts.bistandNAV}
+          jsClassName="navBoerTaTakISaken"
+        />
+      )}
       {!sykmelding.meldingTilNav.navBoerTaTakISakenBegrunnelse ? null : (
         <div className="opplysning subopplysning">
           <h6 className="opplysning__tittel">{texts.begrunnelse}</h6>

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -100,7 +100,10 @@ export const erBedringAvArbeidsevnenInformasjon = (
 export const erMeldingTilNavInformasjon = (
   sykmelding: SykmeldingOldFormat
 ): boolean => {
-  return sykmelding.meldingTilNav.navBoerTaTakISaken || false;
+  return (
+    !!sykmelding.meldingTilNav.navBoerTaTakISaken ||
+    !!sykmelding.meldingTilNav.navBoerTaTakISakenBegrunnelse
+  );
 };
 
 export const erMeldingTilArbeidsgiverInformasjon = (

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -8,7 +8,6 @@ import {
   erFriskmeldingInformasjon,
   erHensynPaaArbeidsplassenInformasjon,
   erMeldingTilArbeidsgiverInformasjon,
-  erMeldingTilNavInformasjon,
   erMulighetForArbeidInformasjon,
   finnAvventendeSykmeldingTekst,
   getDiagnosekodeFromLatestSykmelding,
@@ -374,33 +373,6 @@ describe("sykmeldingUtils", () => {
       };
 
       const erIkkeEkstraInfo = erBedringAvArbeidsevnenInformasjon(sykmelding);
-
-      expect(erIkkeEkstraInfo).to.equal(false);
-    });
-  });
-
-  describe("erMeldingTilNavInformasjon", () => {
-    it("skal returnere true dersom sykmeldingen inneholder informasjon om melding til nav", () => {
-      const sykmelding: SykmeldingOldFormat = {
-        ...baseSykmelding,
-        meldingTilNav: {
-          navBoerTaTakISaken: true,
-        },
-      };
-
-      const erEkstraInfo = erMeldingTilNavInformasjon(sykmelding);
-
-      expect(erEkstraInfo).to.equal(true);
-    });
-    it("skal returnere false dersom sykmeldingen ikke inneholder informasjon om melding til nav", () => {
-      const sykmelding: SykmeldingOldFormat = {
-        ...baseSykmelding,
-        meldingTilNav: {
-          navBoerTaTakISaken: false,
-        },
-      };
-
-      const erIkkeEkstraInfo = erMeldingTilNavInformasjon(sykmelding);
 
       expect(erIkkeEkstraInfo).to.equal(false);
     });

--- a/test/utils/sykmeldingutils/sykmeldingUtilsMeldingTilNavTest.ts
+++ b/test/utils/sykmeldingutils/sykmeldingUtilsMeldingTilNavTest.ts
@@ -1,0 +1,81 @@
+import {
+  SykmeldingOldFormat,
+  SykmeldingStatus,
+} from "@/data/sykmelding/types/SykmeldingOldFormat";
+import { erMeldingTilNavInformasjon } from "@/utils/sykmeldinger/sykmeldingUtils";
+import { expect } from "chai";
+import { BehandlingsutfallStatusDTO } from "@/data/sykmelding/types/BehandlingsutfallStatusDTO";
+import { SporsmalSvarDTO } from "@/data/sykmelding/types/SporsmalSvarDTO";
+
+const baseSykmelding: SykmeldingOldFormat = {
+  arbeidsevne: {},
+  behandlingsutfall: {
+    ruleHits: [],
+    status: BehandlingsutfallStatusDTO.OK,
+  },
+  bekreftelse: {},
+  diagnose: {},
+  friskmelding: {},
+  id: "",
+  meldingTilNav: {},
+  mottattTidspunkt: new Date(),
+  pasient: {},
+  sendtdato: "",
+  skalViseSkravertFelt: false,
+  sporsmal: {},
+  status: SykmeldingStatus.SENDT,
+  tilbakedatering: {},
+  utdypendeOpplysninger: new Map<string, Map<string, SporsmalSvarDTO>>(),
+  mulighetForArbeid: {
+    perioder: [],
+  },
+};
+describe("sykmeldingUtils - Section 8 of sykmelding: Melding Til Nav", () => {
+  describe("erMeldingTilNavInformasjon", () => {
+    it("return true if Sykmelder has checked box 'Ønskes bistand fra NAV nå?'", () => {
+      const sykmelding: SykmeldingOldFormat = {
+        ...baseSykmelding,
+        meldingTilNav: {
+          navBoerTaTakISaken: true,
+        },
+      };
+
+      const erEkstraInfo = erMeldingTilNavInformasjon(sykmelding);
+
+      expect(erEkstraInfo).to.equal(true);
+    });
+
+    it("return true if Sykmelder has given a text reason in section 8 ", () => {
+      const sykmelding: SykmeldingOldFormat = {
+        ...baseSykmelding,
+        meldingTilNav: {
+          navBoerTaTakISaken: false,
+          navBoerTaTakISakenBegrunnelse: "Nav bør se på saken",
+        },
+      };
+
+      const erEkstraInfo = erMeldingTilNavInformasjon(sykmelding);
+
+      expect(erEkstraInfo).to.equal(true);
+    });
+
+    it("return false if Sykmelder has not given any information to Nav in section 8", () => {
+      const sykmelding: SykmeldingOldFormat = {
+        ...baseSykmelding,
+        meldingTilNav: {
+          navBoerTaTakISaken: false,
+        },
+      };
+
+      const erEkstraInfo = erMeldingTilNavInformasjon(sykmelding);
+
+      expect(erEkstraInfo).to.equal(false);
+    });
+
+    it("return false if meldingTilNav is undefined in Sykmelding", () => {
+      const erIkkeEkstraInfo = erMeldingTilNavInformasjon(baseSykmelding);
+
+      expect(erIkkeEkstraInfo).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Sometimes the 'Nav bør ta tak i saken' box isn't checked in the sykmelding (see section 8 here https://cdn.sanity.io/files/gx9wf39f/soknadsveiviser-p/544438c9bbcac38217940ba9ef7ceaff3b501afe.pdf) , but there is still a begrunnelse. Always show the begrunnelse text if it exists.
