### PR TITLE
IS-1868: Add frist-option in trenger oppfølging modal

### DIFF
--- a/mock/huskelapp/mockHuskelapp.tsx
+++ b/mock/huskelapp/mockHuskelapp.tsx
@@ -31,6 +31,7 @@ export const mockIshuskelapp = (server: any) => {
         uuid: huskelappUuid,
         createdBy: VEILEDER_IDENT_DEFAULT,
         oppfolgingsgrunn: body.oppfolgingsgrunn,
+        frist: body.frist,
       };
       res.sendStatus(200);
     }

--- a/src/components/huskelapp/Huskelapp.tsx
+++ b/src/components/huskelapp/Huskelapp.tsx
@@ -1,10 +1,18 @@
 import { oppfolgingsgrunnToText } from "@/data/huskelapp/huskelappTypes";
 import { useRemoveHuskelapp } from "@/data/huskelapp/useRemoveHuskelapp";
-import { BodyShort, Box, Button, Heading, Tooltip } from "@navikt/ds-react";
+import {
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  Tag,
+  Tooltip,
+} from "@navikt/ds-react";
 import { TrashIcon } from "@navikt/aksel-icons";
 import React from "react";
 import { OpenHuskelappModalButton } from "@/components/huskelapp/OpenHuskelappModalButton";
 import { useGetHuskelappQuery } from "@/data/huskelapp/useGetHuskelappQuery";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 
 const texts = {
   title: "Trenger oppfølging",
@@ -26,8 +34,19 @@ export const Huskelapp = () => {
     ? oppfolgingsgrunnToText[huskelapp.oppfolgingsgrunn]
     : null;
 
+  const frist = huskelapp?.frist
+    ? tilLesbarDatoMedArUtenManedNavn(huskelapp?.frist)
+    : undefined;
+
   return isExistingHuskelapp ? (
     <Box background={"surface-default"} padding="4" className="flex-1">
+      {frist && (
+        <Tag
+          variant="warning"
+          size="small"
+          className="mb-4"
+        >{`Frist: ${frist}`}</Tag>
+      )}
       <Heading className="mb-2" size="xsmall">
         {texts.title}
       </Heading>

--- a/src/components/huskelapp/HuskelappModal.tsx
+++ b/src/components/huskelapp/HuskelappModal.tsx
@@ -1,5 +1,12 @@
 import React from "react";
-import { Button, Modal, Radio, RadioGroup } from "@navikt/ds-react";
+import {
+  Button,
+  DatePicker,
+  Modal,
+  Radio,
+  RadioGroup,
+  useDatepicker,
+} from "@navikt/ds-react";
 import styled from "styled-components";
 import { useOppdaterHuskelapp } from "@/data/huskelapp/useOppdaterHuskelapp";
 import {
@@ -11,6 +18,7 @@ import { PaddingSize } from "@/components/Layout";
 import { useForm } from "react-hook-form";
 import * as Amplitude from "@/utils/amplitude";
 import { EventType } from "@/utils/amplitude";
+import dayjs from "dayjs";
 
 const texts = {
   header: "Huskelapp",
@@ -18,10 +26,12 @@ const texts = {
   close: "Avbryt",
   missingOppfolgingsgrunn: "Vennligst angi oppfolgingsgrunn.",
   oppfolgingsgrunnLabel: "Velg oppfølgingsgrunn",
+  datepickerLabel: "Frist",
 };
 
 interface FormValues {
   oppfolgingsgrunn: Oppfolgingsgrunn;
+  frist: string | null;
 }
 
 interface HuskelappModalProps {
@@ -32,6 +42,7 @@ interface HuskelappModalProps {
 const ModalContent = styled(Modal.Body)`
   display: flex;
   flex-direction: column;
+
   > * {
     &:not(:last-child) {
       padding-bottom: ${PaddingSize.SM};
@@ -45,11 +56,13 @@ export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
     register,
     formState: { errors },
     handleSubmit,
+    setValue,
   } = useForm<FormValues>();
 
   const submit = (values: FormValues) => {
     const huskelappDto: HuskelappRequestDTO = {
       oppfolgingsgrunn: values.oppfolgingsgrunn,
+      frist: values.frist,
     };
     oppdaterHuskelapp.mutate(huskelappDto, {
       onSuccess: () => {
@@ -64,6 +77,13 @@ export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
       },
     });
   };
+
+  const { datepickerProps, inputProps } = useDatepicker({
+    onDateChange: (date: Date | undefined) => {
+      setValue("frist", dayjs(date).format("YYYY-MM-DD") ?? null);
+    },
+    fromDate: new Date(),
+  });
 
   return (
     <form onSubmit={handleSubmit(submit)}>
@@ -92,6 +112,13 @@ export const HuskelappModal = ({ isOpen, toggleOpen }: HuskelappModalProps) => {
               </Radio>
             ))}
           </RadioGroup>
+          <DatePicker {...datepickerProps} strategy="fixed">
+            <DatePicker.Input
+              {...inputProps}
+              label={texts.datepickerLabel}
+              size="small"
+            />
+          </DatePicker>
         </ModalContent>
         <Modal.Footer>
           <Button

--- a/src/data/huskelapp/huskelappTypes.ts
+++ b/src/data/huskelapp/huskelappTypes.ts
@@ -13,6 +13,7 @@ const texts = {
 
 export interface HuskelappRequestDTO {
   oppfolgingsgrunn: Oppfolgingsgrunn;
+  frist: string | null;
 }
 
 export interface HuskelappResponseDTO {
@@ -20,6 +21,7 @@ export interface HuskelappResponseDTO {
   createdBy: string;
   tekst?: string;
   oppfolgingsgrunn?: Oppfolgingsgrunn;
+  frist: string | null;
 }
 
 export enum Oppfolgingsgrunn {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Mulighet til å lagre frist når man lager oppfølgingsoppgave, og at fristen vises når man har lagret.

### Screenshots 📸✨

<img width="294" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/80f0cdc9-da3b-48c2-bf4c-f00537b503f1">
<img width="842" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/64512888-13e2-47b1-84bc-55e6fdcad280">

Synes det er litt rart at datepickeren også er i en modal, så blir modal i modal, men er sånn på avventer også. Mulig man kan endre på noen instillinger i komponenten.
<img width="893" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/46bae144-15cf-4baf-8e93-5d8d7153e1c1">


