### PR TITLE
IS: Added smaller margins to dialogmote page panels

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,4 @@
 import styled from "styled-components";
-import Panel from "nav-frontend-paneler";
 
 export enum JustifyContentType {
   CENTER = "center",
@@ -59,13 +58,6 @@ export const FlexRow = styled.div<RowProps>`
 
 export const H2NoMargins = styled.h2`
   margin: 0;
-`;
-
-export const FlexPanel = styled(Panel)`
-  display: flex;
-  flex-direction: column;
-  margin-bottom: ${PaddingSize.MD};
-  padding: 2em;
 `;
 
 interface ButtonRowProps {

--- a/src/components/mote/components/DialogmotePanel.tsx
+++ b/src/components/mote/components/DialogmotePanel.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, ReactNode } from "react";
 import { IconHeader } from "@/components/IconHeader";
-import { FlexPanel } from "@/components/Layout";
+import { Box } from "@navikt/ds-react";
 
 interface Props {
   icon: string;
@@ -11,9 +11,9 @@ interface Props {
 
 export const DialogmotePanel = ({ children, ...rest }: Props): ReactElement => {
   return (
-    <FlexPanel>
+    <Box background="surface-default" className="flex flex-col mb-4 p-8">
       <IconHeader altIcon="moteikon" {...rest} />
       {children}
-    </FlexPanel>
+    </Box>
   );
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til mindre marginer mellom paneler på dialogmøte side

### Screenshots 📸✨
Før:
![Screenshot 2023-12-19 at 15 19 21](https://github.com/navikt/syfomodiaperson/assets/11747383/9ad3f4c0-7742-490e-aeb8-af281a0f280a)
Ettter:
![Screenshot 2023-12-19 at 15 21 07](https://github.com/navikt/syfomodiaperson/assets/11747383/8f8c0281-4b25-4cd4-9b40-443df90160dd)

