### PR TITLE
IS-2020: Adjust how often flexjar is displayed

### DIFF
--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -42,7 +42,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
   const [emojiType, setEmojiType] = useState<EmojiType>();
   const sendFeedback = useFlexjarFeedback();
   const { setStoredValue: setFeedbackDate } = useLocalStorageState<Date>(
-    StoreKey.FLEXJAR_FEEDBACK_DATE
+    StoreKey.FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE
   );
 
   useEffect(() => {

--- a/src/hooks/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 export enum StoreKey {
-  FLEXJAR_FEEDBACK_DATE = "flexjarFeedbackDate",
+  FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE = "flexjarAktivitetskravFeedbackDate",
 }
 
 export const useLocalStorageState = <T>(key: StoreKey) => {

--- a/src/sider/Side.tsx
+++ b/src/sider/Side.tsx
@@ -15,7 +15,6 @@ import { Flexjar } from "@/components/flexjar/Flexjar";
 import { Oppfolgingsoppgave } from "@/components/oppfolgingsoppgave/Oppfolgingsoppgave";
 import { useDiskresjonskodeQuery } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
 import { StoreKey, useLocalStorageState } from "@/hooks/useLocalStorageState";
-import { dagerMellomDatoer } from "@/utils/datoUtils";
 
 export const MODIA_HEADER_ID = "modia-header";
 
@@ -28,12 +27,10 @@ interface SideProps {
 const Side = ({ tittel, aktivtMenypunkt, children }: SideProps) => {
   const { data: diskresjonskode } = useDiskresjonskodeQuery();
   const { storedValue: flexjarFeedbackDate } = useLocalStorageState<Date>(
-    StoreKey.FLEXJAR_FEEDBACK_DATE
+    StoreKey.FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE
   );
 
-  const hasGivenFeedbackLastDay = flexjarFeedbackDate
-    ? dagerMellomDatoer(flexjarFeedbackDate, Date.now()) < 1
-    : false;
+  const hasGivenFeedback = !!flexjarFeedbackDate;
 
   useEffect(() => {
     Amplitude.logEvent({
@@ -47,7 +44,7 @@ const Side = ({ tittel, aktivtMenypunkt, children }: SideProps) => {
     aktivtMenypunkt === Menypunkter.AKTIVITETSKRAV &&
     diskresjonskode !== "6" &&
     diskresjonskode !== "7" &&
-    !hasGivenFeedbackLastDay;
+    !hasGivenFeedback;
 
   return (
     <DocumentTitle

--- a/test/flexjar/FlexjarTest.tsx
+++ b/test/flexjar/FlexjarTest.tsx
@@ -146,6 +146,7 @@ describe("Flexjar", () => {
     clickButton("Horribel");
     clickButton("Send tilbakemelding");
 
-    expect(localStorage.getItem(StoreKey.FLEXJAR_FEEDBACK_DATE)).to.not.be.null;
+    expect(localStorage.getItem(StoreKey.FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE))
+      .to.not.be.null;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

I stedet for å vise flexjar på nytt hver dag, så sier vi nå at dersom du har svart en gang, så får du den ikke opp igjen. Vi kan ha det som utgangspunkt, og så heller endre på dette basert på mengden vi får inn.

Endrer også localstorage key-navnet, ettersom vi kanskje på sikt vil ha flexjar på flere sider enn bare aktivitetskravet. Da kan vi styre hvor ofte vi vil vise ting på hver enkelt side litt bedre.
