### PR TITLE
IS-2121: Add page for sent forhandsvarsel

### DIFF
--- a/src/components/VisBrev.tsx
+++ b/src/components/VisBrev.tsx
@@ -1,10 +1,10 @@
-import { AktivitetskravVarselDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import React, { useState } from "react";
 import * as Amplitude from "@/utils/amplitude";
 import { EventType } from "@/utils/amplitude";
 import { Button } from "@navikt/ds-react";
 import { EyeWithPupilIcon } from "@navikt/aksel-icons";
 import { ForhandsvisningModal } from "@/components/ForhandsvisningModal";
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 
 const texts = {
   visBrev: "Se hele brevet",
@@ -12,10 +12,10 @@ const texts = {
 };
 
 interface VarselBrevProps {
-  varsel: AktivitetskravVarselDTO;
+  document: DocumentComponentDto[];
 }
 
-export const VarselBrev = ({ varsel }: VarselBrevProps) => {
+export const VisBrev = ({ document }: VarselBrevProps) => {
   const [visBrev, setVisBrev] = useState(false);
 
   const handleButtonClick = () => {
@@ -41,7 +41,7 @@ export const VarselBrev = ({ varsel }: VarselBrevProps) => {
         contentLabel={texts.visBrevLabel}
         isOpen={visBrev}
         handleClose={() => setVisBrev(false)}
-        getDocumentComponents={() => varsel.document}
+        getDocumentComponents={() => document}
       />
     </>
   );

--- a/src/sider/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
+++ b/src/sider/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
@@ -18,7 +18,7 @@ import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQuer
 import { vurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 import * as Amplitude from "@/utils/amplitude";
 import { EventType } from "@/utils/amplitude";
-import { VarselBrev } from "@/sider/aktivitetskrav/VarselBrev";
+import { VisBrev } from "@/components/VisBrev";
 
 const texts = {
   header: "Historikk",
@@ -139,7 +139,7 @@ const HistorikkElement = ({ vurdering }: HistorikkElementProps) => {
         )}
         <Paragraph title={texts.vurdertAv} body={veilederinfo?.navn ?? ""} />
         {status === AktivitetskravStatus.FORHANDSVARSEL && varsel?.document && (
-          <VarselBrev varsel={varsel} />
+          <VisBrev document={varsel.document} />
         )}
       </Accordion.Content>
     </Accordion.Item>

--- a/src/sider/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
+++ b/src/sider/aktivitetskrav/vurdering/ForhandsvarselOppsummering.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { AktivitetskravVarselDTO } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { BodyShort, Heading, Panel, Tag } from "@navikt/ds-react";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
-import { VarselBrev } from "@/sider/aktivitetskrav/VarselBrev";
+import { VisBrev } from "@/components/VisBrev";
 import { ExpandableBlockquote } from "@/components/ExpandableBlockquote";
 
 const texts = {
@@ -34,7 +34,7 @@ export const ForhandsvarselOppsummering = ({
           {beskrivelse}
         </ExpandableBlockquote>
       )}
-      <VarselBrev varsel={varsel} />
+      <VisBrev document={varsel.document} />
       <BodyShort>{texts.merInfo}</BodyShort>
     </Panel>
   );

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -7,12 +7,20 @@ import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFr
 import * as Tredelt from "@/sider/TredeltSide";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
+import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
 
 const texts = {
   title: "Vurdering av §8-4 Arbeidsuførhet",
 };
 
+enum Status {
+  NY = "NY",
+  SENDT = "SENDT",
+}
+
 export const ArbeidsuforhetSide = (): ReactElement => {
+  const status: Status = Status.SENDT;
+
   return (
     <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.AKTIVITETSKRAV}>
       <Sidetopp tittel={texts.title} />
@@ -20,7 +28,11 @@ export const ArbeidsuforhetSide = (): ReactElement => {
         <Tredelt.Container>
           <Tredelt.FirstColumn>
             <NotificationProvider>
-              <SendForhandsvarselSkjema />
+              {status === Status.SENDT ? (
+                <ForhandsvarselSendt />
+              ) : (
+                <SendForhandsvarselSkjema />
+              )}
             </NotificationProvider>
           </Tredelt.FirstColumn>
           <Tredelt.SecondColumn>

--- a/src/sider/arbeidsuforhet/ForhandsvarselSendt.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselSendt.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Alert, Box, Button, Heading } from "@navikt/ds-react";
+import { ButtonRow } from "@/components/Layout";
+import { useArbeidsuforhetVarselDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVarselDocument";
+import { VisBrev } from "@/components/VisBrev";
+
+const texts = {
+  title: "Venter på svar fra bruker",
+  iSendt: "Forhåndsvarselet er sendt til bruker",
+  isPassert: "Tiden har gått ut på forhåndsvarselet.",
+  sendtInfo:
+    "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag.",
+  passertInfo: "Tiden har gått ut og du kan nå gå videre med å sende avslag.",
+  seSendtBrev: "Se sendt brev",
+  oppfylt: "Oppfylt",
+  avslag: "Avslag",
+  frist: "Fristen går ut:",
+};
+
+export const ForhandsvarselSendt = () => {
+  const { getForhandsvarselDocument } = useArbeidsuforhetVarselDocument();
+
+  return (
+    <div>
+      <Alert variant="success" className="mb-2">
+        {texts.iSendt}
+      </Alert>
+      <Box background="surface-default" padding="3" className="mb-2">
+        <Heading className="mt-4 mb-4" level="2" size="small">
+          {texts.title}
+        </Heading>
+        <p>{texts.sendtInfo}</p>
+        <ButtonRow className="flex">
+          <VisBrev
+            document={getForhandsvarselDocument({
+              begrunnelse: "Her må begrunnelsen være",
+              frist: new Date(),
+            })}
+          />
+          <Button variant="secondary" className="ml-auto">
+            {texts.oppfylt}
+          </Button>
+          <Button variant="secondary" disabled>
+            {texts.avslag}
+          </Button>
+        </ButtonRow>
+      </Box>
+    </div>
+  );
+};


### PR DESCRIPTION
Mangler kobling til backend.
Nå er det lagt opp til bare en side for både "venter" og "passert frist". Mangler dato for frist til høyre for tittel.
Mangler ordentlig visning av brevet som faktisk ble sendt.

- Vi kan vurdere om vi vil ha to sider eller om det er best å bare endre innholdet på én side basert på hvorvidt fristen er passert eller ikke. Jeg tror kanskje bare én er greiest.
- Til forhåndsvisningen må vi vel bare hente fra backend, er det lagt opp til at DocumentComponents skal sendes med?
- ~Forhåndsvisning heter egentlig "Se sendt brev" i skissene, men det var enklest å bare bruke samme knapp som andre steder nå, selv om den har feil tekst.~ Nå bruker vi VarselBrev i stedet.

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/f7a5f177-6538-4c0d-ba3b-018d0882d34a)
