### PR TITLE
IS-1955: Sikkerhetstiltak tag and tab in personkortet

### DIFF
--- a/mock/syfoperson/persondataMock.ts
+++ b/mock/syfoperson/persondataMock.ts
@@ -14,6 +14,7 @@ export const brukerinfoMock: BrukerinfoDTO = {
   arbeidssituasjon: "ARBEIDSTAKER",
   dodsdato: null,
   tilrettelagtKommunikasjon: null,
+  sikkerhetstiltak: [],
 };
 
 export const diskresjonskodeMock: "6" | "7" | "" = "";

--- a/src/components/personkort/Personkort.tsx
+++ b/src/components/personkort/Personkort.tsx
@@ -6,12 +6,15 @@ import PersonkortSykmeldt from "@/components/personkort/PersonkortSykmeldt";
 import PersonkortLedere from "@/components/personkort/ledere/PersonkortLedere";
 import PersonkortLege from "@/components/personkort/PersonkortLege";
 import PersonkortEnhet from "@/components/personkort/PersonkortEnhet";
+import { PersonkortSikkerhetstiltak } from "@/components/personkort/PersonkortSikkerhetstiltak";
+import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 
 enum Tab {
   SYKMELDT = "SYKMELDT",
   LEDER = "LEDER",
   LEGE = "LEGE",
   ENHET = "ENHET",
+  SIKKERHETSTILTAK = "SIKKERHETSTILTAK",
 }
 
 interface TabProps {
@@ -31,6 +34,9 @@ const tabs: Record<Tab, TabProps> = {
   ENHET: {
     label: "Behandlende enhet",
   },
+  SIKKERHETSTILTAK: {
+    label: "Sikkerhetstiltak",
+  },
 };
 
 interface PersonkortVisningProps {
@@ -47,21 +53,39 @@ const PersonkortVisning = ({ tab }: PersonkortVisningProps): ReactElement => {
       return <PersonkortLedere />;
     case Tab.LEGE:
       return <PersonkortLege />;
+    case Tab.SIKKERHETSTILTAK:
+      return <PersonkortSikkerhetstiltak />;
   }
 };
 
 const Personkort = () => {
+  const { hasSikkerhetstiltak } = useNavBrukerData();
+  const isVisible = (tab: Tab): boolean => {
+    switch (tab) {
+      case Tab.SYKMELDT:
+      case Tab.ENHET:
+      case Tab.LEDER:
+      case Tab.LEGE:
+        return true;
+      case Tab.SIKKERHETSTILTAK:
+        return hasSikkerhetstiltak;
+    }
+  };
+  const visibleTabs = Object.entries(tabs).filter(([key]) =>
+    isVisible(key as Tab)
+  );
+
   return (
     <Ekspanderbartpanel tittel={<PersonkortHeader />} className="mb-2">
       <Tabs size="small" defaultValue={Tab.SYKMELDT}>
         <Tabs.List className="mt-4">
-          {Object.entries(tabs).map(([tab, { label }], index) => (
-            <Tabs.Tab value={tab} label={label} key={index} />
+          {visibleTabs.map(([key, { label }], index) => (
+            <Tabs.Tab value={key} label={label} key={index} />
           ))}
         </Tabs.List>
-        {Object.keys(tabs).map((value, index) => (
-          <Tabs.Panel key={index} value={value} className="mt-8">
-            <PersonkortVisning tab={value as Tab} />
+        {visibleTabs.map(([key], index) => (
+          <Tabs.Panel key={index} value={key} className="mt-8">
+            <PersonkortVisning tab={key as Tab} />
           </Tabs.Panel>
         ))}
       </Tabs>

--- a/src/components/personkort/PersonkortElement.tsx
+++ b/src/components/personkort/PersonkortElement.tsx
@@ -3,20 +3,17 @@ import cn from "classnames";
 
 interface PersonkortElementProps {
   tittel: string;
-  imgUrl: string;
-  imgAlt: string;
+  icon: ReactElement;
   children: ReactElement;
   antallKolonner?: number;
 }
 
-const PersonkortElement = (personkortElementProps: PersonkortElementProps) => {
-  const {
-    tittel,
-    imgUrl,
-    imgAlt,
-    children,
-    antallKolonner = 2,
-  } = personkortElementProps;
+const PersonkortElement = ({
+  children,
+  icon,
+  tittel,
+  antallKolonner = 2,
+}: PersonkortElementProps) => {
   const classNameRad = cn("personkortElement__rad", {
     "personkortElement__rad--treKolonner": antallKolonner === 3,
     "personkortElement__rad--toKolonner": antallKolonner === 2,
@@ -24,7 +21,7 @@ const PersonkortElement = (personkortElementProps: PersonkortElementProps) => {
   return (
     <div className="personkortElement">
       <div className="personkortElement__tittel">
-        <img src={imgUrl} alt={imgAlt} />
+        {icon}
         <h4>{tittel}</h4>
       </div>
       <div className={classNameRad}>{children}</div>

--- a/src/components/personkort/PersonkortEnhet.tsx
+++ b/src/components/personkort/PersonkortEnhet.tsx
@@ -36,8 +36,7 @@ const PersonkortEnhet = () => {
       ) : behandlendeenhet ? (
         <PersonkortElement
           tittel={behandlendeenhet.navn}
-          imgUrl={KontorByggImage}
-          imgAlt="Kontorbygg"
+          icon={<img src={KontorByggImage} alt={"Kontorbygg"} />}
         >
           <StyledPersonkortElement>
             <PersonkortInformasjon

--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -16,28 +16,31 @@ const texts = {
   egenansatt: "Egenansatt",
   talesprakTolk: "Talespråktolk",
   tegnsprakTolk: "Tegnspråktolk",
+  sikkerhetstiltak: "Sikkerhetstiltak",
 };
 
 export const PersonkortHeaderTags = () => {
   const { data: isEgenAnsatt } = useEgenansattQuery();
-  const navbruker = useNavBrukerData();
+  const { dodsdato, hasSikkerhetstiltak, tilrettelagtKommunikasjon } =
+    useNavBrukerData();
   const { error, data: diskresjonskode } = useDiskresjonskodeQuery();
 
-  const isDead = !!navbruker.dodsdato;
-  const dateOfDeath = tilLesbarDatoMedArUtenManedNavn(navbruker.dodsdato);
+  const isDead = !!dodsdato;
+  const dateOfDeath = tilLesbarDatoMedArUtenManedNavn(dodsdato);
   const isKode6 = diskresjonskode === "6";
   const isKode7 = diskresjonskode === "7";
   const talesprakTolkSprakkode =
-    navbruker.tilrettelagtKommunikasjon?.talesprakTolk?.value;
+    tilrettelagtKommunikasjon?.talesprakTolk?.value;
   const tegnsprakTolkSprakkode =
-    navbruker.tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
+    tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
   const visEtiketter =
     isKode6 ||
     isKode7 ||
     isEgenAnsatt ||
     isDead ||
     !!talesprakTolkSprakkode ||
-    !!tegnsprakTolkSprakkode;
+    !!tegnsprakTolkSprakkode ||
+    hasSikkerhetstiltak;
 
   return visEtiketter ? (
     <ErrorBoundary
@@ -75,6 +78,11 @@ export const PersonkortHeaderTags = () => {
             variant="error"
             size="small"
           >{`${texts.dod} ${dateOfDeath}`}</Tag>
+        )}
+        {hasSikkerhetstiltak && (
+          <Tag variant="error" size="small">
+            {texts.sikkerhetstiltak}
+          </Tag>
         )}
       </FlexRow>
     </ErrorBoundary>

--- a/src/components/personkort/PersonkortSikkerhetstiltak.tsx
+++ b/src/components/personkort/PersonkortSikkerhetstiltak.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { Detail } from "@navikt/ds-react";
+import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
+import PersonkortElement from "@/components/personkort/PersonkortElement";
+import { ExclamationmarkTriangleFillIcon } from "@navikt/aksel-icons";
+
+export const PersonkortSikkerhetstiltak = () => {
+  const { sikkerhetstiltak } = useNavBrukerData();
+
+  return (
+    <PersonkortElement
+      tittel="Sikkerhetstiltak"
+      icon={
+        <ExclamationmarkTriangleFillIcon
+          className="mr-2"
+          color="var(--a-icon-danger)"
+          title="advarsel-ikon"
+          fontSize="1.5rem"
+        />
+      }
+    >
+      <>
+        {sikkerhetstiltak.map(
+          ({ beskrivelse, gyldigFom, gyldigTom }, index) => (
+            <div key={index}>
+              <Detail textColor="subtle">
+                {`Gyldig: ${tilLesbarPeriodeMedArUtenManednavn(
+                  gyldigFom,
+                  gyldigTom
+                )}`}
+              </Detail>
+              {beskrivelse}
+            </div>
+          )
+        )}
+      </>
+    </PersonkortElement>
+  );
+};

--- a/src/components/personkort/PersonkortSykmeldt.tsx
+++ b/src/components/personkort/PersonkortSykmeldt.tsx
@@ -58,9 +58,8 @@ const PersonkortSykmeldt = () => {
   return (
     <PersonkortElement
       tittel="Kontaktinformasjon"
-      imgUrl={PersonImage}
-      imgAlt="Bilde av person"
       antallKolonner={3}
+      icon={<img src={PersonImage} alt={"Bilde av person"} />}
     >
       <PersonkortInformasjon
         informasjonNokkelTekster={informasjonNokkelTekster}

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -30,6 +30,7 @@ export const useBrukerinfoQuery = () => {
       talesprakTolk: null,
       tegnsprakTolk: null,
     },
+    sikkerhetstiltak: [],
   };
 
   return {

--- a/src/data/navbruker/navbruker_hooks.ts
+++ b/src/data/navbruker/navbruker_hooks.ts
@@ -1,9 +1,10 @@
 import { BrukerinfoDTO } from "./types/BrukerinfoDTO";
 import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 
-export const useNavBrukerData = (): BrukerinfoDTO => {
+export const useNavBrukerData = () => {
   const brukerinfo: BrukerinfoDTO = useBrukerinfoQuery().brukerinfo;
   return {
+    hasSikkerhetstiltak: brukerinfo.sikkerhetstiltak.length > 0,
     ...brukerinfo,
   };
 };

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -22,8 +22,17 @@ interface Sprak {
   value: string | null;
 }
 
+/* https://pdl-docs.dev.intern.nav.no/ekstern/index.html#_sikkerhetstiltak */
+enum Tiltakstype {
+  FYUS = "FYUS",
+  TFUS = "TFUS",
+  FTUS = "FTUS",
+  DIUS = "DIUS",
+  TOAN = "TOAN",
+}
+
 interface Sikkerhetstiltak {
-  type: string;
+  type: Tiltakstype;
   beskrivelse: string;
   gyldigFom: Date;
   gyldigTom: Date;

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -10,6 +10,7 @@ export interface BrukerinfoDTO {
   arbeidssituasjon: string;
   dodsdato: string | null;
   tilrettelagtKommunikasjon: TilrettelagtKommunikasjon | null;
+  sikkerhetstiltak: Sikkerhetstiltak[];
 }
 
 interface TilrettelagtKommunikasjon {
@@ -19,4 +20,11 @@ interface TilrettelagtKommunikasjon {
 
 interface Sprak {
   value: string | null;
+}
+
+interface Sikkerhetstiltak {
+  type: string;
+  beskrivelse: string;
+  gyldigFom: Date;
+  gyldigTom: Date;
 }

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -13,6 +13,7 @@ import { ARBEIDSTAKER_DEFAULT } from "../../../mock/common/mockConstants";
 import { brukerinfoMock } from "../../../mock/syfoperson/persondataMock";
 import { diskresjonskodeQueryKeys } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
 import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { daysFromToday } from "../../testUtils";
 
 let queryClient: any;
 
@@ -160,5 +161,38 @@ describe("PersonkortHeader", () => {
     expect(screen.getByText("01.12.2023")).to.exist;
     expect(screen.getByText("Utbetalt tom:")).to.exist;
     expect(screen.getByText("01.07.2024")).to.exist;
+  });
+
+  it("viser ikke sikkerhetstiltak-tag når bruker mangler sikkerhetstiltak", () => {
+    queryClient.setQueryData(
+      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => ({
+        ...brukerinfoMock,
+        sikkerhetstiltak: [],
+      })
+    );
+    renderPersonkortHeader();
+
+    expect(screen.queryByText("Sikkerhetstiltak")).to.not.exist;
+  });
+
+  it("viser sikkerhetstiltak-tag når bruker har sikkerhetstiltak", () => {
+    queryClient.setQueryData(
+      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => ({
+        ...brukerinfoMock,
+        sikkerhetstiltak: [
+          {
+            type: "FYUS",
+            beskrivelse: "Fysisk utestengelse",
+            gyldigFom: daysFromToday(-10),
+            gyldigTom: daysFromToday(10),
+          },
+        ],
+      })
+    );
+    renderPersonkortHeader();
+
+    expect(screen.getByText("Sikkerhetstiltak")).to.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser tag i header og ny fane for sikkerhetstiltak i personkortet dersom bruker har sikkerhetstiltak registrert.
Gjenstår å avklare endelig design og visning med Peter/Stine, men regner med det blir noe sånt-ish.

### Screenshots 📸✨

Før:
![image](https://github.com/navikt/syfomodiaperson/assets/79838644/e0e18a7c-84a6-4d75-a32b-0cd5ef44f201)

Etter:
![image](https://github.com/navikt/syfomodiaperson/assets/79838644/db4e22b4-00fe-450f-89b5-e6ed23d3c693)

