### PR TITLE
Hide scrollbars

### DIFF
--- a/src/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
+++ b/src/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
@@ -29,7 +29,7 @@ export const ForhandsvarselOppsummering = ({
         <Tag variant="warning-moderate">{`Frist: ${fristDato}`}</Tag>
       </div>
       {beskrivelse && (
-        <Panel className="border-gray-400 rounded p-4 max-h-24 overflow-y-auto no-scrollbar">
+        <Panel className="border-gray-400 rounded p-4 max-h-24 overflow-y-auto">
           <BodyShort>{beskrivelse}</BodyShort>
         </Panel>
       )}

--- a/src/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
+++ b/src/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
@@ -29,7 +29,7 @@ export const ForhandsvarselOppsummering = ({
         <Tag variant="warning-moderate">{`Frist: ${fristDato}`}</Tag>
       </div>
       {beskrivelse && (
-        <Panel className="border-gray-400 rounded p-4 max-h-24 overflow-scroll">
+        <Panel className="border-gray-400 rounded p-4 max-h-24 overflow-y-auto no-scrollbar">
           <BodyShort>{beskrivelse}</BodyShort>
         </Panel>
       )}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,3 +1,16 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  /* Hide scrollbar for Chrome, Safari and Opera */
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Hide scrollbar for IE, Edge and Firefox */
+  .no-scrollbar {
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+  }
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1,16 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer utilities {
-  /* Hide scrollbar for Chrome, Safari and Opera */
-  .no-scrollbar::-webkit-scrollbar {
-    display: none;
-  }
-
-  /* Hide scrollbar for IE, Edge and Firefox */
-  .no-scrollbar {
-    -ms-overflow-style: none; /* IE and Edge */
-    scrollbar-width: none; /* Firefox */
-  }
-}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det var ganske stygt på ubuntu/windows med scrollbars her, så prøver å gjøre noen forbedringer. Oppdaget ikke dette på min flotte Mac-maskin.
Se: https://dev.to/derick1530/how-to-create-scrollable-element-in-tailwind-without-a-scrollbar-4mbd

### Screenshots 📸✨
Før: 
![image](https://github.com/navikt/syfomodiaperson/assets/37441744/373b926a-ef46-4ac8-9a76-6b14b7e8100e)

Nå: når testen er kort:
![image](https://github.com/navikt/syfomodiaperson/assets/37441744/9927e472-afd4-4d3b-b110-da1f0e67f8a2)

Nå: når teksten er lang:
![image](https://github.com/navikt/syfomodiaperson/assets/37441744/1b5bd79e-c17b-437b-a7a1-a38b5e439ada)


