### PR TITLE
Add toggle and button for retur legeerklaring

### DIFF
--- a/mock/isbehandlerdialog/behandlerdialogMock.ts
+++ b/mock/isbehandlerdialog/behandlerdialogMock.ts
@@ -97,8 +97,17 @@ const defaultStatus = {
   tekst: null,
 };
 
+export const meldingUuids = {
+  tilleggsopplysningerUtgaaende: "5f1e2629-062b-443d-ac1f-3b08e9574cd5",
+  tilleggopplysningerInnkommende: "5f1e2629-062b-442d-ae1f-3b08e9574cd5",
+  legeerklaringInnkommende: "1f1e2639-061b-245e-ac1f-3b08e9574cd5",
+  ubesvartMelding: "5f1e2639-032c-443d-ac1f-3b08e9574cd5",
+  avvistMelding: "9f1e2639-061b-243d-ac1f-3b08e9574cd5",
+  avvistMelding2: "2f1e2639-061b-243d-ac1f-3b08e9574cd5",
+};
+
 export const defaultMelding = {
-  uuid: "5f1e2629-062b-443d-ac1f-3b08e9574cd5",
+  uuid: meldingUuids.tilleggsopplysningerUtgaaende,
   behandlerRef: behandlerRefDoktorLegesen,
   behandlerNavn: null,
   tekst: defaultMeldingTekst,
@@ -147,7 +156,7 @@ export const defaultMeldingInnkommende = {
 
 export const defaultMeldingInnkommendeLegeerklaring = {
   ...defaultMeldingLegeerklaring,
-  uuid: "1f1e2639-061b-245e-ac1f-3b08e9574cd5",
+  uuid: meldingUuids.legeerklaringInnkommende,
   behandlerNavn: `${behandlerDoktorLegesen.fornavn} ${behandlerDoktorLegesen.etternavn}`,
   innkommende: true,
   tidspunkt: "2023-01-03T12:00:00.000+01:00",
@@ -158,7 +167,7 @@ export const defaultMeldingInnkommendeLegeerklaring = {
 
 const ubesvartMelding = {
   ...defaultMelding,
-  uuid: "5f1e2639-032c-443d-ac1f-3b08e9574cd5",
+  uuid: meldingUuids.ubesvartMelding,
 };
 
 const longMelding =
@@ -167,7 +176,7 @@ const longMelding =
 const meldinger = [
   defaultMelding,
   {
-    uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd5",
+    uuid: meldingUuids.tilleggopplysningerInnkommende,
     tekst: longMelding,
     behandlerRef: behandlerRefLegoLasLegesen,
     behandlerNavn: `${behandlerLegoLasLegesen.fornavn} ${behandlerLegoLasLegesen.mellomnavn} ${behandlerLegoLasLegesen.etternavn}`,
@@ -181,7 +190,7 @@ const meldinger = [
   defaultMeldingInnkommende,
   {
     ...defaultMelding,
-    uuid: "9f1e2639-061b-243d-ac1f-3b08e9574cd5",
+    uuid: meldingUuids.avvistMelding,
     tidspunkt: "2023-01-04T12:00:00.000+01:00",
     status: {
       type: MeldingStatusType.AVVIST,
@@ -190,7 +199,7 @@ const meldinger = [
   },
   {
     ...defaultMelding,
-    uuid: "2f1e2639-061b-243d-ac1f-3b08e9574cd5",
+    uuid: meldingUuids.avvistMelding2,
     tidspunkt: "2023-01-05T12:00:00.000+01:00",
     status: {
       ...defaultStatus,
@@ -205,6 +214,16 @@ export const behandlerdialogMock = {
     "conversationRef-456": meldinger.slice(0, 2),
     "conversationRef-789": meldinger,
     "conversationRef-981": [defaultMelding, paminnelseMelding],
+  },
+};
+
+export const behandlerdialogMockInclLegeerklaring = {
+  conversations: {
+    ...behandlerdialogMock.conversations,
+    "conversationRef-819": [
+      defaultMeldingLegeerklaring,
+      defaultMeldingInnkommendeLegeerklaring,
+    ],
   },
 };
 

--- a/mock/isbehandlerdialog/mockIsbehandlerdialog.ts
+++ b/mock/isbehandlerdialog/mockIsbehandlerdialog.ts
@@ -2,13 +2,13 @@ import express = require("express");
 import { ISBEHANDLERDIALOG_ROOT } from "../../src/apiConstants";
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
 import {
-  behandlerdialogMock,
+  behandlerdialogMockInclLegeerklaring,
   behandlerdialogVedleggMock,
   defaultMelding,
 } from "./behandlerdialogMock";
 import { MeldingTilBehandlerDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 
-let behandlerdialogMockdata = behandlerdialogMock;
+let behandlerdialogMockdata = behandlerdialogMockInclLegeerklaring;
 
 export const mockIsbehandlerdialog = (server: any) => {
   server.get(

--- a/mock/ispersonoppgave/personoppgaveMock.ts
+++ b/mock/ispersonoppgave/personoppgaveMock.ts
@@ -5,6 +5,7 @@ import {
 } from "../common/mockConstants";
 import dayjs from "dayjs";
 import { PersonOppgaveType } from "../../src/data/personoppgave/types/PersonOppgave";
+import { meldingUuids } from "../isbehandlerdialog/behandlerdialogMock";
 
 const personOppgaveUbehandletOppfolgingsplanLPS = {
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd0",
@@ -27,14 +28,14 @@ const personOppgaveUbehandletDialogmotesvar = {
 export const personOppgaveUbehandletBehandlerdialogAvvistMelding = {
   ...personOppgaveUbehandletOppfolgingsplanLPS,
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9574ca2",
-  referanseUuid: "9f1e2639-061b-243d-ac1f-3b08e9574cd5",
+  referanseUuid: meldingUuids.avvistMelding,
   type: PersonOppgaveType.BEHANDLERDIALOG_MELDING_AVVIST,
 };
 
 export const personOppgaveBehandletBehandlerdialogAvvistMelding = {
   ...personOppgaveUbehandletOppfolgingsplanLPS,
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9574ca2",
-  referanseUuid: "9f1e2639-061b-243d-ac1f-3b08e9574cd5",
+  referanseUuid: meldingUuids.avvistMelding2,
   type: PersonOppgaveType.BEHANDLERDIALOG_MELDING_AVVIST,
   behandletTidspunkt: new Date().toDateString(),
   behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
@@ -43,14 +44,14 @@ export const personOppgaveBehandletBehandlerdialogAvvistMelding = {
 export const personOppgaveUbehandletBehandlerdialogSvar = {
   ...personOppgaveUbehandletDialogmotesvar,
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd4",
-  referanseUuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd5",
+  referanseUuid: meldingUuids.tilleggopplysningerInnkommende,
   type: "BEHANDLERDIALOG_SVAR",
 };
 
 export const personOppgaveBehandletBehandlerdialogSvar = {
   ...personOppgaveUbehandletBehandlerdialogSvar,
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd8",
-  referanseUuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd9",
+  referanseUuid: meldingUuids.legeerklaringInnkommende,
   behandletTidspunkt: new Date(
     dayjs().subtract(1, "days").toJSON()
   ).toDateString(),
@@ -60,14 +61,14 @@ export const personOppgaveBehandletBehandlerdialogSvar = {
 export const personOppgaveUbehandletBehandlerdialogUbesvartMelding = {
   ...personOppgaveUbehandletBehandlerdialogSvar,
   uuid: "5f1e2629-062b-442d-ae1f-3b08e9234cd4",
-  referanseUuid: "5f1e2639-032c-443d-ac1f-3b08e9574cd5",
+  referanseUuid: meldingUuids.ubesvartMelding,
   type: "BEHANDLERDIALOG_MELDING_UBESVART",
 };
 
 export const personOppgaveBehandletBehandlerdialogUbesvartMelding = {
   ...personOppgaveUbehandletBehandlerdialogUbesvartMelding,
   uuid: "5f1e2629-063b-442d-ae1g-3b08e9234cd4",
-  referanseUuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd9",
+  referanseUuid: meldingUuids.tilleggsopplysningerUtgaaende,
   behandletTidspunkt: new Date(
     dayjs().subtract(1, "days").toJSON()
   ).toDateString(),

--- a/server/routes/unleashRoutes.ts
+++ b/server/routes/unleashRoutes.ts
@@ -91,6 +91,13 @@ export const unleashToggles = (toggles: any, valgtEnhet: any, userId: any) => {
         user: userId,
       }
     ),
+    "syfo.behandlerdialog.returlegeeklaring": unleash.isEnabled(
+      "syfo.behandlerdialog.returlegeeklaring",
+      {
+        valgtEnhet: valgtEnhet,
+        user: userId,
+      }
+    ),
     "syfo.motebehov.tilbakemelding": unleash.isEnabled(
       "syfo.motebehov.tilbakemelding",
       {

--- a/server/routes/unleashRoutes.ts
+++ b/server/routes/unleashRoutes.ts
@@ -91,8 +91,8 @@ export const unleashToggles = (toggles: any, valgtEnhet: any, userId: any) => {
         user: userId,
       }
     ),
-    "syfo.behandlerdialog.returlegeeklaring": unleash.isEnabled(
-      "syfo.behandlerdialog.returlegeeklaring",
+    "syfo.behandlerdialog.returlegeerklaring": unleash.isEnabled(
+      "syfo.behandlerdialog.returlegeerklaring",
       {
         valgtEnhet: valgtEnhet,
         user: userId,

--- a/src/components/behandlerdialog/MeldingActionButton.tsx
+++ b/src/components/behandlerdialog/MeldingActionButton.tsx
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import { Button, ButtonProps } from "@navikt/ds-react";
+import React from "react";
+
+const StyledButton = styled(Button)`
+  align-self: flex-start;
+`;
+
+type MeldingActionButtonProps = Required<
+  Pick<ButtonProps, "icon" | "onClick">
+> &
+  ButtonProps;
+
+export const MeldingActionButton = ({
+  children,
+  ...rest
+}: MeldingActionButtonProps) => {
+  return <StyledButton {...rest}>{children}</StyledButton>;
+};

--- a/src/components/behandlerdialog/legeeklaring/ReturLegeerklaring.tsx
+++ b/src/components/behandlerdialog/legeeklaring/ReturLegeerklaring.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
+import { ArrowUndoIcon } from "@navikt/aksel-icons";
+import { MeldingActionButton } from "@/components/behandlerdialog/MeldingActionButton";
+
+const texts = {
+  button: "Vurder retur av legeerklæring",
+};
+
+interface ReturLegeerklaringProps {
+  melding: MeldingDTO;
+}
+
+export const ReturLegeerklaring = ({ melding }: ReturLegeerklaringProps) => {
+  return (
+    <MeldingActionButton
+      icon={<ArrowUndoIcon aria-hidden />}
+      onClick={() => {
+        console.log("Retur clicked for melding!", melding);
+      }}
+    >
+      {texts.button}
+    </MeldingActionButton>
+  );
+};

--- a/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
@@ -55,7 +55,7 @@ interface MeldingInnholdProps {
 const MeldingFraBehandler = ({ melding }: MeldingInnholdProps) => {
   const { isFeatureEnabled } = useFeatureToggles();
   const isReturLegeerklaringEnabled = isFeatureEnabled(
-    ToggleNames.behandlerdialogReturLegeeklaring
+    ToggleNames.behandlerdialogReturLegeerklaring
   );
   const isLegeerklaring =
     melding.type === MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING;

--- a/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingerISamtale.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   MeldingDTO,
   MeldingStatusType,
+  MeldingType,
 } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { MeldingInnholdPanel } from "@/components/behandlerdialog/meldinger/MeldingInnholdPanel";
 import styled from "styled-components";
@@ -11,6 +12,9 @@ import {
 } from "../../../../img/ImageComponents";
 import { PaminnelseMelding } from "@/components/behandlerdialog/paminnelse/PaminnelseMelding";
 import { AvvistMelding } from "@/components/behandlerdialog/meldinger/AvvistMelding";
+import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
+import { ToggleNames } from "@/data/unleash/unleash_types";
+import { ReturLegeerklaring } from "@/components/behandlerdialog/legeeklaring/ReturLegeerklaring";
 
 const StyledWrapper = styled.div`
   margin: 1em 0;
@@ -49,6 +53,13 @@ interface MeldingInnholdProps {
 }
 
 const MeldingFraBehandler = ({ melding }: MeldingInnholdProps) => {
+  const { isFeatureEnabled } = useFeatureToggles();
+  const isReturLegeerklaringEnabled = isFeatureEnabled(
+    ToggleNames.behandlerdialogReturLegeeklaring
+  );
+  const isLegeerklaring =
+    melding.type === MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING;
+
   return (
     <StyledMelding innkommende>
       <StyledImageWrapper innkommende>
@@ -56,6 +67,9 @@ const MeldingFraBehandler = ({ melding }: MeldingInnholdProps) => {
       </StyledImageWrapper>
       <StyledInnhold>
         <MeldingInnholdPanel melding={melding} />
+        {isReturLegeerklaringEnabled && isLegeerklaring && (
+          <ReturLegeerklaring melding={melding} />
+        )}
       </StyledInnhold>
     </StyledMelding>
   );

--- a/src/components/behandlerdialog/paminnelse/PaminnelseMelding.tsx
+++ b/src/components/behandlerdialog/paminnelse/PaminnelseMelding.tsx
@@ -20,6 +20,7 @@ import { useMeldingTilBehandlerDocument } from "@/hooks/behandlerdialog/document
 import { DocumentComponentVisning } from "@/components/DocumentComponentVisning";
 import { ButtonRow, PaddingSize } from "@/components/Layout";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { MeldingActionButton } from "@/components/behandlerdialog/MeldingActionButton";
 
 const texts = {
   button: "Vurder påminnelse til behandler",
@@ -27,10 +28,6 @@ const texts = {
   fjernOppgave: "Fjern oppgave uten å sende påminnelse",
   cancel: "Lukk",
 };
-
-const StyledButton = styled(Button)`
-  align-self: flex-start;
-`;
 
 const ModalContent = styled(Modal.Content)`
   padding: 2em;
@@ -70,7 +67,7 @@ const VisOgSendPaminnelse = ({
 
   return (
     <>
-      <StyledButton
+      <MeldingActionButton
         icon={<BellIcon aria-hidden />}
         onClick={() => {
           setVisPaminnelseModal(true);
@@ -79,7 +76,7 @@ const VisOgSendPaminnelse = ({
         }}
       >
         {texts.button}
-      </StyledButton>
+      </MeldingActionButton>
       <Modal
         open={visPaminnelseModal}
         onClose={() => setVisPaminnelseModal(false)}
@@ -94,7 +91,7 @@ const VisOgSendPaminnelse = ({
           ))}
           {(paminnelseTilBehandler.isError || behandleOppgave.isError) && (
             <SkjemaInnsendingFeil
-              error={paminnelseTilBehandler.error || behandleOppgave.isError}
+              error={paminnelseTilBehandler.error || behandleOppgave.error}
             />
           )}
           <ButtonRow topPadding={PaddingSize.SM} bottomPadding={PaddingSize.SM}>

--- a/src/data/unleash/unleash_types.ts
+++ b/src/data/unleash/unleash_types.ts
@@ -6,6 +6,6 @@ export type Toggles = {
 export enum ToggleNames {
   virksomhetinput = "syfo.dialogmote.virksomhetinput",
   behandlerdialogLegeerklaring = "syfo.behandlerdialog.legeerklaring",
-  behandlerdialogReturLegeeklaring = "syfo.behandlerdialog.returlegeeklaring",
+  behandlerdialogReturLegeerklaring = "syfo.behandlerdialog.returlegeerklaring",
   vurderMotebehovTilbakemelding = "syfo.motebehov.tilbakemelding",
 }

--- a/src/data/unleash/unleash_types.ts
+++ b/src/data/unleash/unleash_types.ts
@@ -6,5 +6,6 @@ export type Toggles = {
 export enum ToggleNames {
   virksomhetinput = "syfo.dialogmote.virksomhetinput",
   behandlerdialogLegeerklaring = "syfo.behandlerdialog.legeerklaring",
+  behandlerdialogReturLegeeklaring = "syfo.behandlerdialog.returlegeeklaring",
   vurderMotebehovTilbakemelding = "syfo.motebehov.tilbakemelding",
 }

--- a/test/behandlerdialog/MeldingerISamtaleTest.tsx
+++ b/test/behandlerdialog/MeldingerISamtaleTest.tsx
@@ -1,0 +1,143 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MeldingDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
+import { render, screen } from "@testing-library/react";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { navEnhet } from "../dialogmote/testData";
+import { MeldingerISamtale } from "@/components/behandlerdialog/meldinger/MeldingerISamtale";
+import React from "react";
+import {
+  defaultMelding,
+  defaultMeldingInnkommende,
+  defaultMeldingInnkommendeLegeerklaring,
+  defaultMeldingLegeerklaring,
+} from "../../mock/isbehandlerdialog/behandlerdialogMock";
+import { queryClientWithMockData } from "../testQueryClient";
+import { expect } from "chai";
+import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
+import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
+import {
+  personOppgaveBehandletBehandlerdialogUbesvartMelding,
+  personOppgaveUbehandletBehandlerdialogUbesvartMelding,
+} from "../../mock/ispersonoppgave/personoppgaveMock";
+import { getButton } from "../testUtils";
+
+let queryClient: QueryClient;
+
+const renderMeldingerISamtale = (meldinger: MeldingDTO[]) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <MeldingerISamtale meldinger={meldinger} />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+const meldingTilBehandler = {
+  ...defaultMelding,
+  tidspunkt: new Date(),
+};
+const meldingFraBehandler = {
+  ...defaultMeldingInnkommende,
+  tidspunkt: new Date(),
+};
+const foresporselLegeerklaringTilBehandler = {
+  ...defaultMeldingLegeerklaring,
+  tidspunkt: new Date(),
+};
+const legeerklaringFraBehandler = {
+  ...defaultMeldingInnkommendeLegeerklaring,
+  tidspunkt: new Date(),
+};
+
+const paminnelseButtonText = "Vurder påminnelse til behandler";
+const returLegeerklaringButtonText = "Vurder retur av legeerklæring";
+
+describe("MeldingerISamtale", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Påminnelse button", () => {
+    it("render no paminnelse button when no meldinger", () => {
+      renderMeldingerISamtale([]);
+
+      expect(screen.queryByRole("button", { name: paminnelseButtonText })).to
+        .not.exist;
+    });
+    it("render no paminnelse button when no ubesvart melding-oppgave", () => {
+      renderMeldingerISamtale([meldingTilBehandler]);
+
+      expect(screen.queryByRole("button", { name: paminnelseButtonText })).to
+        .not.exist;
+    });
+    it("render no paminnelse button for melding til behandler med behandlet ubesvart melding-oppgave", () => {
+      queryClient.setQueryData(
+        personoppgaverQueryKeys.personoppgaver(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => [
+          {
+            ...personOppgaveBehandletBehandlerdialogUbesvartMelding,
+            referanseUuid: meldingTilBehandler.uuid,
+          },
+        ]
+      );
+      renderMeldingerISamtale([meldingTilBehandler]);
+
+      expect(screen.queryByRole("button", { name: paminnelseButtonText })).to
+        .not.exist;
+    });
+    it("render paminnelse button for melding til behandler med ubehandlet ubesvart melding-oppgave", () => {
+      queryClient.setQueryData(
+        personoppgaverQueryKeys.personoppgaver(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => [
+          {
+            ...personOppgaveUbehandletBehandlerdialogUbesvartMelding,
+            referanseUuid: meldingTilBehandler.uuid,
+          },
+        ]
+      );
+
+      renderMeldingerISamtale([meldingTilBehandler]);
+
+      expect(getButton(paminnelseButtonText)).to.exist;
+    });
+  });
+
+  describe("Retur legeerklæring button", () => {
+    it("renders no retur legeeklæring button when no meldinger", () => {
+      renderMeldingerISamtale([]);
+
+      expect(
+        screen.queryByRole("button", { name: returLegeerklaringButtonText })
+      ).to.not.exist;
+    });
+    it("renders no retur legeeklæring button when no meldinger of type legeerklaring", () => {
+      renderMeldingerISamtale([meldingTilBehandler, meldingFraBehandler]);
+
+      expect(
+        screen.queryByRole("button", { name: returLegeerklaringButtonText })
+      ).to.not.exist;
+    });
+    it("renders no retur legeeklæring button when no melding fra behandler legeerklaring", () => {
+      renderMeldingerISamtale([foresporselLegeerklaringTilBehandler]);
+
+      expect(
+        screen.queryByRole("button", { name: returLegeerklaringButtonText })
+      ).to.not.exist;
+    });
+    it("renders retur legeeklæring button when melding fra behandler is legeerklæring", () => {
+      renderMeldingerISamtale([
+        foresporselLegeerklaringTilBehandler,
+        legeerklaringFraBehandler,
+      ]);
+
+      expect(getButton(returLegeerklaringButtonText)).to.exist;
+    });
+  });
+});

--- a/test/behandlerdialog/PaminnelseTest.tsx
+++ b/test/behandlerdialog/PaminnelseTest.tsx
@@ -4,31 +4,28 @@ import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { navEnhet } from "../dialogmote/testData";
 import React from "react";
 import { expect } from "chai";
-import { MeldingerISamtale } from "@/components/behandlerdialog/meldinger/MeldingerISamtale";
 import {
   MeldingDTO,
   PaminnelseDTO,
 } from "@/data/behandlerdialog/behandlerdialogTypes";
 import { queryClientWithMockData } from "../testQueryClient";
 import { defaultMelding } from "../../mock/isbehandlerdialog/behandlerdialogMock";
-import { clickButton, getButton } from "../testUtils";
+import { clickButton } from "../testUtils";
 import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
-import {
-  personOppgaveBehandletBehandlerdialogUbesvartMelding,
-  personOppgaveUbehandletBehandlerdialogUbesvartMelding,
-} from "../../mock/ispersonoppgave/personoppgaveMock";
+import { personOppgaveUbehandletBehandlerdialogUbesvartMelding } from "../../mock/ispersonoppgave/personoppgaveMock";
 import { expectedPaminnelseDocument } from "./testDataDocuments";
+import { PaminnelseMelding } from "@/components/behandlerdialog/paminnelse/PaminnelseMelding";
 
 let queryClient: QueryClient;
 
-const renderMeldingerISamtale = (meldinger: MeldingDTO[]) => {
+const renderPaminnelseMelding = (melding: MeldingDTO) => {
   render(
     <QueryClientProvider client={queryClient}>
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <MeldingerISamtale meldinger={meldinger} />
+        <PaminnelseMelding melding={melding} />
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>
   );
@@ -43,39 +40,9 @@ const sendButtonText = "Send påminnelse";
 const fjernOppgaveButtonText = "Fjern oppgave uten å sende påminnelse";
 const cancelButtonText = "Lukk";
 
-describe("Melding til behandler påminnelse", () => {
+describe("PåminnelseMelding", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
-  });
-
-  it("render no paminnelse button when no meldinger", () => {
-    renderMeldingerISamtale([]);
-
-    expect(screen.queryByRole("button", { name: paminnelseButtonText })).to.not
-      .exist;
-  });
-  it("render no paminnelse button when no ubesvart melding-oppgave", () => {
-    renderMeldingerISamtale([meldingTilBehandler]);
-
-    expect(screen.queryByRole("button", { name: paminnelseButtonText })).to.not
-      .exist;
-  });
-  it("render no paminnelse button for melding til behandler med behandlet ubesvart melding-oppgave", () => {
-    queryClient.setQueryData(
-      personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [
-        {
-          ...personOppgaveBehandletBehandlerdialogUbesvartMelding,
-          referanseUuid: meldingTilBehandler.uuid,
-        },
-      ]
-    );
-    renderMeldingerISamtale([meldingTilBehandler]);
-
-    expect(screen.queryByRole("button", { name: paminnelseButtonText })).to.not
-      .exist;
-  });
-  it("render paminnelse button for melding til behandler med ubehandlet ubesvart melding-oppgave", () => {
     queryClient.setQueryData(
       personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
       () => [
@@ -85,96 +52,76 @@ describe("Melding til behandler påminnelse", () => {
         },
       ]
     );
-
-    renderMeldingerISamtale([meldingTilBehandler]);
-
-    expect(getButton(paminnelseButtonText)).to.exist;
   });
-  describe("paminnelse button", () => {
-    beforeEach(() => {
-      queryClient.setQueryData(
-        personoppgaverQueryKeys.personoppgaver(
-          ARBEIDSTAKER_DEFAULT.personIdent
-        ),
-        () => [
-          {
-            ...personOppgaveUbehandletBehandlerdialogUbesvartMelding,
-            referanseUuid: meldingTilBehandler.uuid,
-          },
-        ]
-      );
+
+  it("click opens preview with send, fjern oppgave and cancel button", () => {
+    renderPaminnelseMelding(meldingTilBehandler);
+
+    clickButton(paminnelseButtonText);
+
+    const previewModal = screen.getByRole("dialog");
+    expect(previewModal).to.exist;
+
+    const expectedTexts = expectedPaminnelseDocument(
+      meldingTilBehandler
+    ).flatMap((documentComponent) => documentComponent.texts);
+    expectedTexts.forEach((text) => {
+      expect(within(previewModal).getByText(text)).to.exist;
     });
-    it("click opens preview with send, fjern oppgave and cancel button", () => {
-      renderMeldingerISamtale([meldingTilBehandler]);
 
-      clickButton(paminnelseButtonText);
+    expect(within(previewModal).getByRole("button", { name: sendButtonText }))
+      .to.exist;
+    expect(
+      within(previewModal).getByRole("button", {
+        name: fjernOppgaveButtonText,
+      })
+    ).to.exist;
+    expect(within(previewModal).getByRole("button", { name: cancelButtonText }))
+      .to.exist;
+  });
+  it("click cancel in preview closes preview", () => {
+    renderPaminnelseMelding(meldingTilBehandler);
 
-      const previewModal = screen.getByRole("dialog");
-      expect(previewModal).to.exist;
+    clickButton(paminnelseButtonText);
 
-      const expectedTexts = expectedPaminnelseDocument(
-        meldingTilBehandler
-      ).flatMap((documentComponent) => documentComponent.texts);
-      expectedTexts.forEach((text) => {
-        expect(within(previewModal).getByText(text)).to.exist;
-      });
+    const previewModal = screen.getByRole("dialog");
+    expect(previewModal).to.exist;
 
-      expect(within(previewModal).getByRole("button", { name: sendButtonText }))
-        .to.exist;
-      expect(
-        within(previewModal).getByRole("button", {
-          name: fjernOppgaveButtonText,
-        })
-      ).to.exist;
-      expect(
-        within(previewModal).getByRole("button", { name: cancelButtonText })
-      ).to.exist;
-    });
-    it("click cancel in preview closes preview", () => {
-      renderMeldingerISamtale([meldingTilBehandler]);
+    clickButton("Lukk");
 
-      clickButton(paminnelseButtonText);
+    expect(screen.queryByRole("dialog")).to.not.exist;
+    expect(screen.queryByRole("button", { name: sendButtonText })).to.not.exist;
+    expect(screen.queryByRole("button", { name: cancelButtonText })).to.not
+      .exist;
+  });
+  it("click send in preview sends paminnelse with expected values", () => {
+    const expectedPaminnelseDTO: PaminnelseDTO = {
+      document: expectedPaminnelseDocument(meldingTilBehandler),
+    };
 
-      const previewModal = screen.getByRole("dialog");
-      expect(previewModal).to.exist;
+    renderPaminnelseMelding(meldingTilBehandler);
 
-      clickButton("Lukk");
+    clickButton(paminnelseButtonText);
 
-      expect(screen.queryByRole("dialog")).to.not.exist;
-      expect(screen.queryByRole("button", { name: sendButtonText })).to.not
-        .exist;
-      expect(screen.queryByRole("button", { name: cancelButtonText })).to.not
-        .exist;
-    });
-    it("click send in preview sends paminnelse with expected values", () => {
-      const expectedPaminnelseDTO: PaminnelseDTO = {
-        document: expectedPaminnelseDocument(meldingTilBehandler),
-      };
+    clickButton(sendButtonText);
 
-      renderMeldingerISamtale([meldingTilBehandler]);
+    const paminnelseMutation = queryClient.getMutationCache().getAll()[0];
 
-      clickButton(paminnelseButtonText);
+    expect(paminnelseMutation.options.variables).to.deep.equal(
+      expectedPaminnelseDTO
+    );
+  });
+  it("click fjern oppgave in preview behandler oppgave", () => {
+    renderPaminnelseMelding(meldingTilBehandler);
 
-      clickButton(sendButtonText);
+    clickButton(paminnelseButtonText);
 
-      const paminnelseMutation = queryClient.getMutationCache().getAll()[0];
+    clickButton(fjernOppgaveButtonText);
 
-      expect(paminnelseMutation.options.variables).to.deep.equal(
-        expectedPaminnelseDTO
-      );
-    });
-    it("click fjern oppgave in preview behandler oppgave", () => {
-      renderMeldingerISamtale([meldingTilBehandler]);
+    const paminnelseMutation = queryClient.getMutationCache().getAll()[0];
 
-      clickButton(paminnelseButtonText);
-
-      clickButton(fjernOppgaveButtonText);
-
-      const paminnelseMutation = queryClient.getMutationCache().getAll()[0];
-
-      expect(paminnelseMutation.options.variables).to.deep.equal(
-        personOppgaveUbehandletBehandlerdialogUbesvartMelding.uuid
-      );
-    });
+    expect(paminnelseMutation.options.variables).to.deep.equal(
+      personOppgaveUbehandletBehandlerdialogUbesvartMelding.uuid
+    );
   });
 });


### PR DESCRIPTION

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/eb62b6cd-0b2b-44de-9174-5720f10d36ea)

I tillegg:
- Ryddet litt i uuid-er i mockdata
- Flyttet tester på visning av knappene for påminnelse og retur til egen test-fil.
- Refaktorert til MeldingActionButton som brukes av påminnelse og retur.