### PR TITLE
IS: Fix meldingertest.tsx

### DIFF
--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -78,6 +78,10 @@ export const visDato = (d: Date): string => {
   return `${dager[d.getDay()]} ${d.getDate()}. ${maned} ${d.getFullYear()}`;
 };
 
+export const getManedText = (d: Date): string => {
+  return maneder[d.getMonth()];
+};
+
 export const visKlokkeslett = (d: Date): string | null => {
   if (typeof d === "undefined" || d === null) {
     return null;

--- a/test/behandlerdialog/MeldingerTest.tsx
+++ b/test/behandlerdialog/MeldingerTest.tsx
@@ -35,6 +35,7 @@ import {
   returLegeerklaring,
   meldingFraNAVConversationMedSvar,
 } from "./meldingTestdataGenerator";
+import { getManedText } from "@/utils/datoUtils";
 
 let queryClient: QueryClient;
 
@@ -334,7 +335,7 @@ describe("Meldinger panel", () => {
       renderMeldinger();
 
       const accordions = screen.getAllByRole("button", {
-        name: /november/,
+        name: new RegExp(getManedText(new Date())),
       });
       accordions.forEach((accordion) => userEvent.click(accordion));
 
@@ -350,7 +351,7 @@ describe("Meldinger panel", () => {
       renderMeldinger();
 
       const accordions = screen.getAllByRole("button", {
-        name: /november/,
+        name: new RegExp(getManedText(new Date())),
       });
       accordions.forEach((accordion) => userEvent.click(accordion));
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Måned vi lette etter var hardkodet inn i testen. Dette gjorde at testen nå feilet når vi kom til desember.
- Løsningen nå er litt vanskelig å lese synes jeg, men henter månedens navn og prøver å finne denne i stedet for et hardkodet månedsnavn.
