### PR TITLE
IS-1848: Show poststed in personkort

### DIFF
--- a/mock/syfoperson/personAdresseMock.ts
+++ b/mock/syfoperson/personAdresseMock.ts
@@ -4,27 +4,20 @@ import { Vegadresse } from "@/data/personinfo/types/PersonAdresse";
 export const vegadresse: Vegadresse = {
   husnummer: "20",
   adressenavn: "ØKERNVEIEN",
-  kommunenummer: "0301",
   postnummer: "0301",
+  poststed: "OSLO",
 };
 
 export const personAdresseMock = {
   navn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
   bostedsadresse: {
-    angittFlyttedato: "2019-11-03",
-    gyldigFraOgMed: "2019-11-03T00:00:00",
-    gyldigTilOgMed: null,
-    coAdressenavn: null,
     vegadresse,
     matrikkeladresse: null,
     utenlandskAdresse: null,
     ukjentBosted: null,
   },
   kontaktadresse: {
-    gyldigFraOgMed: "2020-11-03T16:12:43",
-    gyldigTilOgMed: "2021-11-03T00:00:00",
     type: "Utland",
-    coAdressenavn: null,
     postboksadresse: null,
     vegadresse: null,
     postadresseIFrittFormat: null,
@@ -39,9 +32,6 @@ export const personAdresseMock = {
     },
   },
   oppholdsadresse: {
-    gyldigFraOgMed: "2019-11-03T00:00:00",
-    gyldigTilOgMed: null,
-    coAdressenavn: null,
     utenlandskAdresse: null,
     vegadresse,
     matrikkeladresse: null,

--- a/src/components/personkort/PersonkortSykmeldt.tsx
+++ b/src/components/personkort/PersonkortSykmeldt.tsx
@@ -6,7 +6,7 @@ import {
   formaterBostedsadresse,
   formaterKontaktadresse,
   formaterOppholdsadresse,
-} from "@/utils/pdladresseUtils";
+} from "@/utils/adresseUtils";
 import { PersonImage } from "../../../img/ImageComponents";
 import { usePersonAdresseQuery } from "@/data/personinfo/personAdresseQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";

--- a/src/data/personinfo/types/PersonAdresse.ts
+++ b/src/data/personinfo/types/PersonAdresse.ts
@@ -6,10 +6,6 @@ export interface PersonAdresse {
 }
 
 export interface Bostedsadresse {
-  angittFlyttedato?: Date;
-  gyldigFraOgMed?: Date;
-  gyldigTilOgMed?: Date;
-  coAdressenavn?: string;
   vegadresse?: Vegadresse;
   matrikkeladresse?: Matrikkeladresse;
   utenlandskAdresse?: UtenlandskAdresse;
@@ -17,10 +13,7 @@ export interface Bostedsadresse {
 }
 
 export interface Kontaktadresse {
-  gyldigFraOgMed?: Date;
-  gyldigTilOgMed?: Date;
   type: KontaktadresseType;
-  coAdressenavn?: string;
   postboksadresse?: Postboksadresse;
   vegadresse?: Vegadresse;
   postadresseIFrittFormat?: PostadresseIFrittFormat;
@@ -34,9 +27,6 @@ export enum KontaktadresseType {
 }
 
 export interface Oppholdsadresse {
-  gyldigFraOgMed?: Date;
-  gyldigTilOgMed?: Date;
-  coAdressenavn?: string;
   utenlandskAdresse?: UtenlandskAdresse;
   vegadresse?: Vegadresse;
   matrikkeladresse?: Matrikkeladresse;
@@ -48,12 +38,14 @@ export interface PostadresseIFrittFormat {
   adresselinje2?: string;
   adresselinje3?: string;
   postnummer?: string;
+  poststed?: string;
 }
 
 export interface Postboksadresse {
   postbokseier?: string;
   postboks: string;
   postnummer?: string;
+  poststed?: string;
 }
 
 export interface UtenlandskAdresse {
@@ -76,22 +68,19 @@ export interface UtenlandskAdresseIFrittFormat {
 }
 
 export interface Vegadresse {
-  matrikkelId?: bigint;
   husnummer?: string;
   husbokstav?: string;
-  bruksenhetsnummer?: string;
   adressenavn?: string;
-  kommunenummer?: string;
-  bydelsnummer?: string;
   tilleggsnavn?: string;
   postnummer?: string;
+  poststed?: string;
 }
 
 export interface Matrikkeladresse {
-  matrikkelId?: bigint;
   bruksenhetsnummer?: string;
   tilleggsnavn?: string;
   postnummer?: string;
+  poststed?: string;
   kommunenummer?: string;
 }
 

--- a/src/utils/adresseUtils.tsx
+++ b/src/utils/adresseUtils.tsx
@@ -97,7 +97,7 @@ const formaterPostboksadresse = (postboksadresse: Postboksadresse) => {
   return hentAdresseRader(
     postboksadresse.postbokseier || "",
     postboksadresse.postboks,
-    postboksadresse.postnummer || "",
+    `${postboksadresse.postnummer || ""} ${postboksadresse.poststed || ""}`,
     "",
     ""
   );
@@ -110,7 +110,9 @@ const formaterPostadresseIFrittFormat = (
     postadresseIFrittFormat.adresselinje1 || "",
     postadresseIFrittFormat.adresselinje2 || "",
     postadresseIFrittFormat.adresselinje3 || "",
-    postadresseIFrittFormat.postnummer || "",
+    `${postadresseIFrittFormat.postnummer || ""} ${
+      postadresseIFrittFormat.poststed || ""
+    }`,
     ""
   );
 };
@@ -121,7 +123,7 @@ const formaterVegadresse = (vegadresse: Vegadresse) => {
       vegadresse.husbokstav || ""
     }`,
     vegadresse.tilleggsnavn || "",
-    vegadresse.postnummer || "",
+    `${vegadresse.postnummer || ""} ${vegadresse.poststed || ""}`,
     "",
     ""
   );
@@ -131,7 +133,7 @@ const formaterMatrikkeladresse = (matrikkeladresse: Matrikkeladresse) => {
   return hentAdresseRader(
     matrikkeladresse.bruksenhetsnummer || "",
     matrikkeladresse.tilleggsnavn || "",
-    matrikkeladresse.postnummer || "",
+    `${matrikkeladresse.postnummer || ""} ${matrikkeladresse.poststed || ""}`,
     matrikkeladresse.kommunenummer || "",
     ""
   );


### PR DESCRIPTION
Veiledere ønsker seg poststed for å slippe å slå opp postnummer.
Bruk de nye objektene fra isperson, med ubrukte felter fjernet og poststed lagt til.

Før:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/ef9462d2-0838-4b9a-b7c8-e1a5a741b766)


Etter (med ny kontaktadresse som ikke er Oslo):
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/37c1fe47-1735-4c7e-9977-d015503b2ba3)
