### PR TITLE
Add amplitude tracking to check how often users open the historikk-accordions

### DIFF
--- a/src/components/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
+++ b/src/components/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
@@ -150,15 +150,32 @@ interface HistorikkElementProps {
 }
 
 const HistorikkElement = ({ vurdering }: HistorikkElementProps) => {
+  const [isOpen, setIsOpen] = useState(false);
   const { data: veilederinfo } = useVeilederInfoQuery(vurdering.createdBy);
   const header = `${headerPrefix(vurdering.status)} - ${tilDatoMedManedNavn(
     vurdering.createdAt
   )}`;
   const arsak = vurdering.arsaker[0];
 
+  const handleAccordionClick = () => {
+    if (!isOpen) {
+      // Vil bare logge klikk som åpner accordion
+      Amplitude.logEvent({
+        type: EventType.AccordionOpen,
+        data: {
+          tekst: `Åpne accordion aktivitetskrav historikk: ${header}`,
+          url: window.location.href,
+        },
+      });
+    }
+    setIsOpen(!isOpen);
+  };
+
   return (
-    <Accordion.Item>
-      <Accordion.Header>{header}</Accordion.Header>
+    <Accordion.Item open={isOpen}>
+      <Accordion.Header onClick={handleAccordionClick}>
+        {header}
+      </Accordion.Header>
       <Accordion.Content>
         {!!arsak && (
           <Paragraph title={texts.arsakTitle} body={getArsakText(arsak)} />

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -9,6 +9,7 @@ export enum EventType {
   PageView = "besøk",
   ButtonClick = "knapp trykket",
   Navigation = "navigere",
+  AccordionOpen = "accordion åpnet",
 }
 
 type EventPageView = {
@@ -35,7 +36,15 @@ type Navigation = {
   };
 };
 
-type Event = EventPageView | EventButtonClick | Navigation;
+type EventAccordionOpen = {
+  type: EventType.AccordionOpen;
+  data: {
+    url: string;
+    tekst: string;
+  };
+};
+
+type Event = EventPageView | EventButtonClick | Navigation | EventAccordionOpen;
 
 export const logEvent = (event: Event) => {
   switch (event.type) {
@@ -57,6 +66,11 @@ export const logEvent = (event: Event) => {
         lenketekst: event.data.lenketekst,
       });
       break;
+    case EventType.AccordionOpen:
+      client.logEvent(EventType.AccordionOpen, {
+        url: event.data.url,
+        tekst: event.data.tekst,
+      });
   }
 };
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Gjør accordionene controlled, og legger på en amplitude-telling. Vi får se om den bærer frukter. 
Visstnok er "accordion åpnet" et eget event, så prøvde å legge det til. Vet ikke om det blir riktig: https://github.com/navikt/analytics-taxonomy/tree/main/events
