### PR TITLE
IS-1605: Add BULLET_POINTS element and fix texts

### DIFF
--- a/mock/isbehandlerdialog/behandlerdialogMock.ts
+++ b/mock/isbehandlerdialog/behandlerdialogMock.ts
@@ -59,7 +59,7 @@ const meldingtilBehandlerDocument = [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -89,7 +89,7 @@ const paminnelseDocument = [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -125,7 +125,7 @@ const returLegeerklaringDocument = [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];

--- a/mock/isdialogmote/dialogmoterMock.ts
+++ b/mock/isdialogmote/dialogmoterMock.ts
@@ -51,7 +51,7 @@ export const createDialogmote = (
             {
               type: "PARAGRAPH",
               title: null,
-              texts: ["Vennlig hilsen", "NAV Staden", "Kari Saksbehandler"],
+              texts: ["Med vennlig hilsen", "NAV Staden", "Kari Saksbehandler"],
             },
           ],
           svar: {

--- a/src/components/DocumentComponentVisning.tsx
+++ b/src/components/DocumentComponentVisning.tsx
@@ -33,7 +33,7 @@ const DocumentComponentLink = (texts: string[], title?: string) => {
 const DocumentComponentHeaderH1 = (texts: string[]) => {
   const header = texts.length === 0 ? "" : texts[0];
   return (
-    <FlexRow topPadding={PaddingSize.MD} bottomPadding={PaddingSize.MD}>
+    <FlexRow topPadding={PaddingSize.SM} bottomPadding={PaddingSize.SM}>
       <Heading size="large">{header}</Heading>
     </FlexRow>
   );
@@ -44,6 +44,17 @@ const DocumentComponentHeaderH2 = (texts: string[]) => {
   return (
     <FlexRow topPadding={PaddingSize.SM}>
       <Heading size="medium">{header}</Heading>
+    </FlexRow>
+  );
+};
+
+const DocumentComponentHeaderH3 = (texts: string[]) => {
+  const header = texts.length === 0 ? "" : texts[0];
+  return (
+    <FlexRow topPadding={PaddingSize.SM}>
+      <Heading level="3" size="small">
+        {header}
+      </Heading>
     </FlexRow>
   );
 };
@@ -70,6 +81,18 @@ const DocumentComponentParagraph = (texts: string[], title?: string) => {
   );
 };
 
+export const DocumentComponentBulletPoints = (texts: string[]) => {
+  return (
+    <ul>
+      {texts.map((text, index) => (
+        <BodyLong size="small" key={index} as={"li"}>
+          {text}
+        </BodyLong>
+      ))}
+    </ul>
+  );
+};
+
 interface DocumentComponentVisningProps {
   documentComponent: DocumentComponentDto;
 }
@@ -87,11 +110,17 @@ export const DocumentComponentVisning = ({
     case DocumentComponentType.HEADER_H2: {
       return DocumentComponentHeaderH2(texts);
     }
+    case DocumentComponentType.HEADER_H3: {
+      return DocumentComponentHeaderH3(texts);
+    }
     case DocumentComponentType.LINK: {
       return DocumentComponentLink(texts, title);
     }
     case DocumentComponentType.PARAGRAPH: {
       return DocumentComponentParagraph(texts, title);
+    }
+    case DocumentComponentType.BULLET_POINTS: {
+      return DocumentComponentBulletPoints(texts);
     }
   }
 };

--- a/src/data/aktivitetskrav/aktivitetskravTexts.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTexts.ts
@@ -35,26 +35,27 @@ export const sendForhandsvarselTexts = {
   varselInfo: {
     header: "Varsel om stans av sykepenger",
     introWithFristDate: (frist: Date) =>
-      `Du har nå vært 100% sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
+      `Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
         frist
       )}.`,
-    intro2:
-      "Når vi vurderer om du oppfyller aktivitetsplikten, ser vi på hva arbeidsgiveren din har gjort for at du kan jobbe. Vi vurderer også om du er for syk til å være i aktivitet.",
   },
   unngaStansInfo: {
     header: "Du kan unngå stans av sykepenger",
     tiltak1:
-      "- Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger.",
+      "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden",
     tiltak2:
-      "- Gir arbeidsgiveren din en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, kan utbetalingen av sykepenger fortsette.",
+      "Gir arbeidsgiveren din en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, kan utbetalingen av sykepenger fortsette.",
     tiltak3:
-      "- Går det fram av sykmeldingen at du er for syk til å arbeide, får du fortsatt sykepenger.",
+      "Går det fram av sykmeldingen at du er for syk til å arbeide, får du fortsatt sykepenger.",
+  },
+  giOssTilbakemelding: {
+    header: "Gi oss tilbakemelding",
     tilbakemeldingWithFristDate: (frist: Date) =>
       `Vi må ha tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
         frist
       )}. Ellers vil sykepengene dine stanses fra denne datoen.`,
     kontaktOss:
-      "Kontakt oss gjerne på nav.no/skrivtiloss eller telefon 55 55 33 33.", //TODO: Vise dette som link?
+      "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
   },
   lovhjemmel: {
     header: "Lovhjemmel",

--- a/src/data/documentcomponent/documentComponentTypes.ts
+++ b/src/data/documentcomponent/documentComponentTypes.ts
@@ -2,7 +2,9 @@ export enum DocumentComponentType {
   HEADER = "HEADER",
   HEADER_H1 = "HEADER_H1",
   HEADER_H2 = "HEADER_H2",
+  HEADER_H3 = "HEADER_H3",
   PARAGRAPH = "PARAGRAPH",
+  BULLET_POINTS = "BULLET_POINTS",
   LINK = "LINK",
 }
 

--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -1,7 +1,9 @@
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
 import {
-  createHeaderH2,
+  createBulletPoints,
+  createHeaderH1,
+  createHeaderH3,
   createParagraph,
 } from "@/utils/documentComponentUtils";
 import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
@@ -12,19 +14,17 @@ export const useAktivitetskravVarselDocument = (): {
     fristDato: Date
   ): DocumentComponentDto[];
 } => {
-  const { getHilsen, getIntroHeiWithPersonIdent } = useDocumentComponents();
+  const { getHilsen } = useDocumentComponents();
 
   const getForhandsvarselDocument = (
     begrunnelse: string | undefined,
     fristDato: Date
   ) => {
     const documentComponents = [
-      getIntroHeiWithPersonIdent(),
-      createHeaderH2(sendForhandsvarselTexts.varselInfo.header),
+      createHeaderH1(sendForhandsvarselTexts.varselInfo.header),
       createParagraph(
         sendForhandsvarselTexts.varselInfo.introWithFristDate(fristDato)
       ),
-      createParagraph(sendForhandsvarselTexts.varselInfo.intro2),
     ];
 
     if (begrunnelse) {
@@ -32,20 +32,22 @@ export const useAktivitetskravVarselDocument = (): {
     }
 
     documentComponents.push(
-      createHeaderH2(sendForhandsvarselTexts.unngaStansInfo.header),
-      createParagraph(
+      createHeaderH3(sendForhandsvarselTexts.unngaStansInfo.header),
+      createBulletPoints(
         sendForhandsvarselTexts.unngaStansInfo.tiltak1,
         sendForhandsvarselTexts.unngaStansInfo.tiltak2,
         sendForhandsvarselTexts.unngaStansInfo.tiltak3
       ),
+
+      createHeaderH3(sendForhandsvarselTexts.giOssTilbakemelding.header),
       createParagraph(
-        sendForhandsvarselTexts.unngaStansInfo.tilbakemeldingWithFristDate(
+        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate(
           fristDato
         )
       ),
-      createParagraph(sendForhandsvarselTexts.unngaStansInfo.kontaktOss),
+      createParagraph(sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss),
 
-      createHeaderH2(sendForhandsvarselTexts.lovhjemmel.header),
+      createHeaderH3(sendForhandsvarselTexts.lovhjemmel.header),
       createParagraph(sendForhandsvarselTexts.lovhjemmel.aktivitetsplikten),
       createParagraph(sendForhandsvarselTexts.lovhjemmel.pliktInfo),
 

--- a/src/hooks/useDocumentComponents.ts
+++ b/src/hooks/useDocumentComponents.ts
@@ -10,10 +10,8 @@ export const useDocumentComponents = () => {
 
   return {
     getHilsen: () =>
-      createParagraph("Vennlig hilsen", veilederinfo?.navn || "", "NAV"),
+      createParagraph("Med vennlig hilsen", veilederinfo?.navn || "", "NAV"),
     getIntroHei: () => createParagraph(`Hei, ${navBruker.navn}`),
-    getIntroHeiWithPersonIdent: () =>
-      createParagraph(`Hei, ${navBruker.navn}, ${valgtPersonident}`),
     getIntroGjelder: () =>
       createParagraph(`Gjelder ${navBruker.navn}, f.nr. ${valgtPersonident}`),
   };

--- a/src/utils/documentComponentUtils.ts
+++ b/src/utils/documentComponentUtils.ts
@@ -23,6 +23,14 @@ export const createParagraph = (...texts: string[]): DocumentComponentDto => ({
   type: DocumentComponentType.PARAGRAPH,
   texts,
 });
+
+export const createBulletPoints = (
+  ...texts: string[]
+): DocumentComponentDto => ({
+  type: DocumentComponentType.BULLET_POINTS,
+  texts,
+});
+
 export const createHeaderH1 = (text: string): DocumentComponentDto => ({
   type: DocumentComponentType.HEADER_H1,
   texts: [text],
@@ -33,12 +41,18 @@ export const createHeaderH2 = (text: string): DocumentComponentDto => ({
   texts: [text],
 });
 
+export const createHeaderH3 = (text: string): DocumentComponentDto => ({
+  type: DocumentComponentType.HEADER_H3,
+  texts: [text],
+});
+
 export const getHeaderText = (
   document: DocumentComponentDto[],
   type:
     | DocumentComponentType.HEADER
     | DocumentComponentType.HEADER_H1
     | DocumentComponentType.HEADER_H2
+    | DocumentComponentType.HEADER_H3
 ): string => {
   const header = document.find((component) => component.type === type);
   return header?.texts[0] ?? "";

--- a/test/aktivitetskrav/varselDocuments.ts
+++ b/test/aktivitetskrav/varselDocuments.ts
@@ -3,25 +3,15 @@ import {
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
 import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
-import {
-  ARBEIDSTAKER_DEFAULT,
-  ARBEIDSTAKER_DEFAULT_FULL_NAME,
-  VEILEDER_DEFAULT,
-} from "../../mock/common/mockConstants";
+import { VEILEDER_DEFAULT } from "../../mock/common/mockConstants";
 import { getFristForForhandsvarsel } from "@/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema";
 
 export const getSendForhandsvarselDocument = (
   beskrivelse: string
 ): DocumentComponentDto[] => [
   {
-    texts: [
-      `Hei, ${ARBEIDSTAKER_DEFAULT_FULL_NAME}, ${ARBEIDSTAKER_DEFAULT.personIdent}`,
-    ],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
     texts: [sendForhandsvarselTexts.varselInfo.header],
-    type: DocumentComponentType.HEADER_H2,
+    type: DocumentComponentType.HEADER_H1,
   },
   {
     texts: [
@@ -32,16 +22,12 @@ export const getSendForhandsvarselDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [sendForhandsvarselTexts.varselInfo.intro2],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
     texts: [beskrivelse],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [sendForhandsvarselTexts.unngaStansInfo.header],
-    type: DocumentComponentType.HEADER_H2,
+    type: DocumentComponentType.HEADER_H3,
   },
   {
     texts: [
@@ -49,23 +35,27 @@ export const getSendForhandsvarselDocument = (
       sendForhandsvarselTexts.unngaStansInfo.tiltak2,
       sendForhandsvarselTexts.unngaStansInfo.tiltak3,
     ],
-    type: DocumentComponentType.PARAGRAPH,
+    type: DocumentComponentType.BULLET_POINTS,
+  },
+  {
+    texts: [sendForhandsvarselTexts.giOssTilbakemelding.header],
+    type: DocumentComponentType.HEADER_H3,
   },
   {
     texts: [
-      sendForhandsvarselTexts.unngaStansInfo.tilbakemeldingWithFristDate(
+      sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate(
         getFristForForhandsvarsel()
       ),
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [sendForhandsvarselTexts.unngaStansInfo.kontaktOss],
+    texts: [sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [sendForhandsvarselTexts.lovhjemmel.header],
-    type: DocumentComponentType.HEADER_H2,
+    type: DocumentComponentType.HEADER_H3,
   },
   {
     texts: [sendForhandsvarselTexts.lovhjemmel.aktivitetsplikten],
@@ -76,7 +66,7 @@ export const getSendForhandsvarselDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];

--- a/test/behandlerdialog/testDataDocuments.ts
+++ b/test/behandlerdialog/testDataDocuments.ts
@@ -52,7 +52,7 @@ export const expectedTilleggsopplysningerDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -91,7 +91,7 @@ export const expectedPaminnelseDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -145,7 +145,7 @@ export const expectedLegeerklaringDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -192,7 +192,7 @@ export const expectedReturLegeerklaringDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -215,7 +215,7 @@ export const expectedMeldingFraNAVDocument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -111,7 +111,7 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -185,7 +185,7 @@ const expectedArbeidsgiverInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -245,7 +245,7 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -335,7 +335,7 @@ const expectedArbeidsgiverEndringsdokument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -429,7 +429,7 @@ const expectedArbeidstakerEndringsdokument = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -496,7 +496,7 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -532,7 +532,7 @@ const expectedAvlysningArbeidsgiver = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -568,7 +568,7 @@ const expectedAvlysningArbeidstaker = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -604,7 +604,7 @@ const expectedAvlysningBehandler = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -695,7 +695,7 @@ export const expectedReferatDocument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -788,7 +788,7 @@ export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: ["Vennlig hilsen", veileder.navn ?? "", "NAV"],
+    texts: ["Med vennlig hilsen", veileder.navn ?? "", "NAV"],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];


### PR DESCRIPTION
Legger til støtte for `BULLET_POINTS` og `HEADER_H3` komponenter i document components. Dette trengs for å rendre pdf riktig med bulletpoints og riktig header størrelse. Se IS-1605 på trello for mer info.

Se tilhørende PR'er i [isaktivitetskrav](https://github.com/navikt/isaktivitetskrav/pull/119) og [isaktivitetskravpdfgen](https://github.com/navikt/isaktivitetskravpdfgen/pull/4)

## Screenshots 📸
![Screenshot 2023-09-20 at 13 09 32](https://github.com/navikt/syfomodiaperson/assets/11747383/502458de-5143-42f4-8e95-e203eda66668)
