### PR TITLE
Use notification alert on final aktivitetskrav vurdering

### DIFF
--- a/src/components/aktivitetskrav/AktivitetskravContainer.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravContainer.tsx
@@ -6,6 +6,7 @@ import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQuer
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import SideLaster from "@/components/SideLaster";
 import { AktivitetskravSide } from "@/components/aktivitetskrav/AktivitetskravSide";
+import { NotificationProvider } from "@/context/notification/NotificationContext";
 
 const texts = {
   title: "Aktivitetskrav",
@@ -30,7 +31,9 @@ export const AktivitetskravContainer = (): ReactElement => {
     <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.AKTIVITETSKRAV}>
       <Sidetopp tittel={texts.title} />
       <SideLaster henter={henter} hentingFeilet={hentingFeilet}>
-        <AktivitetskravSide />
+        <NotificationProvider>
+          <AktivitetskravSide />
+        </NotificationProvider>
       </SideLaster>
     </Side>
   );

--- a/src/components/aktivitetskrav/AktivitetskravSide.tsx
+++ b/src/components/aktivitetskrav/AktivitetskravSide.tsx
@@ -2,13 +2,11 @@ import React from "react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { VurderAktivitetskrav } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskrav";
 import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
-import { AktivitetskravVurderingAlert } from "@/components/aktivitetskrav/vurdering/AktivitetskravVurderingAlert";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import { AktivitetskravHistorikk } from "@/components/aktivitetskrav/historikk/AktivitetskravHistorikk";
 import { Panel } from "@navikt/ds-react";
 import { StartNyVurdering } from "./vurdering/StartNyVurdering";
 import { AktivitetskravAlertstripe } from "@/components/aktivitetskrav/AktivitetskravAlertstripe";
