### PR TITLE
IS-1690: Start ny vurdering uten aktivitetskrav

### DIFF
--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -52,12 +52,13 @@ export const AktivitetskravSide = () => {
       {sisteVurdering && (
         <AktivitetskravVurderingAlert vurdering={sisteVurdering} />
       )}
-      {!aktivitetskravTilVurdering && <StartNyVurdering />}
-      {aktivitetskravTilVurdering && (
+      {aktivitetskravTilVurdering ? (
         <VurderAktivitetskrav
           aktivitetskrav={aktivitetskravTilVurdering}
           oppfolgingstilfelle={oppfolgingstilfelle}
         />
+      ) : (
+        <StartNyVurdering />
       )}
       <Panel className="mb-4 flex flex-col p-8">
         <UtdragFraSykefravaeret />

--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -10,8 +10,9 @@ import {
   aktivitetskravVurderingerForOppfolgingstilfelle,
   oppfolgingstilfelleForAktivitetskrav,
 } from "@/utils/aktivitetskravUtils";
-import { AktivitetskravAlertstripe } from "@/components/aktivitetskrav/AktivitetskravAlertstripe";
 import { Panel } from "@navikt/ds-react";
+import { StartNyVurdering } from "./vurdering/StartNyVurdering";
+import { AktivitetskravAlertstripe } from "@/components/aktivitetskrav/AktivitetskravAlertstripe";
 
 const texts = {
   noTilfelle:
@@ -25,7 +26,8 @@ export const AktivitetskravSide = () => {
 
   const aktivitetskravTilVurdering = data.find(
     (aktivitetskrav) =>
-      aktivitetskrav.status !== AktivitetskravStatus.AUTOMATISK_OPPFYLT
+      aktivitetskrav.status !== AktivitetskravStatus.AUTOMATISK_OPPFYLT &&
+      aktivitetskrav.status !== AktivitetskravStatus.LUKKET
   );
   const oppfolgingstilfelle =
     aktivitetskravTilVurdering &&
@@ -50,10 +52,13 @@ export const AktivitetskravSide = () => {
       {sisteVurdering && (
         <AktivitetskravVurderingAlert vurdering={sisteVurdering} />
       )}
-      <VurderAktivitetskrav
-        aktivitetskrav={aktivitetskravTilVurdering}
-        oppfolgingstilfelle={oppfolgingstilfelle}
-      />
+      {!aktivitetskravTilVurdering && <StartNyVurdering />}
+      {aktivitetskravTilVurdering && (
+        <VurderAktivitetskrav
+          aktivitetskrav={aktivitetskravTilVurdering}
+          oppfolgingstilfelle={oppfolgingstilfelle}
+        />
+      )}
       <Panel className="mb-4 flex flex-col p-8">
         <UtdragFraSykefravaeret />
       </Panel>

--- a/src/components/aktivitetskrav/GjelderOppfolgingstilfelle.tsx
+++ b/src/components/aktivitetskrav/GjelderOppfolgingstilfelle.tsx
@@ -1,0 +1,19 @@
+import { BodyShort } from "@navikt/ds-react";
+import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
+import React from "react";
+import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+
+interface GjelderOppfolgingstilfelleProps {
+  oppfolgingstilfelle: OppfolgingstilfelleDTO;
+}
+
+export const GjelderOppfolgingstilfelle = ({
+  oppfolgingstilfelle,
+}: GjelderOppfolgingstilfelleProps) => {
+  return (
+    <BodyShort className="mb-4">{`Gjelder tilfelle ${tilLesbarPeriodeMedArUtenManednavn(
+      oppfolgingstilfelle.start,
+      oppfolgingstilfelle.end
+    )}`}</BodyShort>
+  );
+};

--- a/src/components/aktivitetskrav/vurdering/StartNyVurdering.tsx
+++ b/src/components/aktivitetskrav/vurdering/StartNyVurdering.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { BodyShort, Button, Heading, Panel } from "@navikt/ds-react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
-import { useStartNyVurdering } from "@/data/aktivitetskrav/useStartNyVurdering";
+import { useCreateAktivitetskrav } from "@/data/aktivitetskrav/useCreateAktivitetskrav";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { GjelderOppfolgingstilfelle } from "@/components/aktivitetskrav/GjelderOppfolgingstilfelle";
 
@@ -15,9 +15,9 @@ export const texts = {
 export const StartNyVurdering = () => {
   const { hasActiveOppfolgingstilfelle, latestOppfolgingstilfelle } =
     useOppfolgingstilfellePersonQuery();
-  const startNyVurdering = useStartNyVurdering();
+  const createAktivitetskrav = useCreateAktivitetskrav();
   const handleStartNyVurdering = () => {
-    startNyVurdering.mutate();
+    createAktivitetskrav.mutate();
   };
 
   return (
@@ -31,13 +31,13 @@ export const StartNyVurdering = () => {
         />
       )}
       <BodyShort className="mb-4">{texts.noAktivitetskrav}</BodyShort>
-      {startNyVurdering.isError && (
-        <SkjemaInnsendingFeil error={startNyVurdering.error} />
+      {createAktivitetskrav.isError && (
+        <SkjemaInnsendingFeil error={createAktivitetskrav.error} />
       )}
       <Button
         variant="secondary"
         className="mr-auto"
-        loading={startNyVurdering.isLoading}
+        loading={createAktivitetskrav.isLoading}
         onClick={handleStartNyVurdering}
       >
         {texts.button}

--- a/src/components/aktivitetskrav/vurdering/StartNyVurdering.tsx
+++ b/src/components/aktivitetskrav/vurdering/StartNyVurdering.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { BodyShort, Button, Heading, Panel } from "@navikt/ds-react";
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { useStartNyVurdering } from "@/data/aktivitetskrav/useStartNyVurdering";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { GjelderOppfolgingstilfelle } from "@/components/aktivitetskrav/GjelderOppfolgingstilfelle";
+
+export const texts = {
+  header: "Start ny aktivitetskrav-vurdering",
+  noAktivitetskrav:
+    "Aktivitetskravet er ikke tidligere vurdert i dette sykefraværet.",
+  button: "Start ny vurdering",
+};
+
+export const StartNyVurdering = () => {
+  const { hasActiveOppfolgingstilfelle, latestOppfolgingstilfelle } =
+    useOppfolgingstilfellePersonQuery();
+  const startNyVurdering = useStartNyVurdering();
+  const handleStartNyVurdering = () => {
+    startNyVurdering.mutate();
+  };
+
+  return (
+    <Panel className="mb-4 flex flex-col p-8">
+      <Heading level="2" size="large" className="mb-1">
+        {texts.header}
+      </Heading>
+      {hasActiveOppfolgingstilfelle && (
+        <GjelderOppfolgingstilfelle
+          oppfolgingstilfelle={latestOppfolgingstilfelle}
+        />
+      )}
+      <BodyShort className="mb-4">{texts.noAktivitetskrav}</BodyShort>
+      {startNyVurdering.isError && (
+        <SkjemaInnsendingFeil error={startNyVurdering.error} />
+      )}
+      <Button
+        variant="secondary"
+        className="mr-auto"
+        loading={startNyVurdering.isLoading}
+        onClick={handleStartNyVurdering}
+      >
+        {texts.button}
+      </Button>
+    </Panel>
+  );
+};

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
@@ -1,18 +1,17 @@
 import React from "react";
-import { FlexRow } from "@/components/Layout";
 import { AktivitetskravDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
-import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
 import { VurderAktivitetskravTabs } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs";
-import { BodyShort, Heading, Panel } from "@navikt/ds-react";
+import { Heading, Panel } from "@navikt/ds-react";
 import { VurderAktivitetskravButtons } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravButtons";
+import { GjelderOppfolgingstilfelle } from "@/components/aktivitetskrav/GjelderOppfolgingstilfelle";
 
 export const texts = {
   header: "Vurdere aktivitetskravet",
 };
 
 interface VurderAktivitetskravProps {
-  aktivitetskrav: AktivitetskravDTO | undefined;
+  aktivitetskrav: AktivitetskravDTO;
   oppfolgingstilfelle: OppfolgingstilfelleDTO | undefined;
 }
 
@@ -23,16 +22,11 @@ export const VurderAktivitetskrav = ({
   return (
     <Panel className="mb-4 flex flex-col pt-4 pr-4 pb-8 pl-8">
       <VurderAktivitetskravButtons aktivitetskrav={aktivitetskrav} />
-      <Heading level="2" size="large">
+      <Heading level="2" size="large" className="mb-1">
         {texts.header}
       </Heading>
       {oppfolgingstilfelle && (
-        <FlexRow>
-          <BodyShort size="small">{`Gjelder tilfelle ${tilLesbarPeriodeMedArUtenManednavn(
-            oppfolgingstilfelle.start,
-            oppfolgingstilfelle.end
-          )}`}</BodyShort>
-        </FlexRow>
+        <GjelderOppfolgingstilfelle oppfolgingstilfelle={oppfolgingstilfelle} />
       )}
       <VurderAktivitetskravTabs aktivitetskrav={aktivitetskrav} />
     </Panel>

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravButtons.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravButtons.tsx
@@ -16,13 +16,13 @@ const texts = {
   ikkeAktuell: "Ikke aktuell",
 };
 
-interface StatusKnapperadProps {
-  aktivitetskrav: AktivitetskravDTO | undefined;
+interface VurderAktivitetskravButtonsProps {
+  aktivitetskrav: AktivitetskravDTO;
 }
 
 export const VurderAktivitetskravButtons = ({
   aktivitetskrav,
-}: StatusKnapperadProps) => {
+}: VurderAktivitetskravButtonsProps) => {
   const [visVurderAktivitetskravModal, setVisVurderAktivitetskravModal] =
     useState(false);
   const [modalType, setModalType] = useState<ModalType>();

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravModal.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravModal.tsx
@@ -3,6 +3,7 @@ import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes"
 import { AvventAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/AvventAktivitetskravSkjema";
 import { IkkeAktuellAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema";
 import { Modal } from "@navikt/ds-react";
+import { VurderAktivitetskravSkjemaProps } from "@/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes";
 
 const texts = {
   modalContentLabel: "Vurder aktivitetskrav",
@@ -13,11 +14,11 @@ export type ModalType = `${Extract<
   AktivitetskravStatus.AVVENT | AktivitetskravStatus.IKKE_AKTUELL
 >}`;
 
-interface VurderAktivitetskravModalProps {
+interface VurderAktivitetskravModalProps
+  extends VurderAktivitetskravSkjemaProps {
   isOpen: boolean;
   setModalOpen: (modalOpen: boolean) => void;
   modalType: ModalType | undefined;
-  aktivitetskravUuid: string | undefined;
 }
 
 export const VurderAktivitetskravModal = ({
@@ -45,10 +46,12 @@ export const VurderAktivitetskravModal = ({
   );
 };
 
-interface VurderAktivitetskravModalContentProps {
-  setModalOpen: (modalOpen: boolean) => void;
+interface VurderAktivitetskravModalContentProps
+  extends Pick<
+    VurderAktivitetskravModalProps,
+    "setModalOpen" | "aktivitetskravUuid" | "modalType"
+  > {
   modalType: ModalType;
-  aktivitetskravUuid: string | undefined;
 }
 
 const VurderAktivitetskravModalContent = ({

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
@@ -35,7 +35,7 @@ enum Tab {
 }
 
 interface VurderAktivitetskravTabsProps {
-  aktivitetskrav: AktivitetskravDTO | undefined;
+  aktivitetskrav: AktivitetskravDTO;
 }
 
 export const VurderAktivitetskravTabs = ({
@@ -51,14 +51,14 @@ export const VurderAktivitetskravTabs = ({
     hasUbehandletVurderStansOppgave ||
     !toggles.isSendingAvForhandsvarselEnabled;
 
-  const aktivitetskravUuid = aktivitetskrav?.uuid;
+  const aktivitetskravUuid = aktivitetskrav.uuid;
 
   return (
     <StyledTabs defaultValue={Tab.UNNTAK}>
       <Tabs.List>
         <Tabs.Tab value={Tab.UNNTAK} label={texts.unntak} />
         <Tabs.Tab value={Tab.OPPFYLT} label={texts.oppfylt} />
-        {aktivitetskrav && toggles.isSendingAvForhandsvarselEnabled && (
+        {toggles.isSendingAvForhandsvarselEnabled && (
           <Tabs.Tab value={Tab.FORHANDSVARSEL} label={texts.forhandsvarsel} />
         )}
         {isIkkeOppfyltTabVisible && (

--- a/src/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes.ts
+++ b/src/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes.ts
@@ -1,5 +1,5 @@
 export interface VurderAktivitetskravSkjemaProps {
-  aktivitetskravUuid: string | undefined;
+  aktivitetskravUuid: string;
 }
 
 export interface AktivitetskravSkjemaValues {

--- a/src/data/aktivitetskrav/useCreateAktivitetskrav.ts
+++ b/src/data/aktivitetskrav/useCreateAktivitetskrav.ts
@@ -4,14 +4,14 @@ import { post } from "@/api/axios";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 
-export const useStartNyVurdering = () => {
+export const useCreateAktivitetskrav = () => {
   const personident = useValgtPersonident();
   const queryClient = useQueryClient();
-  const path = `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav/ny-vurdering`; // TODO: Align med nytt api
-  const postNyVurdering = () => post(path, {}, personident);
+  const path = `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav`;
+  const postAktivitetskrav = () => post(path, {}, personident);
 
   return useMutation({
-    mutationFn: postNyVurdering,
+    mutationFn: postAktivitetskrav,
     onSuccess: () => {
       return queryClient.invalidateQueries(
         aktivitetskravQueryKeys.aktivitetskrav(personident)

--- a/src/data/aktivitetskrav/useStartNyVurdering.ts
+++ b/src/data/aktivitetskrav/useStartNyVurdering.ts
@@ -1,20 +1,17 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ISAKTIVITETSKRAV_ROOT } from "@/apiConstants";
-import { CreateAktivitetskravVurderingDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { post } from "@/api/axios";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 
-export const useVurderAktivitetskrav = (aktivitetskravUuid: string) => {
+export const useStartNyVurdering = () => {
   const personident = useValgtPersonident();
   const queryClient = useQueryClient();
-  const path = `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav/${aktivitetskravUuid}/vurder`;
-  const postVurderAktivitetskrav = (
-    vurdering: CreateAktivitetskravVurderingDTO
-  ) => post(path, vurdering, personident);
+  const path = `${ISAKTIVITETSKRAV_ROOT}/aktivitetskrav/ny-vurdering`; // TODO: Align med nytt api
+  const postNyVurdering = () => post(path, {}, personident);
 
   return useMutation({
-    mutationFn: postVurderAktivitetskrav,
+    mutationFn: postNyVurdering,
     onSuccess: () => {
       return queryClient.invalidateQueries(
         aktivitetskravQueryKeys.aktivitetskrav(personident)

--- a/test/aktivitetskrav/AktivitetskravSideTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravSideTest.tsx
@@ -84,6 +84,86 @@ describe("AktivitetskravSide", () => {
     expect(screen.getByRole("heading", { name: "Utdrag fra sykefraværet" })).to
       .exist;
   });
+  describe("Start ny vurdering", () => {
+    it("Vises når person har oppfølgingstilfelle uten aktivitetskrav", () => {
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
+      mockAktivitetskrav([]);
+
+      renderAktivitetskravSide();
+
+      expect(
+        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
+      ).to.not.exist;
+      expect(
+        screen.getByRole("heading", {
+          name: "Start ny aktivitetskrav-vurdering",
+        })
+      ).to.exist;
+      expect(screen.queryByRole("img", { name: "Advarsel" })).to.not.exist;
+      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
+        .exist;
+    });
+    it("Vises med advarsel når person har inaktivt oppfølgingstilfelle uten aktivitetskrav", () => {
+      mockOppfolgingstilfellePerson([inactiveOppfolgingstilfelle]);
+      mockAktivitetskrav([]);
+
+      renderAktivitetskravSide();
+
+      expect(
+        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
+      ).to.not.exist;
+      expect(
+        screen.getByRole("heading", {
+          name: "Start ny aktivitetskrav-vurdering",
+        })
+      ).to.exist;
+      expect(screen.getByRole("img", { name: "Advarsel" })).to.exist;
+      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
+        .exist;
+    });
+
+    it("Vises med advarsel når person har verken oppfølgingstilfelle eller aktivitetskrav", () => {
+      mockOppfolgingstilfellePerson([]);
+      mockAktivitetskrav([]);
+
+      renderAktivitetskravSide();
+
+      expect(
+        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
+      ).to.not.exist;
+      expect(
+        screen.getByRole("heading", {
+          name: "Start ny aktivitetskrav-vurdering",
+        })
+      ).to.exist;
+      expect(screen.getByRole("img", { name: "Advarsel" })).to.exist;
+      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
+        .exist;
+    });
+    it("Vises når person har oppfølgingstilfelle med bare aktivitetskrav (AUTOMATISK_OPPFYLT)", () => {
+      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
+      mockAktivitetskrav([
+        createAktivitetskrav(
+          daysFromToday(20),
+          AktivitetskravStatus.AUTOMATISK_OPPFYLT
+        ),
+      ]);
+
+      renderAktivitetskravSide();
+
+      expect(
+        screen.queryByRole("heading", { name: "Vurdere aktivitetskravet" })
+      ).to.not.exist;
+      expect(
+        screen.getByRole("heading", {
+          name: "Start ny aktivitetskrav-vurdering",
+        })
+      ).to.exist;
+      expect(screen.queryByRole("img", { name: "Advarsel" })).to.not.exist;
+      expect(screen.queryByRole(noOppfolgingstilfelleAktivitetskravText)).to.not
+        .exist;
+    });
+  });
 
   describe("Vurder aktivitetskravet", () => {
     it("Vises når person har oppfølgingstilfelle med aktivitetskrav (NY)", () => {
@@ -107,77 +187,6 @@ describe("AktivitetskravSide", () => {
       mockAktivitetskrav([
         createAktivitetskrav(daysFromToday(-25), AktivitetskravStatus.NY),
       ]);
-
-      renderAktivitetskravSide();
-
-      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
-        .to.exist;
-      expect(screen.getByRole("img", { name: "Advarsel" })).to.exist;
-      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
-        .exist;
-    });
-    it("Vises når person har oppfølgingstilfelle med bare aktivitetskrav (AUTOMATISK_OPPFYLT)", () => {
-      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
-      mockAktivitetskrav([
-        createAktivitetskrav(
-          daysFromToday(20),
-          AktivitetskravStatus.AUTOMATISK_OPPFYLT
-        ),
-      ]);
-
-      renderAktivitetskravSide();
-
-      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
-        .to.exist;
-      expect(screen.queryByRole("img", { name: "Advarsel" })).to.not.exist;
-      expect(screen.queryByRole(noOppfolgingstilfelleAktivitetskravText)).to.not
-        .exist;
-    });
-    it("Vises når aktivitetskrav gjelder tidligere tilfelle", () => {
-      mockOppfolgingstilfellePerson([
-        inactiveOppfolgingstilfelle,
-        activeOppfolgingstilfelle,
-      ]);
-      mockAktivitetskrav([
-        createAktivitetskrav(daysFromToday(-70), AktivitetskravStatus.NY),
-      ]);
-
-      renderAktivitetskravSide();
-
-      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
-        .to.exist;
-      expect(screen.queryByRole("img", { name: "Advarsel" })).to.not.exist;
-      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
-        .exist;
-    });
-    it("Vises når person har oppfølgingstilfelle uten aktivitetskrav", () => {
-      mockOppfolgingstilfellePerson([activeOppfolgingstilfelle]);
-      mockAktivitetskrav([]);
-
-      renderAktivitetskravSide();
-
-      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
-        .to.exist;
-      expect(screen.queryByRole("img", { name: "Advarsel" })).to.not.exist;
-      expect(screen.queryByText(noOppfolgingstilfelleAktivitetskravText)).to.not
-        .exist;
-    });
-    it("Vises med advarsel når person har inaktivt oppfølgingstilfelle uten aktivitetskrav", () => {
-      mockOppfolgingstilfellePerson([inactiveOppfolgingstilfelle]);
-      mockAktivitetskrav([]);
-
-      renderAktivitetskravSide();
-
-      expect(screen.getByRole("heading", { name: "Vurdere aktivitetskravet" }))
-        .to.exist;
-      expect(screen.getByRole("img", { name: "Advarsel" })).to.exist;
-      expect(screen.getByText(noOppfolgingstilfelleAktivitetskravText)).to
-        .exist;
-    });
-
-    it("Vises med advarsel når person har verken oppfølgingstilfelle eller aktivitetskrav", () => {
-      mockOppfolgingstilfellePerson([]);
-      mockAktivitetskrav([]);
 
       renderAktivitetskravSide();
 

--- a/test/aktivitetskrav/StartNyVurderingTest.tsx
+++ b/test/aktivitetskrav/StartNyVurderingTest.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { navEnhet } from "../dialogmote/testData";
+import React from "react";
+import { StartNyVurdering } from "@/components/aktivitetskrav/vurdering/StartNyVurdering";
+import { expect } from "chai";
+import { queryClientWithMockData } from "../testQueryClient";
+import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
+import { generateOppfolgingstilfelle } from "../testDataUtils";
+import { clickButton, daysFromToday, getButton } from "../testUtils";
+import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
+
+let queryClient: QueryClient;
+
+const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
+const buttonText = "Start ny vurdering";
+const noAktivitetskravText =
+  "Aktivitetskravet er ikke tidligere vurdert i dette sykefraværet.";
+const tilfelleStart = daysFromToday(-50);
+const tilfelleEnd = daysFromToday(50);
+const oppfolgingstilfelle = generateOppfolgingstilfelle(
+  tilfelleStart,
+  tilfelleEnd
+);
+
+const renderStartNyVurdering = () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <StartNyVurdering />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("StartNyVurdering", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+    queryClient.setQueryData(
+      oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(fnr),
+      () => ({
+        personIdent: fnr,
+        oppfolgingstilfelleList: [oppfolgingstilfelle],
+      })
+    );
+  });
+  it("renders panel to start ny vurdering", () => {
+    renderStartNyVurdering();
+
+    const periodeText = tilLesbarPeriodeMedArUtenManednavn(
+      tilfelleStart,
+      tilfelleEnd
+    );
+    expect(
+      screen.getByRole("heading", { name: "Start ny aktivitetskrav-vurdering" })
+    ).to.exist;
+    expect(screen.getByText(`Gjelder tilfelle ${periodeText}`)).to.exist;
+    expect(screen.getByText(noAktivitetskravText)).to.exist;
+    expect(getButton(buttonText)).to.exist;
+  });
+  it("click button runs mutation", () => {
+    renderStartNyVurdering();
+
+    clickButton(buttonText);
+
+    const nyVurderingMutation = queryClient.getMutationCache().getAll()[0];
+    expect(nyVurderingMutation).to.exist;
+  });
+});

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -82,7 +82,7 @@ const tabTexts = {
 const enBeskrivelse = "Her er en beskrivelse";
 
 const renderVurderAktivitetskrav = (
-  aktivitetskravDto: AktivitetskravDTO | undefined,
+  aktivitetskravDto: AktivitetskravDTO,
   oppfolgingstilfelleDto: OppfolgingstilfelleDTO | undefined
 ) =>
   render(
@@ -452,33 +452,6 @@ describe("VurderAktivitetskrav", () => {
       expect(vurderIkkeAktuellMutation.options.variables).to.deep.equal(
         expectedVurdering
       );
-    });
-  });
-  describe("Uten oppfølgingstilfelle med aktivitetskrav", () => {
-    it("Lagre vurdering med verdier fra skjema", async () => {
-      renderVurderAktivitetskrav(undefined, undefined);
-
-      expect(screen.queryByText(/Gjelder tilfelle/)).to.not.exist;
-
-      clickTab(tabTexts["UNNTAK"]);
-
-      const arsakRadioButton = screen.getByText("Medisinske grunner");
-      fireEvent.click(arsakRadioButton);
-      const beskrivelseInput = getTextInput("Begrunnelse (obligatorisk)");
-      changeTextInput(beskrivelseInput, enBeskrivelse);
-      clickButton("Lagre");
-
-      await waitFor(() => {
-        const vurderUnntakMutation = queryClient.getMutationCache().getAll()[0];
-        const expectedVurdering: CreateAktivitetskravVurderingDTO = {
-          beskrivelse: enBeskrivelse,
-          status: AktivitetskravStatus.UNNTAK,
-          arsaker: [UnntakVurderingArsak.MEDISINSKE_GRUNNER],
-        };
-        expect(vurderUnntakMutation.options.variables).to.deep.equal(
-          expectedVurdering
-        );
-      });
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser Start ny vurdering-side dersom det ikke finnes noe aktivitetskrav å vurdere. Trykk på knappen skal kalle nytt api for å opprette aktivitetskrav med status `NY_VURDERING`. Så er tanken at man får dette aktivitetskravet tilbake fra GET-kallet til apiet og VurderAktivitetskrav-siden vil vises.

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/d4a82a86-0fb9-4862-a18c-618c9d044dd4)

NB: Må vente med merging til nytt API er klart i isaktivitetskrav og dette er testet i dev.

