### PR TITLE
IS-1506: Auto select single virksomhet in DM form

### DIFF
--- a/src/components/dialogmote/innkalling/virksomhet/VirksomhetRadioGruppe.tsx
+++ b/src/components/dialogmote/innkalling/virksomhet/VirksomhetRadioGruppe.tsx
@@ -36,8 +36,20 @@ export const VirksomhetRadioGruppe = ({
     velgVirksomhet("");
   };
 
+  let defaultVirksomhet: string | undefined = undefined;
+  if (virksomheter.length === 1) {
+    defaultVirksomhet = virksomheter[0];
+    removeInputAndChooseVirksomhet(defaultVirksomhet);
+  }
+
   return (
-    <RadioGroup legend={label} size="small" id={id} error={error}>
+    <RadioGroup
+      legend={label}
+      size="small"
+      id={id}
+      error={error}
+      defaultValue={defaultVirksomhet}
+    >
       {virksomheter.map((virksomhetsnummer, index) => (
         <VirksomhetRadio
           key={index}


### PR DESCRIPTION
Dette sparer veiledere for mange klikk.
Første arbeidsgiver blir automatisk valgt selv om "oppgi virksomhetsnummer" er tilgjengelig.
Hvis flere virksomheter er tilgjengelig, velges ingen automatisk.
