### PR TITLE
Fix personkort styling

### DIFF
--- a/src/components/personkort/PersonkortHeader/MaksdatoSummary.tsx
+++ b/src/components/personkort/PersonkortHeader/MaksdatoSummary.tsx
@@ -1,24 +1,11 @@
 import React from "react";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { Maksdato } from "@/data/maksdato/useMaksdatoQuery";
+import { SyketilfelleSummaryElement } from "@/components/personkort/PersonkortHeader/SyketilfelleSummary";
 
 const texts = {
   maksdato: "Maksdato: ",
   utbetaltTom: "Utbetalt tom: ",
-};
-
-interface DatoInfoElementProps {
-  tekst: string;
-  dato: Date;
-}
-
-const DatoInfoElement = ({ tekst, dato }: DatoInfoElementProps) => {
-  return (
-    <div className={"font-normal"}>
-      <span>{tekst}</span>
-      <div className={"font-bold"}>{tilLesbarDatoMedArUtenManedNavn(dato)}</div>
-    </div>
-  );
 };
 
 interface MaksdatoSummaryProps {
@@ -27,11 +14,16 @@ interface MaksdatoSummaryProps {
 export const MaksdatoSummary = ({ maxDate }: MaksdatoSummaryProps) => {
   return (
     <div className={"flex flex-row gap-3 items-center"}>
-      <DatoInfoElement
-        tekst={texts.maksdato}
-        dato={maxDate.forelopig_beregnet_slutt}
+      <SyketilfelleSummaryElement
+        keyword={texts.maksdato}
+        value={tilLesbarDatoMedArUtenManedNavn(
+          maxDate.forelopig_beregnet_slutt
+        )}
       />
-      <DatoInfoElement tekst={texts.utbetaltTom} dato={maxDate.utbetalt_tom} />
+      <SyketilfelleSummaryElement
+        keyword={texts.utbetaltTom}
+        value={tilLesbarDatoMedArUtenManedNavn(maxDate.utbetalt_tom)}
+      />
     </div>
   );
 };

--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -14,9 +14,7 @@ import { SyketilfelleSummary } from "@/components/personkort/PersonkortHeader/Sy
 import { Refresh } from "@navikt/ds-icons";
 import { Tooltip } from "@navikt/ds-react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
-import { MaksdatoSummary } from "@/components/personkort/PersonkortHeader/MaksdatoSummary";
 import { PersonkortHeaderTags } from "@/components/personkort/PersonkortHeader/PersonkortHeaderTags";
-import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 
 const texts = {
   copied: "Kopiert!",
@@ -45,7 +43,6 @@ const PersonkortHeader = () => {
   const navbruker = useNavBrukerData();
   const personident = useValgtPersonident();
   const { hasGjentakendeSykefravar } = useOppfolgingstilfellePersonQuery();
-  const { data: maksDato } = useMaksdatoQuery();
 
   return (
     <div className="personkortHeader">
@@ -73,7 +70,6 @@ const PersonkortHeader = () => {
             <CopyButton message={texts.copied} value={personident} />
           </StyledFnr>
           <SyketilfelleSummary />
-          {maksDato?.maxDate && <MaksdatoSummary maxDate={maksDato.maxDate} />}
         </div>
       </div>
       <PersonkortHeaderTags />

--- a/src/components/personkort/PersonkortHeader/SyketilfelleSummary.tsx
+++ b/src/components/personkort/PersonkortHeader/SyketilfelleSummary.tsx
@@ -2,13 +2,36 @@ import React from "react";
 import { Diagnosekode } from "@/components/personkort/PersonkortHeader/Diagnosekode";
 import { TilfellePeriod } from "@/components/personkort/PersonkortHeader/TilfellePeriod";
 import { Varighet } from "@/components/personkort/PersonkortHeader/Varighet";
+import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
+import { MaksdatoSummary } from "@/components/personkort/PersonkortHeader/MaksdatoSummary";
+
+interface SyketilfelleSummaryElementProps {
+  keyword: string;
+  value: string;
+}
+
+export const SyketilfelleSummaryElement = ({
+  keyword,
+  value,
+}: SyketilfelleSummaryElementProps) => {
+  return (
+    <div className={"font-normal"}>
+      <span>{keyword}</span>
+      <b>{value}</b>
+    </div>
+  );
+};
 
 export const SyketilfelleSummary = () => {
+  const { data: maksDato } = useMaksdatoQuery();
   return (
-    <div className={"flex flex-row gap-3 items-center"}>
-      <TilfellePeriod />
-      <Varighet />
-      <Diagnosekode />
-    </div>
+    <>
+      <div className={"flex flex-row gap-3 items-center"}>
+        <TilfellePeriod />
+        <Varighet />
+        <Diagnosekode />
+      </div>
+      {maksDato?.maxDate && <MaksdatoSummary maxDate={maksDato.maxDate} />}
+    </>
   );
 };

--- a/src/components/personkort/PersonkortHeader/TilfellePeriod.tsx
+++ b/src/components/personkort/PersonkortHeader/TilfellePeriod.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import React from "react";
+import { SyketilfelleSummaryElement } from "@/components/personkort/PersonkortHeader/SyketilfelleSummary";
 
 const texts = {
   startDate: "Sykmeldt: ",
@@ -12,12 +13,10 @@ const texts = {
 export const TilfellePeriod = () => {
   const startDate = useStartOfLatestOppfolgingstilfelle();
   const endDate = useEndOfLatestOppfolgingstilfelle();
+  const periode = `${tilLesbarDatoMedArUtenManedNavn(
+    startDate
+  )} - ${tilLesbarDatoMedArUtenManedNavn(endDate)}`;
   return !!startDate && !!endDate ? (
-    <div className={"font-normal"}>
-      <span>{texts.startDate}</span>
-      <div className={"font-bold"}>{`${tilLesbarDatoMedArUtenManedNavn(
-        startDate
-      )} - ${tilLesbarDatoMedArUtenManedNavn(endDate)}`}</div>
-    </div>
+    <SyketilfelleSummaryElement keyword={texts.startDate} value={periode} />
   ) : null;
 };

--- a/src/components/personkort/PersonkortHeader/Varighet.tsx
+++ b/src/components/personkort/PersonkortHeader/Varighet.tsx
@@ -4,6 +4,7 @@ import {
   useStartOfLatestOppfolgingstilfelle,
 } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { getEarliestDate, getWeeksBetween } from "@/utils/datoUtils";
+import { SyketilfelleSummaryElement } from "@/components/personkort/PersonkortHeader/SyketilfelleSummary";
 
 const texts = {
   varighet: "Varighet: ",
@@ -18,9 +19,9 @@ export const Varighet = () => {
   const weeks = getWeeksBetween(startDate, earliest);
 
   return !!startDate ? (
-    <div className={"font-normal"}>
-      <span> {texts.varighet} </span>
-      <div className={"font-bold"}>{`${weeks} ${texts.uker}`}</div>
-    </div>
+    <SyketilfelleSummaryElement
+      keyword={texts.varighet}
+      value={`${weeks} ${texts.uker}`}
+    />
   ) : null;
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det ble noen rariterer i personkortet etter at vi byttet ut mange av `<></>` med `<div>`. 
Har også refaktorert litt kode, ettersom at alle hadde samme logikk for visning med `Noe: noe annet i bold`.
Flytta også maksdato inn under samme komponent som alle de andre lignende infoelementene lå under.

### Screenshots 📸✨
Før:
<img width="482" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/58c10d00-999d-46a7-82a7-2ed127db5473">

Nå:
<img width="607" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/0137d388-b412-47d8-8749-b9e665a97c53">

