### PR TITLE
IS-1806: Add field for begrunnelse in IKKE_AKTUELL vurdering

### DIFF
--- a/src/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema.tsx
@@ -6,9 +6,13 @@ import React from "react";
 import { useVurderAktivitetskrav } from "@/data/aktivitetskrav/useVurderAktivitetskrav";
 import { SkjemaHeading } from "@/components/aktivitetskrav/vurdering/SkjemaHeading";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
-import { VurderAktivitetskravSkjemaProps } from "@/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes";
 import { ButtonRow } from "@/components/Layout";
 import { Button } from "@navikt/ds-react";
+import { useForm } from "react-hook-form";
+import { VurderAktivitetskravSkjemaProps } from "@/components/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes";
+import BegrunnelseTextarea, {
+  begrunnelseMaxLength,
+} from "@/components/aktivitetskrav/vurdering/BegrunnelseTextarea";
 
 const texts = {
   lagre: "Lagre",
@@ -16,6 +20,7 @@ const texts = {
   title: "Ikke aktuell",
   subtitle1:
     "Aktivitetskravet skal ikke vurderes for denne personen. Ved å lagre fjerner du hendelsen fra oversikten.",
+  begrunnelseLabel: "Begrunnelse",
 };
 
 interface IkkeAktuellAktivitetskravSkjemaProps
@@ -23,14 +28,21 @@ interface IkkeAktuellAktivitetskravSkjemaProps
   setModalOpen: (isOpen: boolean) => void;
 }
 
