### PR TITLE
IS-1579: Add forhåndsvarsel to historikk-list, showing beskrivelse

### DIFF
--- a/mock/isaktivitetskrav/aktivitetskravMock.ts
+++ b/mock/isaktivitetskrav/aktivitetskravMock.ts
@@ -1,4 +1,5 @@
 import {
+  AktivitetskravDTO,
   AktivitetskravStatus,
   AvventVurderingArsak,
   OppfyltVurderingArsak,
@@ -92,9 +93,28 @@ const aktivitetskravAutomatiskOppfylt = {
   vurderinger: [],
 };
 
+const aktivitetskravForhandsvarsel: AktivitetskravDTO = {
+  uuid: generateUUID(),
+  createdAt: daysFromToday(-11),
+  status: AktivitetskravStatus.FORHANDSVARSEL,
+  stoppunktAt: daysFromToday(40),
+  vurderinger: [
+    {
+      uuid: generateUUID(),
+      createdAt: daysFromToday(-2),
+      createdBy: VEILEDER_DEFAULT.ident,
+      status: AktivitetskravStatus.FORHANDSVARSEL,
+      beskrivelse: "En begrunnelse for hvorfor det er sendt forhåndsvarsel",
+      arsaker: [],
+      frist: daysFromToday(21),
+    },
+  ],
+};
+
 export const aktivitetskravMock = [
   aktivitetskravNy,
   aktivitetskravAutomatiskOppfylt,
   aktivitetskravOppfylt,
   aktivitetskravUnntak,
+  aktivitetskravForhandsvarsel,
 ];

--- a/src/components/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
+++ b/src/components/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
@@ -28,7 +28,8 @@ const isRelevantForHistorikk = (vurdering: AktivitetskravVurderingDTO) =>
   vurdering.status === AktivitetskravStatus.OPPFYLT ||
   vurdering.status === AktivitetskravStatus.UNNTAK ||
   vurdering.status === AktivitetskravStatus.STANS ||
-  vurdering.status === AktivitetskravStatus.IKKE_OPPFYLT;
+  vurdering.status === AktivitetskravStatus.IKKE_OPPFYLT ||
+  vurdering.status === AktivitetskravStatus.FORHANDSVARSEL;
 
 const byCreatedAt = (
   v1: AktivitetskravVurderingDTO,
@@ -76,9 +77,11 @@ const headerPrefix = (status: AktivitetskravStatus): string => {
     case AktivitetskravStatus.IKKE_OPPFYLT: {
       return "Ikke oppfylt";
     }
+    case AktivitetskravStatus.FORHANDSVARSEL: {
+      return "Forhåndsvarsel";
+    }
     case AktivitetskravStatus.NY:
     case AktivitetskravStatus.AUTOMATISK_OPPFYLT:
-    case AktivitetskravStatus.FORHANDSVARSEL:
     case AktivitetskravStatus.AVVENT:
     case AktivitetskravStatus.IKKE_AKTUELL: {
       // Ikke relevant for historikk

--- a/test/aktivitetskrav/AktivitetskravHistorikkTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravHistorikkTest.tsx
@@ -63,6 +63,12 @@ const stansVurdering = createAktivitetskravVurdering(
   AktivitetskravStatus.STANS,
   []
 );
+const forhandsvarselVurdering = createAktivitetskravVurdering(
+  AktivitetskravStatus.FORHANDSVARSEL,
+  [],
+  enBeskrivelse,
+  today
+);
 
 const renderAktivitetskravHistorikk = (
   vurderinger: AktivitetskravVurderingDTO[]
@@ -95,13 +101,20 @@ describe("AktivitetskravHistorikk", () => {
     );
   });
   it("viser klikkbar overskrift for hver vurdering, sortert etter dato - nyeste øverst", () => {
-    renderAktivitetskravHistorikk([unntakVurdering, oppfyltVurdering]);
+    renderAktivitetskravHistorikk([
+      forhandsvarselVurdering,
+      unntakVurdering,
+      oppfyltVurdering,
+    ]);
 
     const vurderingButtons = screen.getAllByRole("button");
     expect(vurderingButtons[0].textContent).to.contain(
-      `Oppfylt - ${tilDatoMedManedNavn(today)}`
+      `Forhåndsvarsel - ${tilDatoMedManedNavn(today)}`
     );
     expect(vurderingButtons[1].textContent).to.contain(
+      `Oppfylt - ${tilDatoMedManedNavn(today)}`
+    );
+    expect(vurderingButtons[2].textContent).to.contain(
       `Unntak - ${tilDatoMedManedNavn(dayInThePast)}`
     );
   });

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -55,6 +55,7 @@ export const buttonTexts = {
   [AktivitetskravStatus.FORHANDSVARSEL]: "Send forhåndsvarsel",
   [AktivitetskravStatus.IKKE_OPPFYLT]: "Ikke oppfylt",
   [AktivitetskravStatus.IKKE_AKTUELL]: "Ikke aktuell",
+  [AktivitetskravStatus.FORHANDSVARSEL]: "Send forhåndsvarsel",
 };
 
 const enBeskrivelse = "Her er en beskrivelse";


### PR DESCRIPTION
På sikt vil vi også vise brevet/dokumentet som ble sendt ut her, men det krever endringer i endepunktet, slik at dette er foreløpig løsning med kun friteksten/begrunnelsen fra veileder.

<img width="555" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/186b90a6-81a7-4325-a4c1-ba190541a0e4">
