### PR TITLE
IS-1923: Make DM-innkallingskjema more compact

### DIFF
--- a/src/components/dialogmote/DialogmoteTidOgSted.tsx
+++ b/src/components/dialogmote/DialogmoteTidOgSted.tsx
@@ -6,7 +6,6 @@ import DialogmoteDatoField from "./DialogmoteDatoField";
 import DialogmoteInnkallingSkjemaSeksjon from "./innkalling/DialogmoteInnkallingSkjemaSeksjon";
 import styled from "styled-components";
 import { FlexColumn, FlexRow, PaddingSize } from "../Layout";
-import { Innholdstittel } from "nav-frontend-typografi";
 import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";
 import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
@@ -29,10 +28,6 @@ const DatoColumn = styled(FlexColumn)`
   margin-right: 1em;
 `;
 
-const TidOgStedTittel = styled(Innholdstittel)`
-  margin-bottom: 1em;
-`;
-
 const FRIST_DIALOGMOTE2_IN_WEEKS = 26;
 
 interface FristProps {
@@ -41,7 +36,7 @@ interface FristProps {
 
 const Frist = ({ startDate }: FristProps) => {
   const frist = addWeeks(startDate, FRIST_DIALOGMOTE2_IN_WEEKS);
-  return <p>Frist: {visDato(frist)}</p>;
+  return <p>Frist dialogmøte 2: {visDato(frist)}</p>;
 };
 
 interface DialogmoteTidOgStedProps {
@@ -65,13 +60,12 @@ const DialogmoteTidOgSted = ({
 
   return (
     <DialogmoteInnkallingSkjemaSeksjon>
-      <TidOgStedTittel>{texts.title}</TidOgStedTittel>
       {isKandidat &&
         hasActiveOppfolgingstilfelle &&
         latestOppfolgingstilfelle && (
           <Frist startDate={latestOppfolgingstilfelle.start} />
         )}
-      <FlexRow bottomPadding={PaddingSize.MD}>
+      <FlexRow bottomPadding={PaddingSize.SM}>
         <DatoColumn>
           <DialogmoteDatoField />
         </DatoColumn>
@@ -88,7 +82,7 @@ const DialogmoteTidOgSted = ({
           <p>{texts.alertText}</p>
         </AlertstripeFullbredde>
       )}
-      <FlexRow bottomPadding={PaddingSize.MD}>
+      <FlexRow bottomPadding={PaddingSize.SM}>
         <FlexColumn flex={1}>
           <Field<string> name={stedField}>
             {({ input, meta }) => (

--- a/src/components/dialogmote/FritekstSeksjon.tsx
+++ b/src/components/dialogmote/FritekstSeksjon.tsx
@@ -11,7 +11,7 @@ const texts = {
 };
 
 const FritekstWrapper = styled.div`
-  margin-bottom: 4em;
+  margin-bottom: 2em;
 `;
 
 interface FritekstSeksjonProps {

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingBehandler.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingBehandler.tsx
@@ -1,8 +1,5 @@
 import React, { ReactElement } from "react";
 import { Field } from "react-final-form";
-import styled from "styled-components";
-import { Innholdstittel } from "nav-frontend-typografi";
-import DialogmoteInnkallingSkjemaSeksjon from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon";
 import AppSpinner from "@/components/AppSpinner";
 import BehandlerRadioGruppe, {
   BehandlerRadioGruppeTexts,
@@ -11,10 +8,6 @@ import { BehandlerDTO } from "@/data/behandler/BehandlerDTO";
 import { useBehandlereQuery } from "@/data/behandler/behandlereQueryHooks";
 import { SkjemaelementFeilmelding } from "nav-frontend-skjema";
 
-const BehandlerTittel = styled(Innholdstittel)`
-  margin-bottom: 1em;
-`;
-
 export const texts = {
   title: "Behandler",
   legekontor: "Legekontor",
@@ -22,7 +15,7 @@ export const texts = {
 };
 
 const behandlerRadioGruppeTexts: BehandlerRadioGruppeTexts = {
-  behandlerLegend: "Velg behandler som inviteres til dialogmøtet",
+  behandlerLegend: "Behandler",
   behandlerDescription: "Behandleren vil få en dialogmelding med invitasjon.",
   behandlersokTekst: "Legg til en behandler",
 };
@@ -40,32 +33,29 @@ const DialogmoteInnkallingBehandler = ({
   const field = "behandlerRef";
 
   return (
-    <DialogmoteInnkallingSkjemaSeksjon>
-      <BehandlerTittel>{texts.title}</BehandlerTittel>
-      <Field<string> name={field}>
-        {({ input, meta }) => {
-          return (
-            <>
-              {isLoading ? (
-                <AppSpinner />
-              ) : (
-                <BehandlerRadioGruppe
-                  id={field}
-                  input={input}
-                  selectedBehandler={selectedbehandler}
-                  behandlere={behandlere}
-                  setSelectedBehandler={setSelectedBehandler}
-                  behandlerRadioGruppeTexts={behandlerRadioGruppeTexts}
-                />
-              )}
-              <SkjemaelementFeilmelding>
-                {meta.submitFailed && meta.error}
-              </SkjemaelementFeilmelding>
-            </>
-          );
-        }}
-      </Field>
-    </DialogmoteInnkallingSkjemaSeksjon>
+    <Field<string> name={field}>
+      {({ input, meta }) => {
+        return (
+          <>
+            {isLoading ? (
+              <AppSpinner />
+            ) : (
+              <BehandlerRadioGruppe
+                id={field}
+                input={input}
+                selectedBehandler={selectedbehandler}
+                behandlere={behandlere}
+                setSelectedBehandler={setSelectedBehandler}
+                behandlerRadioGruppeTexts={behandlerRadioGruppeTexts}
+              />
+            )}
+            <SkjemaelementFeilmelding>
+              {meta.submitFailed && meta.error}
+            </SkjemaelementFeilmelding>
+          </>
+        );
+      }}
+    </Field>
   );
 };
 

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -38,6 +38,7 @@ import { useSkjemaValuesToDto } from "@/hooks/dialogmote/useSkjemaValuesToDto";
 import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import { Flatknapp, Hovedknapp } from "nav-frontend-knapper";
 import dayjs from "dayjs";
+import DialogmoteInnkallingSkjemaSeksjon from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon";
 
 interface DialogmoteInnkallingSkjemaTekster {
   fritekstArbeidsgiver: string;
@@ -201,11 +202,13 @@ const DialogmoteInnkallingSkjema = () => {
       <Form initialValues={initialValues} onSubmit={submit} validate={validate}>
         {({ handleSubmit, submitFailed, errors }) => (
           <form onSubmit={handleSubmit}>
-            <DialogmoteInnkallingVelgVirksomhet />
-            <DialogmoteInnkallingBehandler
-              setSelectedBehandler={setSelectedBehandler}
-              selectedbehandler={selectedBehandler}
-            />
+            <DialogmoteInnkallingSkjemaSeksjon>
+              <DialogmoteInnkallingVelgVirksomhet />
+              <DialogmoteInnkallingBehandler
+                setSelectedBehandler={setSelectedBehandler}
+                selectedbehandler={selectedBehandler}
+              />
+            </DialogmoteInnkallingSkjemaSeksjon>
             <DialogmoteTidOgSted isFuturisticMeeting={isFuturisticMeeting} />
             <DialogmoteInnkallingTekster
               selectedBehandler={selectedBehandler}

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon.tsx
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 const DialogmoteInnkallingSkjemaSeksjon = styled.div`
-  margin-bottom: 4em;
+  margin-bottom: 1.5em;
 `;
 
 export default DialogmoteInnkallingSkjemaSeksjon;

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingTekster.tsx
@@ -1,8 +1,6 @@
 import React, { ReactElement, useState } from "react";
 import { useFormState } from "react-final-form";
 import DialogmoteInnkallingSkjemaSeksjon from "./DialogmoteInnkallingSkjemaSeksjon";
-import styled from "styled-components";
-import { Innholdstittel } from "nav-frontend-typografi";
 import { DialogmoteInnkallingSkjemaValues } from "./DialogmoteInnkallingSkjema";
 import { useInnkallingDocument } from "@/hooks/dialogmote/document/useInnkallingDocument";
 import { ForhandsvisningModal } from "../../ForhandsvisningModal";
@@ -31,10 +29,6 @@ export const texts = {
   reservertAlert:
     "Denne arbeidstakeren vil få brevet sendt som papirpost. Du kan inkludere telefonnummeret til kontaktsenteret i fritekstfeltet (55 55 33 33), slik at arbeidstakeren kan ta kontakt på telefon hvis tidspunktet ikke passer.",
 };
-
-const TeksterTittel = styled(Innholdstittel)`
-  margin-bottom: 0.5em;
-`;
 
 interface DialogmoteInnkallingTeksterProps {
   selectedBehandler: BehandlerDTO | undefined;
@@ -67,7 +61,6 @@ const DialogmoteInnkallingTekster = ({
 
   return (
     <DialogmoteInnkallingSkjemaSeksjon>
-      <TeksterTittel>{texts.title}</TeksterTittel>
       {brukerKanIkkeVarslesDigitalt && (
         <AlertstripeFullbredde type="advarsel" marginbottom="1em">
           {texts.reservertAlert}

--- a/src/components/dialogmote/innkalling/virksomhet/DialogmoteInnkallingVelgVirksomhet.tsx
+++ b/src/components/dialogmote/innkalling/virksomhet/DialogmoteInnkallingVelgVirksomhet.tsx
@@ -2,9 +2,7 @@ import React from "react";
 import { Input, SkjemaelementFeilmelding } from "nav-frontend-skjema";
 import { Field } from "react-final-form";
 import styled from "styled-components";
-import DialogmoteInnkallingSkjemaSeksjon from "../DialogmoteInnkallingSkjemaSeksjon";
 import { FlexColumn, FlexRow, PaddingSize } from "../../../Layout";
-import { Innholdstittel } from "nav-frontend-typografi";
 import { narmesteLederForVirksomhet } from "@/utils/ledereUtils";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { NoNarmesteLederAlert } from "@/components/mote/NoNarmestLederAlert";
@@ -20,10 +18,6 @@ const texts = {
 
 const LederNavnColumn = styled(FlexColumn)`
   margin-right: 1em;
-`;
-
-const VirksomhetTittel = styled(Innholdstittel)`
-  margin-bottom: 1em;
 `;
 
 const DialogmoteInnkallingVelgVirksomhet = () => {
@@ -43,8 +37,7 @@ const DialogmoteInnkallingVelgVirksomhet = () => {
   const field = "arbeidsgiver";
 
   return (
-    <DialogmoteInnkallingSkjemaSeksjon>
-      <VirksomhetTittel>{texts.title}</VirksomhetTittel>
+    <div className="mb-2">
       <Field<string> name={field}>
         {({ input, meta }) => {
           const virksomhetsnummer = input.value;
@@ -95,7 +88,7 @@ const DialogmoteInnkallingVelgVirksomhet = () => {
           );
         }}
       </Field>
-    </DialogmoteInnkallingSkjemaSeksjon>
+    </div>
   );
 };
 export default DialogmoteInnkallingVelgVirksomhet;


### PR DESCRIPTION
Veiledere don't want to scroll so much when writing an innkalling, so we need to make the form more compact with less air. Change "frist" to "Frist dialogmøte 2" to make it more clear. Remove section headers.
Decrease margin between sections.
Decrease margin between Tid og sted fields.

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/7097f6ac-4f30-4475-85bd-67b6c7245f52)
