### PR TITLE
Fix styling on meldingtypeInfo

### DIFF
--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingTilBehandlerSkjema.tsx
@@ -114,26 +114,28 @@ export const MeldingTilBehandlerSkjema = () => {
           {`Meldingen ble sendt ${tilDatoMedManedNavnOgKlokkeslett(now)}`}
         </Alert>
       )}
-      <Select
-        id="type"
-        className={"w-[23rem]"}
-        label={texts.meldingsType.label}
-        {...register("meldingsType", { required: true })}
-        value={watch("meldingsType")}
-        error={errors.meldingsType && texts.meldingsType.missing}
-      >
-        <option value="">{texts.meldingsType.defaultOption}</option>
-        <MeldingTypeOption
-          type={MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER}
-        />
-        <MeldingTypeOption
-          type={MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING}
-        />
-        <MeldingTypeOption type={MeldingType.HENVENDELSE_MELDING_FRA_NAV} />
-      </Select>
-      {watch("meldingsType") && (
-        <MeldingsTypeInfo meldingType={watch("meldingsType")} />
-      )}
+      <div className="max-w-[23rem]">
+        <Select
+          id="type"
+          className="mb-4"
+          label={texts.meldingsType.label}
+          {...register("meldingsType", { required: true })}
+          value={watch("meldingsType")}
+          error={errors.meldingsType && texts.meldingsType.missing}
+        >
+          <option value="">{texts.meldingsType.defaultOption}</option>
+          <MeldingTypeOption
+            type={MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER}
+          />
+          <MeldingTypeOption
+            type={MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING}
+          />
+          <MeldingTypeOption type={MeldingType.HENVENDELSE_MELDING_FRA_NAV} />
+        </Select>
+        {watch("meldingsType") && (
+          <MeldingsTypeInfo meldingType={watch("meldingsType")} />
+        )}
+      </div>
       <VelgBehandler
         selectedBehandler={selectedBehandler}
         setSelectedBehandler={setSelectedBehandler}

--- a/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
+++ b/src/components/behandlerdialog/meldingtilbehandler/MeldingsTypeInfo.tsx
@@ -1,5 +1,4 @@
 import { MeldingType } from "@/data/behandlerdialog/behandlerdialogTypes";
-import styled from "styled-components";
 import React, { ReactElement } from "react";
 import {
   BlueDocumentImage,
@@ -15,46 +14,39 @@ const texts = {
   meldingFraNAV: "Melding fra NAV til behandler som ikke utløser takst.",
 };
 
-const Icon = styled.img`
-  margin-right: 1em;
-  width: 3em;
-`;
+interface InfoElementProps {
+  icon: string;
+  text: string;
+}
 
-const InfoPanel = styled.div`
-  display: flex;
-  flex-direction: row;
-`;
+const InfoElement = ({ icon, text }: InfoElementProps) => {
+  return (
+    <>
+      <img src={icon} className="mr-4 w-12" alt="Ikon for meldingstypen" />
+      <BodyShort size={"small"}>{text}</BodyShort>
+    </>
+  );
+};
 
-interface Props {
+interface MeldingsTypeInfoProps {
   meldingType: MeldingType;
 }
 
 export const MeldingsTypeInfo = ({
   meldingType,
-}: Props): ReactElement | null => {
+}: MeldingsTypeInfoProps): ReactElement | null => {
   const Info = () => {
     switch (meldingType) {
       case MeldingType.FORESPORSEL_PASIENT_TILLEGGSOPPLYSNINGER:
         return (
-          <>
-            <Icon src={BlyantImage} />
-            <BodyShort size={"small"}>{texts.tilleggsopplysinger}</BodyShort>
-          </>
+          <InfoElement icon={BlyantImage} text={texts.tilleggsopplysinger} />
         );
       case MeldingType.FORESPORSEL_PASIENT_LEGEERKLARING:
         return (
-          <>
-            <Icon src={BlueDocumentImage} />
-            <BodyShort size={"small"}>{texts.legeerklaring}</BodyShort>
-          </>
+          <InfoElement icon={BlueDocumentImage} text={texts.legeerklaring} />
         );
       case MeldingType.HENVENDELSE_MELDING_FRA_NAV:
-        return (
-          <>
-            <Icon src={BlyantImage} />
-            <BodyShort size={"small"}>{texts.meldingFraNAV}</BodyShort>
-          </>
-        );
+        return <InfoElement icon={BlyantImage} text={texts.meldingFraNAV} />;
       case MeldingType.FORESPORSEL_PASIENT_PAMINNELSE:
       case MeldingType.HENVENDELSE_RETUR_LEGEERKLARING:
       case MeldingType.HENVENDELSE_MELDING_TIL_NAV:
@@ -63,8 +55,8 @@ export const MeldingsTypeInfo = ({
   };
 
   return (
-    <InfoPanel>
+    <div className="flex flex-row items-center">
       <Info />
-    </InfoPanel>
+    </div>
   );
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Så at det på et tidspunkt har blitt endret litt i stylingen på skjemaet, muligens i forbindelse med overgangen til react-hook-form. I følge skissene skal teksten være aligned i center, og helst breake på samme sted/ha samme bredde som Select-boksen.
Ellers litt andre forbedringer som å bruke mer tailwind.

### Screenshots 📸✨

Før:
<img width="737" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/4843e4c2-d8c8-44ba-8630-fd04e3e7e329">

Etter:
<img width="656" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/f7882559-ce7e-41d5-ab27-bde0b9c6a2c1">

