### PR TITLE
IS-1609: Hide forhandsvarsel-tab when already sent forhåndsvarsel

### DIFF
--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
@@ -3,7 +3,10 @@ import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { hasUbehandletPersonoppgave } from "@/utils/personOppgaveUtils";
 import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
-import { AktivitetskravDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import {
+  AktivitetskravDTO,
+  AktivitetskravStatus,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { Tabs } from "@navikt/ds-react";
 import { UnntakAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/UnntakAktivitetskravSkjema";
 import { OppfyltAktivitetskravSkjema } from "@/components/aktivitetskrav/vurdering/OppfyltAktivitetskravSkjema";
@@ -34,6 +37,16 @@ enum Tab {
   IKKE_OPPFYLT = "IKKE_OPPFYLT",
 }
 
+const isValidStateForForhandsvarsel = (
+  aktivitetskravStatus: AktivitetskravStatus
+) => {
+  return (
+    aktivitetskravStatus === AktivitetskravStatus.NY ||
+    aktivitetskravStatus === AktivitetskravStatus.NY_VURDERING ||
+    aktivitetskravStatus === AktivitetskravStatus.AVVENT
+  );
+};
+
 interface VurderAktivitetskravTabsProps {
   aktivitetskrav: AktivitetskravDTO;
 }
@@ -50,6 +63,9 @@ export const VurderAktivitetskravTabs = ({
   const isIkkeOppfyltTabVisible =
     hasUbehandletVurderStansOppgave ||
     !toggles.isSendingAvForhandsvarselEnabled;
+  const isForhandsvarselTabVisible =
+    toggles.isSendingAvForhandsvarselEnabled &&
+    isValidStateForForhandsvarsel(aktivitetskrav.status);
 
   const aktivitetskravUuid = aktivitetskrav.uuid;
 
@@ -58,7 +74,7 @@ export const VurderAktivitetskravTabs = ({
       <Tabs.List>
         <Tabs.Tab value={Tab.UNNTAK} label={texts.unntak} />
         <Tabs.Tab value={Tab.OPPFYLT} label={texts.oppfylt} />
-        {toggles.isSendingAvForhandsvarselEnabled && (
+        {isForhandsvarselTabVisible && (
           <Tabs.Tab value={Tab.FORHANDSVARSEL} label={texts.forhandsvarsel} />
         )}
         {isIkkeOppfyltTabVisible && (
@@ -71,9 +87,11 @@ export const VurderAktivitetskravTabs = ({
       <Tabs.Panel value={Tab.OPPFYLT}>
         <OppfyltAktivitetskravSkjema aktivitetskravUuid={aktivitetskravUuid} />
       </Tabs.Panel>
-      <Tabs.Panel value={Tab.FORHANDSVARSEL}>
-        <SendForhandsvarselSkjema aktivitetskravUuid={aktivitetskravUuid} />
-      </Tabs.Panel>
+      {isForhandsvarselTabVisible && (
+        <Tabs.Panel value={Tab.FORHANDSVARSEL}>
+          <SendForhandsvarselSkjema aktivitetskravUuid={aktivitetskravUuid} />
+        </Tabs.Panel>
+      )}
       {isIkkeOppfyltTabVisible && (
         <Tabs.Panel value={Tab.IKKE_OPPFYLT}>
           <IkkeOppfyltAktivitetskravSkjema

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -188,7 +188,9 @@ describe("VurderAktivitetskrav", () => {
         );
       });
 
-      expect(screen.queryByText(enBeskrivelse)).to.not.exist;
+      await waitFor(
+        () => expect(screen.queryByText(enBeskrivelse)).to.not.exist
+      );
     });
   });
   describe("Unntak", () => {
@@ -234,7 +236,9 @@ describe("VurderAktivitetskrav", () => {
         );
       });
 
-      expect(screen.queryByText(enBeskrivelse)).to.not.exist;
+      await waitFor(
+        () => expect(screen.queryByText(enBeskrivelse)).to.not.exist
+      );
     });
   });
   describe("Avvent", () => {
@@ -310,7 +314,9 @@ describe("VurderAktivitetskrav", () => {
         );
       });
 
-      expect(screen.queryByText(enBeskrivelse)).to.not.exist;
+      await waitFor(
+        () => expect(screen.queryByText(enBeskrivelse)).to.not.exist
+      );
     });
   });
   describe("Ikke oppfylt", () => {
@@ -370,7 +376,9 @@ describe("VurderAktivitetskrav", () => {
         );
       });
 
-      expect(screen.queryByText(enBeskrivelse)).to.not.exist;
+      await waitFor(
+        () => expect(screen.queryByText(enBeskrivelse)).to.not.exist
+      );
     });
     it("IKKE_OPPFYLT is present when status is forhandsvarsel and it is expired", () => {
       queryClient.setQueryData(

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -322,7 +322,7 @@ describe("VurderAktivitetskrav", () => {
     });
   });
   describe("Send forhåndsvarsel", () => {
-    it("Does not show AVVENT choice when forhandsvarsel is sent", () => {
+    it("Does not show AVVENT or FORHANDSVARSEL choice when forhandsvarsel is sent", () => {
       renderVurderAktivitetskrav(
         forhandsvarselAktivitetskrav,
         oppfolgingstilfelle
@@ -330,7 +330,7 @@ describe("VurderAktivitetskrav", () => {
 
       expect(screen.queryByRole("tab", { name: "Sett unntak" })).to.exist;
       expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
-      expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to
+      expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.not
         .exist;
       expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
       expect(screen.queryByRole("button", { name: "Avvent" })).to.not.exist;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Kom på at dette er noe vi kanskje burde ha på plass. Det er ikke mulig å sende et forhåndsvarsel to ganger i backenden, men fint å også støtte dette i frontenden ved å skjule fanen. Man kan altså bare sende forhåndsvarsel når statusen er NY, AVVENT eller NY_VURDERING. Det er samme logikk som i backend. Ettersom det ikke er mulig å sette AVVENT etter at et forhåndsvarsel har gått ut, så kan man da heller ikke gjøre forhåndsvarsel --> avvent --> forhåndsvarsel.

Vi hadde også noe async-issues i testene som gjør at de feiler i GA av og til, så fikser det i samme slengen 🤞🏼

### Screenshots 📸✨

<img width="1115" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/88d1757c-1b97-46b5-83ce-053e430fb980">
