### PR TITLE
IS-1764: Show sykmelder in sykmelding

### DIFF
--- a/src/components/motebehov/GenerellSykmeldingInfo.tsx
+++ b/src/components/motebehov/GenerellSykmeldingInfo.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Checkbox } from "nav-frontend-skjema";
 import {
+  arbeidsgivernavnEllerArbeidssituasjon,
   erArbeidsforEtterPerioden,
   erEkstraDiagnoseInformasjon,
   erHensynPaaArbeidsplassenInformasjon,
@@ -22,6 +23,15 @@ const tekster = {
   },
 };
 
+const KeyValueVisning = ({ key, value }: { key: string; value: string }) => {
+  return (
+    <div className="text-base">
+      <b>{key}</b>
+      <span>{value}</span>
+    </div>
+  );
+};
+
 interface GenerellSykmeldingInfoProps {
   sykmelding: SykmeldingOldFormat;
 }
@@ -39,9 +49,14 @@ export const GenerellSykmeldingInfo = ({
     );
   const isEkstraDiagnoseInformasjonVisible =
     erEkstraDiagnoseInformasjon(sykmelding);
-
+  const sykmelder = sykmelding.bekreftelse.sykmelder;
+  const arbeidsgiver = arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
   return (
     <div className="sykmeldingMotebehovVisning__avsnitt">
+      {sykmelder && <KeyValueVisning key={"Sykmelder: "} value={sykmelder} />}
+      {arbeidsgiver && (
+        <KeyValueVisning key={"Arbeidsgiver: "} value={arbeidsgiver} />
+      )}
       <Perioder perioder={sykmeldingPerioderSortertEtterDato} />
 
       <Diagnoser hovedDiagnose={hovedDiagnose} biDiagnoser={biDiagnoser} />

--- a/src/components/motebehov/Perioder.tsx
+++ b/src/components/motebehov/Perioder.tsx
@@ -17,7 +17,7 @@ const kolonne2Tekst = (periode: SykmeldingPeriodeDTO) => {
   if (!!periode.avventende) {
     return "Avventende";
   }
-  return `${periode.grad}%`;
+  return periode.grad ? `${periode.grad}%` : "";
 };
 
 interface PeriodeBoksProps {

--- a/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
@@ -68,6 +68,7 @@ export const SykmeldingTittelbeskrivelse = ({
     sykmeldingPerioderSortertEtterDato
   );
   const diagnose = `${sykmelding.diagnose.hoveddiagnose?.diagnosekode} (${sykmelding.diagnose.hoveddiagnose?.diagnose})`;
+  const erViktigInformasjon = erEkstraInformasjonISykmeldingen(sykmelding);
 
   return (
     <div className="w-full flex flex-col gap-1">
@@ -76,6 +77,9 @@ export const SykmeldingTittelbeskrivelse = ({
           {periode}
           {graderinger}
         </div>
+        {erViktigInformasjon && (
+          <img alt="Viktig informasjon" src={MerInformasjonImage} />
+        )}
       </div>
       {sykmelding.diagnose.hoveddiagnose && (
         <div className="text-gray-500">{diagnose}</div>
@@ -92,19 +96,15 @@ interface UtvidbarSykmeldingProps {
 
 const UtvidbarSykmelding = ({ sykmelding, label }: UtvidbarSykmeldingProps) => {
   const title = label ? label : "Sykmelding uten arbeidsgiver";
-  const erViktigInformasjon = erEkstraInformasjonISykmeldingen(sykmelding);
   return (
     <ExpansionCard aria-label={title}>
       <StyledExpantionCardHeader className="w-full">
-        <ExpansionCard.Title as="div" className="flex justify-between">
-          <Heading as="h4" size="xsmall">
-            {title}
-          </Heading>
-          {erViktigInformasjon && <img alt="Mer" src={MerInformasjonImage} />}
-        </ExpansionCard.Title>
-        <ExpansionCard.Description className="w-full text-base">
+        <ExpansionCard.Title
+          as="div"
+          className="flex justify-between m-0 text-base"
+        >
           <SykmeldingTittelbeskrivelse sykmelding={sykmelding} />
-        </ExpansionCard.Description>
+        </ExpansionCard.Title>
       </StyledExpantionCardHeader>
       <ExpansionCard.Content>
         <SykmeldingMotebehovVisning sykmelding={sykmelding} />

--- a/test/components/UtdragFraSykefravaeretTest.tsx
+++ b/test/components/UtdragFraSykefravaeretTest.tsx
@@ -16,7 +16,7 @@ const renderUtdragFraSykefravaeret = () => {
   );
 };
 
-describe.only("UtdragFraSykefravaeret", () => {
+describe("UtdragFraSykefravaeret", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
   });

--- a/test/components/UtdragFraSykefravaeretTest.tsx
+++ b/test/components/UtdragFraSykefravaeretTest.tsx
@@ -1,20 +1,27 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import React from "react";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { expect } from "chai";
 import { ARBEIDSTAKER_DEFAULT_FULL_NAME } from "../../mock/common/mockConstants";
 import { queryClientWithMockData } from "../testQueryClient";
 
-const queryClient = queryClientWithMockData();
+let queryClient: QueryClient;
 
-describe("UtdragFraSykefravaeret", () => {
+const renderUtdragFraSykefravaeret = () => {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <UtdragFraSykefravaeret />
+    </QueryClientProvider>
+  );
+};
+
+describe.only("UtdragFraSykefravaeret", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
   it("viser spinnsyn-lenke til vedtak", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <UtdragFraSykefravaeret />
-      </QueryClientProvider>
-    );
+    renderUtdragFraSykefravaeret();
 
     expect(screen.getByRole("heading", { name: "Vedtak" })).to.exist;
     const link = screen.getByRole("link", {
@@ -22,5 +29,13 @@ describe("UtdragFraSykefravaeret", () => {
     });
     expect(link.getAttribute("href")).to.contain("spinnsyn-frontend-interne");
     expect(link.getAttribute("href")).to.contain("/syk/sykepenger");
+  });
+
+  it("Viser sykmeldinger med sykmelder og arbeidsgiver", () => {
+    renderUtdragFraSykefravaeret();
+
+    const firstExpansionCard = screen.getAllByRole("region")[0];
+    expect(within(firstExpansionCard).getByText("Lego Las Legesen")).to.exist;
+    expect(within(firstExpansionCard).getByText("BRANN OG BIL AS")).to.exist;
   });
 });

--- a/test/testQueryClient.ts
+++ b/test/testQueryClient.ts
@@ -37,6 +37,8 @@ import { egenansattQueryKeys } from "@/data/egenansatt/egenansattQueryHooks";
 import { personinfoQueryKeys } from "@/data/personinfo/personAdresseQueryHooks";
 import { personAdresseMock } from "../mock/syfoperson/personAdresseMock";
 import { maksdatoQueryKeys } from "@/data/maksdato/useMaksdatoQuery";
+import { sykmeldingerQueryKeys } from "@/data/sykmelding/sykmeldingQueryHooks";
+import { sykmeldingerMock } from "../mock/syfosmregister/sykmeldingerMock";
 
 export const testQueryClient = (): QueryClient => {
   return new QueryClient({
@@ -138,6 +140,11 @@ export const queryClientWithMockData = (): QueryClient => {
   queryClient.setQueryData(
     behandlereQueryKeys.behandlerRef(behandlerRefDoktorLegesen),
     () => behandlerByBehandlerRefMock
+  );
+
+  queryClient.setQueryData(
+    sykmeldingerQueryKeys.sykmeldinger(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => sykmeldingerMock.slice(0, 2)
   );
 
   return queryClient;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Ifbm tredeling endret jeg litt på utseendet til sykmeldingene i utdraget fra sykefraværet, slik at arbeidsgiver var mer synlig. Vi fikk tilbakemeldinger på Yammer om at arbeidsgiver ikke var like viktig, som regel var det den samme hver gang, og at dato, sykmeldingsgrad og diagnose var det de lette etter. 

I tillegg ønsket de å se hvem som hadde sendt inn sykmeldingen, feks hvis de skulle sende en dialogmelding til den gitte meldingen. Det feltet har vi hatt tilgjengelig lenge, uten å vise. Legger derfor til dette også når man åpner sykmeldingen.

### Screenshots 📸✨
<img width="394" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/65d06671-0947-4a49-9e3e-1ad2e31b76c1">
