### PR TITLE
IS-1767: Remove infobox

### DIFF
--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -2,9 +2,8 @@ import React, { useState } from "react";
 import { SendForhandsvarselDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { useAktivitetskravVarselDocument } from "@/hooks/aktivitetskrav/useAktivitetskravVarselDocument";
 import { addWeeks } from "@/utils/datoUtils";
-import { ButtonRow, PaddingSize } from "@/components/Layout";
-import { Alert, Button } from "@navikt/ds-react";
-import styled from "styled-components";
+import { ButtonRow } from "@/components/Layout";
+import { Button } from "@navikt/ds-react";
 import { useSendForhandsvarsel } from "@/data/aktivitetskrav/useSendForhandsvarsel";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import {
@@ -26,19 +25,9 @@ const texts = {
   forhandsvisning: "Forhåndsvisning",
   forhandsvisningLabel: "Forhåndsvis forhåndsvarselet",
   missingBeskrivelse: "Vennligst angi begrunnelse",
-  info: "NB! Forhåndsvarsel skal ikke brukes til å hente mer informasjon om saken.",
   sendVarselButtonText: "Send",
   avbrytButtonText: "Avbryt",
 };
-
-const VarselbrevContent = styled.div`
-  > * {
-    margin-bottom: ${PaddingSize.SM};
-    &:last-child {
-      margin-bottom: ${PaddingSize.MD};
-    }
-  }
-`;
 
 const forhandsvarselFrist = addWeeks(new Date(), 3);
 const defaultValues = { begrunnelse: "", arsak: undefined };
@@ -83,20 +72,16 @@ export const SendForhandsvarselSkjema = ({
   return (
     <form onSubmit={handleSubmit(submit)}>
       <SkjemaHeading title={texts.title} />
-      <VarselbrevContent>
-        <Alert variant="info" className="max-w-max">
-          {texts.info}
-        </Alert>
-        <BegrunnelseTextarea
-          {...register("begrunnelse", {
-            maxLength: begrunnelseMaxLength,
-            required: true,
-          })}
-          value={watch("begrunnelse")}
-          label={texts.beskrivelseLabel}
-          error={errors.begrunnelse && texts.missingBeskrivelse}
-        />
-      </VarselbrevContent>
+      <BegrunnelseTextarea
+        className="mb-8"
+        {...register("begrunnelse", {
+          maxLength: begrunnelseMaxLength,
+          required: true,
+        })}
+        value={watch("begrunnelse")}
+        label={texts.beskrivelseLabel}
+        error={errors.begrunnelse && texts.missingBeskrivelse}
+      />
       {sendForhandsvarsel.isError && (
         <SkjemaInnsendingFeil error={sendForhandsvarsel.error} />
       )}

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -351,11 +351,6 @@ describe("VurderAktivitetskrav", () => {
 
       expect(screen.getByRole("textbox", { name: beskrivelseLabel })).to.exist;
       expect(screen.getByText("Forhåndsvisning")).to.exist;
-      expect(
-        screen.getByText(
-          "NB! Forhåndsvarsel skal ikke brukes til å hente mer informasjon om saken."
-        )
-      ).to.exist;
 
       const beskrivelseInput = getTextInput(beskrivelseLabel);
       changeTextInput(beskrivelseInput, enBeskrivelse);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det er ikke helt avklart med IA- og sykefraværskontoret at dette er strategien vi skal påtvinge kontorene ifbm forhåndsvarselet, så da fjernes den foreløpig.

### Screenshots 📸✨
<img width="1082" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/2a3e6597-1d1e-4b93-8672-b57beff1bca6">

