### PR TITLE
IS-1742: Show veileder and last update for trenger oppfolging

### DIFF
--- a/mock/huskelapp/mockHuskelapp.tsx
+++ b/mock/huskelapp/mockHuskelapp.tsx
@@ -30,6 +30,8 @@ export const mockIshuskelapp = (server: any) => {
       huskelappMock = {
         uuid: huskelappUuid,
         createdBy: VEILEDER_IDENT_DEFAULT,
+        updatedAt: new Date(),
+        createdAt: new Date(),
         oppfolgingsgrunn: body.oppfolgingsgrunn,
         frist: body.frist,
       };

--- a/src/components/huskelapp/Huskelapp.tsx
+++ b/src/components/huskelapp/Huskelapp.tsx
@@ -13,16 +13,25 @@ import React from "react";
 import { OpenHuskelappModalButton } from "@/components/huskelapp/OpenHuskelappModalButton";
 import { useGetHuskelappQuery } from "@/data/huskelapp/useGetHuskelappQuery";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { VeilederinfoDTO } from "@/data/veilederinfo/types/VeilederinfoDTO";
 
 const texts = {
   title: "Trenger oppfølging",
   remove: "Fjern",
   removeTooltip: "Fjerner huskelappen og oppgaven fra oversikten",
+  createdBy: (veileder: VeilederinfoDTO, createdAt: Date) =>
+    `Opprettet av: ${veileder.navn} (${
+      veileder.ident
+    }), ${tilLesbarDatoMedArUtenManedNavn(createdAt)}`,
 };
 
 export const Huskelapp = () => {
   const removeHuskelapp = useRemoveHuskelapp();
   const { huskelapp } = useGetHuskelappQuery();
+  const { data: veilederinfo } = useVeilederInfoQuery(
+    huskelapp?.createdBy ?? ""
+  );
   const isExistingHuskelapp = !!huskelapp;
   const handleRemoveHuskelapp = (uuid: string) => {
     removeHuskelapp.mutate(uuid);
@@ -64,6 +73,11 @@ export const Huskelapp = () => {
           {texts.remove}
         </Button>
       </Tooltip>
+      {veilederinfo && (
+        <BodyShort size="small" textColor="subtle" className="mt-2 text-xs">
+          {texts.createdBy(veilederinfo, huskelapp.createdAt)}
+        </BodyShort>
+      )}
     </Box>
   ) : (
     <OpenHuskelappModalButton />

--- a/src/data/huskelapp/huskelappTypes.ts
+++ b/src/data/huskelapp/huskelappTypes.ts
@@ -19,6 +19,8 @@ export interface HuskelappRequestDTO {
 export interface HuskelappResponseDTO {
   uuid: string;
   createdBy: string;
+  updatedAt: Date;
+  createdAt: Date;
   tekst?: string;
   oppfolgingsgrunn?: Oppfolgingsgrunn;
   frist: string | null;

--- a/test/huskelapp/HuskelappModalTest.tsx
+++ b/test/huskelapp/HuskelappModalTest.tsx
@@ -2,7 +2,10 @@ import { queryClientWithMockData } from "../testQueryClient";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import React from "react";
-import { VEILEDER_IDENT_DEFAULT } from "../../mock/common/mockConstants";
+import {
+  VEILEDER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
+} from "../../mock/common/mockConstants";
 import {
   HuskelappRequestDTO,
   HuskelappResponseDTO,
@@ -17,6 +20,7 @@ import { apiMock } from "../stubs/stubApi";
 import { Huskelapp } from "@/components/huskelapp/Huskelapp";
 import { changeTextInput } from "../testUtils";
 import dayjs from "dayjs";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 
 let queryClient: QueryClient;
 let apiMockScope: nock.Scope;
@@ -27,6 +31,8 @@ const huskelapp: HuskelappResponseDTO = {
   createdBy: VEILEDER_IDENT_DEFAULT,
   uuid: generateUUID(),
   oppfolgingsgrunn: huskelappOppfolgingsgrunn,
+  updatedAt: new Date(),
+  createdAt: new Date(),
   frist: "2030-01-01",
 };
 
@@ -37,7 +43,7 @@ const renderHuskelapp = () =>
     </QueryClientProvider>
   );
 
-describe("HuskelappModal", () => {
+describe("Huskelapp", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
     apiMockScope = apiMock();
@@ -54,8 +60,16 @@ describe("HuskelappModal", () => {
       renderHuskelapp();
 
       expect(await screen.findByText(huskelappOppfogingsgrunnText)).to.exist;
+      expect(await screen.findByText("Frist: 01.01.2030")).to.exist;
       expect(await screen.findByRole("button", { hidden: true, name: "Fjern" }))
         .to.exist;
+      expect(
+        await screen.findByText(
+          `Opprettet av: ${VEILEDER_DEFAULT.navn} (${
+            VEILEDER_DEFAULT.ident
+          }), ${tilLesbarDatoMedArUtenManedNavn(new Date())}`
+        )
+      ).to.exist;
     });
     it("remove deletes huskelapp", async () => {
       renderHuskelapp();
@@ -72,7 +86,7 @@ describe("HuskelappModal", () => {
       );
     });
   });
-  describe("no huskelapp exists", () => {
+  describe("HuskelappModal: no huskelapp exists", () => {
     beforeEach(() => {
       stubHuskelappApi(apiMockScope, undefined);
     });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser veilederen som har laget trenger-oppfolging oppgaven og når den ble sist endret. Jeg tenker man kan snakke litt om vi burde vise `updatedAt` eller `createdAt`. Per idag så kan man ikke oppdatere huskelappen, men "fjern" og cronjob-publisering gjør begge en update på `updatedAt`-feltet. Etter "fjern" vil den ikke vises, og cronjoben kjører 1-2 minutter etter create, så det vil fortsatt være samme dato som createdAt når vi bruker updatedAt (med mindre vi er uheldige og en veileder lager oppgaven kl 23:59). 

Med andre ord: Per idag vil `updatedAt` og `createdAt` være samme dag så lenge oppgaven er synlig i syfomodiaperson, så det har kanskje ikke så mye å si hvilken av dem som vises. Men hvis vi begynner med endringer på dagens mønster, så burde dette tas i betraktning. Jeg valgte å vise `updatedAt` nå fordi det allerede lå i DTOen 🤷🏼‍♂️

### Screenshots 📸✨

<img width="304" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/faf1b9b5-ab39-4fcd-966b-350b34844035">

### Quizinfo om 1742
Svensken [Anders Celsius](https://no.wikipedia.org/wiki/Anders_Celsius) fant opp [celsiusskalaen](https://no.wikipedia.org/wiki/Celsiusskalaen) for [temperaturmålinger](https://no.wikipedia.org/wiki/Temperatur).