### PR TITLE
IS-1648: Disable lagre-button when loading

### DIFF
--- a/src/components/SkeletonShadowbox.tsx
+++ b/src/components/SkeletonShadowbox.tsx
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+export const SkeletonShadowbox = styled.div`
+  --tw-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.15),
+    0px 0px 1px 0px rgba(0, 0, 0, 0.2);
+  --tw-shadow-colored: 0px 1px 3px 0px var(--tw-shadow-color),
+    0px 0px 1px 0px var(--tw-shadow-color);
+  --tw-ring-offset-shadow: 0 0 #0000;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000),
+    var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+  border-radius: 3px;
+  width: auto;
+  padding: 1em;
+`;

--- a/src/components/huskelapp/HuskelappModal.tsx
+++ b/src/components/huskelapp/HuskelappModal.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { useGetHuskelappQuery } from "@/data/huskelapp/useGetHuskelappQuery";
 import { useOppdaterHuskelapp } from "@/data/huskelapp/useOppdaterHuskelapp";
 import { HuskelappDTO } from "@/data/huskelapp/huskelappTypes";
+import { SkeletonShadowbox } from "@/components/SkeletonShadowbox";
 
 const texts = {
   header: "Huskelapp",
@@ -35,9 +36,19 @@ const RightAlignedButtons = styled.div`
   gap: 1em;
 `;
 
-const StyledSkeleton = styled(Skeleton)`
+const StyledSkeletonWrapper = styled(SkeletonShadowbox)`
   margin: 1em;
+  height: 5em;
 `;
+
+const HuskelappSkeleton = () => {
+  return (
+    <StyledSkeletonWrapper>
+      <Skeleton variant="text" width="80%" />
+      <Skeleton variant="text" width="30%" />
+    </StyledSkeletonWrapper>
+  );
+};
 
 export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
   const { huskelapp, isLoading, isSuccess } = useGetHuskelappQuery();
@@ -64,7 +75,7 @@ export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
       <Heading size="medium" as="h2">
         {texts.header}
       </Heading>
-      {isLoading && <StyledSkeleton height={90} variant="rounded" />}
+      {isLoading && <HuskelappSkeleton />}
       {isSuccess && (
         <ModalContent>
           <Textarea


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Vi oppdaget en bug om at man kunne trykke lagre-knappen uten å gjøre endringer på staten, og da lagret man en tom huskelapp. Dette fikset vi ved å sette defaultState til resultatet fra get-kallet. Det kan derimot være slik at en veileder av en eller annen grunn trykker "Lagre" før lappen er lastet inn, og da fjernes innholdet. For å hindre at dette er mulig, blir knappen satt som disabled mens lappen laster. 

I tillegg det et forslag til forbedring av skeleton-komponenten, basert på dette Card-eksempelet i Aksel: https://aksel.nav.no/komponenter/core/skeleton#skeletondemo-card. Dette er mer en estetisk endring enn en funksjonell, så må ikke implementere det 👍🏼 Skal gå gjennom det med Andrea også 😄

### Screenshots 📸✨
Før: 
<img width="1096" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/a5cddfa5-a5f0-4724-bf0b-1ebd71e9afb7">

Nå:
<img width="1043" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/de106532-e087-4867-a1f6-36519c7df833">
