### PR TITLE
Add tracking of open Flexjar-panel

### DIFF
--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -36,7 +36,7 @@ interface FlexjarProps {
 }
 
 export const Flexjar = ({ side }: FlexjarProps) => {
-  const [apen, setApen] = useState<boolean>(false);
+  const [isApen, setIsApen] = useState<boolean>(false);
   const [isValid, setIsValid] = useState<boolean>();
   const [feedback, setFeedback] = useState<string>();
   const [emojiType, setEmojiType] = useState<EmojiType>();
@@ -50,6 +50,19 @@ export const Flexjar = ({ side }: FlexjarProps) => {
       setIsValid(true);
     }
   }, [emojiType]);
+
+  const clickFeedbackPanel = () => {
+    if (!isApen) {
+      Amplitude.logEvent({
+        type: EventType.ButtonClick,
+        data: {
+          tekst: "Åpne Flexjarpanel",
+          url: window.location.href,
+        },
+      });
+    }
+    setIsApen(!isApen);
+  };
 
   const handleSubmit = () => {
     const svar = emojiType && `${emojis[emojiType].score}`;
@@ -84,13 +97,13 @@ export const Flexjar = ({ side }: FlexjarProps) => {
         variant="primary-neutral"
         size="small"
         iconPosition="right"
-        icon={apen ? <ChevronDownIcon /> : <ChevronUpIcon />}
-        onClick={() => setApen(!apen)}
+        icon={isApen ? <ChevronDownIcon /> : <ChevronUpIcon />}
+        onClick={clickFeedbackPanel}
         className="w-max"
       >
         {texts.apneKnapp}
       </Button>
-      {apen && (
+      {isApen && (
         <Box
           background={"surface-default"}
           borderColor="default"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi har ikke fått noen tilbakemeldinger på flexjar enda. Da Stine testet Flexjar tidligere så oppdaget vi ved én anledning at den ble sjult på fullskjerm av en eller annen grunn. Hvis vi tracker om panelet faktisk åpnes så kan vi se om vi mister folk på veien, eller om de bare aldri åpner panelet.

