### PR TITLE
IS-1881: Move AG and sykmelder to header of expansion card

### DIFF
--- a/src/components/motebehov/GenerellSykmeldingInfo.tsx
+++ b/src/components/motebehov/GenerellSykmeldingInfo.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Checkbox } from "nav-frontend-skjema";
 import {
-  arbeidsgivernavnEllerArbeidssituasjon,
   erArbeidsforEtterPerioden,
   erEkstraDiagnoseInformasjon,
   erHensynPaaArbeidsplassenInformasjon,
@@ -23,21 +22,6 @@ const tekster = {
   },
 };
 
-const KeyValueVisning = ({
-  keyword,
-  value,
-}: {
-  keyword: string;
-  value: string;
-}) => {
-  return (
-    <div className="text-base">
-      <b>{keyword}</b>
-      <span>{value}</span>
-    </div>
-  );
-};
-
 interface GenerellSykmeldingInfoProps {
   sykmelding: SykmeldingOldFormat;
 }
@@ -55,24 +39,13 @@ export const GenerellSykmeldingInfo = ({
     );
   const isEkstraDiagnoseInformasjonVisible =
     erEkstraDiagnoseInformasjon(sykmelding);
-  const sykmelder = sykmelding.bekreftelse.sykmelder;
-  const arbeidsgiver = arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
   return (
     <div className="sykmeldingMotebehovVisning__avsnitt">
-      {sykmelder && (
-        <KeyValueVisning keyword={"Sykmelder: "} value={sykmelder} />
-      )}
-      {arbeidsgiver && (
-        <KeyValueVisning keyword={"Arbeidsgiver: "} value={arbeidsgiver} />
-      )}
       <Perioder perioder={sykmeldingPerioderSortertEtterDato} />
-
       <Diagnoser hovedDiagnose={hovedDiagnose} biDiagnoser={biDiagnoser} />
-
       {isEkstraDiagnoseInformasjonVisible && (
         <EkstraDiagnoseInformasjon diagnose={sykmelding.diagnose} />
       )}
-
       {erArbeidsforEtterPerioden(sykmelding) && (
         <Checkbox
           label={tekster.generellSykmeldingInfo.arbeidsforEtterPerioden.tittel}

--- a/src/components/motebehov/SykmeldingUtdragFraSykefravaretVisning.tsx
+++ b/src/components/motebehov/SykmeldingUtdragFraSykefravaretVisning.tsx
@@ -19,7 +19,7 @@ interface SykmeldingMotebehovVisningProps {
   sykmelding: SykmeldingOldFormat;
 }
 
-const SykmeldingMotebehovVisning = ({
+const SykmeldingUtdragFraSykefravaretVisning = ({
   sykmelding,
 }: SykmeldingMotebehovVisningProps) => {
   const isMeldingTilArbeidsgiverVisible =
@@ -55,4 +55,4 @@ const SykmeldingMotebehovVisning = ({
   );
 };
 
-export default SykmeldingMotebehovVisning;
+export default SykmeldingUtdragFraSykefravaretVisning;

--- a/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import SykmeldingMotebehovVisning from "../motebehov/SykmeldingMotebehovVisning";
+import SykmeldingUtdragFraSykefravaretVisning from "../motebehov/SykmeldingUtdragFraSykefravaretVisning";
 import {
   arbeidsgivernavnEllerArbeidssituasjon,
   erEkstraInformasjonISykmeldingen,
@@ -48,6 +48,15 @@ const StyledExpantionCardHeader = styled(ExpansionCard.Header)`
   }
 `;
 
+const Info = ({ label, text }: { label: string; text: string }) => {
+  return (
+    <div className="text-base font-normal">
+      <b>{label}</b>
+      <span>{text}</span>
+    </div>
+  );
+};
+
 interface UtvidbarTittelProps {
   sykmelding: SykmeldingOldFormat;
 }
@@ -69,9 +78,11 @@ export const SykmeldingTittelbeskrivelse = ({
   );
   const diagnose = `${sykmelding.diagnose.hoveddiagnose?.diagnosekode} (${sykmelding.diagnose.hoveddiagnose?.diagnose})`;
   const erViktigInformasjon = erEkstraInformasjonISykmeldingen(sykmelding);
+  const sykmelder = sykmelding.bekreftelse.sykmelder;
+  const arbeidsgiver = arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
 
   return (
-    <div className="w-full flex flex-col gap-1">
+    <div className="w-full flex flex-col">
       <div className="flex justify-between">
         <div>
           {periode}
@@ -82,8 +93,10 @@ export const SykmeldingTittelbeskrivelse = ({
         )}
       </div>
       {sykmelding.diagnose.hoveddiagnose && (
-        <div className="text-gray-500">{diagnose}</div>
+        <Info label={"Diagnose: "} text={diagnose} />
       )}
+      {sykmelder && <Info label={"Sykmelder: "} text={sykmelder} />}
+      {arbeidsgiver && <Info label={"Arbeidsgiver: "} text={arbeidsgiver} />}
       {sykmelding.papirsykmelding && <PapirsykmeldingTag />}
     </div>
   );
@@ -107,7 +120,7 @@ const UtvidbarSykmelding = ({ sykmelding, label }: UtvidbarSykmeldingProps) => {
         </ExpansionCard.Title>
       </StyledExpantionCardHeader>
       <ExpansionCard.Content>
-        <SykmeldingMotebehovVisning sykmelding={sykmelding} />
+        <SykmeldingUtdragFraSykefravaretVisning sykmelding={sykmelding} />
       </ExpansionCard.Content>
     </ExpansionCard>
   );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

På denne måten kan veileder se viktig informasjon allerede før de ekspanderer sykmeldingen. Utseende avklarte med Stine og Andrea.

### Screenshots 📸✨
<img width="1364" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/c6aed27d-1f13-4db0-a471-67bbf8e5fa66">




#### For de quiz-interesserte: 1881 var også året [Pablo Picasso ble født](https://no.wikipedia.org/wiki/1881).