### PR TITLE
IS-2015: Use personident in header in motebehov api-calls

### DIFF
--- a/src/apiConstants.ts
+++ b/src/apiConstants.ts
@@ -17,7 +17,7 @@ export const ISPERSONOPPGAVE_ROOT = "/ispersonoppgave/api/v2";
 export const MODIACONTEXTHOLDER_ROOT = "/modiacontextholder/api";
 export const SYFOBEHANDLENDEENHET_ROOT =
   "/syfobehandlendeenhet/api/internad/v2";
-export const SYFOMOTEBEHOV_ROOT = "/syfomotebehov/api/internad/v2/veileder";
+export const SYFOMOTEBEHOV_ROOT = "/syfomotebehov/api/internad/v3/veileder";
 export const SYFOOPPFOLGINGSPLANSERVICE_ROOT =
   "/syfooppfolgingsplanservice/api/internad/v2";
 export const SYFOPERSON_ROOT = "/syfoperson/api/v2";

--- a/src/data/historikk/historikkQueryHooks.ts
+++ b/src/data/historikk/historikkQueryHooks.ts
@@ -18,8 +18,8 @@ export const historikkQueryKeys = {
 
 export const useHistorikkMotebehovQuery = () => {
   const fnr = useValgtPersonident();
-  const path = `${SYFOMOTEBEHOV_ROOT}/historikk?fnr=${fnr}`;
-  const fetchHistorikkMotebehov = () => get<HistorikkEvent[]>(path);
+  const path = `${SYFOMOTEBEHOV_ROOT}/historikk`;
+  const fetchHistorikkMotebehov = () => get<HistorikkEvent[]>(path, fnr);
   const query = useQuery({
     queryKey: historikkQueryKeys.motebehov(fnr),
     queryFn: fetchHistorikkMotebehov,

--- a/src/data/motebehov/motebehovQueryHooks.ts
+++ b/src/data/motebehov/motebehovQueryHooks.ts
@@ -12,8 +12,8 @@ export const motebehovQueryKeys = {
 
 export const useMotebehovQuery = () => {
   const fnr = useValgtPersonident();
-  const path = `${SYFOMOTEBEHOV_ROOT}/motebehov?fnr=${fnr}`;
-  const fetchMotebehov = () => get<MotebehovVeilederDTO[]>(path);
+  const path = `${SYFOMOTEBEHOV_ROOT}/motebehov`;
+  const fetchMotebehov = () => get<MotebehovVeilederDTO[]>(path, fnr);
 
   const query = useQuery({
     queryKey: motebehovQueryKeys.motebehov(fnr),

--- a/src/data/motebehov/useBehandleMotebehov.ts
+++ b/src/data/motebehov/useBehandleMotebehov.ts
@@ -11,8 +11,8 @@ export const useBehandleMotebehov = () => {
   const { data: veilederinfo } = useAktivVeilederinfoQuery();
   const veilederIdent = veilederinfo?.ident;
   const queryClient = useQueryClient();
-  const path = `${SYFOMOTEBEHOV_ROOT}/motebehov/${fnr}/behandle`;
-  const postBehandleMotebehov = () => post(path, {});
+  const path = `${SYFOMOTEBEHOV_ROOT}/motebehov/behandle`;
+  const postBehandleMotebehov = () => post(path, {}, fnr);
   const motebehovQueryKey = motebehovQueryKeys.motebehov(fnr);
 
   return useMutation({

--- a/src/data/motebehov/useBehandleMotebehovAndSendTilbakemelding.ts
+++ b/src/data/motebehov/useBehandleMotebehovAndSendTilbakemelding.ts
@@ -16,16 +16,16 @@ export const useBehandleMotebehovAndSendTilbakemelding = () => {
   const { data: veilederinfo } = useAktivVeilederinfoQuery();
   const veilederIdent = veilederinfo?.ident;
   const queryClient = useQueryClient();
-  const path = `${SYFOMOTEBEHOV_ROOT}/motebehov/${fnr}/behandle`;
+  const path = `${SYFOMOTEBEHOV_ROOT}/motebehov/behandle`;
   const pathTilbakemelding = `${SYFOMOTEBEHOV_ROOT}/motebehov/tilbakemelding`;
 
   const behandleMotebehovAndSendTilbakemelding = async (
     tilbakemeldinger: MotebehovTilbakemeldingDTO[]
   ) => {
-    await post(path, {});
+    await post(path, {}, fnr);
     await Promise.all(
       tilbakemeldinger.map((tilbakemelding) =>
-        post(pathTilbakemelding, tilbakemelding)
+        post(pathTilbakemelding, tilbakemelding, fnr)
       )
     );
   };

--- a/test/data/historikkQueryHooksTest.tsx
+++ b/test/data/historikkQueryHooksTest.tsx
@@ -27,7 +27,7 @@ describe("historikkQueryHooks", () => {
   });
 
   it("loads motebehov-historikk for valgt personident", async () => {
-    stubMotebehovHistorikkApi(apiMockScope, ARBEIDSTAKER_DEFAULT.personIdent);
+    stubMotebehovHistorikkApi(apiMockScope);
     const wrapper = queryHookWrapper(queryClient);
 
     const { result } = renderHook(() => useHistorikkMotebehovQuery(), {

--- a/test/stubs/stubSyfomotebehov.ts
+++ b/test/stubs/stubSyfomotebehov.ts
@@ -2,8 +2,8 @@ import nock from "nock";
 import { SYFOMOTEBEHOV_ROOT } from "@/apiConstants";
 import { historikkmotebehovMock } from "../../mock/syfomotebehov/historikkmotebehovMock";
 
-export const stubMotebehovHistorikkApi = (scope: nock.Scope, fnr: string) => {
+export const stubMotebehovHistorikkApi = (scope: nock.Scope) => {
   scope
-    .get(`${SYFOMOTEBEHOV_ROOT}/historikk?fnr=${fnr}`)
+    .get(`${SYFOMOTEBEHOV_ROOT}/historikk`)
     .reply(200, () => historikkmotebehovMock);
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Tar i bruk v3 av motebehov-apiet med personident i header i stedet for url. Kan merges etter https://github.com/navikt/syfomotebehov/pull/284