### PR TITLE
Track flexjar-score in amplitude only on submit

### DIFF
--- a/src/components/flexjar/EmojiButton.tsx
+++ b/src/components/flexjar/EmojiButton.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import * as Amplitude from "@/utils/amplitude";
-import { EventType } from "@/utils/amplitude";
 import { Label } from "@navikt/ds-react";
 import { emojis, EmojiType } from "@/components/flexjar/feedbackEmojis";
 
@@ -23,13 +21,6 @@ export const EmojiButton = ({
       setSelectedEmojiType(undefined);
     } else {
       setSelectedEmojiType(emojiType);
-      Amplitude.logEvent({
-        type: EventType.ButtonClick,
-        data: {
-          tekst: `${emoji.score}`,
-          url: window.location.href,
-        },
-      });
     }
   };
 

--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -17,6 +17,8 @@ import { ChevronDownIcon, ChevronUpIcon } from "@navikt/aksel-icons";
 import { defaultErrorTexts } from "@/api/errors";
 import { emojis, EmojiType } from "@/components/flexjar/feedbackEmojis";
 import { StoreKey, useLocalStorageState } from "@/hooks/useLocalStorageState";
+import * as Amplitude from "@/utils/amplitude";
+import { EventType } from "@/utils/amplitude";
 
 const texts = {
   apneKnapp: "Gi oss tilbakemelding",
@@ -59,7 +61,16 @@ export const Flexjar = ({ side }: FlexjarProps) => {
         app: "syfomodiaperson",
       };
       sendFeedback.mutate(body, {
-        onSuccess: () => setFeedbackDate(new Date()),
+        onSuccess: () => {
+          setFeedbackDate(new Date());
+          Amplitude.logEvent({
+            type: EventType.ButtonClick,
+            data: {
+              tekst: svar,
+              url: window.location.href,
+            },
+          });
+        },
       });
     } else {
       setIsValid(false);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Jeg oppdaget at vi logget til amplitude hver gang man trykket på en emoji. Hvis en veileder klikker på feks flere emojies for å prøve seg litt frem, så får vi mange innslag i amplitude. Jeg husker ikke om dette var med vilje, men jeg tenker kanskje vi kun vil sende inn på submit? På den måten kan vi telle det litt lettere i Amplitude også, i stedet for å koble opp Metabase og Bigquery.

@andersrognstad husker du hvorfor vi puttet dette per emoji-trykk opprinnelig?
