### PR TITLE
Add blockquote with button for expanding

### DIFF
--- a/src/components/ExpandableBlockquote.tsx
+++ b/src/components/ExpandableBlockquote.tsx
@@ -1,0 +1,82 @@
+import React, { ReactNode, RefObject } from "react";
+import { ChevronDownIcon, ChevronUpIcon } from "@navikt/aksel-icons";
+import { Button } from "@navikt/ds-react";
+
+const texts = {
+  readMore: "Vis mer",
+  readLess: "Vis mindre",
+};
+
+interface ExpandableBlockquoteProps {
+  className?: string;
+  children: ReactNode;
+}
+
+export const ExpandableBlockquote = ({
+  className,
+  children,
+}: ExpandableBlockquoteProps) => {
+  const [viewAll, setViewAll] = React.useState<boolean>(false);
+  const ref = React.useRef() as RefObject<any>;
+  const isOverflow = useIsOverflow(ref, () => {
+    /*noop*/
+  });
+  const showButton = isOverflow || viewAll;
+  const maxHeight = viewAll ? "max-h-full" : "max-h-24";
+
+  return (
+    <div className="grid grid-cols-1 place-items-center">
+      <blockquote
+        className={`${className} ${maxHeight} mb-2 overflow-hidden w-full`}
+        ref={ref}
+      >
+        {children}
+      </blockquote>
+      {showButton && (
+        <ExpandButton setOpen={setViewAll} isOverflow={!!isOverflow} />
+      )}
+    </div>
+  );
+};
+
+interface ExpandButtonProps {
+  setOpen: (value: boolean) => void;
+  isOverflow: boolean;
+}
+
+const ExpandButton = ({ setOpen, isOverflow }: ExpandButtonProps) => {
+  const text = isOverflow ? texts.readMore : texts.readLess;
+
+  return (
+    <Button
+      size="xsmall"
+      variant="tertiary"
+      className="flex items-center"
+      onClick={() => setOpen(isOverflow)}
+      icon={isOverflow ? <ChevronDownIcon /> : <ChevronUpIcon />}
+    >
+      {text}
+    </Button>
+  );
+};
+
+const useIsOverflow = (
+  ref: React.RefObject<HTMLDivElement>,
+  callback: (hasOverflow: boolean) => void
+) => {
+  const [isOverflow, setIsOverflow] = React.useState<boolean | undefined>(
+    undefined
+  );
+
+  React.useLayoutEffect(() => {
+    const { current } = ref;
+    if (!current) return;
+
+    const hasOverflow = current.scrollHeight > current.clientHeight;
+    setIsOverflow(hasOverflow);
+
+    if (callback) callback(hasOverflow);
+  }, [callback, ref]);
+
+  return isOverflow;
+};

--- a/src/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
+++ b/src/components/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
@@ -3,6 +3,7 @@ import { AktivitetskravVarselDTO } from "@/data/aktivitetskrav/aktivitetskravTyp
 import { BodyShort, Heading, Panel, Tag } from "@navikt/ds-react";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { VarselBrev } from "@/components/aktivitetskrav/VarselBrev";
+import { ExpandableBlockquote } from "@/components/ExpandableBlockquote";
 
 const texts = {
   title: "Oppsummering av forhåndsvarselet",
@@ -29,9 +30,9 @@ export const ForhandsvarselOppsummering = ({
         <Tag variant="warning-moderate">{`Frist: ${fristDato}`}</Tag>
       </div>
       {beskrivelse && (
-        <Panel className="border-gray-400 rounded p-4 max-h-24 overflow-y-auto">
-          <BodyShort>{beskrivelse}</BodyShort>
-        </Panel>
+        <ExpandableBlockquote className="border-gray-400 rounded p-4">
+          {beskrivelse}
+        </ExpandableBlockquote>
       )}
       <VarselBrev varsel={varsel} />
       <BodyShort>{texts.merInfo}</BodyShort>


### PR DESCRIPTION
Shows expand button when text exceeds default size.
Currently only used for showing forhåndsvarsel, but can be used other places as well.
Next iteration could add a way to let user define default size.

![expand_blockquote](https://github.com/navikt/syfomodiaperson/assets/40055758/86ca9936-16d3-45c3-94d6-e3e7bfdf9568)
