### PR TITLE
Migrate to amplitude/analytics-browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
+        "@amplitude/analytics-browser": "2.3.8",
         "@babel/polyfill": "7.12.1",
         "@navikt/aksel-icons": "5.12.2",
         "@navikt/ds-css": "5.12.2",
@@ -17,7 +18,6 @@
         "@navikt/navspa": "4.1.1",
         "@tanstack/react-query": "5.8.4",
         "@tanstack/react-query-devtools": "5.8.4",
-        "@types/amplitude-js": "8.16.5",
         "@types/connect-redis": "0.0.19",
         "@types/express": "4.17.15",
         "@types/express-http-proxy": "1.6.3",
@@ -28,7 +28,6 @@
         "@types/recharts": "1.8.24",
         "@types/redis": "2.8.32",
         "@types/styled-components": "5.1.26",
-        "amplitude-js": "8.21.9",
         "axios": "1.6.3",
         "classnames": "2.3.2",
         "connect-redis": "6.1.3",
@@ -164,47 +163,68 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@amplitude/analytics-browser": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.8.tgz",
+      "integrity": "sha512-K+12aAVJPzAtWIi8Ok5Q5dvg7v7IF4G0cI8PW0COWo3uTyY103r45OcpgrpRVpVAr+41d1eiMo36jqOke89uPA==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.0.10",
+        "@amplitude/analytics-core": "^2.1.3",
+        "@amplitude/analytics-types": "^2.3.1",
+        "@amplitude/plugin-page-view-tracking-browser": "^2.0.18",
+        "@amplitude/plugin-web-attribution-browser": "^2.0.18",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-client-common": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.10.tgz",
+      "integrity": "sha512-IaERGgBN3dmCGFbFd7SFTpTBguJIQzE/uDK44KEnLj0qw9wdoTxpLhoXQpqe5WKWsr46eONL9ROCJybHs4Efnw==",
+      "dependencies": {
+        "@amplitude/analytics-connector": "^1.4.8",
+        "@amplitude/analytics-core": "^2.1.3",
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
+      }
+    },
     "node_modules/@amplitude/analytics-connector": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
       "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
     },
-    "node_modules/@amplitude/types": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.10.2.tgz",
-      "integrity": "sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@amplitude/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@amplitude/utils": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.10.2.tgz",
-      "integrity": "sha512-tVsHXu61jITEtRjB7NugQ5cVDd4QDzne8T3ifmZye7TiJeUfVRvqe44gDtf55A+7VqhDhyEIIXTA1iVcDGqlEw==",
+    "node_modules/@amplitude/analytics-core": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.1.3.tgz",
+      "integrity": "sha512-WHXf9g33t63jYy4a/1uOpq/zHPMfEj5N2HHgJrg7Eu7v4w3kOWtPSMPBAllzFWxC5Ay5HeR9n0hqlJG0yffQWg==",
       "dependencies": {
-        "@amplitude/types": "^1.10.2",
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.3.1.tgz",
+      "integrity": "sha512-yojBG20qvph0rpCJKb4i/FJa+otqLINEwv//hfzvjnCOcPPyS0YscI8oiRBM0rG7kZIDgaL9a6jPwkqK4ACmcw=="
+    },
+    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.18.tgz",
+      "integrity": "sha512-s7PkGOgrx6U06/emzM8k+KRGDuyP9Z2L4OyGdeQwJcURJjiZDVQsmKlTZ5/SeGvxHYgq/4QJYUmMSmzByiGTCA==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.0.10",
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-web-attribution-browser": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.18.tgz",
+      "integrity": "sha512-mPlXu0fEYCCXhT6WpNJoM0FYkp+HIEm7L+KBEa2IHd3GD3+mh2AVDkZmgXLl3LKb++HY8mCiqC5/NcJ2AzTNhA==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.0.10",
+        "@amplitude/analytics-core": "^2.1.3",
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3277,11 +3297,6 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
-    "node_modules/@types/amplitude-js": {
-      "version": "8.16.5",
-      "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-8.16.5.tgz",
-      "integrity": "sha512-W73JfDpwDH4VijOGo+nVuQOqUCiqyEGGVdajU4ziWTLn27cn+QtFuFuBdlhCraIIrO52fDRO4NSOGkawtn77Jw=="
-    },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -4374,19 +4389,6 @@
         "ajv": "^6.9.1"
       }
     },
-    "node_modules/amplitude-js": {
-      "version": "8.21.9",
-      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-8.21.9.tgz",
-      "integrity": "sha512-d0jJH00wbXu7sxKtVwkdSXtVffjqdUrxuACKlnzP7jU5qt9wriXXMgHifdH5Oq+buKmyF8wKL9S02gAykysURA==",
-      "dependencies": {
-        "@amplitude/analytics-connector": "^1.4.6",
-        "@amplitude/ua-parser-js": "0.7.33",
-        "@amplitude/utils": "^1.10.2",
-        "@babel/runtime": "^7.21.0",
-        "blueimp-md5": "^2.19.0",
-        "query-string": "8.1.0"
-      }
-    },
     "node_modules/ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -4917,11 +4919,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
