### PR TITLE
IS-1684: Handle behandlerNavn for HENVENDELSE_MELDING_TIL_NAV

### DIFF
--- a/mock/isbehandlerdialog/behandlerdialogMock.ts
+++ b/mock/isbehandlerdialog/behandlerdialogMock.ts
@@ -234,6 +234,15 @@ export const meldingFraNav = {
   tidspunkt: "2023-01-07T12:00:00.000+01:00",
 };
 
+export const meldingTilNav = {
+  ...defaultMeldingInnkommende,
+  parentRef: null,
+  behandlerRef: null,
+  type: MeldingType.HENVENDELSE_MELDING_TIL_NAV,
+  tekst: "Melding fra behandler til NAV der behandler lurer på noe.",
+  tidspunkt: "2023-01-17T12:00:00.000+01:00",
+};
+
 export const responsPaMeldingFraNAV = {
   ...defaultMelding,
   innkommende: true,
@@ -311,6 +320,7 @@ export const behandlerdialogMock = {
       defaultMeldingInnkommendeLegeerklaring,
       defaultReturLegeerklaring,
     ],
+    "conversationRef-939": [meldingTilNav],
   },
 };
 

--- a/src/components/behandlerdialog/meldinger/SamtaleAccordionItem.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleAccordionItem.tsx
@@ -17,10 +17,20 @@ interface SamtaleAccordionItemProps {
   meldinger: MeldingDTO[];
 }
 
