### PR TITLE
IS-1706: Endret tekst for tag og oppgave fra svar -> melding

### DIFF
--- a/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/components/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -16,7 +16,7 @@ import { FlexRow } from "@/components/Layout";
 
 const texts = {
   fjernOppgave:
-    "Marker nye svar som lest. Oppgaven vil da fjernes fra oversikten.",
+    "Marker nye meldinger som lest. Oppgaven vil da fjernes fra oversikten.",
 };
 
 const sortDateByTidspunkt = (d1: Date | null, d2: Date | null) => {

--- a/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
+++ b/src/components/behandlerdialog/meldinger/SamtaleTags.tsx
@@ -20,7 +20,7 @@ import {
 } from "../../../../test/utils/behandlerdialogUtils";
 
 const texts = {
-  nyttSvar: "Nytt svar",
+  nyMelding: "Ny melding",
   venterSvar: "Venter på svar",
   avvist: "Melding ikke levert",
   paminnelseSendt: "Påminnelse sendt",
@@ -50,7 +50,7 @@ const SamtaleTag = (props: ComponentProps<typeof Tag>) => (
 );
 
 type SamtaleTagStatus =
-  | "NYTT_SVAR"
+  | "NY_MELDING"
   | "AVVIST"
   | "PAMINNELSE_SENDT"
   | "RETUR_SENDT"
@@ -121,7 +121,7 @@ const getSamtaleTagStatus = (
   if (harAvvistMelding) {
     return "AVVIST";
   } else if (harMeldingMedUbehandletSvarOppgave) {
-    return "NYTT_SVAR";
+    return "NY_MELDING";
   } else if (harMeldingMedUbehandletPaminnelseOppgave) {
     return "VURDER_PAMINNELSE";
   } else if (manglerSvarFraBehandler && harPaminnelseMelding) {
@@ -146,8 +146,8 @@ export const SamtaleTags = ({
   const samtaleTagStatus = getSamtaleTagStatus(meldinger, oppgaver);
 
   switch (samtaleTagStatus) {
-    case "NYTT_SVAR": {
-      return <SamtaleTag variant="info">{texts.nyttSvar}</SamtaleTag>;
+    case "NY_MELDING": {
+      return <SamtaleTag variant="info">{texts.nyMelding}</SamtaleTag>;
     }
     case "AVVIST": {
       return <SamtaleTag variant="error">{texts.avvist}</SamtaleTag>;

--- a/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
+++ b/src/components/personoppgave/BehandlePersonOppgaveKnapp.tsx
@@ -16,7 +16,7 @@ const CheckboxPanel = styled(Panel)`
 const getFerdigbehandletPrefixText = (personoppgaveType: PersonOppgaveType) => {
   switch (personoppgaveType) {
     case PersonOppgaveType.BEHANDLERDIALOG_SVAR:
-      return "Siste svar lest av";
+      return "Siste melding lest av";
     default:
       return "Ferdigbehandlet av";
   }

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -439,7 +439,7 @@ describe("Meldinger panel", () => {
 
   describe("Behandling av personoppgave", () => {
     const ubehandletCheckboxTekst =
-      "Marker nye svar som lest. Oppgaven vil da fjernes fra oversikten.";
+      "Marker nye meldinger som lest. Oppgaven vil da fjernes fra oversikten.";
     it("Viser ubehandlet personoppgave for behandlerdialog svar", () => {
       queryClient.setQueryData(
         personoppgaverQueryKeys.personoppgaver(
@@ -471,7 +471,8 @@ describe("Meldinger panel", () => {
       );
       renderMeldinger();
 
-      expect(screen.getByText("Siste svar lest av", { exact: false })).to.exist;
+      expect(screen.getByText("Siste melding lest av", { exact: false })).to
+        .exist;
     });
 
     it("Viser siste ferdigbehandlede personoppgave for behandlerdialog svar når alle oppgaver behandlet", () => {
@@ -494,7 +495,7 @@ describe("Meldinger panel", () => {
       );
       renderMeldinger();
 
-      const expectedFerdigbehandledText = `Siste svar lest av ${
+      const expectedFerdigbehandledText = `Siste melding lest av ${
         VEILEDER_DEFAULT.navn
       } ${twoDaysAgo.format("DD.MM.YYYY")}`;
       expect(screen.getByText(expectedFerdigbehandledText)).to.exist;
@@ -510,8 +511,8 @@ describe("Meldinger panel", () => {
 
       renderMeldinger();
 
-      expect(screen.queryByText("Siste svar lest av", { exact: false })).to.not
-        .exist;
+      expect(screen.queryByText("Siste melding lest av", { exact: false })).to
+        .not.exist;
       expect(screen.queryByText(ubehandletCheckboxTekst, { exact: false })).to
         .not.exist;
     });
@@ -526,8 +527,8 @@ describe("Meldinger panel", () => {
 
       renderMeldinger();
 
-      expect(screen.queryByText("Siste svar lest av", { exact: false })).to.not
-        .exist;
+      expect(screen.queryByText("Siste melding lest av", { exact: false })).to
+        .not.exist;
       expect(screen.queryByText(ubehandletCheckboxTekst, { exact: false })).to
         .not.exist;
     });

--- a/test/behandlerdialog/SamtalerTagsTest.tsx
+++ b/test/behandlerdialog/SamtalerTagsTest.tsx
@@ -52,7 +52,7 @@ describe("Samtaletags", () => {
   });
 
   describe("Visning av tags på samtaler", () => {
-    const nyttSvarTagText = "Nytt svar";
+    const nyMeldingTagText = "Ny melding";
     const venterPaSvarTagText = "Venter på svar";
     const paminnelseSendtTagText = "Påminnelse sendt";
     const vurderPaminnelseTagText = "Vurder påminnelse";
@@ -60,7 +60,7 @@ describe("Samtaletags", () => {
     const returSendtTagText = "Retur sendt";
 
     const assertNoTags = () => {
-      expect(screen.queryByText(nyttSvarTagText)).to.not.exist;
+      expect(screen.queryByText(nyMeldingTagText)).to.not.exist;
       expect(screen.queryByText(paminnelseSendtTagText)).to.not.exist;
       expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
       expect(screen.queryByText(vurderPaminnelseTagText)).to.not.exist;
@@ -68,7 +68,7 @@ describe("Samtaletags", () => {
       expect(screen.queryByText(meldingStatusFeiletTagText)).to.not.exist;
     };
 
-    it("Viser nytt-svar-tag på samtale hvis det er en ny melding i samtalen med ubehandlet oppgave", () => {
+    it("Viser ny melding-tag på samtale hvis det er en ny melding i samtalen med ubehandlet oppgave", () => {
       const innkommendeMeldingUuid = "456uio";
       const meldingResponse = meldingTilOgFraBehandler(innkommendeMeldingUuid);
       queryClient.setQueryData(
@@ -91,7 +91,7 @@ describe("Samtaletags", () => {
 
       renderSamtaler();
 
-      expect(screen.getByText(nyttSvarTagText)).to.exist;
+      expect(screen.getByText(nyMeldingTagText)).to.exist;
     });
 
     it("Viser venter svar-tag på samtale hvis det mangler melding fra behandler og ingen ubesvart melding-oppgave", () => {
@@ -149,7 +149,7 @@ describe("Samtaletags", () => {
       expect(screen.queryByText(venterPaSvarTagText)).to.not.exist;
     });
 
-    it("Viser nytt svar-tag på samtale hvis retur sendt på legeerklæring, men fått ny legeerklæring fra behandler med ubehandlet oppgave", () => {
+    it("Viser ny melding-tag på samtale hvis retur sendt på legeerklæring, men fått ny legeerklæring fra behandler med ubehandlet oppgave", () => {
       queryClient.setQueryData(
         behandlerdialogQueryKeys.behandlerdialog(
           ARBEIDSTAKER_DEFAULT.personIdent
@@ -170,7 +170,7 @@ describe("Samtaletags", () => {
 
       renderSamtaler();
 
-      expect(screen.getByText(nyttSvarTagText)).to.exist;
+      expect(screen.getByText(nyMeldingTagText)).to.exist;
       expect(screen.queryByText(returSendtTagText)).to.not.exist;
     });
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Siden vi snart skal ta inn meldingstypen `HENVENDELSE_MELDING_TIL_NAV` fra behandler.
Endret tekster fra nytt svar til ny melding slik at det også passer for meldinger fra behandler som ikke er svar på en melding fra NAV.

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/1e14ffdc-2952-45cb-9068-121acde907e6)
![image](https://github.com/navikt/syfomodiaperson/assets/79838644/ec90b466-5de1-48fb-9580-92d5a1c33c7b)

