### PR TITLE
IS-2100: Add forhandsvarsel84Skjema

### DIFF
--- a/src/data/arbeidsuforhet/forhandsvarsel84Texts.ts
+++ b/src/data/arbeidsuforhet/forhandsvarsel84Texts.ts
@@ -1,0 +1,42 @@
+import { tilDatoMedManedNavn } from "../../utils/datoUtils";
+
+type Forhandsvarsel84TextsOptions = {
+  frist: Date;
+};
+
+export const getForhandsvarsel84Texts = ({
+  frist,
+}: Forhandsvarsel84TextsOptions) => ({
+  varselInfo: {
+    header: "Varsel om stans av sykepenger",
+    introWithFristDate: `Peer, du lyver! Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
+      frist
+    )}.`,
+  },
+  unngaStansInfo: {
+    header: "Du kan unngå stans av sykepenger",
+    tiltak1:
+      "Kommer du helt eller delvis tilbake i arbeid, oppfyller du aktivitetsplikten og kan fortsatt få sykepenger. Aktivitet kan dokumenteres med gradert sykmelding eller i søknaden om sykepenger.",
+    tiltak2:
+      "Aktivitetsplikten vil også være oppfylt hvis du deltar i et arbeidsrettet tiltak i regi av NAV. Ta kontakt med NAV hvis du tenker at dette er aktuelt for deg.",
+    tiltak3:
+      "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for hvorfor det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.",
+  },
+  giOssTilbakemelding: {
+    header: "Gi oss tilbakemelding",
+    tilbakemeldingWithFristDate: `Vi ber om tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
+      frist
+    )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`,
+    kontaktOss:
+      "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
+  },
+  lovhjemmel: {
+    header: "Lovhjemmel",
+    aktivitetsplikten:
+      "Aktivitetsplikten er beskrevet i folketrygdloven § 8-8 andre ledd.",
+    pliktInfo:
+      "«Medlemmet har plikt til å være i arbeidsrelatert aktivitet, jf. § 8-7 a første ledd og arbeidsmiljøloven § 4-6 første ledd," +
+      " så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet," +
+      " eller arbeidsrelaterte aktiviteter ikke kan gjennomføres på arbeidsplassen.»",
+  },
+});

--- a/src/hooks/arbeidsuforhet/useArbeidsuforhetVarselDocument.ts
+++ b/src/hooks/arbeidsuforhet/useArbeidsuforhetVarselDocument.ts
@@ -1,0 +1,65 @@
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
+import { useDocumentComponents } from "@/hooks/useDocumentComponents";
+import {
+  createBulletPoints,
+  createHeaderH1,
+  createHeaderH3,
+  createParagraph,
+} from "@/utils/documentComponentUtils";
+import { getForhandsvarsel84Texts } from "@/data/arbeidsuforhet/forhandsvarsel84Texts";
+
+type ForhandsvarselDocumentValues = {
+  begrunnelse: string;
+  frist: Date;
+};
+
+export const useArbeidsuforhetVarselDocument = (): {
+  getForhandsvarselDocument(
+    values: ForhandsvarselDocumentValues
+  ): DocumentComponentDto[];
+} => {
+  const { getHilsen } = useDocumentComponents();
+
+  const getForhandsvarselDocument = (values: ForhandsvarselDocumentValues) => {
+    const { begrunnelse, frist } = values;
+    const sendForhandsvarselTexts = getForhandsvarsel84Texts({
+      frist,
+    });
+
+    const documentComponents = [
+      createHeaderH1(sendForhandsvarselTexts.varselInfo.header),
+      createParagraph(sendForhandsvarselTexts.varselInfo.introWithFristDate),
+    ];
+
+    if (begrunnelse) {
+      documentComponents.push(createParagraph(begrunnelse));
+    }
+
+    documentComponents.push(
+      createHeaderH3(sendForhandsvarselTexts.unngaStansInfo.header),
+      createBulletPoints(
+        sendForhandsvarselTexts.unngaStansInfo.tiltak1,
+        sendForhandsvarselTexts.unngaStansInfo.tiltak2,
+        sendForhandsvarselTexts.unngaStansInfo.tiltak3
+      ),
+
+      createHeaderH3(sendForhandsvarselTexts.giOssTilbakemelding.header),
+      createParagraph(
+        sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate
+      ),
+      createParagraph(sendForhandsvarselTexts.giOssTilbakemelding.kontaktOss),
+
+      createHeaderH3(sendForhandsvarselTexts.lovhjemmel.header),
+      createParagraph(sendForhandsvarselTexts.lovhjemmel.aktivitetsplikten),
+      createParagraph(sendForhandsvarselTexts.lovhjemmel.pliktInfo),
+
+      getHilsen()
+    );
+
+    return documentComponents;
+  };
+
+  return {
+    getForhandsvarselDocument,
+  };
+};

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -24,6 +24,7 @@ import { BehandlerdialogContainer } from "@/sider/behandlerdialog/Behandlerdialo
 import * as Amplitude from "@/utils/amplitude";
 import Motelandingsside from "@/sider/mote/Motelandingsside";
 import { SykepengesoknadSide } from "@/sider/sykepengsoknader/container/SykepengesoknadSide";
+import { ArbeidsuforhetSide } from "@/sider/arbeidsuforhet/ArbeidsuforhetSide";
 
 export const appRoutePath = "/sykefravaer";
 
