### PR TITLE
IS-1699: Change beskrivelse to begrunnelse in aktivitetskrav skjema

### DIFF
--- a/src/components/aktivitetskrav/vurdering/AvventAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/AvventAktivitetskravSkjema.tsx
@@ -26,7 +26,7 @@ const texts = {
   subtitle1:
     "Informasjonen du oppgir her vil kun brukes til videre saksbehandling.",
   subtitle2: "Ingenting sendes videre til arbeidstaker eller arbeidsgiver.",
-  beskrivelseLabel: "Beskrivelse (obligatorisk)",
+  beskrivelseLabel: "Begrunnelse (obligatorisk)",
 };
 
 interface AvventAktivitetskravSkjemaValues {

--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -21,7 +21,7 @@ import { VurderAktivitetskravSkjemaProps } from "@/components/aktivitetskrav/vur
 
 const texts = {
   title: "Send forhåndsvarsel",
-  beskrivelseLabel: "Beskrivelse (obligatorisk)",
+  beskrivelseLabel: "Begrunnelse (obligatorisk)",
   forhandsvisning: "Forhåndsvisning",
   warning:
     "Husk å utrede saken tilstrekkelig før du sender forhåndsvarsel om stans av sykepengene.",

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravBeskrivelse.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravBeskrivelse.tsx
@@ -11,7 +11,7 @@ interface VurderAktivitetskravBeskrivelseProps {
 }
 
 export const VurderAktivitetskravBeskrivelse = ({
-  label = "Beskrivelse",
+  label = "Begrunnelse",
 }: VurderAktivitetskravBeskrivelseProps) => {
   return (
     <FlexColumn flex={1}>

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -131,7 +131,7 @@ describe("VurderAktivitetskrav", () => {
       const tooLongBeskrivelse = getTooLongText(
         vurderAktivitetskravBeskrivelseMaxLength
       );
-      const beskrivelseInput = getTextInput("Beskrivelse");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, tooLongBeskrivelse);
       clickButton("Lagre");
 
@@ -151,7 +151,7 @@ describe("VurderAktivitetskrav", () => {
 
       const arsakRadioButton = screen.getByText("Friskmeldt");
       fireEvent.click(arsakRadioButton);
-      const beskrivelseInput = getTextInput("Beskrivelse");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, enBeskrivelse);
       clickButton("Lagre");
 
@@ -175,7 +175,7 @@ describe("VurderAktivitetskrav", () => {
       const tooLongBeskrivelse = getTooLongText(
         vurderAktivitetskravBeskrivelseMaxLength
       );
-      const beskrivelseInput = getTextInput("Beskrivelse");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, tooLongBeskrivelse);
       clickButton("Lagre");
 
@@ -199,7 +199,7 @@ describe("VurderAktivitetskrav", () => {
 
       const arsakRadioButton = screen.getByText("Tilrettelegging ikke mulig");
       fireEvent.click(arsakRadioButton);
-      const beskrivelseInput = getTextInput("Beskrivelse");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, enBeskrivelse);
       clickButton("Lagre");
 
@@ -251,7 +251,7 @@ describe("VurderAktivitetskrav", () => {
         screen.getByText("Drøftes internt");
       fireEvent.click(arsakDroftesInterntRadioButton);
 
-      const beskrivelseInput = getTextInput("Beskrivelse (obligatorisk)");
+      const beskrivelseInput = getTextInput("Begrunnelse (obligatorisk)");
       changeTextInput(beskrivelseInput, enBeskrivelse);
 
       const today = dayjs();
@@ -302,7 +302,7 @@ describe("VurderAktivitetskrav", () => {
 
     it("Send forhåndsvarsel with beskrivelse filled in", () => {
       renderVurderAktivitetskrav(aktivitetskrav, oppfolgingstilfelle);
-      const beskrivelseLabel = "Beskrivelse (obligatorisk)";
+      const beskrivelseLabel = "Begrunnelse (obligatorisk)";
 
       clickButton(buttonTexts["FORHANDSVARSEL"]);
 
@@ -425,7 +425,7 @@ describe("VurderAktivitetskrav", () => {
 
       const arsakRadioButton = screen.getByText("Medisinske grunner");
       fireEvent.click(arsakRadioButton);
-      const beskrivelseInput = getTextInput("Beskrivelse");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, enBeskrivelse);
       clickButton("Lagre");
 


### PR DESCRIPTION
This will make it clearer for veiledere that this is related to a decision they're making, not just some information they're writing. This doesn't change all variable names and such because to rename everything is a big job and has consequences for the backend as well.

### Hva har blitt lagt til✨🌈

Endret navnet på fritekstfeltene i aktivitetskravskjema fra "beskrivelse" til "begrunnelse"

### Screenshots 📸✨

![begrunnelse_aktivitetskrav](https://github.com/navikt/syfomodiaperson/assets/40055758/650e1631-9844-429c-a568-a8eed461bd2b)
