### PR TITLE
IS-2034: Erstattet kall for historikk og oppfolgingsplan med v3 av api (uten fnr i url)

### DIFF
--- a/mock/syfooppfolgingsplanservice/mockSyfooppfolgingsplanservice.ts
+++ b/mock/syfooppfolgingsplanservice/mockSyfooppfolgingsplanservice.ts
@@ -3,14 +3,17 @@ import { oppfolgingsplanMock } from "./oppfolgingsplanMock";
 import { historikkoppfolgingsplanMock } from "./historikkoppfolgingsplanMock";
 import { oppfolgingsplanerLPSMock } from "./oppfolgingsplanLPSMock";
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
-import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "../../src/apiConstants";
+import {
+  SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT,
+  SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT,
+} from "../../src/apiConstants";
 import { dokumentinfoMock } from "./dokumentinfoMock";
 
 const path = require("path");
 
 export const mockSyfooppfolgingsplanservice = (server: any) => {
   server.get(
-    `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/lps`,
+    `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/oppfolgingsplan/lps`,
     (req: express.Request, res: express.Response) => {
       if (req.headers[NAV_PERSONIDENT_HEADER]?.length === 11) {
         res.setHeader("Content-Type", "application/json");
@@ -22,7 +25,7 @@ export const mockSyfooppfolgingsplanservice = (server: any) => {
   );
 
   server.get(
-    `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/lps/:uuid`,
+    `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/lps/:uuid`,
     (req: express.Request, res: express.Response) => {
       const file = path.join(
         __dirname,
@@ -37,7 +40,7 @@ export const mockSyfooppfolgingsplanservice = (server: any) => {
   );
 
   server.get(
-    `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/:fnr`,
+    `${SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT}/oppfolgingsplan/`,
     (req: express.Request, res: express.Response) => {
       res.setHeader("Content-Type", "application/json");
       res.send(JSON.stringify(oppfolgingsplanMock));
@@ -45,7 +48,7 @@ export const mockSyfooppfolgingsplanservice = (server: any) => {
   );
 
   server.get(
-    `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/:fnr/historikk`,
+    `${SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT}/oppfolgingsplan/historikk`,
     (req: express.Request, res: express.Response) => {
       res.setHeader("Content-Type", "application/json");
       res.send(JSON.stringify(historikkoppfolgingsplanMock));
@@ -53,7 +56,7 @@ export const mockSyfooppfolgingsplanservice = (server: any) => {
   );
 
   server.get(
-    `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/:id/dokumentinfo`,
+    `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/:id/dokumentinfo`,
     (req: express.Request, res: express.Response) => {
       res.setHeader("Content-Type", "application/json");
       res.send(JSON.stringify(dokumentinfoMock));

--- a/src/apiConstants.ts
+++ b/src/apiConstants.ts
@@ -18,8 +18,10 @@ export const MODIACONTEXTHOLDER_ROOT = "/modiacontextholder/api";
 export const SYFOBEHANDLENDEENHET_ROOT =
   "/syfobehandlendeenhet/api/internad/v2";
 export const SYFOMOTEBEHOV_ROOT = "/syfomotebehov/api/internad/v3/veileder";
-export const SYFOOPPFOLGINGSPLANSERVICE_ROOT =
+export const SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT =
   "/syfooppfolgingsplanservice/api/internad/v2";
+export const SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT =
+  "/syfooppfolgingsplanservice/api/internad/v3";
 export const SYFOPERSON_ROOT = "/syfoperson/api/v2";
 export const SYFOSMREGISTER_ROOT = "/syfosmregister/api/v2";
 export const SYKEPENGESOKNAD_BACKEND_ROOT = "/sykepengesoknad-backend/api";

--- a/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
@@ -7,7 +7,7 @@ import {
   tilLesbarPeriodeMedArstall,
 } from "@/utils/datoUtils";
 import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
-import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
+import { SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT } from "@/apiConstants";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
 import {
   useOppfolgingsplanerLPSQuery,
@@ -87,7 +87,7 @@ const LpsPlanLenke = ({ lpsPlan }: LpsPlanLenkeProps) => {
   return (
     <a
       className="lenke"
-      href={`${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/lps/${lpsPlan.uuid}`}
+      href={`${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/lps/${lpsPlan.uuid}`}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/data/historikk/historikkQueryHooks.ts
+++ b/src/data/historikk/historikkQueryHooks.ts
@@ -1,6 +1,6 @@
 import {
   SYFOMOTEBEHOV_ROOT,
-  SYFOOPPFOLGINGSPLANSERVICE_ROOT,
+  SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT,
 } from "@/apiConstants";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import {
@@ -35,8 +35,8 @@ export const useHistorikkMotebehovQuery = () => {
 
 export const useHistorikkOppfolgingsplan = () => {
   const fnr = useValgtPersonident();
-  const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/${fnr}/historikk`;
-  const fetchHistorikkOppfolgingsplan = () => get<HistorikkEvent[]>(path);
+  const path = `${SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT}/oppfolgingsplan/historikk`;
+  const fetchHistorikkOppfolgingsplan = () => get<HistorikkEvent[]>(path, fnr);
   const query = useQuery({
     queryKey: historikkQueryKeys.oppfolgingsplan(fnr),
     queryFn: fetchHistorikkOppfolgingsplan,

--- a/src/data/oppfolgingsplan/oppfolgingsplanQueryHooks.ts
+++ b/src/data/oppfolgingsplan/oppfolgingsplanQueryHooks.ts
@@ -1,5 +1,8 @@
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
-import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
+import {
+  SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT,
+  SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT,
+} from "@/apiConstants";
 import { get } from "@/api/axios";
 import { useQuery } from "@tanstack/react-query";
 import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
@@ -16,7 +19,7 @@ export const oppfolgingsplanQueryKeys = {
 
 export const useOppfolgingsplanerQuery = () => {
   const fnr = useValgtPersonident();
-  const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/${fnr}`;
+  const path = `${SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT}/oppfolgingsplan`;
   const fetchOppfolgingsplaner = () => get<OppfolgingsplanDTO[]>(path, fnr);
   const query = useQuery({
     queryKey: oppfolgingsplanQueryKeys.oppfolgingsplaner(fnr),
@@ -42,7 +45,7 @@ export const useOppfolgingsplanerQuery = () => {
 
 export const useOppfolgingsplanerLPSQuery = () => {
   const fnr = useValgtPersonident();
-  const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/lps`;
+  const path = `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/oppfolgingsplan/lps`;
   const fetchOppfolgingsplanerLPS = () => get<OppfolgingsplanLPS[]>(path, fnr);
   const query = useQuery({
     queryKey: oppfolgingsplanQueryKeys.oppfolgingsplanerLPS(fnr),
@@ -58,7 +61,7 @@ export const useOppfolgingsplanerLPSQuery = () => {
 };
 
 export const useDokumentinfoQuery = (oppfolgingsplanId: number) => {
-  const path = `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/${oppfolgingsplanId}/dokumentinfo`;
+  const path = `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/${oppfolgingsplanId}/dokumentinfo`;
   const fetchDokumentinfo = () => get<DokumentinfoDTO>(path);
   return useQuery({
     queryKey: oppfolgingsplanQueryKeys.dokumentinfo(oppfolgingsplanId),

--- a/src/sider/oppfolgingsplan/lps/OppfolgingsplanerOversiktLPS.tsx
+++ b/src/sider/oppfolgingsplan/lps/OppfolgingsplanerOversiktLPS.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { restdatoTilLesbarDato } from "@/utils/datoUtils";
 import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
 import BehandleOppfolgingsplanLPS from "./BehandleOppfolgingsplanLPS";
-import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
+import { SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT } from "@/apiConstants";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
 import { Box, Heading, Tag } from "@navikt/ds-react";
 
@@ -18,7 +18,7 @@ export const ButtonOpenPlan = (buttonOpenPlanProps: ButtonOpenPlanProps) => {
   return (
     <a
       className="lenke"
-      href={`${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/lps/${buttonOpenPlanProps.oppfolgingsplanLPS.uuid}`}
+      href={`${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/lps/${buttonOpenPlanProps.oppfolgingsplanLPS.uuid}`}
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/Oppfolgingsplan.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/Oppfolgingsplan.tsx
@@ -4,7 +4,7 @@ import Knapp from "nav-frontend-knapper";
 import { DokumentinfoDTO } from "@/data/oppfolgingsplan/types/DokumentinfoDTO";
 import Feilmelding from "../../../components/Feilmelding";
 import AppSpinner from "../../../components/AppSpinner";
-import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
+import { SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT } from "@/apiConstants";
 import { OppfolgingsplanDTO } from "@/data/oppfolgingsplan/types/OppfolgingsplanDTO";
 import { useDokumentinfoQuery } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
 
@@ -18,7 +18,7 @@ const PlanVisning = ({ dokumentinfo, oppfolgingsplan }: PlanVisningProps) => {
   if (dokumentinfo) {
     for (let i = 1; i <= dokumentinfo.antallSider; i += 1) {
       bildeUrler.push(
-        `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/${oppfolgingsplan.id}/side/${i}`
+        `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/${oppfolgingsplan.id}/side/${i}`
       );
     }
   }
@@ -58,7 +58,7 @@ const PlanVisning = ({ dokumentinfo, oppfolgingsplan }: PlanVisningProps) => {
           type="standard"
           onClick={() => {
             const newWindow = window.open(
-              `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/${oppfolgingsplan.id}`
+              `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/${oppfolgingsplan.id}`
             );
             newWindow?.print();
           }}

--- a/test/data/historikkQueryHooksTest.tsx
+++ b/test/data/historikkQueryHooksTest.tsx
@@ -10,7 +10,6 @@ import { expect } from "chai";
 import { historikkmotebehovMock } from "../../mock/syfomotebehov/historikkmotebehovMock";
 import { historikkoppfolgingsplanMock } from "../../mock/syfooppfolgingsplanservice/historikkoppfolgingsplanMock";
 import { stubMotebehovHistorikkApi } from "../stubs/stubSyfomotebehov";
-import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
 import { stubOppfolgingsplanHistorikkApi } from "../stubs/stubSyfooppfolgingsplan";
 import { testQueryClient } from "../testQueryClient";
 
@@ -46,10 +45,7 @@ describe("historikkQueryHooks", () => {
     expect(result.current.data).to.deep.equal(expectedHistorikkEvents);
   });
   it("loads oppfolgingsplan-historikk for valgt personident", async () => {
-    stubOppfolgingsplanHistorikkApi(
-      apiMockScope,
-      ARBEIDSTAKER_DEFAULT.personIdent
-    );
+    stubOppfolgingsplanHistorikkApi(apiMockScope);
     const wrapper = queryHookWrapper(queryClient);
 
     const { result } = renderHook(() => useHistorikkOppfolgingsplan(), {

--- a/test/data/oppfolgingsplanQueryHooksTest.tsx
+++ b/test/data/oppfolgingsplanQueryHooksTest.tsx
@@ -16,7 +16,6 @@ import {
 } from "../stubs/stubSyfooppfolgingsplan";
 import { oppfolgingsplanerLPSMock } from "../../mock/syfooppfolgingsplanservice/oppfolgingsplanLPSMock";
 import { dokumentinfoMock } from "../../mock/syfooppfolgingsplanservice/dokumentinfoMock";
-import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
 import { testQueryClient } from "../testQueryClient";
 
 let queryClient: any;
@@ -34,7 +33,7 @@ describe("oppfolgingsplanQueryHooks tests", () => {
   });
 
   it("loads oppfolgingsplaner for valgt personident", async () => {
-    stubOppfolgingsplanApi(apiMockScope, ARBEIDSTAKER_DEFAULT.personIdent);
+    stubOppfolgingsplanApi(apiMockScope);
 
     const wrapper = queryHookWrapper(queryClient);
 

--- a/test/stubs/stubSyfooppfolgingsplan.ts
+++ b/test/stubs/stubSyfooppfolgingsplan.ts
@@ -1,19 +1,22 @@
 import nock from "nock";
-import { SYFOOPPFOLGINGSPLANSERVICE_ROOT } from "@/apiConstants";
+import {
+  SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT,
+  SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT,
+} from "@/apiConstants";
 import { oppfolgingsplanMock } from "../../mock/syfooppfolgingsplanservice/oppfolgingsplanMock";
 import { oppfolgingsplanerLPSMock } from "../../mock/syfooppfolgingsplanservice/oppfolgingsplanLPSMock";
 import { dokumentinfoMock } from "../../mock/syfooppfolgingsplanservice/dokumentinfoMock";
 import { historikkoppfolgingsplanMock } from "../../mock/syfooppfolgingsplanservice/historikkoppfolgingsplanMock";
 
-export const stubOppfolgingsplanApi = (scope: nock.Scope, fnr: string) => {
+export const stubOppfolgingsplanApi = (scope: nock.Scope) => {
   return scope
-    .get(`${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/${fnr}`)
+    .get(`${SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT}/oppfolgingsplan`)
     .reply(200, () => oppfolgingsplanMock);
 };
 
 export const stubOppfolgingsplanLPSApi = (scope: nock.Scope, created: Date) => {
   return scope
-    .get(`${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/lps`)
+    .get(`${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/oppfolgingsplan/lps`)
     .reply(200, () => oppfolgingsplanerLPSMock(created));
 };
 
@@ -23,16 +26,13 @@ export const stubDokumentinfoApi = (
 ) => {
   return scope
     .get(
-      `${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/dokument/${oppfolgingsplanId}/dokumentinfo`
+      `${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/${oppfolgingsplanId}/dokumentinfo`
     )
     .reply(200, () => dokumentinfoMock);
 };
 
-export const stubOppfolgingsplanHistorikkApi = (
-  scope: nock.Scope,
-  fnr: string
-) => {
+export const stubOppfolgingsplanHistorikkApi = (scope: nock.Scope) => {
   scope
-    .get(`${SYFOOPPFOLGINGSPLANSERVICE_ROOT}/oppfolgingsplan/${fnr}/historikk`)
+    .get(`${SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT}/oppfolgingsplan/historikk`)
     .reply(200, () => historikkoppfolgingsplanMock);
 };


### PR DESCRIPTION
Det er ikke laget ny versjon av api for kall uten fnr i url så der brukes fortsatt v2.

NB: Merge etter https://github.com/navikt/syfooppfolgingsplanservice/pull/406
