### PR TITLE
IS-1812: Add forhåndsvarsel brevmal select

### DIFF
--- a/mock/isaktivitetskrav/aktivitetskravMock.ts
+++ b/mock/isaktivitetskrav/aktivitetskravMock.ts
@@ -9,7 +9,7 @@ import { generateUUID } from "../../src/utils/uuidUtils";
 import { VEILEDER_DEFAULT } from "../common/mockConstants";
 import { daysFromToday } from "../../test/testUtils";
 import { DocumentComponentType } from "../../src/data/documentcomponent/documentComponentTypes";
-import { sendForhandsvarselTexts } from "../../src/data/aktivitetskrav/forhandsvarselTexts";
+import { getForhandsvarselTexts } from "../../src/data/aktivitetskrav/forhandsvarselTexts";
 
 const aktivitetskravNy: AktivitetskravDTO = {
   uuid: generateUUID(),
@@ -86,8 +86,12 @@ const aktivitetskravAutomatiskOppfylt: AktivitetskravDTO = {
 
 const getForhandsvarselDocument = (
   begrunnelse: string | undefined,
-  fristDato: Date
+  frist: Date
 ) => {
+  const sendForhandsvarselTexts = getForhandsvarselTexts({
+    frist,
+    mal: "MED_ARBEIDSGIVER",
+  });
   const documentComponents = [
     {
       type: DocumentComponentType.HEADER_H1,
@@ -95,7 +99,7 @@ const getForhandsvarselDocument = (
     },
     {
       type: DocumentComponentType.PARAGRAPH,
-      texts: [sendForhandsvarselTexts.varselInfo.introWithFristDate(fristDato)],
+      texts: [sendForhandsvarselTexts.varselInfo.introWithFristDate],
     },
   ];
 
@@ -126,9 +130,7 @@ const getForhandsvarselDocument = (
     {
       type: DocumentComponentType.PARAGRAPH,
       texts: [
-        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate(
-          fristDato
-        ),
+        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate,
       ],
     },
     {

--- a/mock/isaktivitetskrav/aktivitetskravMock.ts
+++ b/mock/isaktivitetskrav/aktivitetskravMock.ts
@@ -9,7 +9,10 @@ import { generateUUID } from "../../src/utils/uuidUtils";
 import { VEILEDER_DEFAULT } from "../common/mockConstants";
 import { daysFromToday } from "../../test/testUtils";
 import { DocumentComponentType } from "../../src/data/documentcomponent/documentComponentTypes";
-import { getForhandsvarselTexts } from "../../src/data/aktivitetskrav/forhandsvarselTexts";
+import {
+  Brevmal,
+  getForhandsvarselTexts,
+} from "../../src/data/aktivitetskrav/forhandsvarselTexts";
 
 const aktivitetskravNy: AktivitetskravDTO = {
   uuid: generateUUID(),
@@ -90,7 +93,7 @@ const getForhandsvarselDocument = (
 ) => {
   const sendForhandsvarselTexts = getForhandsvarselTexts({
     frist,
-    mal: "MED_ARBEIDSGIVER",
+    mal: Brevmal.MED_ARBEIDSGIVER,
   });
   const documentComponents = [
     {

--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -86,7 +86,7 @@ export const SendForhandsvarselSkjema = ({
       type: EventType.OptionSelected,
       data: {
         url: window.location.href,
-        select: "Aktivitetskrav forhåndsvarsel brevmal",
+        tekst: "Aktivitetskrav forhåndsvarsel brevmal",
         option: e.target.value,
       },
     });

--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -3,7 +3,7 @@ import { SendForhandsvarselDTO } from "@/data/aktivitetskrav/aktivitetskravTypes
 import { useAktivitetskravVarselDocument } from "@/hooks/aktivitetskrav/useAktivitetskravVarselDocument";
 import { addWeeks } from "@/utils/datoUtils";
 import { ButtonRow } from "@/components/Layout";
-import { Button, Select } from "@navikt/ds-react";
+import { Button, HelpText, Label, Select } from "@navikt/ds-react";
 import { useSendForhandsvarsel } from "@/data/aktivitetskrav/useSendForhandsvarsel";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import {
@@ -28,8 +28,9 @@ const texts = {
   missingBeskrivelse: "Vennligst angi begrunnelse",
   sendVarselButtonText: "Send",
   avbrytButtonText: "Avbryt",
-  malLabel: "Velg mal?",
-  malDescription: "Noe om forskjellig tekst i brevet?",
+  malLabel: "Velg arbeidssituasjon",
+  malHelptext:
+    "Her kan du velge mellom ulike brevmaler som er tilpasset den sykmeldtes arbeidssituasjon",
 };
 
 const brevMalTexts: {
@@ -101,8 +102,12 @@ export const SendForhandsvarselSkjema = ({
       <Select
         size="small"
         className="w-fit mb-4"
-        label={texts.malLabel}
-        description={texts.malDescription}
+        label={
+          <div className="flex gap-1 items-center">
+            <Label size="small">{texts.malLabel}</Label>
+            <HelpText placement="right">{texts.malHelptext}</HelpText>
+          </div>
+        }
         onChange={handleBrevmalChanged}
       >
         {Object.keys(brevMalTexts).map((key, index) => (

--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -85,6 +85,7 @@ export const SendForhandsvarselSkjema = ({
     Amplitude.logEvent({
       type: EventType.OptionSelected,
       data: {
+        url: window.location.href,
         select: "Aktivitetskrav forhåndsvarsel brevmal",
         option: e.target.value,
       },

--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -1,8 +1,5 @@
 import React, { ChangeEvent, useState } from "react";
-import {
-  Brevmal,
-  SendForhandsvarselDTO,
-} from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { SendForhandsvarselDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { useAktivitetskravVarselDocument } from "@/hooks/aktivitetskrav/useAktivitetskravVarselDocument";
 import { addWeeks } from "@/utils/datoUtils";
 import { ButtonRow } from "@/components/Layout";
@@ -21,6 +18,7 @@ import { SkjemaHeading } from "@/components/aktivitetskrav/vurdering/SkjemaHeadi
 import { ForhandsvisningModal } from "@/components/ForhandsvisningModal";
 import * as Amplitude from "@/utils/amplitude";
 import { EventType } from "@/utils/amplitude";
+import { Brevmal } from "@/data/aktivitetskrav/forhandsvarselTexts";
 
 const texts = {
   title: "Send forhåndsvarsel",
@@ -32,8 +30,13 @@ const texts = {
   avbrytButtonText: "Avbryt",
   malLabel: "Velg mal?",
   malDescription: "Noe om forskjellig tekst i brevet?",
-  malMedArbeidsgiver: "Med arbeidsgiver",
-  malUtenArbeidsgiver: "Uten arbeidsgiver",
+};
+
+const brevMalTexts: {
+  [key in Brevmal]: string;
+} = {
+  [Brevmal.MED_ARBEIDSGIVER]: "Med arbeidsgiver",
+  [Brevmal.UTEN_ARBEIDSGIVER]: "Uten arbeidsgiver",
 };
 
 const forhandsvarselFrist = addWeeks(new Date(), 3);
@@ -43,7 +46,7 @@ export const SendForhandsvarselSkjema = ({
   aktivitetskravUuid,
 }: VurderAktivitetskravSkjemaProps) => {
   const sendForhandsvarsel = useSendForhandsvarsel(aktivitetskravUuid);
-  const [brevmal, setBrevmal] = useState<Brevmal>("MED_ARBEIDSGIVER");
+  const [brevmal, setBrevmal] = useState<Brevmal>(Brevmal.MED_ARBEIDSGIVER);
   const {
     register,
     watch,
@@ -102,8 +105,11 @@ export const SendForhandsvarselSkjema = ({
         description={texts.malDescription}
         onChange={handleBrevmalChanged}
       >
-        <option value="MED_ARBEIDSGIVER">{texts.malMedArbeidsgiver}</option>
-        <option value="UTEN_ARBEIDSGIVER">{texts.malUtenArbeidsgiver}</option>
+        {Object.keys(brevMalTexts).map((key, index) => (
+          <option key={index} value={key as Brevmal}>
+            {brevMalTexts[key]}
+          </option>
+        ))}
       </Select>
       <BegrunnelseTextarea
         className="mb-8"

--- a/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/components/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -36,8 +36,8 @@ const texts = {
 const brevMalTexts: {
   [key in Brevmal]: string;
 } = {
-  [Brevmal.MED_ARBEIDSGIVER]: "Med arbeidsgiver",
-  [Brevmal.UTEN_ARBEIDSGIVER]: "Uten arbeidsgiver",
+  [Brevmal.MED_ARBEIDSGIVER]: "Har arbeidsgiver",
+  [Brevmal.UTEN_ARBEIDSGIVER]: "Har ikke arbeidsgiver",
 };
 
 const forhandsvarselFrist = addWeeks(new Date(), 3);

--- a/src/components/aktivitetskrav/vurdering/SkjemaHeading.tsx
+++ b/src/components/aktivitetskrav/vurdering/SkjemaHeading.tsx
@@ -12,7 +12,7 @@ export const SkjemaHeading = ({
   subtitles,
 }: VurderAktivitetskravSkjemaHeadingProps) => (
   <>
-    <div className={"mt-4 mb-8"}>
+    <div className={"mt-4 mb-4"}>
       <Heading level="2" size="small">
         {title}
       </Heading>

--- a/src/data/aktivitetskrav/aktivitetskravTypes.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTypes.ts
@@ -87,3 +87,5 @@ export interface SendForhandsvarselDTO {
 export interface NewAktivitetskravDTO {
   previousAktivitetskravUuid: string;
 }
+
+export type Brevmal = "MED_ARBEIDSGIVER" | "UTEN_ARBEIDSGIVER";

--- a/src/data/aktivitetskrav/aktivitetskravTypes.ts
+++ b/src/data/aktivitetskrav/aktivitetskravTypes.ts
@@ -87,5 +87,3 @@ export interface SendForhandsvarselDTO {
 export interface NewAktivitetskravDTO {
   previousAktivitetskravUuid: string;
 }
-
-export type Brevmal = "MED_ARBEIDSGIVER" | "UTEN_ARBEIDSGIVER";

--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -1,5 +1,9 @@
 import { tilDatoMedManedNavn } from "../../utils/datoUtils";
-import { Brevmal } from "@/data/aktivitetskrav/aktivitetskravTypes";
+
+export enum Brevmal {
+  MED_ARBEIDSGIVER = "MED_ARBEIDSGIVER",
+  UTEN_ARBEIDSGIVER = "UTEN_ARBEIDSGIVER",
+}
 
 type ForhandsvarselTextsOptions = {
   mal: Brevmal;
@@ -45,9 +49,9 @@ export const getForhandsvarselTexts = ({
 
 const tiltak3Text = (mal: Brevmal): string => {
   switch (mal) {
-    case "MED_ARBEIDSGIVER":
+    case Brevmal.MED_ARBEIDSGIVER:
       return "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
-    case "UTEN_ARBEIDSGIVER":
+    case Brevmal.UTEN_ARBEIDSGIVER:
       return "Du kan få unntak fra aktivitetsplikten dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
   }
 };

--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -50,7 +50,7 @@ export const getForhandsvarselTexts = ({
 const tiltak3Text = (mal: Brevmal): string => {
   switch (mal) {
     case Brevmal.MED_ARBEIDSGIVER:
-      return "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
+      return "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for hvorfor det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
     case Brevmal.UTEN_ARBEIDSGIVER:
       return "Du kan få unntak fra aktivitetsplikten dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
   }

--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -1,12 +1,20 @@
 import { tilDatoMedManedNavn } from "../../utils/datoUtils";
+import { Brevmal } from "@/data/aktivitetskrav/aktivitetskravTypes";
 
-export const sendForhandsvarselTexts = {
+type ForhandsvarselTextsOptions = {
+  mal: Brevmal;
+  frist: Date;
+};
+
+export const getForhandsvarselTexts = ({
+  frist,
+  mal,
+}: ForhandsvarselTextsOptions) => ({
   varselInfo: {
     header: "Varsel om stans av sykepenger",
-    introWithFristDate: (frist: Date) =>
-      `Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
-        frist
-      )}.`,
+    introWithFristDate: `Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
+      frist
+    )}.`,
   },
   unngaStansInfo: {
     header: "Du kan unngå stans av sykepenger",
@@ -14,15 +22,13 @@ export const sendForhandsvarselTexts = {
       "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden om sykepenger.",
     tiltak2:
       "Aktivitetsplikten vil også være oppfylt hvis du deltar i et arbeidsrettet tiltak i regi av NAV. Ta kontakt med NAV hvis du tenker at dette er aktuelt for deg.",
-    tiltak3:
-      "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.",
+    tiltak3: tiltak3Text(mal),
   },
   giOssTilbakemelding: {
     header: "Gi oss tilbakemelding",
-    tilbakemeldingWithFristDate: (frist: Date) =>
-      `Vi ber om tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
-        frist
-      )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`,
+    tilbakemeldingWithFristDate: `Vi ber om tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
+      frist
+    )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`,
     kontaktOss:
       "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
   },
@@ -35,4 +41,13 @@ export const sendForhandsvarselTexts = {
       " så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet," +
       " eller arbeidsrelaterte aktiviteter ikke kan gjennomføres på arbeidsplassen.»",
   },
+});
+
+const tiltak3Text = (mal: Brevmal): string => {
+  switch (mal) {
+    case "MED_ARBEIDSGIVER":
+      return "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for at det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
+    case "UTEN_ARBEIDSGIVER":
+      return "Du kan få unntak fra aktivitetsplikten dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
+  }
 };

--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -1,4 +1,3 @@
-import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
 import {
@@ -7,24 +6,32 @@ import {
   createHeaderH3,
   createParagraph,
 } from "@/utils/documentComponentUtils";
+import { Brevmal } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { getForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
+
+type ForhandsvarselDocumentValues = {
+  begrunnelse: string;
+  frist: Date;
+  mal: Brevmal;
+};
 
 export const useAktivitetskravVarselDocument = (): {
   getForhandsvarselDocument(
-    begrunnelse: string,
-    fristDato: Date
+    values: ForhandsvarselDocumentValues
   ): DocumentComponentDto[];
 } => {
   const { getHilsen } = useDocumentComponents();
 
-  const getForhandsvarselDocument = (
-    begrunnelse: string | undefined,
-    fristDato: Date
-  ) => {
+  const getForhandsvarselDocument = (values: ForhandsvarselDocumentValues) => {
+    const { mal, begrunnelse, frist } = values;
+    const sendForhandsvarselTexts = getForhandsvarselTexts({
+      mal,
+      frist,
+    });
+
     const documentComponents = [
       createHeaderH1(sendForhandsvarselTexts.varselInfo.header),
-      createParagraph(
-        sendForhandsvarselTexts.varselInfo.introWithFristDate(fristDato)
-      ),
+      createParagraph(sendForhandsvarselTexts.varselInfo.introWithFristDate),
     ];
 
     if (begrunnelse) {
@@ -41,9 +48,7 @@ export const useAktivitetskravVarselDocument = (): {
 
       createHeaderH3(sendForhandsvarselTexts.giOssTilbakemelding.header),
       createParagraph(
-        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate(
-          fristDato
-        )
+        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate
       ),
       createParagraph(sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss),
 

--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -6,8 +6,10 @@ import {
   createHeaderH3,
   createParagraph,
 } from "@/utils/documentComponentUtils";
-import { Brevmal } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { getForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
+import {
+  Brevmal,
+  getForhandsvarselTexts,
+} from "@/data/aktivitetskrav/forhandsvarselTexts";
 
 type ForhandsvarselDocumentValues = {
   begrunnelse: string;

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -84,7 +84,6 @@ type Event =
   | EventButtonClick
   | Navigation
   | EventAccordionOpen
-  | OppfolgingsgrunnSendt
   | ViewPortAndScreenResolution
   | OppfolgingsgrunnSendt
   | OptionSelected;

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -74,7 +74,7 @@ type OptionSelected = {
   type: EventType.OptionSelected;
   data: {
     url: string;
-    select: string;
+    tekst: string;
     option: string;
   };
 };

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -73,6 +73,7 @@ type ViewPortAndScreenResolution = {
 type OptionSelected = {
   type: EventType.OptionSelected;
   data: {
+    url: string;
     select: string;
     option: string;
   };

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -13,6 +13,7 @@ export enum EventType {
   AccordionOpen = "accordion åpnet",
   OppfolgingsgrunnSendt = "oppfolgingsgrunn sendt",
   ViewPortAndScreenResolution = "viewport og skjermstørrelse",
+  OptionSelected = "alternativ valgt",
 }
 
 type EventPageView = {
@@ -69,13 +70,23 @@ type ViewPortAndScreenResolution = {
   };
 };
 
+type OptionSelected = {
+  type: EventType.OptionSelected;
+  data: {
+    select: string;
+    option: string;
+  };
+};
+
 type Event =
   | EventPageView
   | EventButtonClick
   | Navigation
   | EventAccordionOpen
   | OppfolgingsgrunnSendt
-  | ViewPortAndScreenResolution;
+  | ViewPortAndScreenResolution
+  | OppfolgingsgrunnSendt
+  | OptionSelected;
 
 export const logEvent = (event: Event) =>
   client.logEvent(event.type, { ...event.data });

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -51,6 +51,7 @@ import {
 import nock from "nock";
 import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { NotificationContext } from "@/context/notification/NotificationContext";
+import { Brevmal } from "@/data/aktivitetskrav/forhandsvarselTexts";
 
 let queryClient: QueryClient;
 let apiMockScope: any;
@@ -439,7 +440,7 @@ describe("VurderAktivitetskrav", () => {
           fritekst: enBeskrivelse,
           document: getSendForhandsvarselDocument(
             enBeskrivelse,
-            "UTEN_ARBEIDSGIVER"
+            Brevmal.UTEN_ARBEIDSGIVER
           ),
         };
         expect(sendForhandsvarselMutation.state.variables).to.deep.equal(

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -358,13 +358,15 @@ describe("VurderAktivitetskrav", () => {
 
       const velgMalSelect = screen.getByRole("combobox");
       expect(
-        within(velgMalSelect).getByRole("option", { name: "Med arbeidsgiver" })
+        within(velgMalSelect).getByRole("option", { name: "Har arbeidsgiver" })
       ).to.exist;
       expect(
-        within(velgMalSelect).getByRole("option", { name: "Uten arbeidsgiver" })
+        within(velgMalSelect).getByRole("option", {
+          name: "Har ikke arbeidsgiver",
+        })
       ).to.exist;
-      expect(screen.getByDisplayValue("Med arbeidsgiver")).to.exist;
-      expect(screen.queryByDisplayValue("Uten arbeidsgiver")).to.not.exist;
+      expect(screen.getByDisplayValue("Har arbeidsgiver")).to.exist;
+      expect(screen.queryByDisplayValue("Har ikke arbeidsgiver")).to.not.exist;
     });
 
     it("Send forhåndsvarsel with beskrivelse filled in, and reset form after submit", async () => {

--- a/test/aktivitetskrav/varselDocuments.ts
+++ b/test/aktivitetskrav/varselDocuments.ts
@@ -4,14 +4,16 @@ import {
 } from "@/data/documentcomponent/documentComponentTypes";
 import { VEILEDER_DEFAULT } from "../../mock/common/mockConstants";
 import { addWeeks } from "@/utils/datoUtils";
-import { getForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
-import { Brevmal } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import {
+  Brevmal,
+  getForhandsvarselTexts,
+} from "@/data/aktivitetskrav/forhandsvarselTexts";
 
 const expectedFristDate = addWeeks(new Date(), 3);
 
 export const getSendForhandsvarselDocument = (
   beskrivelse: string,
-  mal: Brevmal = "MED_ARBEIDSGIVER"
+  mal: Brevmal = Brevmal.MED_ARBEIDSGIVER
 ): DocumentComponentDto[] => {
   const sendForhandsvarselTexts = getForhandsvarselTexts({
     frist: expectedFristDate,

--- a/test/aktivitetskrav/varselDocuments.ts
+++ b/test/aktivitetskrav/varselDocuments.ts
@@ -4,69 +4,73 @@ import {
 } from "@/data/documentcomponent/documentComponentTypes";
 import { VEILEDER_DEFAULT } from "../../mock/common/mockConstants";
 import { addWeeks } from "@/utils/datoUtils";
-import { sendForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
+import { getForhandsvarselTexts } from "@/data/aktivitetskrav/forhandsvarselTexts";
+import { Brevmal } from "@/data/aktivitetskrav/aktivitetskravTypes";
 
 const expectedFristDate = addWeeks(new Date(), 3);
 
 export const getSendForhandsvarselDocument = (
-  beskrivelse: string
-): DocumentComponentDto[] => [
-  {
-    texts: [sendForhandsvarselTexts.varselInfo.header],
-    type: DocumentComponentType.HEADER_H1,
-  },
-  {
-    texts: [
-      sendForhandsvarselTexts.varselInfo.introWithFristDate(expectedFristDate),
-    ],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
-    texts: [beskrivelse],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
-    texts: [sendForhandsvarselTexts.unngaStansInfo.header],
-    type: DocumentComponentType.HEADER_H3,
-  },
-  {
-    texts: [
-      sendForhandsvarselTexts.unngaStansInfo.tiltak1,
-      sendForhandsvarselTexts.unngaStansInfo.tiltak2,
-      sendForhandsvarselTexts.unngaStansInfo.tiltak3,
-    ],
-    type: DocumentComponentType.BULLET_POINTS,
-  },
-  {
-    texts: [sendForhandsvarselTexts.giOssTilbakemelding.header],
-    type: DocumentComponentType.HEADER_H3,
-  },
-  {
-    texts: [
-      sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate(
-        expectedFristDate
-      ),
-    ],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
-    texts: [sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
-    texts: [sendForhandsvarselTexts.lovhjemmel.header],
-    type: DocumentComponentType.HEADER_H3,
-  },
-  {
-    texts: [sendForhandsvarselTexts.lovhjemmel.aktivitetsplikten],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
-    texts: [sendForhandsvarselTexts.lovhjemmel.pliktInfo],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-  {
-    texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
-    type: DocumentComponentType.PARAGRAPH,
-  },
-];
+  beskrivelse: string,
+  mal: Brevmal = "MED_ARBEIDSGIVER"
+): DocumentComponentDto[] => {
+  const sendForhandsvarselTexts = getForhandsvarselTexts({
+    frist: expectedFristDate,
+    mal,
+  });
+  return [
+    {
+      texts: [sendForhandsvarselTexts.varselInfo.header],
+      type: DocumentComponentType.HEADER_H1,
+    },
+    {
+      texts: [sendForhandsvarselTexts.varselInfo.introWithFristDate],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [beskrivelse],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [sendForhandsvarselTexts.unngaStansInfo.header],
+      type: DocumentComponentType.HEADER_H3,
+    },
+    {
+      texts: [
+        sendForhandsvarselTexts.unngaStansInfo.tiltak1,
+        sendForhandsvarselTexts.unngaStansInfo.tiltak2,
+        sendForhandsvarselTexts.unngaStansInfo.tiltak3,
+      ],
+      type: DocumentComponentType.BULLET_POINTS,
+    },
+    {
+      texts: [sendForhandsvarselTexts.giOssTilbakemelding.header],
+      type: DocumentComponentType.HEADER_H3,
+    },
+    {
+      texts: [
+        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate,
+      ],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [sendForhandsvarselTexts.lovhjemmel.header],
+      type: DocumentComponentType.HEADER_H3,
+    },
+    {
+      texts: [sendForhandsvarselTexts.lovhjemmel.aktivitetsplikten],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [sendForhandsvarselTexts.lovhjemmel.pliktInfo],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+  ];
+};


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til select-komponent med mulighet for å velge brevmal (Med arbeidsgvier / Uten arbeidsgiver) ved sending av forhåndsvarsel.
Design er avsjekket med Andrea. Skal avklare endelige tekster med Stine og om vi trenger både label og description og hva som evt skal stå der. Tar gjerne innspill på det også :+1: 

Har også lagt til logging av event i Amplitude når bruker gjør et valg i selecten.

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/42057b3b-4435-4f96-9855-eeeb0db0c7e8)

