### PR TITLE
IS-1648: Use previous huskelapptekst as defaultstate if it exists

### DIFF
--- a/src/components/huskelapp/HuskelappModal.tsx
+++ b/src/components/huskelapp/HuskelappModal.tsx
@@ -41,7 +41,7 @@ const StyledSkeleton = styled(Skeleton)`
 
 export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
   const { huskelapp, isLoading, isSuccess } = useGetHuskelappQuery();
-  const [tekst, setTekst] = useState<string>("");
+  const [tekst, setTekst] = useState<string>(huskelapp?.tekst ?? "");
   const oppdaterHuskelappQuery = useOppdaterHuskelapp();
 
   const oppdaterTekst = (e: React.ChangeEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
En bug som oppsto dersom man åpnet huskelappen uten å skrive noe, og deretter trykket lagre. Dette skjedde fordi hva som lagres var basert på staten i komponenten, som ble satt til tom streng som default. Nå bruker vi den gamle teksten fra get-kallet som default.
