### PR TITLE
Justerer avvist-melding-oppgavetekst og fjerner feilmelding-alert

### DIFF
--- a/src/components/behandlerdialog/meldinger/AvvistMelding.tsx
+++ b/src/components/behandlerdialog/meldinger/AvvistMelding.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { isBehandletOppgave } from "@/utils/personOppgaveUtils";
 import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
-import { Alert } from "@navikt/ds-react";
 import BehandlePersonOppgaveKnapp from "@/components/personoppgave/BehandlePersonOppgaveKnapp";
 import { useBehandlePersonoppgave } from "@/data/personoppgave/useBehandlePersonoppgave";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
@@ -14,14 +13,10 @@ const texts = {
 };
 
 interface AvvistMeldingProps {
-  avvistMeldingStatusTekst: string | null;
   meldingUuid: string;
 }
 
-export const AvvistMelding = ({
-  avvistMeldingStatusTekst,
-  meldingUuid,
-}: AvvistMeldingProps) => {
+export const AvvistMelding = ({ meldingUuid }: AvvistMeldingProps) => {
   const { isFeatureEnabled } = useFeatureToggles();
   const isAvvistMeldingOppgaveEnabled = isFeatureEnabled(
     ToggleNames.avvistMeldingOppgave
@@ -37,9 +32,6 @@ export const AvvistMelding = ({
 
   return (
     <>
-      {avvistMeldingStatusTekst && (
-        <Alert variant="error">{avvistMeldingStatusTekst}</Alert>
-      )}
       {isAvvistMeldingOppgaveEnabled && avvistOppgave && (
         <BehandlePersonOppgaveKnapp
           personOppgave={avvistOppgave}

--- a/src/components/behandlerdialog/meldinger/AvvistMelding.tsx
+++ b/src/components/behandlerdialog/meldinger/AvvistMelding.tsx
@@ -10,7 +10,7 @@ import { ToggleNames } from "@/data/unleash/unleash_types";
 
 const texts = {
   behandleOppgaveText:
-    "Jeg har registrert at meldingen ikke ble sendt og funnet andre måter å kontakte behandleren på.",
+    "Jeg har forstått at meldingen ikke ble levert. Oppgaven kan fjernes.",
 };
 
 interface AvvistMeldingProps {

--- a/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
@@ -67,10 +67,7 @@ const MeldingTilBehandler = ({ melding }: MeldingInnholdProps) => {
       <StyledInnhold>
         <MeldingInnholdPanel melding={melding} />
         {melding.status?.type === MeldingStatusType.AVVIST && (
-          <AvvistMelding
-            avvistMeldingStatusTekst={melding.status.tekst}
-            meldingUuid={melding.uuid}
-          />
+          <AvvistMelding meldingUuid={melding.uuid} />
         )}
         <PaminnelseMelding melding={melding} />
       </StyledInnhold>

--- a/test/behandlerdialog/AvvistMeldingTest.tsx
+++ b/test/behandlerdialog/AvvistMeldingTest.tsx
@@ -17,19 +17,13 @@ import {
 
 let queryClient: QueryClient;
 
-const renderAvvistMelding = (
-  avvistMeldingStatusTekst: string | null,
-  meldingUuid: string
-) => {
+const renderAvvistMelding = (meldingUuid: string) => {
   render(
     <QueryClientProvider client={queryClient}>
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <AvvistMelding
-          avvistMeldingStatusTekst={avvistMeldingStatusTekst}
-          meldingUuid={meldingUuid}
-        />
+        <AvvistMelding meldingUuid={meldingUuid} />
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>
   );
@@ -46,7 +40,7 @@ describe("Avvist melding", () => {
   });
 
   const avvistOppgaveText =
-    "Jeg har registrert at meldingen ikke ble sendt og funnet andre måter å kontakte behandleren på.";
+    "Jeg har forstått at meldingen ikke ble levert. Oppgaven kan fjernes.";
   const statusTekst = "Mottaker finnes ikke";
   const avvistStatus = {
     type: MeldingStatusType.AVVIST,
@@ -58,22 +52,18 @@ describe("Avvist melding", () => {
   };
 
   it("render nothing when melding with meldingstatus OK", () => {
-    renderAvvistMelding(
-      meldingTilBehandler.status.tekst,
-      meldingTilBehandler.uuid
-    );
+    renderAvvistMelding(meldingTilBehandler.uuid);
 
     expect(screen.queryByRole("div")).to.not.exist;
   });
 
-  it("render alert with tekst when melding with meldingstatus AVVIST", () => {
-    renderAvvistMelding(avvistMelding.status.tekst, avvistMelding.uuid);
+  it("render nothing when AVVIST melding and no oppgave", () => {
+    renderAvvistMelding(avvistMelding.uuid);
 
-    expect(screen.getByText(statusTekst)).to.exist;
     expect(screen.queryByText(avvistOppgaveText)).to.not.exist;
   });
 
-  it("render alert with tekst and checkbox when melding with meldingstatus AVVIST and has personoppgave", () => {
+  it("render checkbox when melding with meldingstatus AVVIST and has personoppgave", () => {
     queryClient.setQueryData(
       personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
       () => [personOppgaveUbehandletBehandlerdialogAvvistMelding]
@@ -83,13 +73,12 @@ describe("Avvist melding", () => {
       ...avvistMelding,
       uuid: personOppgaveUbehandletBehandlerdialogAvvistMelding.referanseUuid,
     };
-    renderAvvistMelding(melding.status.tekst, melding.uuid);
+    renderAvvistMelding(melding.uuid);
 
-    expect(screen.getByText(statusTekst)).to.exist;
     expect(screen.getByText(avvistOppgaveText)).to.exist;
   });
 
-  it("render checkbox when melding with meldingstatus AVVIST and has personoppgave, but no alert when no text", () => {
+  it("render checkbox when melding with meldingstatus AVVIST and has personoppgave", () => {
     queryClient.setQueryData(
       personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
       () => [personOppgaveUbehandletBehandlerdialogAvvistMelding]
@@ -103,13 +92,12 @@ describe("Avvist melding", () => {
       },
       uuid: personOppgaveUbehandletBehandlerdialogAvvistMelding.referanseUuid,
     };
-    renderAvvistMelding(melding.status.tekst, melding.uuid);
+    renderAvvistMelding(melding.uuid);
 
-    expect(screen.queryByText(statusTekst)).to.not.exist;
     expect(screen.getByText(avvistOppgaveText)).to.exist;
   });
 
-  it("render alert with tekst and checkbox when melding with meldingstatus AVVIST and has behandlet personoppgave", () => {
+  it("render checkbox when melding with meldingstatus AVVIST and has behandlet personoppgave", () => {
     queryClient.setQueryData(
       personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
       () => [personOppgaveBehandletBehandlerdialogAvvistMelding]
@@ -119,9 +107,8 @@ describe("Avvist melding", () => {
       ...avvistMelding,
       uuid: personOppgaveBehandletBehandlerdialogAvvistMelding.referanseUuid,
     };
-    renderAvvistMelding(melding.status.tekst, melding.uuid);
+    renderAvvistMelding(melding.uuid);
 
-    expect(screen.getByText(statusTekst)).to.exist;
     expect(screen.getByText("Ferdigbehandlet av", { exact: false })).to.exist;
   });
 });

--- a/test/behandlerdialog/SamtalerTagsTest.tsx
+++ b/test/behandlerdialog/SamtalerTagsTest.tsx
@@ -177,24 +177,6 @@ describe("Samtaletags", () => {
       expect(screen.getByText(meldingStatusFeiletTagText)).to.exist;
     });
 
-    it("Viser alert under melding dersom man har statusTekst for melding som er avvist", () => {
-      const meldingResponse = meldingTilBehandlerMedMeldingStatus(
-        MeldingStatusType.AVVIST,
-        "Statustekst"
-      );
-      queryClient.setQueryData(
-        behandlerdialogQueryKeys.behandlerdialog(
-          ARBEIDSTAKER_DEFAULT.personIdent
-        ),
-        () => meldingResponse
-      );
-
-      renderSamtaler();
-      const accordions = screen.getAllByRole("button");
-      userEvent.click(accordions[0]);
-      expect(screen.getByText("Statustekst")).to.exist;
-    });
-
     it("viser ingen tags på samtale hvis det er melding fra behandler i samtalen og oppgaven for denne er behandlet", () => {
       const innkommendeMeldingUuid = "456uio";
       const meldingResponse = meldingTilOgFraBehandler(innkommendeMeldingUuid);


### PR DESCRIPTION
Før:
<img width="990" alt="avvist_foer" src="https://github.com/navikt/syfomodiaperson/assets/79838644/41b07b2f-62ed-4b11-b86d-16576824b1b9">
Etter:
<img width="977" alt="avvist_etter" src="https://github.com/navikt/syfomodiaperson/assets/79838644/4c59bcd5-0e18-4904-819b-5e9271a67217">
