### PR TITLE
IS-1601: Add button for showing preview of varsel-document

### DIFF
--- a/mock/isaktivitetskrav/aktivitetskravMock.ts
+++ b/mock/isaktivitetskrav/aktivitetskravMock.ts
@@ -8,6 +8,8 @@ import {
 import { generateUUID } from "../../src/utils/uuidUtils";
 import { VEILEDER_DEFAULT } from "../common/mockConstants";
 import { daysFromToday } from "../../test/testUtils";
+import { DocumentComponentType } from "../../src/data/documentcomponent/documentComponentTypes";
+import { sendForhandsvarselTexts } from "../../src/data/aktivitetskrav/forhandsvarselTexts";
 
 const aktivitetskravNy = {
   uuid: generateUUID(),
@@ -93,7 +95,80 @@ const aktivitetskravAutomatiskOppfylt = {
   vurderinger: [],
 };
 
+const getForhandsvarselDocument = (
+  begrunnelse: string | undefined,
+  fristDato: Date
+) => {
+  const documentComponents = [
+    {
+      type: DocumentComponentType.HEADER_H1,
+      texts: [sendForhandsvarselTexts.varselInfo.header],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [sendForhandsvarselTexts.varselInfo.introWithFristDate(fristDato)],
+    },
+  ];
+
+  if (begrunnelse) {
+    documentComponents.push({
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [begrunnelse],
+    });
+  }
+
+  documentComponents.push(
+    {
+      type: DocumentComponentType.HEADER_H3,
+      texts: [sendForhandsvarselTexts.unngaStansInfo.header],
+    },
+    {
+      type: DocumentComponentType.BULLET_POINTS,
+      texts: [
+        sendForhandsvarselTexts.unngaStansInfo.tiltak1,
+        sendForhandsvarselTexts.unngaStansInfo.tiltak2,
+        sendForhandsvarselTexts.unngaStansInfo.tiltak3,
+      ],
+    },
+    {
+      type: DocumentComponentType.HEADER_H3,
+      texts: [sendForhandsvarselTexts.giOssTilbakemelding.header],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [
+        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate(
+          fristDato
+        ),
+      ],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss],
+    },
+    {
+      type: DocumentComponentType.HEADER_H3,
+      texts: [sendForhandsvarselTexts.lovhjemmel.header],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [sendForhandsvarselTexts.lovhjemmel.aktivitetsplikten],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [sendForhandsvarselTexts.lovhjemmel.pliktInfo],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+    }
+  );
+
+  return documentComponents;
+};
+
 export const varselUuid = generateUUID();
+const begrunnelse = "En begrunnelse for hvorfor det er sendt forhåndsvarsel";
 
 const aktivitetskravForhandsvarsel: AktivitetskravDTO = {
   uuid: generateUUID(),
@@ -106,13 +181,14 @@ const aktivitetskravForhandsvarsel: AktivitetskravDTO = {
       createdAt: daysFromToday(-2),
       createdBy: VEILEDER_DEFAULT.ident,
       status: AktivitetskravStatus.FORHANDSVARSEL,
-      beskrivelse: "En begrunnelse for hvorfor det er sendt forhåndsvarsel",
+      beskrivelse: begrunnelse,
       arsaker: [],
       frist: undefined,
       varsel: {
         uuid: varselUuid,
         createdAt: daysFromToday(-2),
         svarfrist: daysFromToday(19),
+        document: getForhandsvarselDocument(begrunnelse, daysFromToday(1)),
       },
     },
   ],

--- a/src/data/aktivitetskrav/aktivitetskravTexts.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTexts.ts
@@ -4,7 +4,6 @@ import {
   UnntakVurderingArsak,
   VurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 
 export type VurderingArsakTexts = {
   [key in VurderingArsak]?: string;
@@ -31,41 +30,4 @@ export const avventVurderingArsakTexts: VurderingArsakTexts = {
   [AvventVurderingArsak.DROFTES_MED_ROL]: "Drøftes med ROL",
   [AvventVurderingArsak.DROFTES_INTERNT]: "Drøftes internt",
   [AvventVurderingArsak.ANNET]: "Annet",
-};
-
-export const sendForhandsvarselTexts = {
-  varselInfo: {
-    header: "Varsel om stans av sykepenger",
-    introWithFristDate: (frist: Date) =>
-      `Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
-        frist
-      )}.`,
-  },
-  unngaStansInfo: {
-    header: "Du kan unngå stans av sykepenger",
-    tiltak1:
-      "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden",
-    tiltak2:
-      "Gir arbeidsgiveren din en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, kan utbetalingen av sykepenger fortsette.",
-    tiltak3:
-      "Går det fram av sykmeldingen at du er for syk til å arbeide, får du fortsatt sykepenger.",
-  },
-  giOssTilbakemelding: {
-    header: "Gi oss tilbakemelding",
-    tilbakemeldingWithFristDate: (frist: Date) =>
-      `Vi må ha tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
-        frist
-      )}. Ellers vil sykepengene dine stanses fra denne datoen.`,
-    kontaktOss:
-      "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
-  },
-  lovhjemmel: {
-    header: "Lovhjemmel",
-    aktivitetsplikten:
-      "Aktivitetsplikten er beskrevet i folketrygdloven § 8-8 2.ledd.",
-    pliktInfo:
-      "«Medlemmet har plikt til å være i arbeidsrelatert aktivitet, jf. § 8-7 a første ledd og arbeidsmiljøloven § 4-6 første ledd," +
-      " så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet," +
-      " eller arbeidsrelaterte aktiviteter ikke kan gjennomføres på arbeidsplassen.»",
-  },
 };

--- a/src/data/aktivitetskrav/aktivitetskravTypes.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTypes.ts
@@ -57,6 +57,7 @@ export interface AktivitetskravVarselDTO {
   uuid: string;
   createdAt: Date;
   svarfrist: Date;
+  document: DocumentComponentDto[];
 }
 
 export type VurderingArsak =

--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -1,0 +1,38 @@
+import { tilDatoMedManedNavn } from "../../utils/datoUtils";
+
+export const sendForhandsvarselTexts = {
+  varselInfo: {
+    header: "Varsel om stans av sykepenger",
+    introWithFristDate: (frist: Date) =>
+      `Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
+        frist
+      )}.`,
+  },
+  unngaStansInfo: {
+    header: "Du kan unngå stans av sykepenger",
+    tiltak1:
+      "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden",
+    tiltak2:
+      "Gir arbeidsgiveren din en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, kan utbetalingen av sykepenger fortsette.",
+    tiltak3:
+      "Går det fram av sykmeldingen at du er for syk til å arbeide, får du fortsatt sykepenger.",
+  },
+  giOssTilbakemelding: {
+    header: "Gi oss tilbakemelding",
+    tilbakemeldingWithFristDate: (frist: Date) =>
+      `Vi må ha tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
+        frist
+      )}. Ellers vil sykepengene dine stanses fra denne datoen.`,
+    kontaktOss:
+      "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
+  },
+  lovhjemmel: {
+    header: "Lovhjemmel",
+    aktivitetsplikten:
+      "Aktivitetsplikten er beskrevet i folketrygdloven § 8-8 2.ledd.",
+    pliktInfo:
+      "«Medlemmet har plikt til å være i arbeidsrelatert aktivitet, jf. § 8-7 a første ledd og arbeidsmiljøloven § 4-6 første ledd," +
+      " så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet," +
+      " eller arbeidsrelaterte aktiviteter ikke kan gjennomføres på arbeidsplassen.»",
+  },
+};

--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -1,3 +1,4 @@
+import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
 import {
@@ -6,7 +7,6 @@ import {
   createHeaderH3,
   createParagraph,
 } from "@/utils/documentComponentUtils";
-import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 
 export const useAktivitetskravVarselDocument = (): {
   getForhandsvarselDocument(

--- a/test/aktivitetskrav/varselDocuments.ts
+++ b/test/aktivitetskrav/varselDocuments.ts
@@ -2,9 +2,9 @@ import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
-import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 import { VEILEDER_DEFAULT } from "../../mock/common/mockConstants";
 import { addWeeks } from "@/utils/datoUtils";
+import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
 
 const expectedFristDate = addWeeks(new Date(), 3);
 

--- a/test/testDataUtils.ts
+++ b/test/testDataUtils.ts
@@ -103,5 +103,10 @@ export const forhandsvarselVurdering = createAktivitetskravVurdering(
   "Begrunnelse for forhåndsvarsel",
   new Date(),
   undefined,
-  { uuid: generateUUID(), createdAt: new Date(), svarfrist: daysFromToday(21) }
+  {
+    uuid: generateUUID(),
+    createdAt: new Date(),
+    svarfrist: daysFromToday(21),
+    document: [],
+  }
 );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Gjør det mulig å se hele varsel-brevet som ble sendt ut ifbm forhåndsvarsel i historikk-fanen i akt.kravet. Har også lagt på noen enkle forbedringer:
- Beskrivelse -> Begrunnelse
- "Vurdert av" overskrift før navnet på veileder dukker opp

Har også lagt på en måling i amplitude av hvor ofte knappen trykkes på. Dette kan man feks se opp mot sidebesøk på Akt.krav-siden. Tror ikke det er rent sammenlignbart, fordi de sikkert er inne på den siden veldig ofte, og alle har jo ikke et forhåndsvarsel 🤷🏼‍♂️ Tenker jeg skal legge på en måling på accordionene også, så vi kan finne ut av om de bruker historikken veldig mye eller ikke, men tar det i en egen PR.

### Screenshots 📸✨
<img width="652" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/43e783f6-20ba-428b-aaac-bfdac74079dd">
