### PR TITLE
IS-1815: Set begrunnelse optional

### DIFF
--- a/src/components/aktivitetskrav/vurdering/OppfyltAktivitetskravSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/OppfyltAktivitetskravSkjema.tsx
@@ -23,9 +23,8 @@ import { useAktivitetskravNotificationAlert } from "@/components/aktivitetskrav/
 const texts = {
   title: "Er i aktivitet",
   arsakLegend: "Årsak (obligatorisk)",
-  begrunnelseLabel: "Begrunnelse (obligatorisk)",
+  begrunnelseLabel: "Begrunnelse",
   missingArsak: "Vennligst angi årsak",
-  missingBegrunnelse: "Vennligst angi begrunnelse",
   lagre: "Lagre",
 };
 
@@ -91,9 +90,7 @@ export const OppfyltAktivitetskravSkjema = ({
         <BegrunnelseTextarea
           {...register("begrunnelse", {
             maxLength: begrunnelseMaxLength,
-            required: true,
           })}
-          error={errors.begrunnelse && texts.missingBegrunnelse}
           value={watch("begrunnelse")}
           label={texts.begrunnelseLabel}
         />

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -164,7 +164,7 @@ describe("VurderAktivitetskrav", () => {
 
       clickTab(tabTexts["OPPFYLT"]);
       const tooLongBeskrivelse = getTooLongText(begrunnelseMaxLength);
-      const beskrivelseInput = getTextInput("Begrunnelse (obligatorisk)");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, tooLongBeskrivelse);
       clickButton("Lagre");
 
@@ -181,7 +181,7 @@ describe("VurderAktivitetskrav", () => {
 
       const arsakRadioButton = screen.getByText("Friskmeldt");
       fireEvent.click(arsakRadioButton);
-      const beskrivelseInput = getTextInput("Begrunnelse (obligatorisk)");
+      const beskrivelseInput = getTextInput("Begrunnelse");
       changeTextInput(beskrivelseInput, enBeskrivelse);
       clickButton("Lagre");
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- "Begrunnelse" felt er ikke lenger obligatorisk å fylle ut når veileder vurderer innbygger til "I aktivitet"/`OPPFYLT`

