### PR TITLE
IS-2083: Add nynorsktekst for endre-tid-sted dialogmøte

### DIFF
--- a/src/components/MalformRadioGroup.tsx
+++ b/src/components/MalformRadioGroup.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { Radio, RadioGroup } from "@navikt/ds-react";
 import { Malform, useMalform } from "@/context/malform/MalformContext";
 
+const texts = {
+  husk: "Husk å skrive nynorsk i alle fritekstfelt",
+};
+
 export const MalformRadioGroup = () => {
   const { malform, setMalform } = useMalform();
   return (
@@ -13,7 +17,12 @@ export const MalformRadioGroup = () => {
       className="mb-4"
     >
       <Radio value={Malform.BOKMAL}>Bokmål</Radio>
-      <Radio value={Malform.NYNORSK}>Nynorsk</Radio>
+      <Radio
+        value={Malform.NYNORSK}
+        description={malform === Malform.NYNORSK ? texts.husk : undefined}
+      >
+        Nynorsk
+      </Radio>
     </RadioGroup>
   );
 };

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -94,7 +94,8 @@ export const getInnkallingTexts = (malform: Malform) => {
     : innkallingTextsBokmal;
 };
 
-export const endreTidStedTexts = {
+const endreTidStedTextsBokmal = {
+  header: "Endret dialogmøte",
   intro1:
     "Du har tidligere blitt innkalt til et dialogmøte. Møtet skulle vært avholdt",
   intro2: "Møtet må flyttes. Dette tidspunktet og møtestedet gjelder nå:",
@@ -136,7 +137,61 @@ export const endreTidStedTexts = {
       "Det er obligatorisk å delta i dialogmøtet. Gi oss svar om tidspunktet passer eller ikke.",
     outro:
       "Vi minner om at det ikke må sendes sensitive personopplysninger over e-post eller SMS.",
+    endring: "Endret dialogmøte, svar ønskes",
   },
+};
+
+const endreTidStedTextsNynorsk = {
+  header: "Endra dialogmøte",
+  intro1:
+    "Du har tidlegare blitt kalla inn til dialogmøte. Møtet skulle etter planen ha vore",
+  intro2: "Møtet må flyttast. Følgjande tidspunkt og møtestad gjeld no:",
+  arbeidsgiver: {
+    outro1:
+      "I møtet ønskjer vi å høyre kva du og den tilsette seier om arbeidssituasjonen og moglegheitene for jobb. Vi blir einige om ein plan som kan hjelpe den tilsette vidare.",
+    outro2:
+      "Fastlegen eller annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",
+    outro1WithBehandler:
+      "I møtet ønskjer vi å høyre kva du, den tilsette og behandlarane seier om arbeidssituasjonen og moglegheitene for jobb. Vi blir einige om ein plan som kan hjelpe den tilsette vidare.",
+    outro2WithBehandler:
+      "Fastlegen eller annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi sett behov for å kalle inn",
+    outroObligatorisk:
+      "Det er obligatorisk å delta i dialogmøtet. Gi oss svar om tidspunktet passar eller ikkje. Vi minner om at sensitive personopplysningar ikkje skal sendast på e-post eller SMS.",
+    outro3Title: "Før møtet",
+    outro3:
+      "Det er viktig at de fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+    outro3WithBehandler:
+      "Det er viktig at du og arbeidstakaren din fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+  },
+  arbeidstaker: {
+    outro1:
+      "Vi ønskjer å høyre kva du og arbeidsgivaren seier om arbeidssituasjonen og moglegheitene for å jobbe. Vi blir einige om ein plan som kan hjelpe deg vidare.",
+    outro2:
+      "Fastlegen eller annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi ikkje sett behov for det.",
+    outro1WithBehandler:
+      "Vi ønskjer å høyre kva du, arbeidsgivaren og behandlaren seier om arbeidssituasjonen og moglegheitene for å jobbe. Vi blir einige om ein plan som kan hjelpe deg vidare.",
+    outro2WithBehandler:
+      "Fastlegen eller annan behandlar kan bli invitert til å delta i dialogmøtet. Til dette møtet har vi sett behov for å kalle inn",
+    outroObligatorisk: "Det er obligatorisk å delta i dialogmøtet.",
+    outro3Title: "Før møtet",
+    outro3:
+      "Det er viktig at de fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+    outro3WithBehandler:
+      "Det er viktig at du og arbeidsgivaren din fyller ut oppfølgingsplanen saman og deler han med NAV. Denne gir oss eit godt utgangspunkt for å snakke om kva som fungerer, kva som har blitt forsøkt, og kva moglegheiter som finst framover.",
+  },
+  behandler: {
+    intro:
+      "Det er obligatorisk å delta i dialogmøtet. Gi oss svar om tidspunktet passar eller ikkje.",
+    outro:
+      "Vi minner om at sensitive personopplysningar ikkje skal sendast på e-post eller SMS.",
+    endring: "Endra dialogmøte (ønskje om svar)",
+  },
+};
+
+export const getEndreTidStedTexts = (malform: Malform) => {
+  return malform === Malform.NYNORSK
+    ? endreTidStedTextsNynorsk
+    : endreTidStedTextsBokmal;
 };
 
 export const avlysningTexts = {

--- a/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
+++ b/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
@@ -33,7 +33,7 @@ export const useDialogmoteDocumentComponents = () => {
   const getMoteInfo = (
     values: Partial<TidStedSkjemaValues>,
     virksomhetsnummer: string | undefined,
-    malform?: Malform
+    malform?: Malform // TODO: Fjern når alle tekster bruker målform og ta inn i hooken
   ) => {
     const { dato, klokkeslett, sted, videoLink } = values;
     const commonTexts = getCommonTexts(malform ? malform : Malform.BOKMAL);

--- a/src/sider/mote/components/endre/EndreDialogmoteContainer.tsx
+++ b/src/sider/mote/components/endre/EndreDialogmoteContainer.tsx
@@ -13,6 +13,7 @@ import * as Tredelt from "@/sider/TredeltSide";
 import { DeltakereSvarInfo } from "@/components/dialogmote/DeltakereSvarInfo";
 import { BodyLong, Box, Heading } from "@navikt/ds-react";
 import { MoteIkonBlaaImage } from "../../../../../img/ImageComponents";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 const texts = {
   pageTitle: "Endre dialogmøte",
@@ -43,7 +44,9 @@ const EndreDialogmoteContainer = () => {
               {brukerKanIkkeVarslesDigitalt && (
                 <BrukerKanIkkeVarslesPapirpostAdvarsel />
               )}
-              <EndreDialogmoteSkjema dialogmote={dialogmote} />
+              <MalformProvider>
+                <EndreDialogmoteSkjema dialogmote={dialogmote} />
+              </MalformProvider>
             </Tredelt.FirstColumn>
             <Tredelt.SecondColumn>
               <Box

--- a/src/sider/mote/components/endre/EndreDialogmoteSkjema.tsx
+++ b/src/sider/mote/components/endre/EndreDialogmoteSkjema.tsx
@@ -26,6 +26,10 @@ import DialogmoteSted, {
 import DialogmoteVideolink from "@/sider/mote/components/DialogmoteVideolink";
 import DialogmoteKlokkeslett from "@/sider/mote/components/DialogmoteKlokkeslett";
 import { DialogmoteFrist } from "@/components/dialogmote/DialogmoteFrist";
+import { MalformRadioGroup } from "@/components/MalformRadioGroup";
+import * as Amplitude from "@/utils/amplitude";
+import { EventType } from "@/utils/amplitude";
+import { useMalform } from "@/context/malform/MalformContext";
 
 export const texts = {
   send: "Send",
@@ -70,6 +74,7 @@ const EndreDialogmoteSkjema = ({ dialogmote }: Props) => {
   const { sted, arbeidsgiver, tid, uuid, behandler, videoLink } = dialogmote;
   const fnr = useValgtPersonident();
   const { currentLedere } = useLedereQuery();
+  const { malform } = useMalform();
 
   const narmesteLeder = narmesteLederForVirksomhet(
     currentLedere,
@@ -127,7 +132,18 @@ const EndreDialogmoteSkjema = ({ dialogmote }: Props) => {
 
   const submit = (values: EndreTidStedSkjemaValues) => {
     const dialogmoteEndring = toEndreTidSted(values);
-    endreTidStedDialogmote.mutate(dialogmoteEndring);
+    endreTidStedDialogmote.mutate(dialogmoteEndring, {
+      onSuccess: () => {
+        Amplitude.logEvent({
+          type: EventType.OptionSelected,
+          data: {
+            url: window.location.href,
+            tekst: "Målform valgt",
+            option: malform,
+          },
+        });
+      },
+    });
   };
 
   if (endreTidStedDialogmote.isSuccess) {
@@ -135,10 +151,11 @@ const EndreDialogmoteSkjema = ({ dialogmote }: Props) => {
   }
 
   return (
-    <Box background="surface-default" padding="6">
+    <Box background="surface-default" padding="6" className="mb-2">
       <FormProvider {...methods}>
         <form onSubmit={handleSubmit(submit)}>
           <div className="flex flex-col gap-4 mb-6">
+            <MalformRadioGroup />
             <DialogmoteFrist />
             <div className="flex gap-4 items-start">
               <DialogmoteDato />

--- a/src/utils/behandlerUtils.ts
+++ b/src/utils/behandlerUtils.ts
@@ -11,13 +11,6 @@ export const behandlerNavn = (
     .join(" ");
 };
 
-export const behandlerDeltakerTekst = (
-  pretekst: string,
-  behandler: DialogmotedeltakerBehandlerDTO
-) => {
-  return `${pretekst} ${behandler.behandlerNavn}`;
-};
-
 export const behandlerDeltokTekst = (
   behandler: DialogmotedeltakerBehandlerDTO,
   deltatt: boolean | undefined

--- a/test/dialogmote/EndreDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/EndreDialogmoteSkjemaTest.tsx
@@ -33,6 +33,9 @@ import { stubFeatureTogglesApi } from "../stubs/stubUnleash";
 import { stubAktivVeilederinfoApi } from "../stubs/stubSyfoveileder";
 import { queryClientWithMockData } from "../testQueryClient";
 import { DocumentComponentType } from "@/data/documentcomponent/documentComponentTypes";
+import { Malform, MalformProvider } from "@/context/malform/MalformContext";
+import { getEndreTidStedTexts } from "@/data/dialogmote/dialogmoteTexts";
+import { StoreKey } from "@/hooks/useLocalStorageState";
 
 let queryClient: QueryClient;
 let apiMockScope;
@@ -41,6 +44,10 @@ describe("EndreDialogmoteSkjemaTest", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
     apiMockScope = apiMock();
+  });
+
+  afterEach(() => {
+    localStorage.setItem(StoreKey.MALFORM, Malform.BOKMAL);
   });
 
   it("validerer begrunnelser og dato", async () => {
@@ -335,6 +342,24 @@ describe("EndreDialogmoteSkjemaTest", () => {
           .exist;
       });
   });
+
+  it("forhåndsviser endring med nynorsktekster hvis dette er valgt", () => {
+    renderEndreDialogmoteSkjema(dialogmoteMedBehandler);
+    passSkjemaInput();
+
+    const malformRadioNynorsk = screen.getByRole("radio", {
+      name: "Nynorsk",
+    });
+    userEvent.click(malformRadioNynorsk);
+
+    const forhandsvisningButton = screen.getAllByRole("button", {
+      name: "Forhåndsvisning",
+    })[0];
+    userEvent.click(forhandsvisningButton);
+
+    expect(screen.getByText(getEndreTidStedTexts(Malform.NYNORSK).intro2)).to
+      .exist;
+  });
 });
 
 const renderEndreDialogmoteSkjema = (dialogmote: DialogmoteDTO) => {
@@ -343,7 +368,9 @@ const renderEndreDialogmoteSkjema = (dialogmote: DialogmoteDTO) => {
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <EndreDialogmoteSkjema dialogmote={dialogmote} />
+        <MalformProvider>
+          <EndreDialogmoteSkjema dialogmote={dialogmote} />
+        </MalformProvider>
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
     `${dialogmoteRoutePath}/:dialogmoteUuid/endre`,

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -12,8 +12,8 @@ import {
 } from "./testData";
 import {
   avlysningTexts,
-  commonTextsBokmal,
-  endreTidStedTexts,
+  getCommonTexts,
+  getEndreTidStedTexts,
   getInnkallingTexts,
   getReferatTexts,
 } from "@/data/dialogmote/dialogmoteTexts";
@@ -32,6 +32,8 @@ import { behandlerNavn } from "@/utils/behandlerUtils";
 
 const innkallingTextsBokmal = getInnkallingTexts(Malform.BOKMAL);
 const referatTextsBokmal = getReferatTexts(Malform.BOKMAL);
+const commonTextsBokmal = getCommonTexts(Malform.BOKMAL);
+const endreTidStedTextsBokmal = getEndreTidStedTexts(Malform.BOKMAL);
 
 const expectedArbeidstakerInnkalling = (
   medBehandler = false
@@ -275,14 +277,14 @@ const expectedArbeidsgiverEndringsdokument = (
   },
   {
     texts: [
-      `${endreTidStedTexts.intro1} ${tilDatoMedManedNavnOgKlokkeslettWithComma(
-        dialogmote.tid
-      )}.`,
+      `${
+        endreTidStedTextsBokmal.intro1
+      } ${tilDatoMedManedNavnOgKlokkeslettWithComma(dialogmote.tid)}.`,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [endreTidStedTexts.intro2],
+    texts: [endreTidStedTextsBokmal.intro2],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -316,32 +318,32 @@ const expectedArbeidsgiverEndringsdokument = (
   {
     texts: [
       medBehandler
-        ? endreTidStedTexts.arbeidsgiver.outro1WithBehandler
-        : endreTidStedTexts.arbeidsgiver.outro1,
+        ? endreTidStedTextsBokmal.arbeidsgiver.outro1WithBehandler
+        : endreTidStedTextsBokmal.arbeidsgiver.outro1,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [endreTidStedTexts.arbeidsgiver.outroObligatorisk],
+    texts: [endreTidStedTextsBokmal.arbeidsgiver.outroObligatorisk],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
         ? `${
-            endreTidStedTexts.arbeidsgiver.outro2WithBehandler
+            endreTidStedTextsBokmal.arbeidsgiver.outro2WithBehandler
           } ${behandlerNavn(behandler)}.`
-        : endreTidStedTexts.arbeidsgiver.outro2,
+        : endreTidStedTextsBokmal.arbeidsgiver.outro2,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? endreTidStedTexts.arbeidsgiver.outro3WithBehandler
-        : endreTidStedTexts.arbeidsgiver.outro3,
+        ? endreTidStedTextsBokmal.arbeidsgiver.outro3WithBehandler
+        : endreTidStedTextsBokmal.arbeidsgiver.outro3,
     ],
-    title: endreTidStedTexts.arbeidsgiver.outro3Title,
+    title: endreTidStedTextsBokmal.arbeidsgiver.outro3Title,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -371,14 +373,14 @@ const expectedArbeidstakerEndringsdokument = (
   },
   {
     texts: [
-      `${endreTidStedTexts.intro1} ${tilDatoMedManedNavnOgKlokkeslettWithComma(
-        dialogmote.tid
-      )}.`,
+      `${
+        endreTidStedTextsBokmal.intro1
+      } ${tilDatoMedManedNavnOgKlokkeslettWithComma(dialogmote.tid)}.`,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [endreTidStedTexts.intro2],
+    texts: [endreTidStedTextsBokmal.intro2],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -412,32 +414,32 @@ const expectedArbeidstakerEndringsdokument = (
   {
     texts: [
       medBehandler
-        ? endreTidStedTexts.arbeidstaker.outro1WithBehandler
-        : endreTidStedTexts.arbeidstaker.outro1,
+        ? endreTidStedTextsBokmal.arbeidstaker.outro1WithBehandler
+        : endreTidStedTextsBokmal.arbeidstaker.outro1,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [endreTidStedTexts.arbeidstaker.outroObligatorisk],
+    texts: [endreTidStedTextsBokmal.arbeidstaker.outroObligatorisk],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
         ? `${
-            endreTidStedTexts.arbeidstaker.outro2WithBehandler
+            endreTidStedTextsBokmal.arbeidstaker.outro2WithBehandler
           } ${behandlerNavn(behandler)}.`
-        : endreTidStedTexts.arbeidstaker.outro2,
+        : endreTidStedTextsBokmal.arbeidstaker.outro2,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [
       medBehandler
-        ? endreTidStedTexts.arbeidstaker.outro3WithBehandler
-        : endreTidStedTexts.arbeidstaker.outro3,
+        ? endreTidStedTextsBokmal.arbeidstaker.outro3WithBehandler
+        : endreTidStedTextsBokmal.arbeidstaker.outro3,
     ],
-    title: endreTidStedTexts.arbeidstaker.outro3Title,
+    title: endreTidStedTextsBokmal.arbeidstaker.outro3Title,
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -452,7 +454,7 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [endreTidStedTexts.behandler.intro],
+    texts: [endreTidStedTextsBokmal.behandler.intro],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -465,14 +467,14 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
   },
   {
     texts: [
-      `${endreTidStedTexts.intro1} ${tilDatoMedManedNavnOgKlokkeslettWithComma(
-        dialogmote.tid
-      )}.`,
+      `${
+        endreTidStedTextsBokmal.intro1
+      } ${tilDatoMedManedNavnOgKlokkeslettWithComma(dialogmote.tid)}.`,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [endreTidStedTexts.intro2],
+    texts: [endreTidStedTextsBokmal.intro2],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -504,7 +506,7 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [endreTidStedTexts.behandler.outro],
+    texts: [endreTidStedTextsBokmal.behandler.outro],
     type: DocumentComponentType.PARAGRAPH,
   },
   {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Egne tekster for endre tid og sted på dialogmøteinnkalling.

### Screenshots 📸✨

Ett av brevene:
<img width="955" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/888d0eb6-03d3-4c7e-9503-939255717d2e">

Endret også litt på tekst i radiogruppa, Peter ville ha en "nudging" der
<img width="414" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/dee63db6-5be4-4010-a57a-a550727c35ee">