-import { ForhandsvarselOppsummering } from "@/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering";
 
 const texts = {
   noTilfelle:
@@ -20,7 +18,6 @@ export const AktivitetskravSide = () => {
   const { data } = useAktivitetskravQuery();
 
   const aktivitetskrav = data[0];
-  const sisteVurdering = aktivitetskrav?.vurderinger[0];
   const showStartNyVurdering = !aktivitetskrav || aktivitetskrav.inFinalState;
 
   return (
@@ -29,15 +26,6 @@ export const AktivitetskravSide = () => {
         <AktivitetskravAlertstripe variant="warning" size="small">
           {texts.noTilfelle}
         </AktivitetskravAlertstripe>
-      )}
-      {sisteVurdering && (
-        <AktivitetskravVurderingAlert vurdering={sisteVurdering} />
-      )}
-      {sisteVurdering?.varsel && (
-        <ForhandsvarselOppsummering
-          varsel={sisteVurdering.varsel}
-          beskrivelse={sisteVurdering.beskrivelse}
-        />
       )}
       {showStartNyVurdering ? (
         <StartNyVurdering aktivitetskrav={aktivitetskrav} />

--- a/src/components/aktivitetskrav/useAktivitetskravNotificationAlert.ts
+++ b/src/components/aktivitetskrav/useAktivitetskravNotificationAlert.ts
@@ -1,0 +1,42 @@
+import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { useNotification } from "@/context/notification/NotificationContext";
+import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+
+type AktivitetskravStatusSuccess =
+  | AktivitetskravStatus.OPPFYLT
+  | AktivitetskravStatus.UNNTAK
+  | AktivitetskravStatus.IKKE_OPPFYLT
+  | AktivitetskravStatus.IKKE_AKTUELL;
+
+export const useAktivitetskravNotificationAlert = () => {
+  const { navn: brukersNavn } = useNavBrukerData();
+  const { setNotification, notification } = useNotification();
+  const today = tilLesbarDatoMedArUtenManedNavn(new Date());
+
+  const getText = (status: AktivitetskravStatusSuccess) => {
+    switch (status) {
+      case AktivitetskravStatus.OPPFYLT: {
+        return `Det er vurdert at ${brukersNavn} er i aktivitet ${today}.`;
+      }
+      case AktivitetskravStatus.UNNTAK: {
+        return `Det er vurdert unntak for ${brukersNavn} ${today}.`;
+      }
+      case AktivitetskravStatus.IKKE_OPPFYLT: {
+        return `Det er vurdert at aktivitetskravet ikke er oppfylt for ${brukersNavn} ${today}.`;
+      }
+      case AktivitetskravStatus.IKKE_AKTUELL: {
+        return `Det er vurdert at aktivitetskravet ikke er aktuelt for ${brukersNavn} ${today}.`;
+      }
+    }
+  };
+
+  return {
+    displayNotification: (status: AktivitetskravStatusSuccess) => {
+      setNotification({
+        message: getText(status),
+      });
+    },
+    notification,
+  };
+};

--- a/src/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema.tsx
@@ -8,6 +8,7 @@ import { SkjemaHeading } from "@/components/aktivitetskrav/vurdering/SkjemaHeadi
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { ButtonRow } from "@/components/Layout";
 import { Button } from "@navikt/ds-react";
+import { useAktivitetskravNotificationAlert } from "@/components/aktivitetskrav/useAktivitetskravNotificationAlert";
 import { useForm } from "react-hook-form";
 import { VurderAktivitetskravSkjemaProps } from "@/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes";
 import BegrunnelseTextarea, {
@@ -37,16 +38,22 @@ export const IkkeAktuellAktivitetskravSkjema = ({
   setModalOpen,
 }: IkkeAktuellAktivitetskravSkjemaProps) => {
   const vurderAktivitetskrav = useVurderAktivitetskrav(aktivitetskravUuid);
+  const { displayNotification } = useAktivitetskravNotificationAlert();
+
   const { handleSubmit, register, watch } = useForm<SkjemaValues>();
   const onSubmit = (values: SkjemaValues) => {
     const isBlank = values.begrunnelse?.trim() === "";
+    const status = AktivitetskravStatus.IKKE_AKTUELL;
     const createAktivitetskravVurderingDTO: CreateAktivitetskravVurderingDTO = {
-      status: AktivitetskravStatus.IKKE_AKTUELL,
+      status,
       beskrivelse: isBlank ? undefined : values.begrunnelse,
       arsaker: [],
     };
     vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO, {
-      onSuccess: () => setModalOpen(false),
+      onSuccess: () => {
+        setModalOpen(false);
+        displayNotification(status);
+      },
     });
   };
 

--- a/src/components/aktivitetskrav/vurdering/IkkeOppfyltAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/IkkeOppfyltAktivitetskravSkjema.tsx
@@ -9,6 +9,7 @@ import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { VurderAktivitetskravSkjemaProps } from "@/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes";
 import { Button } from "@navikt/ds-react";
 import { ButtonRow } from "@/components/Layout";
+import { useAktivitetskravNotificationAlert } from "@/components/aktivitetskrav/useAktivitetskravNotificationAlert";
 
 const texts = {
   lagre: "Lagre",
@@ -22,12 +23,19 @@ export const IkkeOppfyltAktivitetskravSkjema = ({
   aktivitetskravUuid,
 }: VurderAktivitetskravSkjemaProps) => {
   const vurderAktivitetskrav = useVurderAktivitetskrav(aktivitetskravUuid);
+  const { displayNotification } = useAktivitetskravNotificationAlert();
+
   const submit = () => {
+    const status = AktivitetskravStatus.IKKE_OPPFYLT;
     const createAktivitetskravVurderingDTO: CreateAktivitetskravVurderingDTO = {
-      status: AktivitetskravStatus.IKKE_OPPFYLT,
+      status,
       arsaker: [],
     };
-    vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO);
+    vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO, {
+      onSuccess: () => {
+        displayNotification(status);
+      },
+    });
   };
 
   return (

--- a/src/components/aktivitetskrav/vurdering/OppfyltAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/OppfyltAktivitetskravSkjema.tsx
@@ -18,6 +18,7 @@ import { Button, Radio, RadioGroup } from "@navikt/ds-react";
 import BegrunnelseTextarea, {
   begrunnelseMaxLength,
 } from "@/components/aktivitetskrav/vurdering/BegrunnelseTextarea";
+import { useAktivitetskravNotificationAlert } from "@/components/aktivitetskrav/useAktivitetskravNotificationAlert";
 
 const texts = {
   title: "Er i aktivitet",
@@ -48,15 +49,20 @@ export const OppfyltAktivitetskravSkjema = ({
     defaultValues,
   });
   const vurderAktivitetskrav = useVurderAktivitetskrav(aktivitetskravUuid);
+  const { displayNotification } = useAktivitetskravNotificationAlert();
 
   const submit = (values: OppfyltAktivitetskravSkjemaValues) => {
+    const status = AktivitetskravStatus.OPPFYLT;
     const createAktivitetskravVurderingDTO: CreateAktivitetskravVurderingDTO = {
-      status: AktivitetskravStatus.OPPFYLT,
+      status,
       arsaker: [values.arsak],
       beskrivelse: values.begrunnelse,
     };
     vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO, {
-      onSuccess: () => reset(),
+      onSuccess: () => {
+        reset();
+        displayNotification(status);
+      },
     });
   };
 

--- a/src/components/aktivitetskrav/vurdering/StartNyVurdering.tsx
+++ b/src/components/aktivitetskrav/vurdering/StartNyVurdering.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { BodyShort, Button, Heading, Panel } from "@navikt/ds-react";
+import { Alert, BodyShort, Button, Heading, Panel } from "@navikt/ds-react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { useCreateAktivitetskrav } from "@/data/aktivitetskrav/useCreateAktivitetskrav";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
@@ -11,6 +11,7 @@ import {
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 import { vurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
+import { useAktivitetskravNotificationAlert } from "@/components/aktivitetskrav/useAktivitetskravNotificationAlert";
 
 export const texts = {
   header: "Start ny aktivitetskrav-vurdering",
@@ -76,6 +77,8 @@ export const StartNyVurdering = ({ aktivitetskrav }: StartNyVurderingProps) => {
   const { hasActiveOppfolgingstilfelle, latestOppfolgingstilfelle } =
     useOppfolgingstilfellePersonQuery();
   const createAktivitetskrav = useCreateAktivitetskrav();
+  const { notification } = useAktivitetskravNotificationAlert();
+
   const handleStartNyVurdering = () => {
     const newAktivitetskrav = aktivitetskrav
       ? { previousAktivitetskravUuid: aktivitetskrav?.uuid }
@@ -85,31 +88,38 @@ export const StartNyVurdering = ({ aktivitetskrav }: StartNyVurderingProps) => {
   const sisteVurdering = aktivitetskrav?.vurderinger[0];
 
   return (
-    <Panel className="mb-4 flex flex-col p-8">
-      <Heading level="2" size="large" className="mb-1">
-        {texts.header}
-      </Heading>
-      {hasActiveOppfolgingstilfelle && (
-        <GjelderOppfolgingstilfelle
-          oppfolgingstilfelle={latestOppfolgingstilfelle}
-        />
+    <>
+      {notification && (
+        <Alert className="mb-4" variant="success">
+          {notification.message}
+        </Alert>
       )}
-      {sisteVurdering ? (
-        <VurderingText vurdering={sisteVurdering} />
-      ) : (
-        <BodyShort className="mb-4">{texts.noVurdering}</BodyShort>
-      )}
-      {createAktivitetskrav.isError && (
-        <SkjemaInnsendingFeil error={createAktivitetskrav.error} />
-      )}
-      <Button
-        variant="secondary"
-        className="mr-auto"
-        loading={createAktivitetskrav.isLoading}
-        onClick={handleStartNyVurdering}
-      >
-        {texts.button}
-      </Button>
-    </Panel>
+      <Panel className="mb-4 flex flex-col p-8">
+        <Heading level="2" size="large" className="mb-1">
+          {texts.header}
+        </Heading>
+        {hasActiveOppfolgingstilfelle && (
+          <GjelderOppfolgingstilfelle
+            oppfolgingstilfelle={latestOppfolgingstilfelle}
+          />
+        )}
+        {sisteVurdering ? (
+          <VurderingText vurdering={sisteVurdering} />
+        ) : (
+          <BodyShort className="mb-4">{texts.noVurdering}</BodyShort>
+        )}
+        {createAktivitetskrav.isError && (
+          <SkjemaInnsendingFeil error={createAktivitetskrav.error} />
+        )}
+        <Button
+          variant="secondary"
+          className="mr-auto"
+          loading={createAktivitetskrav.isLoading}
+          onClick={handleStartNyVurdering}
+        >
+          {texts.button}
+        </Button>
+      </Panel>
+    </>
   );
 };

--- a/src/components/aktivitetskrav/vurdering/UnntakAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/UnntakAktivitetskravSkjema.tsx
@@ -18,6 +18,7 @@ import { Button, Radio, RadioGroup } from "@navikt/ds-react";
 import BegrunnelseTextarea, {
   begrunnelseMaxLength,
 } from "@/components/aktivitetskrav/vurdering/BegrunnelseTextarea";
+import { useAktivitetskravNotificationAlert } from "@/components/aktivitetskrav/useAktivitetskravNotificationAlert";
 
 const texts = {
   title: "Sett unntak fra aktivitetskravet",
@@ -46,15 +47,20 @@ export const UnntakAktivitetskravSkjema = ({
     reset,
   } = useForm<UnntakAktivitetskravSkjemaValues>({ defaultValues });
   const vurderAktivitetskrav = useVurderAktivitetskrav(aktivitetskravUuid);
+  const { displayNotification } = useAktivitetskravNotificationAlert();
 
   const submit = (values: UnntakAktivitetskravSkjemaValues) => {
+    const status = AktivitetskravStatus.UNNTAK;
     const createAktivitetskravVurderingDTO: CreateAktivitetskravVurderingDTO = {
-      status: AktivitetskravStatus.UNNTAK,
+      status,
       arsaker: [values.arsak],
       beskrivelse: values.begrunnelse,
     };
     vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO, {
-      onSuccess: () => reset(),
+      onSuccess: () => {
+        reset();
+        displayNotification(status);
+      },
     });
   };
 

--- a/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
+++ b/src/components/aktivitetskrav/vurdering/VurderAktivitetskrav.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { AktivitetskravDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import {
+  AktivitetskravDTO,
+  AktivitetskravStatus,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { VurderAktivitetskravTabs } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravTabs";
 import { Heading, Panel } from "@navikt/ds-react";
 import { VurderAktivitetskravButtons } from "@/components/aktivitetskrav/vurdering/VurderAktivitetskravButtons";
 import { GjelderOppfolgingstilfelle } from "@/components/aktivitetskrav/GjelderOppfolgingstilfelle";
 import { oppfolgingstilfelleForAktivitetskrav } from "@/utils/aktivitetskravUtils";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { AktivitetskravVurderingAlert } from "@/components/aktivitetskrav/vurdering/AktivitetskravVurderingAlert";
+import { ForhandsvarselOppsummering } from "@/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering";
 
 export const texts = {
   header: "Vurdere aktivitetskravet",
@@ -23,17 +28,34 @@ export const VurderAktivitetskrav = ({
     aktivitetskrav,
     tilfellerDescendingStart
   );
+  const currentVurdering = aktivitetskrav.vurderinger[0];
+  const showVurderAktivitetskravAlert =
+    currentVurdering?.status === AktivitetskravStatus.AVVENT ||
+    currentVurdering?.status === AktivitetskravStatus.FORHANDSVARSEL;
 
   return (
-    <Panel className="mb-4 flex flex-col pt-4 pr-4 pb-8 pl-8">
-      <VurderAktivitetskravButtons aktivitetskrav={aktivitetskrav} />
-      <Heading level="2" size="large" className="mb-1">
-        {texts.header}
-      </Heading>
-      {oppfolgingstilfelle && (
-        <GjelderOppfolgingstilfelle oppfolgingstilfelle={oppfolgingstilfelle} />
+    <>
+      {showVurderAktivitetskravAlert && (
+        <AktivitetskravVurderingAlert vurdering={currentVurdering} />
       )}
-      <VurderAktivitetskravTabs aktivitetskrav={aktivitetskrav} />
-    </Panel>
+      {currentVurdering?.varsel && (
+        <ForhandsvarselOppsummering
+          varsel={currentVurdering.varsel}
+          beskrivelse={currentVurdering.beskrivelse}
+        />
+      )}
+      <Panel className="mb-4 flex flex-col pt-4 pr-4 pb-8 pl-8">
+        <VurderAktivitetskravButtons aktivitetskrav={aktivitetskrav} />
+        <Heading level="2" size="large" className="mb-1">
+          {texts.header}
+        </Heading>
+        {oppfolgingstilfelle && (
+          <GjelderOppfolgingstilfelle
+            oppfolgingstilfelle={oppfolgingstilfelle}
+          />
+        )}
+        <VurderAktivitetskravTabs aktivitetskrav={aktivitetskrav} />
+      </Panel>
+    </>
   );
 };

--- a/src/context/notification/NotificationContext.tsx
+++ b/src/context/notification/NotificationContext.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from "react";
+
+export interface Notification {
+  message: string;
+}
+
+type NotificationProviderProps = {
+  children: React.ReactNode;
+};
+
+type NotificationContextState = {
+  notification: Notification | undefined;
+  setNotification: (notification: Notification | undefined) => void;
+};
+
+export const NotificationContext = React.createContext<
+  NotificationContextState | undefined
+>(undefined);
+
+export const NotificationProvider = ({
+  children,
+}: NotificationProviderProps) => {
+  const [notification, setNotification] = useState<Notification | undefined>(
+    undefined
+  );
+  return (
+    <NotificationContext.Provider
+      value={{
+        notification,
+        setNotification: (notification) => setNotification(notification),
+      }}
+    >
+      {children}
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotification = () => {
+  const context = React.useContext(NotificationContext);
+  if (!context) {
+    throw new Error(
+      `useNotifications must be used within a NotificationProvider`
+    );
+  }
+  return context;
+};

--- a/test/aktivitetskrav/AktivitetskravVurderingAlertTest.tsx
+++ b/test/aktivitetskrav/AktivitetskravVurderingAlertTest.tsx
@@ -3,10 +3,6 @@ import {
   avventVurderingUtenFrist,
   createAktivitetskravVurdering,
   forhandsvarselVurdering,
-  ikkeAktuellVurdering,
-  ikkeOppfyltVurdering,
-  oppfyltVurdering,
-  unntakVurdering,
 } from "../testDataUtils";
 import {
   AktivitetskravStatus,
@@ -84,36 +80,6 @@ describe("AktivitetskravVurderingAlert", () => {
       .exist;
     expect(screen.getByText("Har bedt om mer informasjon fra behandler")).to
       .exist;
-  });
-  it("viser suksess når siste aktivitetskrav-vurdering er OPPFYLT", () => {
-    renderAktivitetskravVurderingAlert(oppfyltVurdering);
-
-    expect(screen.getByRole("img", { name: "Suksess" })).to.exist;
-    expect(
-      screen.getByText(/Det er vurdert at Samuel Sam Jones er i aktivitet/)
-    ).to.exist;
-  });
-  it("viser suksess når siste aktivitetskrav-vurdering er UNNTAK", () => {
-    renderAktivitetskravVurderingAlert(unntakVurdering);
-
-    expect(screen.getByRole("img", { name: "Suksess" })).to.exist;
-    expect(screen.getByText(/Det er vurdert unntak/)).to.exist;
-  });
-  it("viser suksess når siste aktivitetskrav-vurdering er IKKE_OPPFYLT", () => {
-    renderAktivitetskravVurderingAlert(ikkeOppfyltVurdering);
-
-    expect(screen.getByRole("img", { name: "Suksess" })).to.exist;
-    expect(
-      screen.getByText(/Det er vurdert at aktivitetskravet ikke er oppfylt/)
-    ).to.exist;
-  });
-  it("viser suksess når siste aktivitetskrav-vurdering er IKKE_AKTUELL", () => {
-    renderAktivitetskravVurderingAlert(ikkeAktuellVurdering);
-
-    expect(screen.getByRole("img", { name: "Suksess" })).to.exist;
-    expect(
-      screen.getByText(/Det er vurdert at aktivitetskravet ikke er aktuelt/)
-    ).to.exist;
   });
   it("viser info når siste aktivitetskrav-vurdering er FORHANDSVARSEL uten vurder stans-oppgave", () => {
     renderAktivitetskravVurderingAlert(forhandsvarselVurdering);

--- a/test/aktivitetskrav/StartNyVurderingTest.tsx
+++ b/test/aktivitetskrav/StartNyVurderingTest.tsx
@@ -24,6 +24,7 @@ import {
   UnntakVurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { vurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
+import { NotificationContext } from "@/context/notification/NotificationContext";
 
 let queryClient: QueryClient;
 
@@ -72,7 +73,11 @@ const renderStartNyVurdering = (aktivitetskrav?: AktivitetskravDTO) => {
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <StartNyVurdering aktivitetskrav={aktivitetskrav} />
+        <NotificationContext.Provider
+          value={{ notification: undefined, setNotification: () => void 0 }}
+        >
+          <StartNyVurdering aktivitetskrav={aktivitetskrav} />
+        </NotificationContext.Provider>
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Endrer til å vise success-alert for vurdering bare etter vurderingen er sendt og ikke hver gang man går inn på aktivitetskrav-siden.

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/991d407a-2aa5-4c6a-be2d-d9de34b30491)


