### PR TITLE
[IS-1598] Add link to enhetens oversikt from modia

### DIFF
--- a/src/components/personkort/OversiktLenker.tsx
+++ b/src/components/personkort/OversiktLenker.tsx
@@ -6,17 +6,25 @@ import styled from "styled-components";
 const texts = {
   oversikt: "Min oversikt",
   moter: "Mine møter",
+  enhetensOversikt: "Enhetens oversikt",
 };
 
-const MinOversiktLenke = styled(Lenke)`
-  margin-right: 2em;
+const StyledLenkeRad = styled.div`
+  > * {
+    &:not(:last-child) {
+      margin-right: 2em;
+    }
+  }
 `;
 
 export const OversiktLenker = (): ReactElement => (
-  <>
-    <MinOversiktLenke href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
+  <StyledLenkeRad>
+    <Lenke href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
       {texts.oversikt}
-    </MinOversiktLenke>
+    </Lenke>
+    <Lenke href={fullNaisUrlIntern("syfooversikt", "/enhet")}>
+      {texts.enhetensOversikt}
+    </Lenke>
     <Lenke href={fullNaisUrlIntern("syfomoteoversikt")}>{texts.moter}</Lenke>
-  </>
+  </StyledLenkeRad>
 );

--- a/src/components/personkort/OversiktLenker.tsx
+++ b/src/components/personkort/OversiktLenker.tsx
@@ -19,11 +19,11 @@ const StyledLenkeRad = styled.div`
 
 export const OversiktLenker = (): ReactElement => (
   <StyledLenkeRad>
-    <Link href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
-      {texts.oversikt}
-    </Link>
     <Link href={fullNaisUrlIntern("syfooversikt", "/enhet")}>
       {texts.enhetensOversikt}
+    </Link>
+    <Link href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
+      {texts.oversikt}
     </Link>
     <Link href={fullNaisUrlIntern("syfomoteoversikt")}>{texts.moter}</Link>
   </StyledLenkeRad>

--- a/src/components/personkort/OversiktLenker.tsx
+++ b/src/components/personkort/OversiktLenker.tsx
@@ -1,7 +1,7 @@
 import { fullNaisUrlIntern } from "@/utils/miljoUtil";
-import Lenke from "nav-frontend-lenker";
 import React, { ReactElement } from "react";
 import styled from "styled-components";
+import { Link } from "@navikt/ds-react";
 
 const texts = {
   oversikt: "Min oversikt",
@@ -19,12 +19,12 @@ const StyledLenkeRad = styled.div`
 
 export const OversiktLenker = (): ReactElement => (
   <StyledLenkeRad>
-    <Lenke href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
+    <Link href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
       {texts.oversikt}
-    </Lenke>
-    <Lenke href={fullNaisUrlIntern("syfooversikt", "/enhet")}>
+    </Link>
+    <Link href={fullNaisUrlIntern("syfooversikt", "/enhet")}>
       {texts.enhetensOversikt}
-    </Lenke>
-    <Lenke href={fullNaisUrlIntern("syfomoteoversikt")}>{texts.moter}</Lenke>
+    </Link>
+    <Link href={fullNaisUrlIntern("syfomoteoversikt")}>{texts.moter}</Link>
   </StyledLenkeRad>
 );


### PR DESCRIPTION
Etter ønske fra Tor Halle og veiledere på åpen dag
<img width="419" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/dc5a9fd1-cd69-43ad-bad1-c739ab4226ef">
