### PR TITLE
Open LPS-planer in new tab

### DIFF
--- a/src/components/oppfolgingsplan/lps/OppfolgingsplanerOversiktLPS.tsx
+++ b/src/components/oppfolgingsplan/lps/OppfolgingsplanerOversiktLPS.tsx
@@ -19,7 +19,8 @@ export const ButtonOpenPlan = (buttonOpenPlanProps: ButtonOpenPlanProps) => {
     <a
       className="lenke"
       href={`${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/lps/${buttonOpenPlanProps.oppfolgingsplanLPS.uuid}`}
-      download="oppfølgingsplan"
+      target="_blank"
+      rel="noopener noreferrer"
     >
       {texts.buttonOpenPlan}
     </a>


### PR DESCRIPTION
Veiledere don't want to download the pdf, so we should open it in a new tab instead.