### PR TITLE
Use request response types for huskelapp

### DIFF
--- a/mock/huskelapp/mockHuskelapp.tsx
+++ b/mock/huskelapp/mockHuskelapp.tsx
@@ -1,9 +1,16 @@
 import { ISHUSKELAPP_ROOT } from "../../src/apiConstants";
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
 import express from "express";
-import { HuskelappDTO } from "@/data/huskelapp/huskelappTypes";
+import {
+  HuskelappRequestDTO,
+  HuskelappResponseDTO,
+} from "../../src/data/huskelapp/huskelappTypes";
+import { generateUUID } from "../../src/utils/uuidUtils";
+import { VEILEDER_IDENT_DEFAULT } from "../common/mockConstants";
 
-let huskelappMock: HuskelappDTO = {
+let huskelappMock: HuskelappResponseDTO = {
+  uuid: generateUUID(),
+  createdBy: VEILEDER_IDENT_DEFAULT,
   tekst: "Dette er en veldig fin tekst",
 };
 
@@ -21,8 +28,9 @@ export const mockIshuskelapp = (server: any) => {
   server.post(
     `${ISHUSKELAPP_ROOT}/huskelapp`,
     (req: express.Request, res: express.Response) => {
-      const body = req.body as HuskelappDTO;
+      const body = req.body as HuskelappRequestDTO;
       huskelappMock = {
+        ...huskelappMock,
         tekst: body.tekst,
       };
       res.sendStatus(200);

--- a/src/components/huskelapp/HuskelappModal.tsx
+++ b/src/components/huskelapp/HuskelappModal.tsx
@@ -3,8 +3,8 @@ import { Button, Heading, Modal, Skeleton, Textarea } from "@navikt/ds-react";
 import styled from "styled-components";
 import { useGetHuskelappQuery } from "@/data/huskelapp/useGetHuskelappQuery";
 import { useOppdaterHuskelapp } from "@/data/huskelapp/useOppdaterHuskelapp";
-import { HuskelappDTO } from "@/data/huskelapp/huskelappTypes";
 import { SkeletonShadowbox } from "@/components/SkeletonShadowbox";
+import { HuskelappRequestDTO } from "@/data/huskelapp/huskelappTypes";
 
 const texts = {
   header: "Huskelapp",
@@ -53,15 +53,15 @@ const HuskelappSkeleton = () => {
 export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
   const { huskelapp, isLoading, isSuccess } = useGetHuskelappQuery();
   const [tekst, setTekst] = useState<string>(huskelapp?.tekst ?? "");
-  const oppdaterHuskelappQuery = useOppdaterHuskelapp();
+  const oppdaterHuskelapp = useOppdaterHuskelapp();
 
   const oppdaterTekst = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setTekst(e.target.value);
   };
 
-  const oppdaterHuskelapp = () => {
-    const huskelappDto: HuskelappDTO = { tekst: tekst };
-    oppdaterHuskelappQuery.mutate(huskelappDto, {
+  const handleOppdaterHuskelapp = () => {
+    const huskelappDto: HuskelappRequestDTO = { tekst: tekst };
+    oppdaterHuskelapp.mutate(huskelappDto, {
       onSuccess: () => toggleOpen(false),
     });
   };
@@ -92,8 +92,8 @@ export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
         </Button>
         <Button
           variant="primary"
-          onClick={oppdaterHuskelapp}
-          loading={oppdaterHuskelappQuery.isLoading}
+          onClick={handleOppdaterHuskelapp}
+          loading={oppdaterHuskelapp.isLoading}
           disabled={isLoading}
         >
           {texts.save}

--- a/src/data/huskelapp/huskelappTypes.ts
+++ b/src/data/huskelapp/huskelappTypes.ts
@@ -1,3 +1,9 @@
-export interface HuskelappDTO {
+export interface HuskelappRequestDTO {
+  tekst: string;
+}
+
+export interface HuskelappResponseDTO {
+  uuid: string;
+  createdBy: string;
   tekst: string;
 }

--- a/src/data/huskelapp/useGetHuskelappQuery.tsx
+++ b/src/data/huskelapp/useGetHuskelappQuery.tsx
@@ -2,7 +2,7 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISHUSKELAPP_ROOT } from "@/apiConstants";
 import { get } from "@/api/axios";
 import { useQuery } from "@tanstack/react-query";
-import { HuskelappDTO } from "@/data/huskelapp/huskelappTypes";
+import { HuskelappResponseDTO } from "@/data/huskelapp/huskelappTypes";
 
 export const huskelappQueryKeys = {
   huskelapp: (personident: string) => ["huskelapp", personident],
@@ -11,7 +11,7 @@ export const huskelappQueryKeys = {
 export const useGetHuskelappQuery = () => {
   const personident = useValgtPersonident();
   const path = `${ISHUSKELAPP_ROOT}/huskelapp`;
-  const getHuskelapp = () => get<HuskelappDTO>(path, personident);
+  const getHuskelapp = () => get<HuskelappResponseDTO>(path, personident);
 
   const {
     data: huskelapp,

--- a/src/data/huskelapp/useOppdaterHuskelapp.tsx
+++ b/src/data/huskelapp/useOppdaterHuskelapp.tsx
@@ -1,16 +1,16 @@
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISHUSKELAPP_ROOT } from "@/apiConstants";
 import { post } from "@/api/axios";
-import { HuskelappDTO } from "@/data/huskelapp/huskelappTypes";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { huskelappQueryKeys } from "@/data/huskelapp/useGetHuskelappQuery";
+import { HuskelappRequestDTO } from "@/data/huskelapp/huskelappTypes";
 
 export const useOppdaterHuskelapp = () => {
   const personident = useValgtPersonident();
   const queryClient = useQueryClient();
   const path = `${ISHUSKELAPP_ROOT}/huskelapp`;
-  const postHuskelapp = (nyHuskelapp: HuskelappDTO) =>
-    post<HuskelappDTO>(path, nyHuskelapp, personident);
+  const postHuskelapp = (nyHuskelapp: HuskelappRequestDTO) =>
+    post<HuskelappRequestDTO>(path, nyHuskelapp, personident);
 
   return useMutation({
     mutationFn: postHuskelapp,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Endrer fra `HuskelappDTO` til egne typer for request og response (sånn det er i backend). Vi trenger uuid på responsen for å fjerne en huskelapp.

