### PR TITLE
Add test for getWeeksBetween to datoer

### DIFF
--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -271,7 +271,7 @@ export const getEarliestDate = (date1, date2): Date => {
 };
 
 export const getWeeksBetween = (date1, date2): number => {
-  return Math.round(
+  return Math.floor(
     Math.abs(new Date(date1).getTime() - new Date(date2).getTime()) /
       ONE_WEEK_MILLIS
   );

--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -28,7 +28,6 @@ const dager = [
 const SKILLETEGN_PERIODE = "–";
 
 export const ANTALL_MS_DAG = 1000 * 60 * 60 * 24;
-const ONE_WEEK_MILLIS = 7 * ANTALL_MS_DAG;
 
 const pad = (int: number): string | number => {
   if (int < 10) {
@@ -271,8 +270,5 @@ export const getEarliestDate = (date1, date2): Date => {
 };
 
 export const getWeeksBetween = (date1, date2): number => {
-  return Math.floor(
-    Math.abs(new Date(date1).getTime() - new Date(date2).getTime()) /
-      ONE_WEEK_MILLIS
-  );
+  return Math.abs(dayjs(date1).diff(date2, "week"));
 };

--- a/test/utils/datoUtilsTest.ts
+++ b/test/utils/datoUtilsTest.ts
@@ -4,6 +4,7 @@ import {
   dagerMellomDatoer,
   erIdag,
   erIkkeIdag,
+  getWeeksBetween,
   manederMellomDatoer,
   restdatoTildato,
   restdatoTilLesbarDato,
@@ -175,6 +176,24 @@ describe("datoUtils", () => {
 
       const dateWithAddedWeeks = addWeeks(date1, 26);
       expect(dateWithAddedWeeks.getDate()).to.equal(date2.getDate());
+    });
+  });
+
+  describe("Uker mellom datoer", () => {
+    it("Runder opp når det er 7 uker og 6 dager mellom to datoer", () => {
+      const date1 = new Date("2023-07-31");
+      const date2 = new Date("2023-09-24");
+
+      const weeks = getWeeksBetween(date1, date2);
+      expect(weeks).to.equal(8);
+    });
+
+    it("Runder ned når det er 7 uker og 2 dager mellom to datoer", () => {
+      const date1 = new Date("2023-07-31");
+      const date2 = new Date("2023-09-20");
+
+      const weeks = getWeeksBetween(date1, date2);
+      expect(weeks).to.equal(7);
     });
   });
 });

--- a/test/utils/datoUtilsTest.ts
+++ b/test/utils/datoUtilsTest.ts
@@ -180,17 +180,9 @@ describe("datoUtils", () => {
   });
 
   describe("Uker mellom datoer", () => {
-    it("Runder opp når det er 7 uker og 6 dager mellom to datoer", () => {
+    it("Runder ned når det er 7 uker og 6 dager mellom to datoer", () => {
       const date1 = new Date("2023-07-31");
       const date2 = new Date("2023-09-24");
-
-      const weeks = getWeeksBetween(date1, date2);
-      expect(weeks).to.equal(8);
-    });
-
-    it("Runder ned når det er 7 uker og 2 dager mellom to datoer", () => {
-      const date1 = new Date("2023-07-31");
-      const date2 = new Date("2023-09-20");
 
       const weeks = getWeeksBetween(date1, date2);
       expect(weeks).to.equal(7);


### PR DESCRIPTION
Vi fikk en JIRA-sak der det ikke hadde blitt generert aktivitetskrav, men så stod det "Varighet: 8 uker" i personkortet i modia. Varighet bruker `getWeeksBetween` som runder av til nærmeste heltall.

Hvorvidt dette er riktig logikk kan Stine og TH vurdere, jeg tenker feks at `Math.floor()` kanskje hadde vært bedre slik at man ikke viser et lenger sykefravær enn de egentlig har 🤔 

Her er hvertfall en test for utils-metoden, siden vi manglet det.