### PR TITLE
IS-1836: Tekstendringer forhåndsvarselet

### DIFF
--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -15,7 +15,7 @@ export const sendForhandsvarselTexts = {
     tiltak2:
       "Aktivitetsplikten vil også være oppfylt hvis du deltar i et arbeidsrettet tiltak i regi av NAV. Ta kontakt med NAV hvis du tenker at dette er aktuelt for deg.",
     tiltak3:
-      "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for deg at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.",
+      "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.",
   },
   giOssTilbakemelding: {
     header: "Gi oss tilbakemelding",

--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -11,25 +11,25 @@ export const sendForhandsvarselTexts = {
   unngaStansInfo: {
     header: "Du kan unngå stans av sykepenger",
     tiltak1:
-      "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden",
+      "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden om sykepenger.",
     tiltak2:
-      "Gir arbeidsgiveren din en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, kan utbetalingen av sykepenger fortsette.",
+      "Aktivitetsplikten vil også være oppfylt hvis du deltar i et arbeidsrettet tiltak i regi av NAV. Ta kontakt med NAV hvis du tenker at dette er aktuelt for deg.",
     tiltak3:
-      "Går det fram av sykmeldingen at du er for syk til å arbeide, får du fortsatt sykepenger.",
+      "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for deg at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.",
   },
   giOssTilbakemelding: {
     header: "Gi oss tilbakemelding",
     tilbakemeldingWithFristDate: (frist: Date) =>
-      `Vi må ha tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
+      `Vi ber om tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
         frist
-      )}. Ellers vil sykepengene dine stanses fra denne datoen.`,
+      )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`,
     kontaktOss:
       "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
   },
   lovhjemmel: {
     header: "Lovhjemmel",
     aktivitetsplikten:
-      "Aktivitetsplikten er beskrevet i folketrygdloven § 8-8 2.ledd.",
+      "Aktivitetsplikten er beskrevet i folketrygdloven § 8-8 andre ledd.",
     pliktInfo:
       "«Medlemmet har plikt til å være i arbeidsrelatert aktivitet, jf. § 8-7 a første ledd og arbeidsmiljøloven § 4-6 første ledd," +
       " så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet," +


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Endret noen tekster i forhåndsvarselet iht https://trello.com/c/yLjwI96W/1836-endringer-i-brevmalen-for-forh%C3%A5ndsvarsel

**Info om året 1836**

[Republikken Texas](https://no.wikipedia.org/wiki/Republikken_Texas) erklærer seg uavhengig fra [Mexico](https://no.wikipedia.org/wiki/Mexico).