-    "node_modules/blueimp-md5": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
-      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
     },
     "node_modules/body-parser": {
       "version": "1.20.1",
@@ -6302,14 +6299,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
-    },
-    "node_modules/decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
-      "engines": {
-        "node": ">=14.16"
-      }
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -8004,17 +7993,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/final-form": {
@@ -13096,22 +13074,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/query-string": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
-      "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
-      "dependencies": {
-        "decode-uri-component": "^0.4.1",
-        "filter-obj": "^5.1.0",
-        "split-on-first": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -14384,17 +14346,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
-      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -15097,9 +15048,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -16250,28 +16201,68 @@
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
     },
+    "@amplitude/analytics-browser": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.8.tgz",
+      "integrity": "sha512-K+12aAVJPzAtWIi8Ok5Q5dvg7v7IF4G0cI8PW0COWo3uTyY103r45OcpgrpRVpVAr+41d1eiMo36jqOke89uPA==",
+      "requires": {
+        "@amplitude/analytics-client-common": "^2.0.10",
+        "@amplitude/analytics-core": "^2.1.3",
+        "@amplitude/analytics-types": "^2.3.1",
+        "@amplitude/plugin-page-view-tracking-browser": "^2.0.18",
+        "@amplitude/plugin-web-attribution-browser": "^2.0.18",
+        "tslib": "^2.4.1"
+      }
+    },
+    "@amplitude/analytics-client-common": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.10.tgz",
+      "integrity": "sha512-IaERGgBN3dmCGFbFd7SFTpTBguJIQzE/uDK44KEnLj0qw9wdoTxpLhoXQpqe5WKWsr46eONL9ROCJybHs4Efnw==",
+      "requires": {
+        "@amplitude/analytics-connector": "^1.4.8",
+        "@amplitude/analytics-core": "^2.1.3",
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
+      }
+    },
     "@amplitude/analytics-connector": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
       "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
     },
-    "@amplitude/types": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/types/-/types-1.10.2.tgz",
-      "integrity": "sha512-I8qenRI7uU6wKNb9LiZrAosSHVoNHziXouKY81CrqxH9xhVTEIJFXeuCV0hbtBr0Al/8ejnGjQRx+S2SvU/pPg=="
-    },
-    "@amplitude/ua-parser-js": {
-      "version": "0.7.33",
-      "resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
-      "integrity": "sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA=="
-    },
-    "@amplitude/utils": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@amplitude/utils/-/utils-1.10.2.tgz",
-      "integrity": "sha512-tVsHXu61jITEtRjB7NugQ5cVDd4QDzne8T3ifmZye7TiJeUfVRvqe44gDtf55A+7VqhDhyEIIXTA1iVcDGqlEw==",
+    "@amplitude/analytics-core": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.1.3.tgz",
+      "integrity": "sha512-WHXf9g33t63jYy4a/1uOpq/zHPMfEj5N2HHgJrg7Eu7v4w3kOWtPSMPBAllzFWxC5Ay5HeR9n0hqlJG0yffQWg==",
       "requires": {
-        "@amplitude/types": "^1.10.2",
-        "tslib": "^2.0.0"
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "@amplitude/analytics-types": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.3.1.tgz",
+      "integrity": "sha512-yojBG20qvph0rpCJKb4i/FJa+otqLINEwv//hfzvjnCOcPPyS0YscI8oiRBM0rG7kZIDgaL9a6jPwkqK4ACmcw=="
+    },
+    "@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.18.tgz",
+      "integrity": "sha512-s7PkGOgrx6U06/emzM8k+KRGDuyP9Z2L4OyGdeQwJcURJjiZDVQsmKlTZ5/SeGvxHYgq/4QJYUmMSmzByiGTCA==",
+      "requires": {
+        "@amplitude/analytics-client-common": "^2.0.10",
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "@amplitude/plugin-web-attribution-browser": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.18.tgz",
+      "integrity": "sha512-mPlXu0fEYCCXhT6WpNJoM0FYkp+HIEm7L+KBEa2IHd3GD3+mh2AVDkZmgXLl3LKb++HY8mCiqC5/NcJ2AzTNhA==",
+      "requires": {
+        "@amplitude/analytics-client-common": "^2.0.10",
+        "@amplitude/analytics-core": "^2.1.3",
+        "@amplitude/analytics-types": "^2.3.1",
+        "tslib": "^2.4.1"
       }
     },
     "@ampproject/remapping": {
@@ -18401,11 +18392,6 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
-    "@types/amplitude-js": {
-      "version": "8.16.5",
-      "resolved": "https://registry.npmjs.org/@types/amplitude-js/-/amplitude-js-8.16.5.tgz",
-      "integrity": "sha512-W73JfDpwDH4VijOGo+nVuQOqUCiqyEGGVdajU4ziWTLn27cn+QtFuFuBdlhCraIIrO52fDRO4NSOGkawtn77Jw=="
-    },
     "@types/aria-query": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
@@ -19326,19 +19312,6 @@
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true
     },
