### PR TITLE
IS-2099: Add nynorsk to avlysning dialogmøte

### DIFF
--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -194,12 +194,26 @@ export const getEndreTidStedTexts = (malform: Malform) => {
     : endreTidStedTextsBokmal;
 };
 
-export const avlysningTexts = {
+const avlysningTextsBokmal = {
+  header: "Avlysning av dialogmøte",
   intro1: "NAV har tidligere innkalt til dialogmøtet som skulle vært avholdt",
   intro2: "Dette møtet er avlyst.",
 };
 
-export const commonTextsBokmal = {
+const avlysningTextsNynorsk = {
+  header: "Avlysing dialogmøte",
+  intro1:
+    "NAV har tidlegare kalla inn til eit dialogmøte som etter planen skulle vere",
+  intro2: "Dette møtet er avlyst.",
+};
+
+export const getAvlysningTexts = (malform: Malform) => {
+  return malform === Malform.NYNORSK
+    ? avlysningTextsNynorsk
+    : avlysningTextsBokmal;
+};
+
+const commonTextsBokmal = {
   arbeidsgiverTitle: "Arbeidsgiver",
   moteTidTitle: "Møtetidspunkt",
   moteStedTitle: "Møtested",

--- a/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
+++ b/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
@@ -9,21 +9,20 @@ import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { genererDato } from "@/sider/mote/utils";
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
-import { Malform } from "@/context/malform/MalformContext";
+import { useMalform } from "@/context/malform/MalformContext";
 
 export const useDialogmoteDocumentComponents = () => {
   const { getHilsen, getIntroGjelder, getIntroHei } = useDocumentComponents();
   const { getCurrentNarmesteLeder } = useLedereQuery();
+  const { malform } = useMalform();
+  const commonTexts = getCommonTexts(malform);
 
   const getVirksomhetsnavn = (
-    virksomhetsnummer: string | undefined,
-    malform?: Malform
+    virksomhetsnummer: string | undefined
   ): DocumentComponentDto | undefined => {
     const arbeidsgiver =
       virksomhetsnummer &&
       getCurrentNarmesteLeder(virksomhetsnummer)?.virksomhetsnavn;
-
-    const commonTexts = getCommonTexts(malform ? malform : Malform.BOKMAL);
 
     return arbeidsgiver
       ? createParagraphWithTitle(commonTexts.arbeidsgiverTitle, arbeidsgiver)
@@ -32,11 +31,9 @@ export const useDialogmoteDocumentComponents = () => {
 
   const getMoteInfo = (
     values: Partial<TidStedSkjemaValues>,
-    virksomhetsnummer: string | undefined,
-    malform?: Malform // TODO: Fjern når alle tekster bruker målform og ta inn i hooken
+    virksomhetsnummer: string | undefined
   ) => {
     const { dato, klokkeslett, sted, videoLink } = values;
-    const commonTexts = getCommonTexts(malform ? malform : Malform.BOKMAL);
     const tidStedTekst =
       dato && klokkeslett
         ? tilDatoMedUkedagOgManedNavnOgKlokkeslett(
@@ -55,7 +52,7 @@ export const useDialogmoteDocumentComponents = () => {
       components.push(createLink(commonTexts.videoLinkTitle, videoLink));
     }
 
-    const virksomhetsnavn = getVirksomhetsnavn(virksomhetsnummer, malform);
+    const virksomhetsnavn = getVirksomhetsnavn(virksomhetsnummer);
     if (virksomhetsnavn) {
       components.push(virksomhetsnavn);
     }

--- a/src/hooks/dialogmote/document/useInnkallingDocument.ts
+++ b/src/hooks/dialogmote/document/useInnkallingDocument.ts
@@ -65,7 +65,7 @@ export const useInnkallingDocument = (): IInnkallingDocument => {
   ) => {
     const documentComponents = [
       ...introComponents,
-      ...getMoteInfo(values, values.arbeidsgiver, malform),
+      ...getMoteInfo(values, values.arbeidsgiver),
       getIntroHei(),
       ...arbeidstakerIntro(valgtBehandler, malform),
     ];
@@ -86,7 +86,7 @@ export const useInnkallingDocument = (): IInnkallingDocument => {
   ) => {
     const documentComponents = [
       ...introComponents,
-      ...getMoteInfo(values, values.arbeidsgiver, malform),
+      ...getMoteInfo(values, values.arbeidsgiver),
       gjelderParagraph,
       createParagraph(innkallingTexts.arbeidsgiver.intro1),
     ];
@@ -114,7 +114,7 @@ export const useInnkallingDocument = (): IInnkallingDocument => {
         `Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`
       ),
       createParagraph(innkallingTexts.behandler.intro),
-      ...getMoteInfo(values, values.arbeidsgiver, malform),
+      ...getMoteInfo(values, values.arbeidsgiver),
       gjelderParagraph,
     ];
 

--- a/src/hooks/dialogmote/document/useReferatDocument.ts
+++ b/src/hooks/dialogmote/document/useReferatDocument.ts
@@ -193,8 +193,7 @@ export const useReferatDocument = (
     );
 
     const virksomhetsnavn = getVirksomhetsnavn(
-      dialogmote.arbeidsgiver.virksomhetsnummer,
-      malform
+      dialogmote.arbeidsgiver.virksomhetsnummer
     );
     if (virksomhetsnavn) {
       documentComponents.push(virksomhetsnavn);

--- a/src/hooks/dialogmote/document/useTidStedDocument.ts
+++ b/src/hooks/dialogmote/document/useTidStedDocument.ts
@@ -73,7 +73,7 @@ export const useTidStedDocument = (
       sendtDato,
       gjelderParagraph,
       ...introComponents,
-      ...getMoteInfo(values, arbeidsgiver.virksomhetsnummer, malform),
+      ...getMoteInfo(values, arbeidsgiver.virksomhetsnummer),
     ];
 
     if (values.begrunnelseArbeidsgiver) {
@@ -116,7 +116,7 @@ export const useTidStedDocument = (
       sendtDato,
       getIntroHei(),
       ...introComponents,
-      ...getMoteInfo(values, arbeidsgiver.virksomhetsnummer, malform),
+      ...getMoteInfo(values, arbeidsgiver.virksomhetsnummer),
     ];
 
     if (values.begrunnelseArbeidstaker) {
@@ -156,7 +156,7 @@ export const useTidStedDocument = (
       sendtDato,
       gjelderParagraph,
       ...introComponents,
-      ...getMoteInfo(values, arbeidsgiver.virksomhetsnummer, malform),
+      ...getMoteInfo(values, arbeidsgiver.virksomhetsnummer),
     ];
     if (values.begrunnelseBehandler) {
       documentComponents.push(createParagraph(values.begrunnelseBehandler));

--- a/src/sider/mote/components/avlys/AvlysDialogmoteContainer.tsx
+++ b/src/sider/mote/components/avlys/AvlysDialogmoteContainer.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from "react";
 import AvlysDialogmoteSkjema from "./AvlysDialogmoteSkjema";
 import { DialogmoteSideContainer } from "../../../../components/dialogmote/DialogmoteSideContainer";
+import { MalformProvider } from "@/context/malform/MalformContext";
 
 const texts = {
   pageTitle: "Avlys dialogmøte",
@@ -10,10 +11,12 @@ const texts = {
 const AvlysDialogmoteContainer = (): ReactElement => (
   <DialogmoteSideContainer title={texts.pageTitle} header={texts.pageHeader}>
     {(dialogmote) => (
-      <AvlysDialogmoteSkjema
-        dialogmote={dialogmote}
-        pageTitle={texts.pageTitle}
-      />
+      <MalformProvider>
+        <AvlysDialogmoteSkjema
+          dialogmote={dialogmote}
+          pageTitle={texts.pageTitle}
+        />
+      </MalformProvider>
     )}
   </DialogmoteSideContainer>
 );

--- a/src/sider/mote/components/avlys/AvlysDialogmoteSkjema.tsx
+++ b/src/sider/mote/components/avlys/AvlysDialogmoteSkjema.tsx
@@ -14,6 +14,10 @@ import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { useForm } from "react-hook-form";
 import TextareaField from "@/components/dialogmote/TextareaField";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
+import { MalformRadioGroup } from "@/components/MalformRadioGroup";
+import * as Amplitude from "@/utils/amplitude";
+import { EventType } from "@/utils/amplitude";
+import { useMalform } from "@/context/malform/MalformContext";
 
 export const MAX_LENGTH_AVLYS_BEGRUNNELSE = 500;
 
@@ -64,6 +68,7 @@ const AvlysDialogmoteSkjema = ({
     getAvlysningDocumentArbeidsgiver,
     getAvlysningDocumentBehandler,
   } = useAvlysningDocument(dialogmote);
+  const { malform } = useMalform();
 
   const {
     register,
@@ -92,7 +97,18 @@ const AvlysDialogmoteSkjema = ({
       };
     }
 
-    avlysDialogmote.mutate(avlysDto);
+    avlysDialogmote.mutate(avlysDto, {
+      onSuccess: () => {
+        Amplitude.logEvent({
+          type: EventType.OptionSelected,
+          data: {
+            url: window.location.href,
+            tekst: "Målform valgt",
+            option: malform,
+          },
+        });
+      },
+    });
   };
 
   if (avlysDialogmote.isSuccess) {
@@ -102,6 +118,7 @@ const AvlysDialogmoteSkjema = ({
   return (
     <Box background="surface-default" padding="6">
       <form onSubmit={handleSubmit(submit)}>
+        <MalformRadioGroup />
         <div className="mb-8 flex flex-col">
           <Label size="small">{texts.gjelderTitle}</Label>
           {tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid)}

--- a/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
@@ -21,13 +21,19 @@ import userEvent from "@testing-library/user-event";
 import { expectedAvlysningDocuments } from "./testDataDocuments";
 import { queryClientWithMockData } from "../testQueryClient";
 import { renderWithRouter } from "../testRouterUtils";
-import { MalformProvider } from "@/context/malform/MalformContext";
+import { Malform, MalformProvider } from "@/context/malform/MalformContext";
+import { getAvlysningTexts } from "@/data/dialogmote/dialogmoteTexts";
+import { StoreKey } from "@/hooks/useLocalStorageState";
 
 let queryClient: QueryClient;
 
 describe("AvlysDialogmoteSkjemaTest", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
+  });
+
+  afterEach(() => {
+    localStorage.setItem(StoreKey.MALFORM, Malform.BOKMAL);
   });
 
   it("viser møtetidspunkt", () => {
@@ -364,6 +370,28 @@ describe("AvlysDialogmoteSkjemaTest", () => {
         expect(within(forhandsvisningAvlysningBehandler).getByText(text)).to
           .exist;
       });
+  });
+
+  it("forhåndsviser avlysning med nynorsktekster hvis dette er valgt", () => {
+    renderAvlysDialogmoteSkjema(dialogmoteMedBehandler);
+
+    const malformRadioNynorsk = screen.getByRole("radio", {
+      name: "Nynorsk",
+    });
+    userEvent.click(malformRadioNynorsk);
+
+    const forhandsvisningButton = screen.getAllByRole("button", {
+      name: "Forhåndsvisning",
+    })[0];
+    userEvent.click(forhandsvisningButton);
+
+    expect(
+      screen.getByText(getAvlysningTexts(Malform.NYNORSK).intro1, {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText(getAvlysningTexts(Malform.NYNORSK).header)).to
+      .exist;
   });
 });
 

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -11,7 +11,7 @@ import {
   veileder,
 } from "./testData";
 import {
-  avlysningTexts,
+  getAvlysningTexts,
   getCommonTexts,
   getEndreTidStedTexts,
   getInnkallingTexts,
@@ -34,6 +34,7 @@ const innkallingTextsBokmal = getInnkallingTexts(Malform.BOKMAL);
 const referatTextsBokmal = getReferatTexts(Malform.BOKMAL);
 const commonTextsBokmal = getCommonTexts(Malform.BOKMAL);
 const endreTidStedTextsBokmal = getEndreTidStedTexts(Malform.BOKMAL);
+const avlysningTextsBokmal = getAvlysningTexts(Malform.BOKMAL);
 
 const expectedArbeidstakerInnkalling = (
   medBehandler = false
@@ -530,9 +531,11 @@ const expectedAvlysningArbeidsgiver = (): DocumentComponentDto[] => [
   },
   {
     texts: [
-      `${avlysningTexts.intro1} ${tilDatoMedManedNavnOgKlokkeslettWithComma(
-        dialogmote.tid
-      )}. ${avlysningTexts.intro2}`,
+      `${
+        avlysningTextsBokmal.intro1
+      } ${tilDatoMedManedNavnOgKlokkeslettWithComma(dialogmote.tid)}. ${
+        avlysningTextsBokmal.intro2
+      }`,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
@@ -566,9 +569,11 @@ const expectedAvlysningArbeidstaker = (): DocumentComponentDto[] => [
   },
   {
     texts: [
-      `${avlysningTexts.intro1} ${tilDatoMedManedNavnOgKlokkeslettWithComma(
-        dialogmote.tid
-      )}. ${avlysningTexts.intro2}`,
+      `${
+        avlysningTextsBokmal.intro1
+      } ${tilDatoMedManedNavnOgKlokkeslettWithComma(dialogmote.tid)}. ${
+        avlysningTextsBokmal.intro2
+      }`,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },
@@ -602,9 +607,11 @@ const expectedAvlysningBehandler = (): DocumentComponentDto[] => [
   },
   {
     texts: [
-      `${avlysningTexts.intro1} ${tilDatoMedManedNavnOgKlokkeslettWithComma(
-        dialogmote.tid
-      )}. ${avlysningTexts.intro2}`,
+      `${
+        avlysningTextsBokmal.intro1
+      } ${tilDatoMedManedNavnOgKlokkeslettWithComma(dialogmote.tid)}. ${
+        avlysningTextsBokmal.intro2
+      }`,
     ],
     type: DocumentComponentType.PARAGRAPH,
   },


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt inn nynorsktekster for avlysning. Ettersom dette var siste brevet som ble oversatt, så fikk vi fjernet litt målform-parametere som måtte bli sendt rundt, og heller håndterer dette globalt. Det er fortsatt noe som kunne blitt flyttet ut til hjelpefunksjoner, men som brukes på tvers av dialogmøte og aktivitetskrav. La inn noen TODOs, men kan godt fjerne det også 👍🏼

### Screenshots 📸✨

<img width="1024" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/196b9834-8fa7-4e2c-8f96-54c9fe77935e">