### PR TITLE
IS-1814: Show ikke oppfylt tab all the time

### DIFF
--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
@@ -1,8 +1,5 @@
 import React from "react";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
-import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
-import { hasUbehandletPersonoppgave } from "@/utils/personOppgaveUtils";
-import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
 import {
   AktivitetskravDTO,
   AktivitetskravStatus,
@@ -55,14 +52,6 @@ export const VurderAktivitetskravTabs = ({
   aktivitetskrav,
 }: VurderAktivitetskravTabsProps) => {
   const { toggles } = useFeatureToggles();
-  const { data: oppgaver } = usePersonoppgaverQuery();
-  const hasUbehandletVurderStansOppgave = hasUbehandletPersonoppgave(
-    oppgaver,
-    PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
-  );
-  const isIkkeOppfyltTabVisible =
-    hasUbehandletVurderStansOppgave ||
-    !toggles.isSendingAvForhandsvarselEnabled;
   const isForhandsvarselTabVisible =
     toggles.isSendingAvForhandsvarselEnabled &&
     isValidStateForForhandsvarsel(aktivitetskrav.status);
@@ -77,9 +66,7 @@ export const VurderAktivitetskravTabs = ({
         {isForhandsvarselTabVisible && (
           <Tabs.Tab value={Tab.FORHANDSVARSEL} label={texts.forhandsvarsel} />
         )}
-        {isIkkeOppfyltTabVisible && (
-          <Tabs.Tab value={Tab.IKKE_OPPFYLT} label={texts.ikkeOppfylt} />
-        )}
+        <Tabs.Tab value={Tab.IKKE_OPPFYLT} label={texts.ikkeOppfylt} />
       </Tabs.List>
       <Tabs.Panel value={Tab.UNNTAK}>
         <UnntakAktivitetskravSkjema aktivitetskravUuid={aktivitetskravUuid} />
@@ -92,13 +79,11 @@ export const VurderAktivitetskravTabs = ({
           <SendForhandsvarselSkjema aktivitetskravUuid={aktivitetskravUuid} />
         </Tabs.Panel>
       )}
-      {isIkkeOppfyltTabVisible && (
-        <Tabs.Panel value={Tab.IKKE_OPPFYLT}>
-          <IkkeOppfyltAktivitetskravSkjema
-            aktivitetskravUuid={aktivitetskravUuid}
-          />
-        </Tabs.Panel>
-      )}
+      <Tabs.Panel value={Tab.IKKE_OPPFYLT}>
+        <IkkeOppfyltAktivitetskravSkjema
+          aktivitetskravUuid={aktivitetskravUuid}
+        />
+      </Tabs.Panel>
     </StyledTabs>
   );
 };

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -115,7 +115,7 @@ describe("VurderAktivitetskrav", () => {
     expect(screen.queryByRole("tab", { name: "Sett unntak" })).to.exist;
     expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
     expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.exist;
-    expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
+    expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.exist;
   });
 
   it("renders ikke-oppfylt when ubehandlet vurder-stans oppgave", () => {
@@ -337,7 +337,7 @@ describe("VurderAktivitetskrav", () => {
       expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
       expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.not
         .exist;
-      expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
+      expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.exist;
       expect(screen.queryByRole("button", { name: "Avvent" })).to.not.exist;
     });
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi viser `Ikke oppfylt` selv uten forhåndsvarsel, ettersom at de som har sendt forhåndsvarsel fra Arena vil sluttføre ting i Modia, særlig hvis de har satt feks Avventer først.

### Screenshots 📸✨
<img width="1065" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/ce0dff11-bfe1-42a8-b416-0227fd06b02d">