-    "amplitude-js": {
-      "version": "8.21.9",
-      "resolved": "https://registry.npmjs.org/amplitude-js/-/amplitude-js-8.21.9.tgz",
-      "integrity": "sha512-d0jJH00wbXu7sxKtVwkdSXtVffjqdUrxuACKlnzP7jU5qt9wriXXMgHifdH5Oq+buKmyF8wKL9S02gAykysURA==",
-      "requires": {
-        "@amplitude/analytics-connector": "^1.4.6",
-        "@amplitude/ua-parser-js": "0.7.33",
-        "@amplitude/utils": "^1.10.2",
-        "@babel/runtime": "^7.21.0",
-        "blueimp-md5": "^2.19.0",
-        "query-string": "8.1.0"
-      }
-    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -19722,11 +19695,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
       "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
-    "blueimp-md5": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
-      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w=="
     },
     "body-parser": {
       "version": "1.20.1",
@@ -20731,11 +20699,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
-    },
-    "decode-uri-component": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
-      "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ=="
     },
     "decompress-response": {
       "version": "6.0.0",
@@ -22016,11 +21979,6 @@
       "requires": {
         "to-regex-range": "^5.0.1"
       }
-    },
-    "filter-obj": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
-      "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng=="
     },
     "final-form": {
       "version": "4.20.8",
@@ -25506,16 +25464,6 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
-    "query-string": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-8.1.0.tgz",
-      "integrity": "sha512-BFQeWxJOZxZGix7y+SByG3F36dA0AbTy9o6pSmKFcFz7DAj0re9Frkty3saBn3nHo3D0oZJ/+rx3r8H8r8Jbpw==",
-      "requires": {
-        "decode-uri-component": "^0.4.1",
-        "filter-obj": "^5.1.0",
-        "split-on-first": "^3.0.0"
-      }
-    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -26499,11 +26447,6 @@
         }
       }
     },
-    "split-on-first": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
-      "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA=="
-    },
     "ssri": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
@@ -27016,9 +26959,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "author": "Team DigiSyfo <digisyfo@nav.no>",
   "license": "ISC",
   "dependencies": {
+    "@amplitude/analytics-browser": "2.3.8",
     "@babel/polyfill": "7.12.1",
     "@navikt/aksel-icons": "5.12.2",
     "@navikt/ds-css": "5.12.2",
@@ -30,7 +31,6 @@
     "@navikt/navspa": "4.1.1",
     "@tanstack/react-query": "5.8.4",
     "@tanstack/react-query-devtools": "5.8.4",
-    "@types/amplitude-js": "8.16.5",
     "@types/connect-redis": "0.0.19",
     "@types/express": "4.17.15",
     "@types/express-http-proxy": "1.6.3",
@@ -41,7 +41,6 @@
     "@types/recharts": "1.8.24",
     "@types/redis": "2.8.32",
     "@types/styled-components": "5.1.26",
-    "amplitude-js": "8.21.9",
     "axios": "1.6.3",
     "classnames": "2.3.2",
     "connect-redis": "6.1.3",

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -1,4 +1,4 @@
-import amplitude from "amplitude-js";
+import * as amplitude from "@amplitude/analytics-browser";
 import { erProd } from "@/utils/miljoUtil";
 import { Oppfolgingsgrunn } from "@/data/huskelapp/huskelappTypes";
 import { IkkeAktuellArsak } from "@/data/aktivitetskrav/aktivitetskravTypes";
@@ -99,10 +99,10 @@ type Event =
   | OptionSelected;
 
 export const logEvent = (event: Event) =>
-  client.logEvent(event.type, { ...event.data });
+  amplitude.track(event.type, { ...event.data });
 
 export function logViewportAndScreenSize() {
-  client.logEvent(EventType.ViewPortAndScreenResolution, {
+  amplitude.track(EventType.ViewPortAndScreenResolution, {
     viewport: {
       width: window.innerWidth,
       height: window.innerHeight,
@@ -120,11 +120,6 @@ const getApiKey = () => {
     : "c7bcaaf5d0fddda592412234dd3da1ba";
 };
 
-const client = amplitude.getInstance();
-client.init(getApiKey(), "", {
-  apiEndpoint: "amplitude.nav.no/collect",
-  saveEvents: false,
-  includeUtm: true,
-  batchEvents: false,
-  includeReferrer: true,
+amplitude.init(getApiKey(), undefined, {
+  serverUrl: "https://amplitude.nav.no/collect",
 });


### PR DESCRIPTION
Ref https://nav-it.slack.com/archives/CMK1SCBP1/p1703242354102479
Se https://www.docs.developers.amplitude.com/data/sdks/typescript-browser/migration/
En del av config-parameterne er ikke støttet lenger så vi får heller justere etter hvert hvis ikke defaultene i den nye SDKen gjør jobben.