### PR TITLE
Adjust vedlegg link for legeerklaring

### DIFF
--- a/mock/isbehandlerdialog/behandlerdialogMock.ts
+++ b/mock/isbehandlerdialog/behandlerdialogMock.ts
@@ -229,6 +229,11 @@ export const defaultMeldingInnkommendeLegeerklaringNy = {
   uuid: meldingUuids.legeerklaringInnkommendeNy,
 };
 
+export const defaultMeldingInnkommendeLegeerklaringMedTreVedlegg = {
+  ...defaultMeldingInnkommendeLegeerklaring,
+  antallVedlegg: 3,
+};
+
 const ubesvartMelding = {
   ...defaultMelding,
   uuid: meldingUuids.ubesvartMelding,

--- a/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
+++ b/src/components/behandlerdialog/meldinger/MeldingInnholdPanel.tsx
@@ -118,7 +118,7 @@ export const MeldingInnholdPanel = ({ melding }: MeldingInnholdPanelProps) => {
           <PaperclipIcon title="Binders-ikon for vedlegg" fontSize="1.25em" />
           {[...Array(melding.antallVedlegg)].map((_, index) => (
             <PdfVedleggLink
-              meldingUuid={melding.uuid}
+              melding={melding}
               vedleggNumber={index}
               key={index}
             />

--- a/src/components/behandlerdialog/meldinger/PdfVedleggLink.tsx
+++ b/src/components/behandlerdialog/meldinger/PdfVedleggLink.tsx
@@ -2,22 +2,40 @@ import React from "react";
 import { Link } from "@navikt/ds-react";
 import styled from "styled-components";
 import { ISBEHANDLERDIALOG_ROOT } from "@/apiConstants";
+import {
+  MeldingDTO,
+  MeldingType,
+} from "@/data/behandlerdialog/behandlerdialogTypes";
 
 const StyledLink = styled(Link)`
   padding-right: 0.25em;
 `;
 
 interface PdfVedleggProps {
-  meldingUuid: string;
+  melding: MeldingDTO;
   vedleggNumber: number;
 }
 
-const PdfVedleggLink = ({ meldingUuid, vedleggNumber }: PdfVedleggProps) => {
-  const pdfUrl = `${ISBEHANDLERDIALOG_ROOT}/melding/${meldingUuid}/${vedleggNumber}/pdf`;
-  const oneIndexedVedleggNumber = vedleggNumber + 1;
+const getVedleggLinkText = (
+  melding: MeldingDTO,
+  vedleggNumber: number
+): string => {
+  const isInnkommendeLegeerklaring =
+    melding.innkommende &&
+    melding.type === MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING;
+  if (isInnkommendeLegeerklaring) {
+    return vedleggNumber === 0 ? "Legeerklæring" : `Vedlegg ${vedleggNumber}`;
+  } else {
+    return `Vedlegg ${vedleggNumber + 1}`;
+  }
+};
+
+const PdfVedleggLink = ({ melding, vedleggNumber }: PdfVedleggProps) => {
+  const pdfUrl = `${ISBEHANDLERDIALOG_ROOT}/melding/${melding.uuid}/${vedleggNumber}/pdf`;
+  const vedleggLinkText = getVedleggLinkText(melding, vedleggNumber);
   return (
     <StyledLink href={pdfUrl} target="_blank" rel="noreferrer">
-      Vedlegg {oneIndexedVedleggNumber}
+      {vedleggLinkText}
     </StyledLink>
   );
 };

--- a/test/behandlerdialog/meldingTestdataGenerator.ts
+++ b/test/behandlerdialog/meldingTestdataGenerator.ts
@@ -3,6 +3,7 @@ import {
   defaultMelding,
   defaultMeldingInnkommende,
   defaultMeldingInnkommendeLegeerklaring,
+  defaultMeldingInnkommendeLegeerklaringMedTreVedlegg,
   defaultMeldingInnkommendeLegeerklaringNy,
   defaultMeldingLegeerklaring,
   defaultReturLegeerklaring,
@@ -121,6 +122,15 @@ export const meldingResponseLegeerklaring = {
     ["conversationRef567"]: [
       defaultMeldingLegeerklaring,
       defaultMeldingInnkommendeLegeerklaring,
+    ],
+  },
+};
+
+export const meldingResponseLegeerklaringMedTreVedlegg = {
+  conversations: {
+    ["conversationRef567"]: [
+      defaultMeldingLegeerklaring,
+      defaultMeldingInnkommendeLegeerklaringMedTreVedlegg,
     ],
   },
 };


### PR DESCRIPTION
For en innkommende legeerklæring-melding vil første vedlegg alltid være selve legeerklæringen - justerer vedlegg lenke-teksten iht dette.
![image](https://github.com/navikt/syfomodiaperson/assets/79838644/66e04ec6-0b04-4436-b7e3-a1fdb7be748a)
