### PR TITLE
IS-1925: Show motehistorikk as accordion

### DIFF
--- a/src/components/dialogmote/motehistorikk/MoteHistorikkUnntak.tsx
+++ b/src/components/dialogmote/motehistorikk/MoteHistorikkUnntak.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from "react";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { ForhandsvisDocumentButtonRow } from "@/components/dialogmote/motehistorikk/MotehistorikkPanel";
+import { ForhandsvisDocumentAccordionItem } from "@/components/dialogmote/motehistorikk/MotehistorikkPanel";
 
 import {
   DocumentComponentDto,
@@ -66,11 +66,8 @@ export const MoteHistorikkUnntak = ({
   const { data: veilederinfo } = useVeilederInfoQuery(unntak.createdBy);
   const unntakDocument = createUnntakDocument(unntak, veilederinfo?.navn);
   return (
-    <ForhandsvisDocumentButtonRow
-      document={unntakDocument}
-      title={texts.unntakTitle}
-    >
+    <ForhandsvisDocumentAccordionItem document={unntakDocument}>
       {unntakLenkeText(unntak.createdAt)}
-    </ForhandsvisDocumentButtonRow>
+    </ForhandsvisDocumentAccordionItem>
   );
 };

--- a/src/components/dialogmote/motehistorikk/MotehistorikkPanel.tsx
+++ b/src/components/dialogmote/motehistorikk/MotehistorikkPanel.tsx
@@ -1,20 +1,17 @@
 import { FortidenImage } from "../../../../img/ImageComponents";
-import { FlexRow } from "../../Layout";
-import React, { ReactElement, useState } from "react";
+import React, { ReactElement } from "react";
 import {
   DialogmoteDTO,
   DialogmoteStatus,
   MotedeltakerVarselType,
 } from "@/data/dialogmote/types/dialogmoteTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { ForhandsvisningModal } from "../../ForhandsvisningModal";
 import { useDialogmoteReferat } from "@/hooks/dialogmote/useDialogmoteReferat";
-import styled from "styled-components";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { MoteHistorikkUnntak } from "@/components/dialogmote/motehistorikk/MoteHistorikkUnntak";
-import { Flatknapp } from "nav-frontend-knapper";
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
-import { BodyLong, Box, Heading } from "@navikt/ds-react";
+import { Accordion, BodyLong, Box, Heading } from "@navikt/ds-react";
+import { DocumentComponentVisning } from "@/components/document/DocumentComponentVisning";
 
 const texts = {
   header: "Møtehistorikk",
@@ -26,42 +23,24 @@ const texts = {
   avlysningsBrev: "Avlysningsbrev",
 };
 
-const ButtonRow = styled(FlexRow)`
-  padding-bottom: 0.5em;
-`;
-
-interface ForhandsvisDocumentButtonRowProps {
+interface ForhandsvisDocumentAccordionItemProps {
   document: DocumentComponentDto[];
-  title: string;
   children: string;
 }
 
-export const ForhandsvisDocumentButtonRow = ({
+export const ForhandsvisDocumentAccordionItem = ({
   document,
-  title,
   children,
-}: ForhandsvisDocumentButtonRowProps): ReactElement => {
-  const [modalIsOpen, setModalIsOpen] = useState(false);
+}: ForhandsvisDocumentAccordionItemProps): ReactElement => {
   return (
-    <ButtonRow>
-      <Flatknapp
-        mini
-        kompakt
-        htmlType="button"
-        onClick={() => {
-          setModalIsOpen(true);
-        }}
-      >
-        {children}
-      </Flatknapp>
-      <ForhandsvisningModal
-        title={title}
-        contentLabel={title}
-        isOpen={modalIsOpen}
-        handleClose={() => setModalIsOpen(false)}
-        getDocumentComponents={() => document}
-      />
-    </ButtonRow>
+    <Accordion.Item>
+      <Accordion.Header>{children}</Accordion.Header>
+      <Accordion.Content>
+        {document.map((component, index) => (
+          <DocumentComponentVisning key={index} documentComponent={component} />
+        ))}
+      </Accordion.Content>
+    </Accordion.Item>
   );
 };
 
@@ -81,12 +60,9 @@ const MoteHistorikk = ({ mote }: MoteHistorikkProps): ReactElement => {
       )?.document || [];
 
     return (
-      <ForhandsvisDocumentButtonRow
-        document={document}
-        title={texts.avlysningsBrev}
-      >
+      <ForhandsvisDocumentAccordionItem document={document}>
         {`${texts.avlystMote} ${moteDatoTekst}`}
-      </ForhandsvisDocumentButtonRow>
+      </ForhandsvisDocumentAccordionItem>
     );
   }
 
@@ -98,13 +74,12 @@ const MoteHistorikk = ({ mote }: MoteHistorikkProps): ReactElement => {
           : "";
 
         return (
-          <ForhandsvisDocumentButtonRow
+          <ForhandsvisDocumentAccordionItem
             key={index}
             document={referat.document}
-            title={texts.referat}
           >
             {`${texts.avholdtMote} ${moteDatoTekst}${suffix}`}
-          </ForhandsvisDocumentButtonRow>
+          </ForhandsvisDocumentAccordionItem>
         );
       })}
     </>
@@ -131,12 +106,14 @@ export const MotehistorikkPanel = ({
           <BodyLong size="small">{texts.subtitle}</BodyLong>
         </div>
       </div>
-      {historiskeMoter.map((mote, index) => (
-        <MoteHistorikk key={index} mote={mote} />
-      ))}
-      {dialogmoteunntak.map((unntak, index) => (
-        <MoteHistorikkUnntak key={index} unntak={unntak} />
-      ))}
+      <Accordion>
+        {historiskeMoter.map((mote, index) => (
+          <MoteHistorikk key={index} mote={mote} />
+        ))}
+        {dialogmoteunntak.map((unntak, index) => (
+          <MoteHistorikkUnntak key={index} unntak={unntak} />
+        ))}
+      </Accordion>
     </Box>
   );
 };

--- a/test/dialogmote/MotehistorikkTest.tsx
+++ b/test/dialogmote/MotehistorikkTest.tsx
@@ -13,7 +13,7 @@ import {
   VEILEDER_IDENT_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../../mock/common/mockConstants";
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { createFerdigstiltReferat } from "./testData";
 import {
   dialogmoteunntakMedBeskrivelse,
@@ -22,7 +22,6 @@ import {
 import { unntakLenkeText } from "@/components/dialogmote/motehistorikk/MoteHistorikkUnntak";
 import { testQueryClient } from "../testQueryClient";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
-import userEvent from "@testing-library/user-event";
 import { veilederinfoQueryKeys } from "@/data/veilederinfo/veilederinfoQueryHooks";
 
 let queryClient: any;
@@ -151,10 +150,12 @@ describe("Historiske dialogmøter", () => {
 
     const buttons = screen.getAllByRole("button");
     expect(buttons).to.have.length(2);
-    expect(buttons[0].textContent).to.equal(
+    expect(buttons[0].textContent).to.contain(
       "Referat fra møte 15. januar 2021 - Endret 15. januar 2021"
     );
-    expect(buttons[1].textContent).to.equal("Referat fra møte 15. januar 2021");
+    expect(buttons[1].textContent).to.contain(
+      "Referat fra møte 15. januar 2021"
+    );
   });
   it("Fremviser dialogmoteunntak", () => {
     const dialogmoteunntakListe = [
@@ -187,15 +188,7 @@ describe("Historiske dialogmøter", () => {
     );
     renderMotehistorikk(dialogmoteunntakListe, []);
 
-    const unntakButton = screen.getByRole("button", {
-      name: "Unntak fra dialogmøte 20. april 2020",
-    });
-    userEvent.click(unntakButton);
-    const unntakModal = screen.getByRole("dialog", {
-      hidden: true,
-    });
-
-    expect(within(unntakModal).getByText("Vurdert av")).to.exist;
-    expect(within(unntakModal).getByText("Vetle Veileder (Z990000)")).to.exist;
+    expect(screen.getByText("Vurdert av")).to.exist;
+    expect(screen.getByText("Vetle Veileder (Z990000)")).to.exist;
   });
 });


### PR DESCRIPTION
Veiledere don't want modal because then they have to repeatedly open and close it when filling out the form.

Før:
![motehistorikk_modal](https://github.com/navikt/syfomodiaperson/assets/40055758/29f5858b-2a72-40f8-bff1-5d2553385ccb)


Etter:
![motehistorikk_accordion](https://github.com/navikt/syfomodiaperson/assets/40055758/fb62e75c-618d-4dd0-a57e-517b62583f5a)