@@ -88,6 +89,10 @@ const AktivBrukerRouter = (): ReactElement => {
           <Route
             path={`${appRoutePath}/sykepengesoknader`}
             element={<SykepengesoknaderSide />}
+          />
+          <Route
+            path={`${appRoutePath}/arbeidsuforhet`}
+            element={<ArbeidsuforhetSide />}
           />
           <Route
             path={`${appRoutePath}/sykepengesoknader/:sykepengesoknadId`}

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -1,0 +1,33 @@
+import React, { ReactElement } from "react";
+import Side from "@/sider/Side";
+import Sidetopp from "@/components/Sidetopp";
+import SideLaster from "@/components/SideLaster";
+import { NotificationProvider } from "@/context/notification/NotificationContext";
+import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
+import * as Tredelt from "@/sider/TredeltSide";
+import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
+import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
+
+const texts = {
+  title: "Vurdering av §8-4 Arbeidsuførhet",
+};
+
+export const ArbeidsuforhetSide = (): ReactElement => {
+  return (
+    <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.AKTIVITETSKRAV}>
+      <Sidetopp tittel={texts.title} />
+      <SideLaster henter={false} hentingFeilet={false}>
+        <Tredelt.Container>
+          <Tredelt.FirstColumn>
+            <NotificationProvider>
+              <SendForhandsvarselSkjema />
+            </NotificationProvider>
+          </Tredelt.FirstColumn>
+          <Tredelt.SecondColumn>
+            <UtdragFraSykefravaeret />
+          </Tredelt.SecondColumn>
+        </Tredelt.Container>
+      </SideLaster>
+    </Side>
+  );
+};

--- a/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
+++ b/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { addWeeks } from "@/utils/datoUtils";
+import { ButtonRow } from "@/components/Layout";
+import { Box, Button, Heading, Textarea } from "@navikt/ds-react";
+import { useForm } from "react-hook-form";
+import { useArbeidsuforhetVarselDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVarselDocument";
+import { Forhandsvisning } from "@/components/Forhandsvisning";
+
+const texts = {
+  title: "Send forhåndsvarsel",
+  beskrivelseLabel: "Begrunnelse (obligatorisk)",
+  begrunnelseDescription:
+    "Begrunnelsen din blir en del av en større brevmal. Åpne forhåndsvisning for å se hele varselet.",
+  forhandsvisning: "Forhåndsvisning",
+  forhandsvisningLabel: "Forhåndsvis forhåndsvarselet",
+  missingBeskrivelse: "Vennligst angi begrunnelse",
+  sendVarselButtonText: "Send",
+  avbrytButtonText: "Avbryt",
+};
+
+const forhandsvarselFrist = addWeeks(new Date(), 3);
+const defaultValues = { begrunnelse: "" };
+const begrunnelseMaxLength = 1000;
+
+interface SkjemaValues {
+  begrunnelse: string;
+}
+
+export const SendForhandsvarselSkjema = () => {
+  const {
+    register,
+    watch,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<SkjemaValues>({ defaultValues });
+  const { getForhandsvarselDocument } = useArbeidsuforhetVarselDocument();
+
+  const submit = (values: SkjemaValues) => {
+    console.log(values);
+    // TODO: Mutate arbeidsuforhet (og sett loading på send-knappen)
+  };
+
+  return (
+    <Box background="surface-default" padding="6">
+      <form onSubmit={handleSubmit(submit)}>
+        <Heading className="mt-4 mb-4" level="2" size="small">
+          {texts.title}
+        </Heading>
+        <Textarea
+          className="mb-8"
+          {...register("begrunnelse", {
+            maxLength: begrunnelseMaxLength,
+            required: texts.missingBeskrivelse,
+          })}
+          value={watch("begrunnelse")}
+          label={texts.beskrivelseLabel}
+          description={texts.begrunnelseDescription}
+          error={errors.begrunnelse?.message}
+          size="small"
+          minRows={6}
+          maxLength={begrunnelseMaxLength}
+        />
+        {/* TODO: <SkjemaInnsendingFeil /> */}
+        <ButtonRow className="flex">
+          <Button variant="secondary" type="button">
+            {texts.avbrytButtonText}
+          </Button>
+          <Forhandsvisning
+            contentLabel={texts.forhandsvisningLabel}
+            getDocumentComponents={() =>
+              getForhandsvarselDocument({
+                begrunnelse: watch("begrunnelse"),
+                frist: forhandsvarselFrist,
+              })
+            }
+            title={texts.forhandsvisningLabel}
+          />
+          <Button loading={false} type="submit" className="ml-auto">
+            {texts.sendVarselButtonText}
+          </Button>
+        </ButtonRow>
+      </form>
+    </Box>
+  );
+};


### PR DESCRIPTION
Begynt på skjema for forhåndsvarsel, men uten funksjonalitet på knappene.
Tekstene er kopiert fra aktivitetskrav, så vi må legge inn de nye.
Lagt til en Side nå, vi må vurdere om vi ønsker både Container og Side etter hvert som det skal være mer enn bare et Skjema.
Vi vil vel ikke bruke 84 i navn på ting, men det kan fint endres etter hvert.

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/e622b5ed-c491-46bd-bdfe-8adba730dcc7)
