### PR TITLE
Remove warning for møtedato too far into future

### DIFF
--- a/src/components/dialogmote/DialogmoteTidOgSted.tsx
+++ b/src/components/dialogmote/DialogmoteTidOgSted.tsx
@@ -6,9 +6,6 @@ import DialogmoteDatoField from "./DialogmoteDatoField";
 import DialogmoteInnkallingSkjemaSeksjon from "./innkalling/DialogmoteInnkallingSkjemaSeksjon";
 import styled from "styled-components";
 import { FlexColumn, FlexRow, PaddingSize } from "../Layout";
-import { AlertstripeFullbredde } from "@/components/AlertstripeFullbredde";
-import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
-import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { addWeeks, visDato } from "@/utils/datoUtils";
 import { useDialogmotekandidat } from "@/data/dialogmotekandidat/dialogmotekandidatQueryHooks";
@@ -39,21 +36,10 @@ const Frist = ({ startDate }: FristProps) => {
   return <p>Frist dialogmøte 2: {visDato(frist)}</p>;
 };
 
-interface DialogmoteTidOgStedProps {
-  isFuturisticMeeting?: boolean;
-}
-
-const DialogmoteTidOgSted = ({
-  isFuturisticMeeting,
-}: DialogmoteTidOgStedProps): ReactElement => {
+const DialogmoteTidOgSted = (): ReactElement => {
   const klokkeslettField = "klokkeslett";
   const stedField = "sted";
   const videoLinkField = "videoLink";
-  const { data: veilederinfo } = useAktivVeilederinfoQuery();
-  const ABTestHit = Number(veilederinfo?.ident.slice(-1)) >= 5;
-  const { brukerKanVarslesDigitalt } = useBrukerinfoQuery();
-  const showFuturisticWarning =
-    !!isFuturisticMeeting && ABTestHit && brukerKanVarslesDigitalt;
   const { hasActiveOppfolgingstilfelle, latestOppfolgingstilfelle } =
     useOppfolgingstilfellePersonQuery();
   const { isKandidat } = useDialogmotekandidat();
@@ -77,11 +63,6 @@ const DialogmoteTidOgSted = ({
           />
         </FlexColumn>
       </FlexRow>
-      {showFuturisticWarning && (
-        <AlertstripeFullbredde type="info" marginbottom="2em">
-          <p>{texts.alertText}</p>
-        </AlertstripeFullbredde>
-      )}
       <FlexRow bottomPadding={PaddingSize.SM}>
         <FlexColumn flex={1}>
           <Field<string> name={stedField}>

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -37,7 +37,6 @@ import { behandlerNavn } from "@/utils/behandlerUtils";
 import { useSkjemaValuesToDto } from "@/hooks/dialogmote/useSkjemaValuesToDto";
 import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import { Flatknapp, Hovedknapp } from "nav-frontend-knapper";
-import dayjs from "dayjs";
 import DialogmoteInnkallingSkjemaSeksjon from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon";
 
 interface DialogmoteInnkallingSkjemaTekster {
@@ -117,13 +116,6 @@ const toInnkalling = (
   return innkalling;
 };
 
-const isDateFuturistic = (date?: string) => {
-  const today = dayjs(new Date());
-  const selectedDate = dayjs(date);
-
-  return selectedDate.isAfter(today.add(21, "days"), "date");
-};
-
 const DialogmoteInnkallingSkjema = () => {
   const initialValues: Partial<DialogmoteInnkallingSkjemaValues> = {};
   const fnr = useValgtPersonident();
@@ -136,9 +128,6 @@ const DialogmoteInnkallingSkjema = () => {
 
   const { toTidStedDto } = useSkjemaValuesToDto();
   const opprettInnkalling = useOpprettInnkallingDialogmote(fnr);
-
-  const [isFuturisticMeeting, setIsFuturisticMeeting] =
-    useState<boolean>(false);
 
   const validate = (
     values: Partial<DialogmoteInnkallingSkjemaValues>
@@ -162,8 +151,6 @@ const DialogmoteInnkallingSkjema = () => {
             }
           : {}),
       });
-
-    setIsFuturisticMeeting(isDateFuturistic(values.dato));
 
     const feilmeldinger: DialogmoteInnkallingSkjemaFeil = {
       arbeidsgiver: validerArbeidsgiver(values.arbeidsgiver),
@@ -209,7 +196,7 @@ const DialogmoteInnkallingSkjema = () => {
                 selectedbehandler={selectedBehandler}
               />
             </DialogmoteInnkallingSkjemaSeksjon>
-            <DialogmoteTidOgSted isFuturisticMeeting={isFuturisticMeeting} />
+            <DialogmoteTidOgSted />
             <DialogmoteInnkallingTekster
               selectedBehandler={selectedBehandler}
             />


### PR DESCRIPTION
The experiment is concluded, so the code is no longer needed.
The warning didn't make veiledere select møtedato closer to innkallingsdato.

Før:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/922d9d9b-9c5b-42fb-848b-042a463dda47)

Etter:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/e1deb841-5e68-49ee-86f1-9a19e81c0174)
