### PR TITLE
IS-1959: Avlys dialogmote react hook form

### DIFF
--- a/src/components/Forhandsvisning.tsx
+++ b/src/components/Forhandsvisning.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import {
+  ForhandsvisningModal,
+  ForhandsvisningModalProps,
+} from "@/components/ForhandsvisningModal";
+import { Button } from "@navikt/ds-react";
+
+const texts = {
+  forhandsvisning: "Forhåndsvisning",
+};
+
+export const Forhandsvisning = (
+  props: Omit<ForhandsvisningModalProps, "isOpen" | "handleClose">
+) => {
+  const [displayForhandsvisning, setDisplayForhandsvisning] = useState(false);
+
+  return (
+    <>
+      <Button
+        variant="secondary"
+        type="button"
+        onClick={() => setDisplayForhandsvisning(true)}
+      >
+        {texts.forhandsvisning}
+      </Button>
+      <ForhandsvisningModal
+        {...props}
+        isOpen={displayForhandsvisning}
+        handleClose={() => setDisplayForhandsvisning(false)}
+      />
+    </>
+  );
+};

--- a/src/components/ForhandsvisningModal.tsx
+++ b/src/components/ForhandsvisningModal.tsx
@@ -8,7 +8,7 @@ const texts = {
   close: "Lukk",
 };
 
-interface ForhandsvisningProps {
+export interface ForhandsvisningModalProps {
   title?: string;
   contentLabel: string;
   isOpen: boolean;
@@ -22,7 +22,7 @@ export const ForhandsvisningModal = ({
   title,
   contentLabel,
   getDocumentComponents,
-}: ForhandsvisningProps): ReactElement => {
+}: ForhandsvisningModalProps): ReactElement => {
   const documentComponents = isOpen ? getDocumentComponents() : [];
   return (
     <Modal

--- a/src/components/dialogmote/TextareaField.tsx
+++ b/src/components/dialogmote/TextareaField.tsx
@@ -1,0 +1,11 @@
+import { Textarea, TextareaProps } from "@navikt/ds-react";
+import React, { ForwardedRef } from "react";
+
+const TextareaField = (
+  props: TextareaProps,
+  ref: ForwardedRef<HTMLTextAreaElement>
+) => (
+  <Textarea className="mb-4" size="small" minRows={4} ref={ref} {...props} />
+);
+
+export default React.forwardRef(TextareaField);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Migrert dialogmote avlys-skjema til react hook form.

### Screenshots 📸✨

Fjernet for enkelhets skyld feiloppsumeringen nederst siden dette er et såpass enkelt skjema og feiloppsummeringskomponenten ikke uten videre fungerer med react-hook-form-feil.
![image](https://github.com/navikt/syfomodiaperson/assets/79838644/c7cf7b01-5004-4ba5-b738-c42705f66fe2)