+interface SkjemaValues {
+  begrunnelse?: string;
+}
+
 export const IkkeAktuellAktivitetskravSkjema = ({
   aktivitetskravUuid,
   setModalOpen,
 }: IkkeAktuellAktivitetskravSkjemaProps) => {
   const vurderAktivitetskrav = useVurderAktivitetskrav(aktivitetskravUuid);
-  const submit = () => {
+  const { handleSubmit, register, watch } = useForm<SkjemaValues>();
+  const onSubmit = (values: SkjemaValues) => {
+    const isBlank = values.begrunnelse?.trim() === "";
     const createAktivitetskravVurderingDTO: CreateAktivitetskravVurderingDTO = {
       status: AktivitetskravStatus.IKKE_AKTUELL,
+      beskrivelse: isBlank ? undefined : values.begrunnelse,
       arsaker: [],
     };
     vurderAktivitetskrav.mutate(createAktivitetskravVurderingDTO, {
@@ -40,18 +52,28 @@ export const IkkeAktuellAktivitetskravSkjema = ({
 
   return (
     <>
-      <SkjemaHeading title={texts.title} subtitles={[texts.subtitle1]} />
-      {vurderAktivitetskrav.isError && (
-        <SkjemaInnsendingFeil error={vurderAktivitetskrav.error} />
-      )}
-      <ButtonRow>
-        <Button loading={vurderAktivitetskrav.isLoading} onClick={submit}>
-          {texts.lagre}
-        </Button>
-        <Button variant="tertiary" onClick={() => setModalOpen(false)}>
-          {texts.avbryt}
-        </Button>
-      </ButtonRow>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <SkjemaHeading title={texts.title} subtitles={[texts.subtitle1]} />
+        <BegrunnelseTextarea
+          className={"mb-4"}
+          {...register("begrunnelse", {
+            maxLength: begrunnelseMaxLength,
+          })}
+          value={watch("begrunnelse")}
+          label={texts.begrunnelseLabel}
+        />
+        {vurderAktivitetskrav.isError && (
+          <SkjemaInnsendingFeil error={vurderAktivitetskrav.error} />
+        )}
+        <ButtonRow>
+          <Button loading={vurderAktivitetskrav.isLoading} type="submit">
+            {texts.lagre}
+          </Button>
+          <Button variant="tertiary" onClick={() => setModalOpen(false)}>
+            {texts.avbryt}
+          </Button>
+        </ButtonRow>
+      </form>
     </>
   );
 };

--- a/src/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/IkkeAktuellAktivitetskravSkjema.tsx
@@ -51,29 +51,27 @@ export const IkkeAktuellAktivitetskravSkjema = ({
   };
 
   return (
-    <>
-      <form onSubmit={handleSubmit(onSubmit)}>
-        <SkjemaHeading title={texts.title} subtitles={[texts.subtitle1]} />
-        <BegrunnelseTextarea
-          className={"mb-4"}
-          {...register("begrunnelse", {
-            maxLength: begrunnelseMaxLength,
-          })}
-          value={watch("begrunnelse")}
-          label={texts.begrunnelseLabel}
-        />
-        {vurderAktivitetskrav.isError && (
-          <SkjemaInnsendingFeil error={vurderAktivitetskrav.error} />
-        )}
-        <ButtonRow>
-          <Button loading={vurderAktivitetskrav.isLoading} type="submit">
-            {texts.lagre}
-          </Button>
-          <Button variant="tertiary" onClick={() => setModalOpen(false)}>
-            {texts.avbryt}
-          </Button>
-        </ButtonRow>
-      </form>
-    </>
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <SkjemaHeading title={texts.title} subtitles={[texts.subtitle1]} />
+      <BegrunnelseTextarea
+        className={"mb-4"}
+        {...register("begrunnelse", {
+          maxLength: begrunnelseMaxLength,
+        })}
+        value={watch("begrunnelse")}
+        label={texts.begrunnelseLabel}
+      />
+      {vurderAktivitetskrav.isError && (
+        <SkjemaInnsendingFeil error={vurderAktivitetskrav.error} />
+      )}
+      <ButtonRow>
+        <Button loading={vurderAktivitetskrav.isLoading} type="submit">
+          {texts.lagre}
+        </Button>
+        <Button variant="tertiary" onClick={() => setModalOpen(false)}>
+          {texts.avbryt}
+        </Button>
+      </ButtonRow>
+    </form>
   );
 };

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -421,7 +421,7 @@ describe("VurderAktivitetskrav", () => {
     });
   });
   describe("Ikke aktuell", () => {
-    it("Lagre vurdering med verdier fra skjema", () => {
+    it("Lagre vurdering med verdier fra skjema", async () => {
       renderVurderAktivitetskrav(aktivitetskrav);
 
       clickButton(buttonTexts["IKKE_AKTUELL"]);
@@ -440,22 +440,27 @@ describe("VurderAktivitetskrav", () => {
         )
       ).to.exist;
 
+      const beskrivelseInput = getTextInput("Begrunnelse");
+      changeTextInput(beskrivelseInput, enBeskrivelse);
+
       const lagreButton = within(screen.getByRole("dialog")).getByRole(
         "button",
         { name: "Lagre" }
       );
       fireEvent.click(lagreButton);
-
-      const vurderIkkeAktuellMutation = queryClient
-        .getMutationCache()
-        .getAll()[0];
-      const expectedVurdering: CreateAktivitetskravVurderingDTO = {
-        status: AktivitetskravStatus.IKKE_AKTUELL,
-        arsaker: [],
-      };
-      expect(vurderIkkeAktuellMutation.options.variables).to.deep.equal(
-        expectedVurdering
-      );
+      await waitFor(() => {
+        const vurderIkkeAktuellMutation = queryClient
+          .getMutationCache()
+          .getAll()[0];
+        const expectedVurdering: CreateAktivitetskravVurderingDTO = {
+          status: AktivitetskravStatus.IKKE_AKTUELL,
+          beskrivelse: enBeskrivelse,
+          arsaker: [],
+        };
+        expect(vurderIkkeAktuellMutation.options.variables).to.deep.equal(
+          expectedVurdering
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til "begrunnelse" felt for når en veileder ønsker å gjøre en `IKKE_AKTUELL` vurdering.

- [x] Test i dev slik at vi er sikre på at dette flyr i `isaktivitetskrav`
Ser ut til å fungere utav boksen.

### Screenshots 📸✨
![Screenshot 2023-11-15 at 15 27 40](https://github.com/navikt/syfomodiaperson/assets/11747383/3b2015f2-0f3a-4d48-8cbd-d6668595c3d8)
