### PR TITLE
IS-1626: Hide venter-på-svar tag if melding is of type melding fra NAV

### DIFF
--- a/mock/isbehandlerdialog/mockIsbehandlerdialog.ts
+++ b/mock/isbehandlerdialog/mockIsbehandlerdialog.ts
@@ -9,6 +9,18 @@ import {
 import { MeldingTilBehandlerDTO } from "@/data/behandlerdialog/behandlerdialogTypes";
 
 let behandlerdialogMockData = behandlerdialogMock;
+
+const replaceNumberInString = (originalString: string, searchValue: string) => {
+  const replaceValue = Math.round(Math.random() * 10).toString();
+
+  return originalString.replace(
+    searchValue,
+    replaceValue !== searchValue
+      ? replaceValue
+      : Math.round(Math.random() * 10).toString()
+  );
+};
+
 export const mockIsbehandlerdialog = (server: any) => {
   server.get(
     `${ISBEHANDLERDIALOG_ROOT}/melding`,
@@ -41,10 +53,12 @@ export const mockIsbehandlerdialog = (server: any) => {
       const body = req.body as MeldingTilBehandlerDTO;
       behandlerdialogMockData = {
         conversations: {
-          ...behandlerdialogMock.conversations,
+          ...behandlerdialogMockData.conversations,
           [`${body.tekst}`]: [
             {
               ...defaultMelding,
+              uuid: replaceNumberInString(defaultMelding.uuid, "5"),
+              type: body.type,
               tekst: body.tekst,
               tidspunkt: new Date(),
             },

--- a/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
@@ -105,6 +105,11 @@ const getSamtaleTagStatus = (
     antallReturLegeerklaring >= antallInnkommendeLegeerklaringer;
   const manglerSvarFraBehandler =
     innkommende.length === 0 || manglerSvarPaaRetur;
+  const utgaendeMeldingForventerSvar = meldinger.some(
+    (melding) =>
+      !melding.innkommende &&
+      melding.type !== MeldingType.HENVENDELSE_MELDING_FRA_NAV
+  );
   const harPaminnelseMelding = hasMeldingOfType(
     meldinger,
     MeldingType.FORESPORSEL_PASIENT_PAMINNELSE
@@ -123,7 +128,11 @@ const getSamtaleTagStatus = (
     return "PAMINNELSE_SENDT";
   } else if (manglerSvarPaaRetur && harReturLegeerklaringMelding) {
     return "RETUR_SENDT";
-  } else if (manglerSvarFraBehandler && harIngenMeldingMedPaminnelseOppgave) {
+  } else if (
+    manglerSvarFraBehandler &&
+    harIngenMeldingMedPaminnelseOppgave &&
+    utgaendeMeldingForventerSvar
+  ) {
     return "VENTER_SVAR";
   } else {
     return "INGEN";

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -33,7 +33,7 @@ import {
   meldingResponseMedVedlegg,
   meldingTilOgFraBehandler,
   returLegeerklaring,
-  meldingFraNAVConversation,
+  meldingFraNAVConversationMedSvar,
 } from "./meldingTestdataGenerator";
 
 let queryClient: QueryClient;
@@ -181,7 +181,7 @@ describe("Meldinger panel", () => {
     });
 
     it("Viser at antall melding som finnes av meldingtype 'melding fra NAV', rendres", () => {
-      const meldingResponse = meldingFraNAVConversation;
+      const meldingResponse = meldingFraNAVConversationMedSvar;
       queryClient.setQueryData(
         behandlerdialogQueryKeys.behandlerdialog(
           ARBEIDSTAKER_DEFAULT.personIdent

--- a/test/behandlerdialog/SamtalerTagsTest.tsx
+++ b/test/behandlerdialog/SamtalerTagsTest.tsx
@@ -7,6 +7,7 @@ import { Samtaler } from "@/components/behandlerdialog/meldinger/Samtaler";
 import { queryClientWithMockData } from "../testQueryClient";
 import {
   defaultMeldingResponse,
+  meldingFraNAVConversation,
   meldingResponseLegeerklaringMedRetur,
   meldingResponseLegeerklaringMedReturOgNyLegeerklaring,
   meldingResponseLegeerklaringMedReturOgPaminnelse,
@@ -105,6 +106,19 @@ describe("Samtaletags", () => {
 
       expect(screen.getByText(venterPaSvarTagText)).to.exist;
       expect(screen.queryByText(paminnelseSendtTagText)).to.not.exist;
+    });
+
+    it("Viser ikke venter svar-tag på samtale hvis det mangler melding fra behandler, men er en 'melding fra NAV' som ikke nødvendigvis forventer svar", () => {
+      queryClient.setQueryData(
+        behandlerdialogQueryKeys.behandlerdialog(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => meldingFraNAVConversation
+      );
+
+      renderSamtaler();
+
+      expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
     });
 
     it("Viser påminnelse sendt-tag på samtale hvis påminnelse sendt og det mangler melding fra behandler", () => {

--- a/test/behandlerdialog/meldingTestdataGenerator.ts
+++ b/test/behandlerdialog/meldingTestdataGenerator.ts
@@ -202,6 +202,12 @@ export const meldingResponseLegeerklaringMedReturOgNyLegeerklaring = {
 
 export const meldingFraNAVConversation = {
   conversations: {
+    ["conversationRef567"]: [meldingFraNav],
+  },
+};
+
+export const meldingFraNAVConversationMedSvar = {
+  conversations: {
     ["conversationRef567"]: [meldingFraNav, responsPaMeldingFraNAV],
   },
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjerner den gule "Venter på svar"-tagen fra `Melding fra NAV`-meldingene. Se også samtale i slack: https://nav-it.slack.com/archives/C04M11803C1/p1695644242139439

I mange tilfeller forventer ikke veileder svar på disse type meldingene, og derfor har det kommet kommentarer fra pilotgruppa at det står en gul "Venter på svar"-tag på samtalen for evig. En løsning er derfor å ikke vise den tagen når den utgående meldingen er en Melding fra NAV. Veileder vil uansett få en oppgave dersom det kommer inn et svar, så tror ikke denne tagen er så viktig å vise for denne meldingtypen.

### Screenshots 📸✨
Vises fortsatt for de to andre meldingstypene

<img width="1104" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/5f874d8e-fe9d-4bbd-8e23-e3137872bd1c">

