### PR TITLE
IS-1189: Add nynorsk to dialogmoteinnkalling

### DIFF
--- a/src/components/ChooseMalform.tsx
+++ b/src/components/ChooseMalform.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Radio, RadioGroup } from "@navikt/ds-react";
+import { Malform, useMalform } from "@/context/malform/MalformContext";
+
+export const ChooseMalform = () => {
+  const { malform, setMalform } = useMalform();
+  return (
+    <RadioGroup
+      legend="Velg målform"
+      onChange={(value) => setMalform(value as Malform)}
+      size="small"
+      defaultValue={malform}
+      className="mb-4"
+    >
+      <Radio value={Malform.BOKMAL}>Bokmål</Radio>
+      <Radio value={Malform.NYNORSK}>Nynorsk</Radio>
+    </RadioGroup>
+  );
+};

--- a/src/components/MalformRadioGroup.tsx
+++ b/src/components/MalformRadioGroup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Radio, RadioGroup } from "@navikt/ds-react";
 import { Malform, useMalform } from "@/context/malform/MalformContext";
 
-export const ChooseMalform = () => {
+export const MalformRadioGroup = () => {
   const { malform, setMalform } = useMalform();
   return (
     <RadioGroup

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -35,7 +35,7 @@ import { useSkjemaValuesToDto } from "@/hooks/dialogmote/useSkjemaValuesToDto";
 import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import DialogmoteInnkallingSkjemaSeksjon from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon";
 import { Box, Button } from "@navikt/ds-react";
-import { ChooseMalform } from "@/components/ChooseMalform";
+import { MalformRadioGroup } from "@/components/MalformRadioGroup";
 
 interface DialogmoteInnkallingSkjemaTekster {
   fritekstArbeidsgiver: string;
@@ -179,7 +179,7 @@ const DialogmoteInnkallingSkjema = () => {
 
   return (
     <Box background="surface-default" padding="6" className="mb-2">
-      <ChooseMalform />
+      <MalformRadioGroup />
       <Form initialValues={initialValues} onSubmit={submit} validate={validate}>
         {({ handleSubmit, submitFailed, errors }) => (
           <form onSubmit={handleSubmit}>

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -36,6 +36,9 @@ import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import DialogmoteInnkallingSkjemaSeksjon from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon";
 import { Box, Button } from "@navikt/ds-react";
 import { MalformRadioGroup } from "@/components/MalformRadioGroup";
+import * as Amplitude from "@/utils/amplitude";
+import { EventType } from "@/utils/amplitude";
+import { useMalform } from "@/context/malform/MalformContext";
 
 interface DialogmoteInnkallingSkjemaTekster {
   fritekstArbeidsgiver: string;
@@ -121,6 +124,7 @@ const DialogmoteInnkallingSkjema = () => {
 
   const { toTidStedDto } = useSkjemaValuesToDto();
   const opprettInnkalling = useOpprettInnkallingDialogmote(fnr);
+  const { malform } = useMalform();
 
   const validate = (
     values: Partial<DialogmoteInnkallingSkjemaValues>
@@ -175,6 +179,14 @@ const DialogmoteInnkallingSkjema = () => {
       selectedBehandler
     );
     opprettInnkalling.mutate(dialogmoteInnkalling);
+    Amplitude.logEvent({
+      type: EventType.OptionSelected,
+      data: {
+        url: window.location.href,
+        tekst: "Målform valgt",
+        option: malform,
+      },
+    });
   };
 
   return (

--- a/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/components/dialogmote/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -6,8 +6,8 @@ import DialogmoteInnkallingTekster, {
 } from "./DialogmoteInnkallingTekster";
 import { Form } from "react-final-form";
 import {
-  validerArbeidsgiver,
   behandlerRefValidationErrors,
+  validerArbeidsgiver,
   validerSkjemaTekster,
   validerSted,
   validerTidspunkt,
@@ -35,6 +35,7 @@ import { useSkjemaValuesToDto } from "@/hooks/dialogmote/useSkjemaValuesToDto";
 import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import DialogmoteInnkallingSkjemaSeksjon from "@/components/dialogmote/innkalling/DialogmoteInnkallingSkjemaSeksjon";
 import { Box, Button } from "@navikt/ds-react";
+import { ChooseMalform } from "@/components/ChooseMalform";
 
 interface DialogmoteInnkallingSkjemaTekster {
   fritekstArbeidsgiver: string;
@@ -178,6 +179,7 @@ const DialogmoteInnkallingSkjema = () => {
 
   return (
     <Box background="surface-default" padding="6" className="mb-2">
+      <ChooseMalform />
       <Form initialValues={initialValues} onSubmit={submit} validate={validate}>
         {({ handleSubmit, submitFailed, errors }) => (
           <form onSubmit={handleSubmit}>

--- a/src/context/malform/MalformContext.tsx
+++ b/src/context/malform/MalformContext.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from "react";
-import { StoreKey, useLocalStorageState } from "@/hooks/useLocalStorageState";
+import {
+  StoreKey,
+  useLocalStorageState,
+} from "../../hooks/useLocalStorageState";
 
 export enum Malform {
   BOKMAL = "nb",

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -54,7 +54,7 @@ const innkallingTextsNynorsk = {
     intro2:
       "Vi ønskjer å høyre kva du og arbeidsgivaren seier om arbeidssituasjonen og moglegheitene for å jobbe.",
     intro2WithBehandler:
-      "Vi ønskjer å høyre kva du, arbeidsgivaren og behandlarane seier om arbeidssituasjonen og moglegheitene for å jobbe.", // TODO: behandlarane -> behandlaren?
+      "Vi ønskjer å høyre kva du, arbeidsgivaren og behandlaren seier om arbeidssituasjonen og moglegheitene for å jobbe.",
     outroObligatorisk: "Det er obligatorisk å delta i dialogmøtet.",
     outro1:
       "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -1,21 +1,57 @@
+import { Malform } from "../../context/malform/MalformContext";
+
 export const innkallingTexts = {
   arbeidstaker: {
-    intro1:
-      "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre.",
-    intro2:
-      "I møtet vil vi høre både hva du og arbeidsgiveren sier om arbeidssituasjonen og mulighetene for å jobbe.",
-    intro2WithBehandler:
-      "I møtet vil vi høre både hva du, arbeidsgiveren og behandleren sier om arbeidssituasjonen og mulighetene for å jobbe.",
-    outroObligatorisk: "Det er obligatorisk å delta i dialogmøtet.",
-    outro1:
-      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi ikke sett behov for det.",
-    outro1WithBehandler:
-      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å innkalle",
-    outro2Title: "Før møtet",
-    outro2:
-      "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
-    outro2WithBehandler:
-      "Det er viktig at du og arbeidsgiveren din fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
+    intro1: {
+      [Malform.BOKMAL]:
+        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre.",
+      [Malform.NYNORSK]:
+        "Velkomen til dialogmøte mellom deg, arbeidsgivaren din og ein rettleiar frå NAV. I møtet kjem vi til å snakke om situasjonen din og bli samde om ein plan som kan hjelpe deg vidare.",
+    },
+    intro2: {
+      [Malform.BOKMAL]:
+        "I møtet vil vi høre både hva du og arbeidsgiveren sier om arbeidssituasjonen og mulighetene for å jobbe.",
+      [Malform.NYNORSK]:
+        "Vi ønskjer å høyre kva du og arbeidsgivaren seier om arbeidssituasjonen og moglegheitene for å jobbe.",
+    },
+    intro2WithBehandler: {
+      [Malform.BOKMAL]:
+        "I møtet vil vi høre både hva du, arbeidsgiveren og behandleren sier om arbeidssituasjonen og mulighetene for å jobbe.",
+      [Malform.NYNORSK]:
+        "Vi ønskjer å høyre kva du, arbeidsgivaren og behandlarane seier om arbeidssituasjonen og moglegheitene for å jobbe.", // TODO: behandlarane -> behandlaren?
+    },
+    outroObligatorisk: {
+      [Malform.BOKMAL]: "Det er obligatorisk å delta i dialogmøtet.",
+      [Malform.NYNORSK]: "Det er obligatorisk å delta i dialogmøtet.",
+    },
+    outro1: {
+      [Malform.BOKMAL]:
+        "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi ikke sett behov for det.",
+      [Malform.NYNORSK]:
+        "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",
+    },
+    outro1WithBehandler: {
+      [Malform.BOKMAL]:
+        "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å innkalle",
+      [Malform.NYNORSK]:
+        "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi sett behov for å kalle inn sjukmeldar ",
+    },
+    outro2Title: {
+      [Malform.BOKMAL]: "Før møtet",
+      [Malform.NYNORSK]: "Før møtet",
+    },
+    outro2: {
+      [Malform.BOKMAL]:
+        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
+      [Malform.NYNORSK]:
+        "Det er viktig at de fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+    },
+    outro2WithBehandler: {
+      [Malform.BOKMAL]:
+        "Det er viktig at du og arbeidsgiveren din fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
+      [Malform.NYNORSK]:
+        "Det er viktig at du og arbeidsgivaren din fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke saman om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+    },
   },
   arbeidsgiver: {
     intro1:
@@ -38,6 +74,11 @@ export const innkallingTexts = {
       "Vi ønsker svar fra deg om du kan stille til møtet. Det er i utgangspunktet obligatorisk å delta i dialogmøtet, men tidspunktet kan endres eller møtet kan avlyses ved behov.",
     outro:
       "Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS.",
+  },
+
+  hilsen: {
+    [Malform.BOKMAL]: "Med vennlig hilsen",
+    [Malform.NYNORSK]: "Vennleg helsing",
   },
 };
 
@@ -92,9 +133,18 @@ export const avlysningTexts = {
 };
 
 export const commonTexts = {
-  arbeidsgiverTitle: "Arbeidsgiver",
-  moteTidTitle: "Møtetidspunkt",
-  moteStedTitle: "Møtested",
+  arbeidsgiverTitle: {
+    [Malform.BOKMAL]: "Arbeidsgiver",
+    [Malform.NYNORSK]: "Arbeidsgivar",
+  },
+  moteTidTitle: {
+    [Malform.BOKMAL]: "Møtetidspunkt",
+    [Malform.NYNORSK]: "Møtetidspunkt",
+  },
+  moteStedTitle: {
+    [Malform.BOKMAL]: "Møtested",
+    [Malform.NYNORSK]: "Møtestad",
+  },
   videoLinkTitle: "Lenke til videomøte",
   arbeidsgiverTlfLabel: "Arbeidsgivertelefonen",
   arbeidsgiverTlf: "55 55 33 36",

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -1,57 +1,23 @@
 import { Malform } from "../../context/malform/MalformContext";
 
-export const innkallingTexts = {
+const innkallingTextsBokmal = {
   arbeidstaker: {
-    intro1: {
-      [Malform.BOKMAL]:
-        "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre.",
-      [Malform.NYNORSK]:
-        "Velkomen til dialogmøte mellom deg, arbeidsgivaren din og ein rettleiar frå NAV. I møtet kjem vi til å snakke om situasjonen din og bli samde om ein plan som kan hjelpe deg vidare.",
-    },
-    intro2: {
-      [Malform.BOKMAL]:
-        "I møtet vil vi høre både hva du og arbeidsgiveren sier om arbeidssituasjonen og mulighetene for å jobbe.",
-      [Malform.NYNORSK]:
-        "Vi ønskjer å høyre kva du og arbeidsgivaren seier om arbeidssituasjonen og moglegheitene for å jobbe.",
-    },
-    intro2WithBehandler: {
-      [Malform.BOKMAL]:
-        "I møtet vil vi høre både hva du, arbeidsgiveren og behandleren sier om arbeidssituasjonen og mulighetene for å jobbe.",
-      [Malform.NYNORSK]:
-        "Vi ønskjer å høyre kva du, arbeidsgivaren og behandlarane seier om arbeidssituasjonen og moglegheitene for å jobbe.", // TODO: behandlarane -> behandlaren?
-    },
-    outroObligatorisk: {
-      [Malform.BOKMAL]: "Det er obligatorisk å delta i dialogmøtet.",
-      [Malform.NYNORSK]: "Det er obligatorisk å delta i dialogmøtet.",
-    },
-    outro1: {
-      [Malform.BOKMAL]:
-        "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi ikke sett behov for det.",
-      [Malform.NYNORSK]:
-        "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",
-    },
-    outro1WithBehandler: {
-      [Malform.BOKMAL]:
-        "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å innkalle",
-      [Malform.NYNORSK]:
-        "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi sett behov for å kalle inn sjukmeldar ",
-    },
-    outro2Title: {
-      [Malform.BOKMAL]: "Før møtet",
-      [Malform.NYNORSK]: "Før møtet",
-    },
-    outro2: {
-      [Malform.BOKMAL]:
-        "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
-      [Malform.NYNORSK]:
-        "Det er viktig at de fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
-    },
-    outro2WithBehandler: {
-      [Malform.BOKMAL]:
-        "Det er viktig at du og arbeidsgiveren din fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
-      [Malform.NYNORSK]:
-        "Det er viktig at du og arbeidsgivaren din fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke saman om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
-    },
+    intro1:
+      "Velkommen til dialogmøte mellom deg, arbeidsgiveren din og en veileder fra NAV. I møtet skal vi snakke om situasjonen din og bli enige om en plan som kan hjelpe deg videre.",
+    intro2:
+      "I møtet vil vi høre både hva du og arbeidsgiveren sier om arbeidssituasjonen og mulighetene for å jobbe.",
+    intro2WithBehandler:
+      "I møtet vil vi høre både hva du, arbeidsgiveren og behandleren sier om arbeidssituasjonen og mulighetene for å jobbe.",
+    outroObligatorisk: "Det er obligatorisk å delta i dialogmøtet.",
+    outro1:
+      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi ikke sett behov for det.",
+    outro1WithBehandler:
+      "Fastlegen eller en annen behandler kan bli invitert til å delta i dialogmøte. Til dette møtet har vi sett behov for å innkalle",
+    outro2Title: "Før møtet",
+    outro2:
+      "Det er viktig at dere fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
+    outro2WithBehandler:
+      "Det er viktig at du og arbeidsgiveren din fyller ut oppfølgingsplanen sammen og deler den med NAV. Den gir oss et godt utgangspunkt for å snakke om hva som fungerer, hva som har blitt forsøkt, og hvilke muligheter som finnes framover.",
   },
   arbeidsgiver: {
     intro1:
@@ -70,16 +36,68 @@ export const innkallingTexts = {
   },
 
   behandler: {
+    header: "Innkalling til dialogmøte, svar ønskes",
     intro:
       "Vi ønsker svar fra deg om du kan stille til møtet. Det er i utgangspunktet obligatorisk å delta i dialogmøtet, men tidspunktet kan endres eller møtet kan avlyses ved behov.",
     outro:
       "Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS.",
   },
 
-  hilsen: {
-    [Malform.BOKMAL]: "Med vennlig hilsen",
-    [Malform.NYNORSK]: "Vennleg helsing",
+  hilsen: "Med vennlig hilsen",
+  gjelder: "Gjelder",
+};
+
+const innkallingTextsNynorsk = {
+  arbeidstaker: {
+    intro1:
+      "Velkomen til dialogmøte mellom deg, arbeidsgivaren din og ein rettleiar frå NAV. I møtet kjem vi til å snakke om situasjonen din og bli samde om ein plan som kan hjelpe deg vidare.",
+    intro2:
+      "Vi ønskjer å høyre kva du og arbeidsgivaren seier om arbeidssituasjonen og moglegheitene for å jobbe.",
+    intro2WithBehandler:
+      "Vi ønskjer å høyre kva du, arbeidsgivaren og behandlarane seier om arbeidssituasjonen og moglegheitene for å jobbe.", // TODO: behandlarane -> behandlaren?
+    outroObligatorisk: "Det er obligatorisk å delta i dialogmøtet.",
+    outro1:
+      "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",
+    outro1WithBehandler:
+      "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi sett behov for å kalle inn",
+    outro2Title: "Før møtet",
+    outro2:
+      "Det er viktig at de fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+    outro2WithBehandler:
+      "Det er viktig at du og arbeidsgivaren din fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke saman om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
   },
+  arbeidsgiver: {
+    intro1:
+      "Velkomen til dialogmøte mellom deg, arbeidstakaren din og ein rettleiar frå NAV. I møtet kjem vi til å snakke om arbeidssituasjonen til arbeidstakaren din og moglegheitene vedkomande har til å jobbe. Målet er å bli samde om ein plan som kan hjelpe arbeidstakaren din vidare.",
+    outroObligatorisk:
+      "Det er obligatorisk å delta i dialogmøtet. Gi oss svar om tidspunktet passar eller ikkje. Vi minner om at sensitive personopplysningar ikkje skal sendast på e-post eller SMS.",
+    outro1:
+      "Fastlegen eller ein annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",
+    outro1WithBehandler:
+      "Fastlege eller annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi sett behov for å kalle inn",
+    outro2Title: "Før møtet",
+    outro2:
+      "Det er viktig at de fyller ut oppfølgingsplanen saman og deler han med NAV seinast éi veke før møtet. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+    outro2WithBehandler:
+      "Det er viktig at du og arbeidstakaren din fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+  },
+
+  behandler: {
+    header: "Innkalling til dialogmøte (ønskje om svar)",
+    intro:
+      "Vi ønskjer svar frå deg om du kan stille til møtet. Det er i utgangspunktet obligatorisk å delta i dialogmøtet, men tidspunktet kan endrast eller møtet kan avlysast ved behov.",
+    outro:
+      "Vi minner om at sensitive personopplysningar ikkje skal sendast på e-post eller SMS.",
+  },
+
+  hilsen: "Vennleg helsing",
+  gjelder: "Gjeld",
+};
+
+export const getInnkallingTexts = (malform: Malform) => {
+  return malform === Malform.NYNORSK
+    ? innkallingTextsNynorsk
+    : innkallingTextsBokmal;
 };
 
 export const endreTidStedTexts = {
@@ -132,22 +150,26 @@ export const avlysningTexts = {
   intro2: "Dette møtet er avlyst.",
 };
 
-export const commonTexts = {
-  arbeidsgiverTitle: {
-    [Malform.BOKMAL]: "Arbeidsgiver",
-    [Malform.NYNORSK]: "Arbeidsgivar",
-  },
-  moteTidTitle: {
-    [Malform.BOKMAL]: "Møtetidspunkt",
-    [Malform.NYNORSK]: "Møtetidspunkt",
-  },
-  moteStedTitle: {
-    [Malform.BOKMAL]: "Møtested",
-    [Malform.NYNORSK]: "Møtestad",
-  },
+export const commonTextsBokmal = {
+  arbeidsgiverTitle: "Arbeidsgiver",
+  moteTidTitle: "Møtetidspunkt",
+  moteStedTitle: "Møtested",
   videoLinkTitle: "Lenke til videomøte",
   arbeidsgiverTlfLabel: "Arbeidsgivertelefonen",
   arbeidsgiverTlf: "55 55 33 36",
+};
+
+const commonTextsNynorsk = {
+  arbeidsgiverTitle: "Arbeidsgivar",
+  moteTidTitle: "Møtetidspunkt",
+  moteStedTitle: "Møtestad",
+  videoLinkTitle: "Lenke til videomøte",
+  arbeidsgiverTlfLabel: "Arbeidsgivartelefonen",
+  arbeidsgiverTlf: "55 55 33 36",
+};
+
+export const getCommonTexts = (malform: Malform) => {
+  return malform === Malform.NYNORSK ? commonTextsNynorsk : commonTextsBokmal;
 };
 
 // Disse nøklene knyttes til linker i eSyfo og skal ikke endres.

--- a/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
+++ b/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
@@ -2,7 +2,7 @@ import {
   createLink,
   createParagraphWithTitle,
 } from "@/utils/documentComponentUtils";
-import { commonTexts } from "@/data/dialogmote/dialogmoteTexts";
+import { getCommonTexts } from "@/data/dialogmote/dialogmoteTexts";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { TidStedSkjemaValues } from "@/data/dialogmote/types/skjemaTypes";
 import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
@@ -23,11 +23,10 @@ export const useDialogmoteDocumentComponents = () => {
       virksomhetsnummer &&
       getCurrentNarmesteLeder(virksomhetsnummer)?.virksomhetsnavn;
 
+    const commonTexts = getCommonTexts(malform ? malform : Malform.BOKMAL);
+
     return arbeidsgiver
-      ? createParagraphWithTitle(
-          commonTexts.arbeidsgiverTitle[malform ? malform : Malform.BOKMAL],
-          arbeidsgiver
-        )
+      ? createParagraphWithTitle(commonTexts.arbeidsgiverTitle, arbeidsgiver)
       : undefined;
   };
 
@@ -37,6 +36,7 @@ export const useDialogmoteDocumentComponents = () => {
     malform?: Malform
   ) => {
     const { dato, klokkeslett, sted, videoLink } = values;
+    const commonTexts = getCommonTexts(malform ? malform : Malform.BOKMAL);
     const tidStedTekst =
       dato && klokkeslett
         ? tilDatoMedUkedagOgManedNavnOgKlokkeslett(
@@ -46,16 +46,10 @@ export const useDialogmoteDocumentComponents = () => {
         : "";
     const components: DocumentComponentDto[] = [];
     components.push(
-      createParagraphWithTitle(
-        commonTexts.moteTidTitle[malform ? malform : Malform.BOKMAL],
-        tidStedTekst
-      )
+      createParagraphWithTitle(commonTexts.moteTidTitle, tidStedTekst)
     );
     components.push(
-      createParagraphWithTitle(
-        commonTexts.moteStedTitle[malform ? malform : Malform.BOKMAL],
-        sted || ""
-      )
+      createParagraphWithTitle(commonTexts.moteStedTitle, sted || "")
     );
     if (videoLink) {
       components.push(createLink(commonTexts.videoLinkTitle, videoLink));

--- a/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
+++ b/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
@@ -9,46 +9,59 @@ import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { genererDato } from "@/sider/mote/utils";
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
+import { Malform } from "@/context/malform/MalformContext";
 
 export const useDialogmoteDocumentComponents = () => {
   const { getHilsen, getIntroGjelder, getIntroHei } = useDocumentComponents();
   const { getCurrentNarmesteLeder } = useLedereQuery();
 
   const getVirksomhetsnavn = (
-    virksomhetsnummer: string | undefined
+    virksomhetsnummer: string | undefined,
+    malform?: Malform
   ): DocumentComponentDto | undefined => {
     const arbeidsgiver =
       virksomhetsnummer &&
       getCurrentNarmesteLeder(virksomhetsnummer)?.virksomhetsnavn;
 
     return arbeidsgiver
-      ? createParagraphWithTitle(commonTexts.arbeidsgiverTitle, arbeidsgiver)
+      ? createParagraphWithTitle(
+          commonTexts.arbeidsgiverTitle[malform ? malform : Malform.BOKMAL],
+          arbeidsgiver
+        )
       : undefined;
   };
 
   const getMoteInfo = (
     values: Partial<TidStedSkjemaValues>,
-    virksomhetsnummer: string | undefined
+    virksomhetsnummer: string | undefined,
+    malform?: Malform
   ) => {
     const { dato, klokkeslett, sted, videoLink } = values;
     const tidStedTekst =
       dato && klokkeslett
         ? tilDatoMedUkedagOgManedNavnOgKlokkeslett(
-            genererDato(dato, klokkeslett)
+            genererDato(dato, klokkeslett),
+            malform
           )
         : "";
     const components: DocumentComponentDto[] = [];
     components.push(
-      createParagraphWithTitle(commonTexts.moteTidTitle, tidStedTekst)
+      createParagraphWithTitle(
+        commonTexts.moteTidTitle[malform ? malform : Malform.BOKMAL],
+        tidStedTekst
+      )
     );
     components.push(
-      createParagraphWithTitle(commonTexts.moteStedTitle, sted || "")
+      createParagraphWithTitle(
+        commonTexts.moteStedTitle[malform ? malform : Malform.BOKMAL],
+        sted || ""
+      )
     );
     if (videoLink) {
       components.push(createLink(commonTexts.videoLinkTitle, videoLink));
     }
 
-    const virksomhetsnavn = getVirksomhetsnavn(virksomhetsnummer);
+    const virksomhetsnavn = getVirksomhetsnavn(virksomhetsnummer, malform);
     if (virksomhetsnavn) {
       components.push(virksomhetsnavn);
     }

--- a/src/hooks/dialogmote/document/useInnkallingDocument.ts
+++ b/src/hooks/dialogmote/document/useInnkallingDocument.ts
@@ -10,7 +10,6 @@ import {
   createParagraphWithTitle,
 } from "@/utils/documentComponentUtils";
 import { BehandlerDTO } from "@/data/behandler/BehandlerDTO";
-import { capitalizeWord } from "@/utils/stringUtils";
 import { behandlerNavn } from "@/utils/behandlerUtils";
 import { useDialogmoteDocumentComponents } from "@/hooks/dialogmote/document/useDialogmoteDocumentComponents";
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
@@ -153,7 +152,7 @@ const arbeidstakerIntro = (
   ];
 };
 
-const addBehandlerTypeAndName = (
+export const addBehandlerTypeAndName = (
   preText: string,
   valgtBehandler: BehandlerDTO
 ) => {

--- a/src/hooks/dialogmote/document/useReferatDocument.ts
+++ b/src/hooks/dialogmote/document/useReferatDocument.ts
@@ -25,6 +25,7 @@ import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
+import { Malform } from "@/context/malform/MalformContext";
 
 export interface IReferatDocument {
   getReferatDocument(
@@ -124,10 +125,13 @@ const info = (
   return [
     createParagraph(`F.nr. ${personident}`),
     createParagraphWithTitle(
-      commonTexts.moteTidTitle,
+      commonTexts.moteTidTitle[Malform.BOKMAL],
       tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)
     ),
-    createParagraphWithTitle(commonTexts.moteStedTitle, dialogmote.sted),
+    createParagraphWithTitle(
+      commonTexts.moteStedTitle[Malform.BOKMAL],
+      dialogmote.sted
+    ),
     createParagraphWithTitle(
       referatTexts.deltakereTitle,
       ...deltakereTekst,

--- a/src/hooks/dialogmote/document/useReferatDocument.ts
+++ b/src/hooks/dialogmote/document/useReferatDocument.ts
@@ -28,7 +28,6 @@ import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
-import { Malform } from "@/context/malform/MalformContext";
 
 export interface IReferatDocument {
   getReferatDocument(
@@ -128,13 +127,10 @@ const info = (
   return [
     createParagraph(`F.nr. ${personident}`),
     createParagraphWithTitle(
-      commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
+      commonTextsBokmal.moteTidTitle,
       tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)
     ),
-    createParagraphWithTitle(
-      commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
-      dialogmote.sted
-    ),
+    createParagraphWithTitle(commonTextsBokmal.moteStedTitle, dialogmote.sted),
     createParagraphWithTitle(
       referatTexts.deltakereTitle,
       ...deltakereTekst,

--- a/src/hooks/dialogmote/document/useReferatDocument.ts
+++ b/src/hooks/dialogmote/document/useReferatDocument.ts
@@ -16,7 +16,10 @@ import {
 } from "@/utils/documentComponentUtils";
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { VeilederinfoDTO } from "@/data/veilederinfo/types/VeilederinfoDTO";
-import { commonTexts, referatTexts } from "@/data/dialogmote/dialogmoteTexts";
+import {
+  commonTextsBokmal,
+  referatTexts,
+} from "@/data/dialogmote/dialogmoteTexts";
 import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { behandlerDeltokTekst } from "@/utils/behandlerUtils";
 import { useDialogmoteDocumentComponents } from "@/hooks/dialogmote/document/useDialogmoteDocumentComponents";
@@ -125,11 +128,11 @@ const info = (
   return [
     createParagraph(`F.nr. ${personident}`),
     createParagraphWithTitle(
-      commonTexts.moteTidTitle[Malform.BOKMAL],
+      commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
       tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)
     ),
     createParagraphWithTitle(
-      commonTexts.moteStedTitle[Malform.BOKMAL],
+      commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
       dialogmote.sted
     ),
     createParagraphWithTitle(

--- a/src/hooks/dialogmote/document/useTidStedDocument.ts
+++ b/src/hooks/dialogmote/document/useTidStedDocument.ts
@@ -6,7 +6,7 @@ import {
 } from "@/utils/documentComponentUtils";
 import { tilDatoMedManedNavnOgKlokkeslettWithComma } from "@/utils/datoUtils";
 import {
-  commonTexts,
+  commonTextsBokmal,
   endreTidStedTexts,
 } from "@/data/dialogmote/dialogmoteTexts";
 import {
@@ -89,8 +89,8 @@ export const useTidStedDocument = (
       ),
       getHilsen(),
       createParagraph(
-        commonTexts.arbeidsgiverTlfLabel,
-        commonTexts.arbeidsgiverTlf
+        commonTextsBokmal.arbeidsgiverTlfLabel,
+        commonTextsBokmal.arbeidsgiverTlf
       )
     );
 

--- a/src/utils/behandlerUtils.ts
+++ b/src/utils/behandlerUtils.ts
@@ -15,9 +15,7 @@ export const behandlerDeltakerTekst = (
   pretekst: string,
   behandler: DialogmotedeltakerBehandlerDTO
 ) => {
-  return `${pretekst} ${capitalizeWord(
-    behandler.behandlerType.toLowerCase() ?? ""
-  )} ${behandler.behandlerNavn}`;
+  return `${pretekst} ${behandler.behandlerNavn}`;
 };
 
 export const behandlerDeltokTekst = (

--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -1,5 +1,6 @@
 import { firstLetterToUpperCase } from "./stringUtils";
 import dayjs from "dayjs";
+import { Malform } from "../context/malform/MalformContext";
 
 const maneder = [
   "januar",
@@ -23,6 +24,16 @@ const dager = [
   "Torsdag",
   "Fredag",
   "Lørdag",
+];
+
+const nynorskDager = [
+  "Søndag",
+  "Måndag",
+  "Tysdag",
+  "Onsdag",
+  "Torsdag",
+  "Fredag",
+  "Laurdag",
 ];
 
 const SKILLETEGN_PERIODE = "–";
@@ -116,14 +127,21 @@ export const tilDatoMedManedNavn = (dato): string => {
   return `${dag}. ${maaned} ${aar}`;
 };
 
-export const tilDatoMedUkedagOgManedNavn = (dato): string => {
-  const { ukeDag, dag, maaned, aar } = getDatoKomponenter(dato);
+export const tilDatoMedUkedagOgManedNavn = (
+  dato: Date | string,
+  malform?: Malform
+): string => {
+  const { ukeDag, dag, maaned, aar } = getDatoKomponenter(dato, malform);
   return `${ukeDag} ${dag}. ${maaned} ${aar}`;
 };
 
-export const getDatoKomponenter = (dato) => {
+export const getDatoKomponenter = (dato: Date | string, malform?: Malform) => {
   const nyDato = new Date(dato);
-  const ukeDag = firstLetterToUpperCase(dager[nyDato.getDay()]);
+  const ukeDag = firstLetterToUpperCase(
+    malform !== Malform.NYNORSK
+      ? dager[nyDato.getDay()]
+      : nynorskDager[nyDato.getDay()]
+  );
   const dag = nyDato.getDate();
   const maaned = maneder[nyDato.getMonth()];
   const aar = nyDato.getFullYear();
@@ -149,9 +167,12 @@ export const tilDatoMedManedNavnOgKlokkeslett = (dato): string => {
   return `${date} kl. ${time}`;
 };
 
-export const tilDatoMedUkedagOgManedNavnOgKlokkeslett = (dato): string => {
+export const tilDatoMedUkedagOgManedNavnOgKlokkeslett = (
+  dato: Date | string,
+  malform?: Malform
+): string => {
   const newDate = new Date(dato);
-  const date = tilDatoMedUkedagOgManedNavn(newDate);
+  const date = tilDatoMedUkedagOgManedNavn(newDate, malform);
   const time = visKlokkeslett(newDate);
   return `${date} kl. ${time}`;
 };

--- a/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
@@ -21,6 +21,7 @@ import userEvent from "@testing-library/user-event";
 import { expectedAvlysningDocuments } from "./testDataDocuments";
 import { queryClientWithMockData } from "../testQueryClient";
 import { renderWithRouter } from "../testRouterUtils";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 let queryClient: QueryClient;
 
@@ -369,7 +370,9 @@ describe("AvlysDialogmoteSkjemaTest", () => {
 const renderAvlysDialogmoteSkjema = (dialogmote: DialogmoteDTO) => {
   return renderWithRouter(
     <QueryClientProvider client={queryClient}>
-      <AvlysDialogmoteSkjema dialogmote={dialogmote} pageTitle="test" />
+      <MalformProvider>
+        <AvlysDialogmoteSkjema dialogmote={dialogmote} pageTitle="test" />
+      </MalformProvider>
     </QueryClientProvider>,
     `${dialogmoteRoutePath}/:dialogmoteUuid/avlys`,
     [`${dialogmoteRoutePath}/123abc/avlys`]

--- a/test/dialogmote/DialogmoteInnkallingContainerTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingContainerTest.tsx
@@ -17,6 +17,7 @@ import {
 import { expect } from "chai";
 import { daysFromToday } from "../testUtils";
 import { navEnhet } from "./testData";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 let queryClient: QueryClient;
 
@@ -52,7 +53,9 @@ const renderDialogmoteInnkallingContainer = () =>
         <ValgtEnhetContext.Provider
           value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
         >
-          <DialogmoteInnkallingSide />
+          <MalformProvider>
+            <DialogmoteInnkallingSide />
+          </MalformProvider>
         </ValgtEnhetContext.Provider>
       </QueryClientProvider>
     </MemoryRouter>

--- a/test/dialogmote/DialogmoteInnkallingSkjema/BehandlerInnkallingTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/BehandlerInnkallingTest.tsx
@@ -31,6 +31,7 @@ import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { behandlereQueryKeys } from "@/data/behandler/behandlereQueryHooks";
 import { renderWithRouter } from "../../testRouterUtils";
 import { stubFeatureTogglesApi } from "../../stubs/stubUnleash";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 let queryClient: QueryClient;
 let apiMockScope;
@@ -157,7 +158,9 @@ const renderDialogmoteInnkallingSkjema = () => {
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <DialogmoteInnkallingSkjema />
+        <MalformProvider>
+          <DialogmoteInnkallingSkjema />
+        </MalformProvider>
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
     dialogmoteRoutePath,

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingPreviewTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingPreviewTest.tsx
@@ -23,6 +23,7 @@ import { behandlereQueryKeys } from "@/data/behandler/behandlereQueryHooks";
 import { renderWithRouter } from "../../testRouterUtils";
 import { stubFeatureTogglesApi } from "../../stubs/stubUnleash";
 import { apiMock } from "../../stubs/stubApi";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 let queryClient: any;
 let mockApiScope;
@@ -163,7 +164,9 @@ const renderDialogmoteInnkallingSkjema = () =>
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <DialogmoteInnkallingSkjema />
+        <MalformProvider>
+          <DialogmoteInnkallingSkjema />
+        </MalformProvider>
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
     dialogmoteRoutePath,

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
@@ -30,6 +30,7 @@ import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/p
 import { OppfolgingstilfellePersonDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
 import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 let queryClient: QueryClient;
 
@@ -263,7 +264,9 @@ const renderDialogmoteInnkallingSkjema = () => {
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <DialogmoteInnkallingSkjema />
+        <MalformProvider>
+          <DialogmoteInnkallingSkjema />
+        </MalformProvider>
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
     dialogmoteRoutePath,

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
@@ -30,9 +30,27 @@ import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/p
 import { OppfolgingstilfellePersonDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
 import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
-import { MalformProvider } from "@/context/malform/MalformContext";
+import { Malform, MalformProvider } from "@/context/malform/MalformContext";
+import userEvent from "@testing-library/user-event";
+import { getInnkallingTexts } from "@/data/dialogmote/dialogmoteTexts";
 
 let queryClient: QueryClient;
+
+const renderDialogmoteInnkallingSkjema = () => {
+  return renderWithRouter(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <MalformProvider>
+          <DialogmoteInnkallingSkjema />
+        </MalformProvider>
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>,
+    dialogmoteRoutePath,
+    [dialogmoteRoutePath]
+  );
+};
 
 describe("DialogmoteInnkallingSkjema", () => {
   let clock: any;
@@ -256,23 +274,25 @@ describe("DialogmoteInnkallingSkjema", () => {
     );
     expect(videoLink).to.equal(link);
   });
-});
 
-const renderDialogmoteInnkallingSkjema = () => {
-  return renderWithRouter(
-    <QueryClientProvider client={queryClient}>
-      <ValgtEnhetContext.Provider
-        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
-      >
-        <MalformProvider>
-          <DialogmoteInnkallingSkjema />
-        </MalformProvider>
-      </ValgtEnhetContext.Provider>
-    </QueryClientProvider>,
-    dialogmoteRoutePath,
-    [dialogmoteRoutePath]
-  );
-};
+  it("velger nynorske brev og endrer tekstene", () => {
+    renderDialogmoteInnkallingSkjema();
+
+    const malformRadio = screen.getByRole("radio", {
+      name: "Nynorsk",
+    });
+    userEvent.click(malformRadio);
+
+    const forhandsvisningButton = screen.getAllByRole("button", {
+      name: "Forhåndsvisning",
+    })[0];
+    userEvent.click(forhandsvisningButton);
+
+    expect(
+      screen.getByText(getInnkallingTexts(Malform.NYNORSK).arbeidstaker.intro2)
+    ).to.exist;
+  });
+});
 
 const passSkjemaInput = () => {
   const virksomhetSelect = screen.getByRole("radio", {

--- a/test/dialogmote/DialogmoteInnkallingTeksterTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingTeksterTest.tsx
@@ -13,6 +13,7 @@ import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
 import { brukerinfoMock } from "../../mock/syfoperson/persondataMock";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 const queryClient = queryClientWithAktivBruker();
 
@@ -55,7 +56,9 @@ const renderDialogmoteInnkallingTekster = (navBrukerKanVarsles: boolean) => {
             }}
           >
             {() => (
-              <DialogmoteInnkallingTekster selectedBehandler={undefined} />
+              <MalformProvider>
+                <DialogmoteInnkallingTekster selectedBehandler={undefined} />
+              </MalformProvider>
             )}
           </Form>
         </ValgtEnhetContext.Provider>

--- a/test/dialogmote/testData.ts
+++ b/test/dialogmote/testData.ts
@@ -19,7 +19,6 @@ import {
   VEILEDER_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../../mock/common/mockConstants";
-import { capitalizeWord } from "@/utils/stringUtils";
 import { behandlerNavn } from "@/utils/behandlerUtils";
 import { referatTexts } from "@/data/dialogmote/dialogmoteTexts";
 import { BehandlerDTO, BehandlerType } from "@/data/behandler/BehandlerDTO";
@@ -177,9 +176,7 @@ const begrunnelseEndring = "Noe tekst om hvorfor referatet endres";
 
 export const annenDeltakerNavn = "Bodil Bolle";
 export const annenDeltakerFunksjon = "Verneombud";
-export const behandlerDeltakerTekst = `Behandler: ${capitalizeWord(
-  behandler.type.toLowerCase()
-)} ${behandlerNavn(behandler)}`;
+export const behandlerDeltakerTekst = `Behandler: ${behandlerNavn(behandler)}`;
 
 export const mote = {
   sted: moteSted,

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -29,6 +29,7 @@ import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
+import { Malform } from "@/context/malform/MalformContext";
 
 const behandlerTypeNavnText = `${capitalizeWord(
   behandler.type.toLowerCase()
@@ -51,12 +52,12 @@ const expectedArbeidstakerInnkalling = (
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTexts.moteTidTitle,
+    title: commonTexts.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTexts.moteStedTitle,
+    title: commonTexts.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -74,14 +75,14 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.arbeidstaker.intro1],
+    texts: [innkallingTexts.arbeidstaker.intro1[Malform.BOKMAL]],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? innkallingTexts.arbeidstaker.intro2WithBehandler
-        : innkallingTexts.arbeidstaker.intro2,
+        ? innkallingTexts.arbeidstaker.intro2WithBehandler[Malform.BOKMAL]
+        : innkallingTexts.arbeidstaker.intro2[Malform.BOKMAL],
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
@@ -90,24 +91,26 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.arbeidstaker.outroObligatorisk],
+    texts: [innkallingTexts.arbeidstaker.outroObligatorisk[Malform.BOKMAL]],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? `${innkallingTexts.arbeidstaker.outro1WithBehandler} ${behandlerTypeNavnText}.`
-        : innkallingTexts.arbeidstaker.outro1,
+        ? `${
+            innkallingTexts.arbeidstaker.outro1WithBehandler[Malform.BOKMAL]
+          } ${behandlerTypeNavnText}.`
+        : innkallingTexts.arbeidstaker.outro1[Malform.BOKMAL],
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? innkallingTexts.arbeidstaker.outro2WithBehandler
-        : innkallingTexts.arbeidstaker.outro2,
+        ? innkallingTexts.arbeidstaker.outro2WithBehandler[Malform.BOKMAL]
+        : innkallingTexts.arbeidstaker.outro2[Malform.BOKMAL],
     ],
-    title: innkallingTexts.arbeidstaker.outro2Title,
+    title: innkallingTexts.arbeidstaker.outro2Title[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -133,12 +136,12 @@ const expectedArbeidsgiverInnkalling = (
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTexts.moteTidTitle,
+    title: commonTexts.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTexts.moteStedTitle,
+    title: commonTexts.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -213,12 +216,12 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTexts.moteTidTitle,
+    title: commonTexts.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTexts.moteStedTitle,
+    title: commonTexts.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -628,12 +631,12 @@ export const expectedReferatDocument = (): DocumentComponentDto[] => [
   },
   {
     texts: [tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)],
-    title: commonTexts.moteTidTitle,
+    title: commonTexts.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [dialogmote.sted],
-    title: commonTexts.moteStedTitle,
+    title: commonTexts.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -728,12 +731,12 @@ export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
   },
   {
     texts: [tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)],
-    title: commonTexts.moteTidTitle,
+    title: commonTexts.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [dialogmote.sted],
-    title: commonTexts.moteStedTitle,
+    title: commonTexts.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -13,7 +13,7 @@ import {
 } from "./testData";
 import {
   avlysningTexts,
-  commonTexts,
+  commonTextsBokmal,
   endreTidStedTexts,
   innkallingTexts,
   referatTexts,
@@ -52,17 +52,17 @@ const expectedArbeidstakerInnkalling = (
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTexts.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTexts.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.videolink],
-    title: commonTexts.videoLinkTitle,
+    title: commonTextsBokmal.videoLinkTitle,
     type: DocumentComponentType.LINK,
   },
   {
@@ -136,17 +136,17 @@ const expectedArbeidsgiverInnkalling = (
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTexts.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTexts.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.videolink],
-    title: commonTexts.videoLinkTitle,
+    title: commonTextsBokmal.videoLinkTitle,
     type: DocumentComponentType.LINK,
   },
   {
@@ -192,7 +192,10 @@ const expectedArbeidsgiverInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [commonTexts.arbeidsgiverTlfLabel, commonTexts.arbeidsgiverTlf],
+    texts: [
+      commonTextsBokmal.arbeidsgiverTlfLabel,
+      commonTextsBokmal.arbeidsgiverTlf,
+    ],
     type: DocumentComponentType.PARAGRAPH,
   },
 ];
@@ -216,17 +219,17 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTexts.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTexts.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.videolink],
-    title: commonTexts.videoLinkTitle,
+    title: commonTextsBokmal.videoLinkTitle,
     type: DocumentComponentType.LINK,
   },
   {
@@ -631,12 +634,12 @@ export const expectedReferatDocument = (): DocumentComponentDto[] => [
   },
   {
     texts: [tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)],
-    title: commonTexts.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [dialogmote.sted],
-    title: commonTexts.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -731,12 +734,12 @@ export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
   },
   {
     texts: [tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)],
-    title: commonTexts.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [dialogmote.sted],
-    title: commonTexts.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
     type: DocumentComponentType.PARAGRAPH,
   },
   {

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -15,7 +15,7 @@ import {
   avlysningTexts,
   commonTextsBokmal,
   endreTidStedTexts,
-  innkallingTexts,
+  getInnkallingTexts,
   referatTexts,
 } from "@/data/dialogmote/dialogmoteTexts";
 import {
@@ -23,17 +23,15 @@ import {
   tilDatoMedUkedagOgManedNavnOgKlokkeslett,
 } from "@/utils/datoUtils";
 import { genererDato } from "@/sider/mote/utils";
-import { capitalizeWord } from "@/utils/stringUtils";
-import { behandlerNavn } from "@/utils/behandlerUtils";
 import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
 import { Malform } from "@/context/malform/MalformContext";
+import { addBehandlerTypeAndName } from "@/hooks/dialogmote/document/useInnkallingDocument";
+import { behandlerNavn } from "@/utils/behandlerUtils";
 
-const behandlerTypeNavnText = `${capitalizeWord(
-  behandler.type.toLowerCase()
-)} ${behandlerNavn(behandler)}`;
+const innkallingTextsBokmal = getInnkallingTexts(Malform.BOKMAL);
 
 const expectedArbeidstakerInnkalling = (
   medBehandler = false
@@ -52,12 +50,12 @@ const expectedArbeidstakerInnkalling = (
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -75,14 +73,14 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.arbeidstaker.intro1[Malform.BOKMAL]],
+    texts: [innkallingTextsBokmal.arbeidstaker.intro1],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? innkallingTexts.arbeidstaker.intro2WithBehandler[Malform.BOKMAL]
-        : innkallingTexts.arbeidstaker.intro2[Malform.BOKMAL],
+        ? innkallingTextsBokmal.arbeidstaker.intro2WithBehandler
+        : innkallingTextsBokmal.arbeidstaker.intro2,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
@@ -91,26 +89,27 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.arbeidstaker.outroObligatorisk[Malform.BOKMAL]],
+    texts: [innkallingTextsBokmal.arbeidstaker.outroObligatorisk],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? `${
-            innkallingTexts.arbeidstaker.outro1WithBehandler[Malform.BOKMAL]
-          } ${behandlerTypeNavnText}.`
-        : innkallingTexts.arbeidstaker.outro1[Malform.BOKMAL],
+        ? addBehandlerTypeAndName(
+            innkallingTextsBokmal.arbeidstaker.outro1WithBehandler,
+            behandler
+          )
+        : innkallingTextsBokmal.arbeidstaker.outro1,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? innkallingTexts.arbeidstaker.outro2WithBehandler[Malform.BOKMAL]
-        : innkallingTexts.arbeidstaker.outro2[Malform.BOKMAL],
+        ? innkallingTextsBokmal.arbeidstaker.outro2WithBehandler
+        : innkallingTextsBokmal.arbeidstaker.outro2,
     ],
-    title: innkallingTexts.arbeidstaker.outro2Title[Malform.BOKMAL],
+    title: innkallingTextsBokmal.arbeidstaker.outro2Title,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -136,12 +135,12 @@ const expectedArbeidsgiverInnkalling = (
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -159,7 +158,7 @@ const expectedArbeidsgiverInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.arbeidsgiver.intro1],
+    texts: [innkallingTextsBokmal.arbeidsgiver.intro1],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -167,23 +166,26 @@ const expectedArbeidsgiverInnkalling = (
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.arbeidsgiver.outroObligatorisk],
+    texts: [innkallingTextsBokmal.arbeidsgiver.outroObligatorisk],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? `${innkallingTexts.arbeidsgiver.outro1WithBehandler} ${behandlerTypeNavnText}.`
-        : innkallingTexts.arbeidsgiver.outro1,
+        ? addBehandlerTypeAndName(
+            innkallingTextsBokmal.arbeidsgiver.outro1WithBehandler,
+            behandler
+          )
+        : innkallingTextsBokmal.arbeidsgiver.outro1,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    title: innkallingTexts.arbeidsgiver.outro2Title,
+    title: innkallingTextsBokmal.arbeidsgiver.outro2Title,
     texts: [
       medBehandler
-        ? innkallingTexts.arbeidsgiver.outro2WithBehandler
-        : innkallingTexts.arbeidsgiver.outro2,
+        ? innkallingTextsBokmal.arbeidsgiver.outro2WithBehandler
+        : innkallingTextsBokmal.arbeidsgiver.outro2,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
@@ -210,7 +212,7 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.behandler.intro],
+    texts: [innkallingTextsBokmal.behandler.intro],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -219,12 +221,12 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
         genererDato(mote.datoAsISODateString, mote.klokkeslett)
       ),
     ],
-    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.sted],
-    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -247,7 +249,7 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [innkallingTexts.behandler.outro],
+    texts: [innkallingTextsBokmal.behandler.outro],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -326,7 +328,9 @@ const expectedArbeidsgiverEndringsdokument = (
   {
     texts: [
       medBehandler
-        ? `${endreTidStedTexts.arbeidsgiver.outro2WithBehandler} ${behandlerTypeNavnText}.`
+        ? `${
+            endreTidStedTexts.arbeidsgiver.outro2WithBehandler
+          } ${behandlerNavn(behandler)}.`
         : endreTidStedTexts.arbeidsgiver.outro2,
     ],
     type: DocumentComponentType.PARAGRAPH,
@@ -420,7 +424,9 @@ const expectedArbeidstakerEndringsdokument = (
   {
     texts: [
       medBehandler
-        ? `${endreTidStedTexts.arbeidstaker.outro2WithBehandler} ${behandlerTypeNavnText}.`
+        ? `${
+            endreTidStedTexts.arbeidstaker.outro2WithBehandler
+          } ${behandlerNavn(behandler)}.`
         : endreTidStedTexts.arbeidstaker.outro2,
     ],
     type: DocumentComponentType.PARAGRAPH,
@@ -634,12 +640,12 @@ export const expectedReferatDocument = (): DocumentComponentDto[] => [
   },
   {
     texts: [tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)],
-    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [dialogmote.sted],
-    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -734,12 +740,12 @@ export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
   },
   {
     texts: [tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)],
-    title: commonTextsBokmal.moteTidTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteTidTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [dialogmote.sted],
-    title: commonTextsBokmal.moteStedTitle[Malform.BOKMAL],
+    title: commonTextsBokmal.moteStedTitle,
     type: DocumentComponentType.PARAGRAPH,
   },
   {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Her er et utkast for hvordan det kommer til å se ut. Tanken er at alle tekster skal være på formen `BOKMAL` eller `NYNORSK`, selv om det ikke er forskjell på tekstene. 
Det blir også noen anti-patterns her fordi det er mange brev i dialogmøte som bruker felleskomponenter, der kun innkallingen foreløpig skal ta i bruk målform. Feks må vi ta inn `malform` i noen metoder og sende nedover utils-funksjonene 😕 

Gjerne gi tilbakemelding i PR eller muntlig hvordan dere synes det fungerer!
Vi har basert tankegangen litt på denne artikkelen: https://blogg.bekk.no/lag-ditt-eget-typesikre-oversettelsesbibliotek-54f066348540

Se også context-state og localstorage-bruk her: https://github.com/navikt/syfomodiaperson/pull/1199

### Screenshots 📸✨
Slik ser velgeren ut per nå
<img width="1042" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/40820897-44ea-44dd-810f-f1df210d7469">
