### PR TITLE
IS-1880: Add description that begrunnelse is part of bigger template

### DIFF
--- a/src/sider/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/sider/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -20,6 +20,8 @@ import { Brevmal } from "@/data/aktivitetskrav/forhandsvarselTexts";
 const texts = {
   title: "Send forhåndsvarsel",
   beskrivelseLabel: "Begrunnelse (obligatorisk)",
+  begrunnelseDescription:
+    "Begrunnelsen din blir en del av en større brevmal. Se forhåndsvisning for å se hele varselet",
   forhandsvisning: "Forhåndsvisning",
   forhandsvisningLabel: "Forhåndsvis forhåndsvarselet",
   missingBeskrivelse: "Vennligst angi begrunnelse",
@@ -122,6 +124,7 @@ export const SendForhandsvarselSkjema = ({
         })}
         value={watch("begrunnelse")}
         label={texts.beskrivelseLabel}
+        description={texts.begrunnelseDescription}
         error={errors.begrunnelse && texts.missingBeskrivelse}
         size="small"
         minRows={6}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til info om at begrunnelsen er en del av en større brevmal. Dette er noe som har vist seg å ikke være helt tydelig for brukerne våre.

### Screenshots 📸✨
![Screenshot 2024-01-22 at 14 45 27](https://github.com/navikt/syfomodiaperson/assets/11747383/e2fb1d4b-991c-4bf1-befe-4b4fb1f881d6)