+interface BehandlerNavnProps {
+  behandlerRef: string;
+}
+
+const BehandlerNavn = ({ behandlerRef }: BehandlerNavnProps) => {
+  const navn = useBehandlerNavn(behandlerRef);
+  return <>{navn}</>;
+};
+
 export const SamtaleAccordionItem = ({
   meldinger,
 }: SamtaleAccordionItemProps) => {
-  const behandlerNavn = useBehandlerNavn(meldinger[0].behandlerRef);
+  const firstMelding = meldinger[0];
+  const behandlerRef = firstMelding.behandlerRef;
   const newestMelding = meldinger.slice(-1)[0];
   const dateAndTimeForNewestMelding = `${tilDatoMedManedNavnOgKlokkeslett(
     newestMelding.tidspunkt
@@ -31,7 +41,14 @@ export const SamtaleAccordionItem = ({
       <Accordion.Header>
         <FlexRow>
           <StyledImage src={StetoskopIkon} alt="Stetoskopikon for behandler" />
-          {`${behandlerNavn} ${dateAndTimeForNewestMelding}`}
+          <>
+            {behandlerRef ? (
+              <BehandlerNavn behandlerRef={behandlerRef} />
+            ) : (
+              firstMelding.behandlerNavn
+            )}{" "}
+            {dateAndTimeForNewestMelding}
+          </>
           <SamtaleTags meldinger={meldinger} />
         </FlexRow>
       </Accordion.Header>

--- a/src/components/behandlerdialog/meldinger/SamtaleAccordionItem.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleAccordionItem.tsx
@@ -46,8 +46,8 @@ export const SamtaleAccordionItem = ({
               <BehandlerNavn behandlerRef={behandlerRef} />
             ) : (
               firstMelding.behandlerNavn
-            )}{" "}
-            {dateAndTimeForNewestMelding}
+            )}
+            {` ${dateAndTimeForNewestMelding}`}
           </>
           <SamtaleTags meldinger={meldinger} />
         </FlexRow>

--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
@@ -55,6 +55,7 @@ export const MeldingsTypeInfo = ({ meldingType }: Props): ReactElement => {
         );
       case MeldingType.FORESPORSEL_PASIENT_PAMINNELSE:
       case MeldingType.HENVENDELSE_RETUR_LEGEERKLARING:
+      case MeldingType.HENVENDELSE_MELDING_TIL_NAV:
         return <></>; // Not supported
     }
   };

--- a/src/data/behandlerdialog/behandlerdialogTexts.ts
+++ b/src/data/behandlerdialog/behandlerdialogTexts.ts
@@ -9,4 +9,5 @@ export const meldingTypeTexts: {
   [MeldingType.FORESPORSEL_PASIENT_PAMINNELSE]: "Påminnelse",
   [MeldingType.HENVENDELSE_RETUR_LEGEERKLARING]: "Retur av legeerklæring",
   [MeldingType.HENVENDELSE_MELDING_FRA_NAV]: "Melding fra NAV",
+  [MeldingType.HENVENDELSE_MELDING_TIL_NAV]: "Melding til NAV",
 };

--- a/src/data/behandlerdialog/behandlerdialogTypes.ts
+++ b/src/data/behandlerdialog/behandlerdialogTypes.ts
@@ -30,7 +30,7 @@ export interface MeldingDTO {
   uuid: string;
   conversationRef: string;
   parentRef: string | null;
-  behandlerRef: string;
+  behandlerRef: string | null;
   behandlerNavn: string | null;
   tekst: string;
   tidspunkt: Date;
@@ -61,4 +61,5 @@ export enum MeldingType {
   FORESPORSEL_PASIENT_PAMINNELSE = "FORESPORSEL_PASIENT_PAMINNELSE",
   HENVENDELSE_RETUR_LEGEERKLARING = "HENVENDELSE_RETUR_LEGEERKLARING",
   HENVENDELSE_MELDING_FRA_NAV = "HENVENDELSE_MELDING_FRA_NAV",
+  HENVENDELSE_MELDING_TIL_NAV = "HENVENDELSE_MELDING_TIL_NAV",
 }

--- a/src/hooks/behandlerdialog/document/useMeldingTilBehandlerDocument.ts
+++ b/src/hooks/behandlerdialog/document/useMeldingTilBehandlerDocument.ts
@@ -48,6 +48,8 @@ export const useMeldingTilBehandlerDocument = (): {
         throw new Error("use getReturLegeerklaringDocument");
       case MeldingType.HENVENDELSE_MELDING_FRA_NAV:
         return meldingFraNavDocument(values);
+      case MeldingType.HENVENDELSE_MELDING_TIL_NAV:
+        throw new Error("not supported");
       case undefined:
         return [];
     }

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -80,14 +80,15 @@ describe("Meldinger panel", () => {
       const accordions = screen.getAllByRole("button", {
         name: /januar/,
       });
-      expect(accordions).to.have.length(7);
-      expect(accordions[0].textContent).to.contain("7. januar");
-      expect(accordions[1].textContent).to.contain("6. januar");
-      expect(accordions[2].textContent).to.contain("5. januar");
-      expect(accordions[3].textContent).to.contain("4. januar");
-      expect(accordions[4].textContent).to.contain("3. januar");
-      expect(accordions[5].textContent).to.contain("2. januar");
-      expect(accordions[6].textContent).to.contain("1. januar");
+      expect(accordions).to.have.length(8);
+      expect(accordions[0].textContent).to.contain("17. januar");
+      expect(accordions[1].textContent).to.contain("7. januar");
+      expect(accordions[2].textContent).to.contain("6. januar");
+      expect(accordions[3].textContent).to.contain("5. januar");
+      expect(accordions[4].textContent).to.contain("4. januar");
+      expect(accordions[5].textContent).to.contain("3. januar");
+      expect(accordions[6].textContent).to.contain("2. januar");
+      expect(accordions[7].textContent).to.contain("1. januar");
     });
 
     it("Viser GuidePanel når det ikke finnes dialogmeldinger på personen", () => {
@@ -113,7 +114,7 @@ describe("Meldinger panel", () => {
         2
       );
       expect(screen.getAllByText("Skrevet av Doktor Legesen")).to.have.length(
-        3
+        4
       );
     });
 
@@ -231,7 +232,7 @@ describe("Meldinger panel", () => {
       const accordions = screen.getAllByRole("button", {
         name: /januar/,
       });
-      expect(accordions).to.have.length(7);
+      expect(accordions).to.have.length(8);
       accordions.forEach((accordion) => userEvent.click(accordion));
       const seMeldingButtons = screen.getAllByRole("button", {
         name: seMeldingButtonTekst,
@@ -245,7 +246,7 @@ describe("Meldinger panel", () => {
       const accordions = screen.getAllByRole("button", {
         name: /januar/,
       });
-      expect(accordions).to.have.length(7);
+      expect(accordions).to.have.length(8);
 
       const seMeldingButton = screen.getAllByRole("button", {
         name: seMeldingButtonTekst,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til meldingstype `HENVENDELSE_MELDING_TIL_NAV`, gjort `behandlerRef` nullable i MeldingDTO og håndterer visning av navn på behandler for meldinger uten behandlerRef.
For meldinger initiert av veileder vil `behandlerRef` være satt ut i fra behandleren som er valgt som mottaker. Meldinger fra behandler til NAV vil ikke ha satt dette feltet. I disse tilfellene kan vi bruke behandlerNavn-feltet fra meldingen (kommer fra dialogmeldingen) til å vise navn på behandler.

