### PR TITLE
IS-2036: Add NY sykmeldinger and show as "ikke tatt i bruk"

### DIFF
--- a/mock/syfosmregister/sykmeldingerMock.ts
+++ b/mock/syfosmregister/sykmeldingerMock.ts
@@ -312,7 +312,7 @@ export const sykmeldingerMock = [
       },
     ],
     sykmeldingStatus: {
-      statusEvent: "SENDT",
+      statusEvent: "APEN",
       timestamp: "2020-01-29T09:38:05.414834Z",
       arbeidsgiver: {
         orgnummer: VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
@@ -878,7 +878,7 @@ export const sykmeldingerMock = [
       },
     ],
     sykmeldingStatus: {
-      statusEvent: "SENDT",
+      statusEvent: "APEN",
       timestamp: "2020-01-29T09:38:05.414834Z",
       arbeidsgiver: {
         orgnummer: "170100000",

--- a/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
@@ -3,7 +3,6 @@ import SykmeldingUtdragFraSykefravaretVisning from "../motebehov/SykmeldingUtdra
 import {
   arbeidsgivernavnEllerArbeidssituasjon,
   erEkstraInformasjonISykmeldingen,
-  getSendteOrNyeSykmeldinger,
   stringMedAlleGraderingerFraSykmeldingPerioder,
   sykmeldingerGruppertEtterVirksomhet,
   sykmeldingerInnenforOppfolgingstilfelle,
@@ -22,7 +21,6 @@ import {
 import { MerInformasjonImage } from "../../../img/ImageComponents";
 import { UtdragOppfolgingsplaner } from "./UtdragOppfolgingsplaner";
 import { SpinnsynLenke } from "@/components/vedtak/SpinnsynLenke";
-import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
@@ -162,16 +160,14 @@ const UtvidbarSykmelding = ({ sykmelding, label }: UtvidbarSykmeldingProps) => {
   );
 };
 
-interface SykmeldingerForVirksomhetProps {
-  latestOppfolgingstilfelle?: OppfolgingstilfelleDTO;
-  sykmeldinger: SykmeldingOldFormat[];
-}
-
-export const SykmeldingerForVirksomhet = ({
-  latestOppfolgingstilfelle,
-  sykmeldinger,
-}: SykmeldingerForVirksomhetProps) => {
-  const aktuelleSykmeldinger = getSendteOrNyeSykmeldinger(sykmeldinger);
+export const SykmeldingerForVirksomhet = () => {
+  const { sykmeldinger } = useSykmeldingerQuery();
+  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
+  const aktuelleSykmeldinger = sykmeldinger.filter(
+    (sykmelding) =>
+      sykmelding.status === SykmeldingStatus.SENDT ||
+      sykmelding.status === SykmeldingStatus.NY
+  );
   const sykmeldingerIOppfolgingstilfellet =
     sykmeldingerInnenforOppfolgingstilfelle(
       aktuelleSykmeldinger,
@@ -267,12 +263,7 @@ const UtdragFraSykefravaeret = () => {
         {texts.header}
       </Heading>
       <UtdragOppfolgingsplaner />
-
-      <SykmeldingerForVirksomhet
-        latestOppfolgingstilfelle={latestOppfolgingstilfelle}
-        sykmeldinger={sykmeldinger}
-      />
-
+      <SykmeldingerForVirksomhet />
       {sykmeldingerSortertPaSykmeldingsperiode?.length > 0 && (
         <SykmeldingerUtenArbeidsgiver
           sykmeldingerSortertPaUtstedelsesdato={
@@ -280,7 +271,6 @@ const UtdragFraSykefravaeret = () => {
           }
         />
       )}
-
       <Samtalereferat />
       <Heading size="small" level="3">
         {texts.vedtak.header}

--- a/src/data/sykmelding/types/SykmeldingStatusDTO.ts
+++ b/src/data/sykmelding/types/SykmeldingStatusDTO.ts
@@ -1,8 +1,9 @@
 import { SporsmalDTO } from "./SporsmalDTO";
 import { ArbeidsgiverStatusDTO } from "./ArbeidsgiverStatusDTO";
+import { NyeSykmeldingStatuser } from "@/utils/sykmeldinger/sykmeldingstatuser";
 
 export interface SykmeldingStatusDTO {
-  readonly statusEvent: string;
+  readonly statusEvent: NyeSykmeldingStatuser;
   readonly timestamp: string;
   readonly arbeidsgiver?: ArbeidsgiverStatusDTO;
   readonly sporsmalOgSvarListe: SporsmalDTO[];

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -166,16 +166,6 @@ export const arbeidsgivernavnEllerArbeidssituasjon = (
   }
 };
 
-export const getSendteOrNyeSykmeldinger = (
-  sykmeldinger: SykmeldingOldFormat[]
-): SykmeldingOldFormat[] => {
-  return sykmeldinger.filter(
-    (sykmelding) =>
-      sykmelding.status === SykmeldingStatus.SENDT ||
-      sykmelding.status === SykmeldingStatus.NY
-  );
-};
-
 export const sykmeldingerUtenArbeidsgiver = (
   sykmeldinger: SykmeldingOldFormat[]
 ): SykmeldingOldFormat[] => {

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -147,6 +147,11 @@ export const arbeidsgivernavnEllerArbeidssituasjon = (
     sykmelding.innsendtArbeidsgivernavn.length > 0
   ) {
     return sykmelding.innsendtArbeidsgivernavn;
+  } else if (
+    sykmelding.status === SykmeldingStatus.NY &&
+    sykmelding.arbeidsgiver
+  ) {
+    return `${sykmelding.arbeidsgiver} (fylt inn av sykmelder)`;
   }
 
   switch (sykmelding.sporsmal.arbeidssituasjon) {
@@ -157,15 +162,17 @@ export const arbeidsgivernavnEllerArbeidssituasjon = (
     case ArbeidssituasjonType.FRILANSER:
       return "Frilanser";
     default:
-      return "Annet";
+      return "Ukjent";
   }
 };
 
-export const sykmeldingerMedStatusSendt = (
+export const getSendteOrNyeSykmeldinger = (
   sykmeldinger: SykmeldingOldFormat[]
 ): SykmeldingOldFormat[] => {
   return sykmeldinger.filter(
-    (sykmelding) => sykmelding.status === SykmeldingStatus.SENDT
+    (sykmelding) =>
+      sykmelding.status === SykmeldingStatus.SENDT ||
+      sykmelding.status === SykmeldingStatus.NY
   );
 };
 
@@ -265,7 +272,8 @@ export const sykmeldingerGruppertEtterVirksomhet = (
 ): SykmeldingerPerVirksomhet => {
   return sykmeldinger.reduce((memo: SykmeldingerPerVirksomhet, sykmelding) => {
     const virksomhetsnummer =
-      sykmelding.mottakendeArbeidsgiver?.virksomhetsnummer;
+      sykmelding.mottakendeArbeidsgiver?.virksomhetsnummer ??
+      "Ukjent virksomhet";
     const memo2 = { ...memo };
     if (virksomhetsnummer) {
       if (!memo2[virksomhetsnummer]) {

--- a/test/components/UtdragFraSykefravaeretTest.tsx
+++ b/test/components/UtdragFraSykefravaeretTest.tsx
@@ -40,4 +40,14 @@ describe("UtdragFraSykefravaeret", () => {
     expect(within(firstExpansionCard).getByText("Arbeidsgiver:")).to.exist;
     expect(within(firstExpansionCard).getByText("BRANN OG BIL AS")).to.exist;
   });
+
+  it("Viser sykmeldinger som både er sendt og ikke tatt i bruk", () => {
+    renderUtdragFraSykefravaeret();
+
+    const sykmeldingExpansionCards = screen.getAllByRole("region");
+    expect(sykmeldingExpansionCards.length).to.equal(2);
+
+    expect(within(sykmeldingExpansionCards[0]).getByText("Ikke tatt i bruk")).to
+      .exist;
+  });
 });

--- a/test/mockdata/sykmeldinger/mockSykmeldingExtraInfo.ts
+++ b/test/mockdata/sykmeldinger/mockSykmeldingExtraInfo.ts
@@ -8,6 +8,7 @@ import { SvartypeDTO } from "@/data/sykmelding/types/SvartypeDTO";
 import { ShortNameDTO } from "@/data/sykmelding/types/ShortNameDTO";
 import { AnnenFraverGrunnDTO } from "@/data/sykmelding/types/AnnenFraverGrunnDTO";
 import { mockSykmeldinger } from "./mockSykmeldinger";
+import { NyeSykmeldingStatuser } from "@/utils/sykmeldinger/sykmeldingstatuser";
 
 const mockSM = mockSykmeldinger[0];
 
@@ -119,7 +120,7 @@ export const mockSykmeldingWithoutMottakendeArbeidsgiver: SykmeldingNewFormatDTO
     ...mockSM,
     sykmeldingStatus: {
       ...mockSM.sykmeldingStatus,
-      statusEvent: "APEN",
+      statusEvent: NyeSykmeldingStatuser.APEN,
       timestamp: "2020-01-28T09:38:05.414834Z",
       arbeidsgiver: undefined,
     },

--- a/test/mockdata/sykmeldinger/mockSykmeldinger.ts
+++ b/test/mockdata/sykmeldinger/mockSykmeldinger.ts
@@ -14,6 +14,7 @@ import {
   SykepengesoknadDTO,
 } from "@/data/sykepengesoknad/types/SykepengesoknadDTO";
 import { VIRKSOMHET_PONTYPANDY } from "../../../mock/common/mockConstants";
+import { NyeSykmeldingStatuser } from "@/utils/sykmeldinger/sykmeldingstatuser";
 
 export const mockSykmeldingId = "test-id";
 
@@ -56,7 +57,7 @@ export const mockSykmeldinger: SykmeldingNewFormatDTO[] = [
       },
     ],
     sykmeldingStatus: {
-      statusEvent: "SENDT",
+      statusEvent: NyeSykmeldingStatuser.SENDT,
       timestamp: "2020-01-29T09:38:05.414834Z",
       arbeidsgiver: {
         orgnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -16,7 +16,6 @@ import {
   stringMedAlleGraderingerFraSykmeldingPerioder,
   sykmeldingerGruppertEtterVirksomhet,
   sykmeldingerInnenforOppfolgingstilfelle,
-  getSendteOrNyeSykmeldinger,
   sykmeldingerSortertNyestTilEldstPeriode,
   sykmeldingperioderSortertEldstTilNyest,
 } from "@/utils/sykmeldinger/sykmeldingUtils";
@@ -433,33 +432,6 @@ describe("sykmeldingUtils", () => {
         arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
 
       expect(arbeidssituasjon).to.equal("Selvstendig næringsdrivende");
-    });
-  });
-
-  describe("sykmeldingerMedStatusSendtOgNy", () => {
-    it("skal returnere en liste med bare innsendte og nye sykmeldinger", () => {
-      const allSykmeldinger: SykmeldingOldFormat[] = [
-        {
-          ...baseSykmelding,
-          status: SykmeldingStatus.AVBRUTT,
-        },
-        {
-          ...baseSykmelding,
-          status: SykmeldingStatus.SENDT,
-        },
-        {
-          ...baseSykmelding,
-          status: SykmeldingStatus.AVBRUTT,
-        },
-        {
-          ...baseSykmelding,
-          status: SykmeldingStatus.NY,
-        },
-      ];
-
-      const sykmeldinger = getSendteOrNyeSykmeldinger(allSykmeldinger);
-
-      expect(sykmeldinger.length).to.equal(2);
     });
   });
 

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -16,7 +16,7 @@ import {
   stringMedAlleGraderingerFraSykmeldingPerioder,
   sykmeldingerGruppertEtterVirksomhet,
   sykmeldingerInnenforOppfolgingstilfelle,
-  sykmeldingerMedStatusSendt,
+  getSendteOrNyeSykmeldinger,
   sykmeldingerSortertNyestTilEldstPeriode,
   sykmeldingperioderSortertEldstTilNyest,
 } from "@/utils/sykmeldinger/sykmeldingUtils";
@@ -436,9 +436,9 @@ describe("sykmeldingUtils", () => {
     });
   });
 
-  describe("sykmeldingerMedStatusSendt", () => {
-    it("skal returnere en liste med bare innsendte sykmeldinger", () => {
-      const sykmeldinger: SykmeldingOldFormat[] = [
+  describe("sykmeldingerMedStatusSendtOgNy", () => {
+    it("skal returnere en liste med bare innsendte og nye sykmeldinger", () => {
+      const allSykmeldinger: SykmeldingOldFormat[] = [
         {
           ...baseSykmelding,
           status: SykmeldingStatus.AVBRUTT,
@@ -451,11 +451,15 @@ describe("sykmeldingUtils", () => {
           ...baseSykmelding,
           status: SykmeldingStatus.AVBRUTT,
         },
+        {
+          ...baseSykmelding,
+          status: SykmeldingStatus.NY,
+        },
       ];
 
-      const sendteSykmeldinger = sykmeldingerMedStatusSendt(sykmeldinger);
+      const sykmeldinger = getSendteOrNyeSykmeldinger(allSykmeldinger);
 
-      expect(sendteSykmeldinger.length).to.equal(1);
+      expect(sykmeldinger.length).to.equal(2);
     });
   });
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjernet filtrering av at det kun er sendte sykmeldinger som vises i utdraget fra sykefraværet. I tillegg legger vi på en tag for å vise for veilederen at denne ikke er tatt i bruk enda.

### Screenshots 📸✨

<img width="1527" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/c94010c6-7eef-409c-8ece-9aafa960f378">

