### PR TITLE
IS-1816: Bare vis Ikke oppfylt etter forhåndsvarsel er utgått

### DIFF
--- a/src/sider/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
+++ b/src/sider/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
@@ -1,4 +1,7 @@
 import React from "react";
+import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
+import { hasUbehandletPersonoppgave } from "@/utils/personOppgaveUtils";
+import { PersonOppgaveType } from "@/data/personoppgave/types/PersonOppgave";
 import {
   AktivitetskravDTO,
   AktivitetskravStatus,
@@ -50,6 +53,11 @@ interface VurderAktivitetskravTabsProps {
 export const VurderAktivitetskravTabs = ({
   aktivitetskrav,
 }: VurderAktivitetskravTabsProps) => {
+  const { data: oppgaver } = usePersonoppgaverQuery();
+  const isIkkeOppfyltTabVisible = hasUbehandletPersonoppgave(
+    oppgaver,
+    PersonOppgaveType.AKTIVITETSKRAV_VURDER_STANS
+  );
   const isForhandsvarselTabVisible = isValidStateForForhandsvarsel(
     aktivitetskrav.status
   );
@@ -64,7 +72,9 @@ export const VurderAktivitetskravTabs = ({
         {isForhandsvarselTabVisible && (
           <Tabs.Tab value={Tab.FORHANDSVARSEL} label={texts.forhandsvarsel} />
         )}
-        <Tabs.Tab value={Tab.IKKE_OPPFYLT} label={texts.ikkeOppfylt} />
+        {isIkkeOppfyltTabVisible && (
+          <Tabs.Tab value={Tab.IKKE_OPPFYLT} label={texts.ikkeOppfylt} />
+        )}
       </Tabs.List>
       <Tabs.Panel value={Tab.UNNTAK}>
         <UnntakAktivitetskravSkjema aktivitetskravUuid={aktivitetskravUuid} />
@@ -77,11 +87,13 @@ export const VurderAktivitetskravTabs = ({
           <SendForhandsvarselSkjema aktivitetskravUuid={aktivitetskravUuid} />
         </Tabs.Panel>
       )}
-      <Tabs.Panel value={Tab.IKKE_OPPFYLT}>
-        <IkkeOppfyltAktivitetskravSkjema
-          aktivitetskravUuid={aktivitetskravUuid}
-        />
-      </Tabs.Panel>
+      {isIkkeOppfyltTabVisible && (
+        <Tabs.Panel value={Tab.IKKE_OPPFYLT}>
+          <IkkeOppfyltAktivitetskravSkjema
+            aktivitetskravUuid={aktivitetskravUuid}
+          />
+        </Tabs.Panel>
+      )}
     </StyledTabs>
   );
 };

--- a/test/aktivitetskrav/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/VurderAktivitetskravTest.tsx
@@ -129,7 +129,7 @@ describe("VurderAktivitetskrav", () => {
     expect(screen.queryByRole("tab", { name: "Sett unntak" })).to.exist;
     expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
     expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.exist;
-    expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.exist;
+    expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
   });
 
   it("renders ikke-oppfylt when ubehandlet vurder-stans oppgave", () => {
@@ -377,7 +377,7 @@ describe("VurderAktivitetskrav", () => {
       expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
       expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.not
         .exist;
-      expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
       expect(screen.queryByRole("button", { name: "Avvent" })).to.not.exist;
     });
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

IKKE_OPPFYLT skal bare vises etter et forhåndsvarsel er sendt og utgått (dvs det er laget oppgave for å vurdere stans). Sjekken var fjernet tidligere pga påbegynte forhåndsvarsler i Arena.

