### PR TITLE
IS-2125: Tilpasser tekst som journalføres ved ikke-aktuell-vurdering

### DIFF
--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -91,9 +91,7 @@ export const useAktivitetskravVarselDocument = (): {
       documentComponents.push(createParagraph(`Begrunnelse: ${begrunnelse}`));
     }
     documentComponents.push(
-      createParagraph(
-        "Vedtak ble fattet etter folketrygdloven § 8-8 andre ledd, samt tilhørende rundskriv."
-      ),
+      createParagraph(getVedtakText(varselType)),
       createParagraph(`Vurdert av ${veilederinfo?.navn || ""}`)
     );
 
@@ -105,7 +103,6 @@ export const useAktivitetskravVarselDocument = (): {
     getVurderingDocument,
   };
 };
-
 const getVurderingText = (type: VarselType, arsak: VurderingArsak): string => {
   const arsakText = vurderingArsakTexts[arsak] ?? "";
   const vurdertDato = tilDatoMedManedNavn(new Date());
@@ -118,6 +115,21 @@ const getVurderingText = (type: VarselType, arsak: VurderingArsak): string => {
     }
     case VarselType.IKKE_AKTUELL: {
       return `Det ble vurdert at aktivitetskravet ikke er aktuelt den ${vurdertDato}. Årsak: ${arsakText}.`;
+    }
+    case VarselType.FORHANDSVARSEL_STANS_AV_SYKEPENGER: {
+      throw new Error("use getForhandsvarselDocument");
+    }
+  }
+};
+
+const getVedtakText = (type: VarselType) => {
+  switch (type) {
+    case VarselType.UNNTAK:
+    case VarselType.OPPFYLT: {
+      return "Vedtak ble fattet etter folketrygdloven § 8-8 andre ledd, samt tilhørende rundskriv.";
+    }
+    case VarselType.IKKE_AKTUELL: {
+      return "Det er vurdert at folketrygdloven § 8-8 andre ledd ikke kommer til anvendelse i dette tilfellet.";
     }
     case VarselType.FORHANDSVARSEL_STANS_AV_SYKEPENGER: {
       throw new Error("use getForhandsvarselDocument");

--- a/test/aktivitetskrav/varselDocuments.ts
+++ b/test/aktivitetskrav/varselDocuments.ts
@@ -62,7 +62,7 @@ export const getIkkeAktuellDocument = (
       type: DocumentComponentType.PARAGRAPH,
     },
     vurderingBegrunnelse(begrunnelse),
-    vurderingHjemmel,
+    ikkeAktuellHjemmel,
     vurderingHilsen,
   ];
 };
@@ -113,6 +113,13 @@ const vurderingHilsen = {
 const vurderingHjemmel = {
   texts: [
     "Vedtak ble fattet etter folketrygdloven § 8-8 andre ledd, samt tilhørende rundskriv.",
+  ],
+  type: DocumentComponentType.PARAGRAPH,
+};
+
+const ikkeAktuellHjemmel = {
+  texts: [
+    "Det er vurdert at folketrygdloven § 8-8 andre ledd ikke kommer til anvendelse i dette tilfellet.",
   ],
   type: DocumentComponentType.PARAGRAPH,
 };

--- a/test/aktivitetskrav/vurdering/AktivitetskravForhandsvarselTest.tsx
+++ b/test/aktivitetskrav/vurdering/AktivitetskravForhandsvarselTest.tsx
@@ -1,0 +1,269 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { navEnhet } from "../../dialogmote/testData";
+import React from "react";
+import { VurderAktivitetskrav } from "@/sider/aktivitetskrav/vurdering/VurderAktivitetskrav";
+import { queryClientWithMockData } from "../../testQueryClient";
+import {
+  changeTextInput,
+  clickButton,
+  clickTab,
+  getTextInput,
+  getTooLongText,
+} from "../../testUtils";
+import {
+  AktivitetskravDTO,
+  AktivitetskravStatus,
+  CreateAktivitetskravVurderingDTO,
+  SendForhandsvarselDTO,
+} from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { expect } from "chai";
+import { getSendForhandsvarselDocument } from "../varselDocuments";
+import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
+import { personOppgaveUbehandletVurderStans } from "../../../mock/ispersonoppgave/personoppgaveMock";
+import { ARBEIDSTAKER_DEFAULT } from "../../../mock/common/mockConstants";
+import { apiMock } from "../../stubs/stubApi";
+import { stubVurderAktivitetskravForhandsvarselApi } from "../../stubs/stubIsaktivitetskrav";
+import nock from "nock";
+import { NotificationContext } from "@/context/notification/NotificationContext";
+import { Brevmal } from "@/data/aktivitetskrav/forhandsvarselTexts";
+import {
+  aktivitetskrav,
+  enLangBeskrivelse,
+  forhandsvarselAktivitetskrav,
+  tabTexts,
+} from "./vurderingTestUtils";
+
+let queryClient: QueryClient;
+let apiMockScope: any;
+
+const renderVurderAktivitetskrav = (aktivitetskravDto: AktivitetskravDTO) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <NotificationContext.Provider
+          value={{ notification: undefined, setNotification: () => void 0 }}
+        >
+          <VurderAktivitetskrav aktivitetskrav={aktivitetskravDto} />
+        </NotificationContext.Provider>
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+describe("VurderAktivitetskrav forhåndsvarsel", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+    apiMockScope = apiMock();
+  });
+  afterEach(() => {
+    nock.cleanAll();
+  });
+  describe("Send forhåndsvarsel", () => {
+    it("Does not show AVVENT or FORHANDSVARSEL choice when forhandsvarsel is sent", () => {
+      renderVurderAktivitetskrav(forhandsvarselAktivitetskrav);
+
+      expect(screen.queryByRole("tab", { name: "Sett unntak" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.not
+        .exist;
+      expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
+      expect(screen.queryByRole("button", { name: "Avvent" })).to.not.exist;
+    });
+
+    it("Viser select for valg av mal med 'Med arbeidsgiver' forhåndsvalgt", () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+      clickTab(tabTexts["FORHANDSVARSEL"]);
+
+      const velgMalSelect = screen.getByRole("combobox");
+      expect(
+        within(velgMalSelect).getByRole("option", { name: "Har arbeidsgiver" })
+      ).to.exist;
+      expect(
+        within(velgMalSelect).getByRole("option", {
+          name: "Har ikke arbeidsgiver",
+        })
+      ).to.exist;
+      expect(screen.getByDisplayValue("Har arbeidsgiver")).to.exist;
+      expect(screen.queryByDisplayValue("Har ikke arbeidsgiver")).to.not.exist;
+    });
+
+    it("Send forhåndsvarsel with beskrivelse filled in, and reset form after submit", async () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+      stubVurderAktivitetskravForhandsvarselApi(apiMockScope);
+      const beskrivelseLabel = "Begrunnelse (obligatorisk)";
+
+      clickTab(tabTexts["FORHANDSVARSEL"]);
+
+      expect(
+        screen.getByRole("heading", {
+          name: "Send forhåndsvarsel",
+        })
+      ).to.exist;
+
+      expect(screen.getByRole("textbox", { name: beskrivelseLabel })).to.exist;
+      expect(screen.getByText("Forhåndsvisning")).to.exist;
+
+      const beskrivelseInput = getTextInput(beskrivelseLabel);
+      changeTextInput(beskrivelseInput, enLangBeskrivelse);
+
+      clickButton("Send");
+
+      await waitFor(() => {
+        const sendForhandsvarselMutation = queryClient
+          .getMutationCache()
+          .getAll()[0];
+        const expectedVurdering: SendForhandsvarselDTO = {
+          fritekst: enLangBeskrivelse,
+          document: getSendForhandsvarselDocument(enLangBeskrivelse),
+        };
+        expect(sendForhandsvarselMutation.state.variables).to.deep.equal(
+          expectedVurdering
+        );
+      });
+
+      await waitFor(
+        () => expect(screen.queryByText(enLangBeskrivelse)).to.not.exist
+      );
+    });
+
+    it("Send forhåndsvarsel with mal 'Uten arbeidsgiver'", async () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+      stubVurderAktivitetskravForhandsvarselApi(apiMockScope);
+      const beskrivelseLabel = "Begrunnelse (obligatorisk)";
+
+      clickTab(tabTexts["FORHANDSVARSEL"]);
+
+      expect(
+        screen.getByRole("heading", {
+          name: "Send forhåndsvarsel",
+        })
+      ).to.exist;
+
+      expect(screen.getByRole("textbox", { name: beskrivelseLabel })).to.exist;
+      expect(screen.getByText("Forhåndsvisning")).to.exist;
+
+      const beskrivelseInput = getTextInput(beskrivelseLabel);
+      changeTextInput(beskrivelseInput, enLangBeskrivelse);
+
+      const velgMalSelect = screen.getByRole("combobox");
+      fireEvent.change(velgMalSelect, {
+        target: { value: "UTEN_ARBEIDSGIVER" },
+      });
+
+      clickButton("Send");
+
+      await waitFor(() => {
+        const sendForhandsvarselMutation = queryClient
+          .getMutationCache()
+          .getAll()[0];
+        const expectedVurdering: SendForhandsvarselDTO = {
+          fritekst: enLangBeskrivelse,
+          document: getSendForhandsvarselDocument(
+            enLangBeskrivelse,
+            Brevmal.UTEN_ARBEIDSGIVER
+          ),
+        };
+        expect(sendForhandsvarselMutation.state.variables).to.deep.equal(
+          expectedVurdering
+        );
+      });
+
+      await waitFor(
+        () => expect(screen.queryByText(enLangBeskrivelse)).to.not.exist
+      );
+    });
+
+    it("IKKE_OPPFYLT is present when status is forhandsvarsel and it is expired", () => {
+      queryClient.setQueryData(
+        personoppgaverQueryKeys.personoppgaver(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => [personOppgaveUbehandletVurderStans]
+      );
+      renderVurderAktivitetskrav(forhandsvarselAktivitetskrav);
+
+      clickTab(tabTexts["IKKE_OPPFYLT"]);
+
+      expect(
+        screen.getByRole("heading", {
+          name: "Ikke oppfylt",
+        })
+      ).to.exist;
+
+      expect(
+        screen.getByText(/Innstilling må skrives og sendes til NAY i Gosys/)
+      ).to.exist;
+      clickButton("Lagre");
+
+      const vurderIkkeOppfyltMutation = queryClient
+        .getMutationCache()
+        .getAll()[0];
+      const expectedVurdering: CreateAktivitetskravVurderingDTO = {
+        status: AktivitetskravStatus.IKKE_OPPFYLT,
+        arsaker: [],
+      };
+      expect(vurderIkkeOppfyltMutation.state.variables).to.deep.equal(
+        expectedVurdering
+      );
+    });
+    it("Fails to send forhåndsvarsel when no beskrivelse is filled in", async () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+      clickTab(tabTexts["FORHANDSVARSEL"]);
+      clickButton("Send");
+
+      expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
+    });
+    it("Validerer maks tegn beskrivelse", async () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+      clickTab(tabTexts["FORHANDSVARSEL"]);
+
+      const tooLongBeskrivelse = getTooLongText(1000);
+      const beskrivelseInput = getTextInput("Begrunnelse (obligatorisk)");
+      changeTextInput(beskrivelseInput, tooLongBeskrivelse);
+      clickButton("Send");
+
+      expect(await screen.findByText("1 tegn for mye")).to.exist;
+    });
+  });
+  describe("ForhandsvarselOppsummering", () => {
+    it("Viser oppsummering når forhåndsvarsel er sendt", () => {
+      renderVurderAktivitetskrav(forhandsvarselAktivitetskrav);
+
+      expect(
+        screen.getByRole("heading", {
+          name: "Oppsummering av forhåndsvarselet",
+        })
+      ).to.exist;
+      expect(screen.getByText("Frist: ", { exact: false })).to.exist;
+      expect(
+        screen.getByText(
+          "Husk å sjekke Gosys og Modia for mer informasjon før du vurderer."
+        )
+      ).to.exist;
+    });
+
+    it("Viser ikke oppsummering når forhåndsvarsel ikke er sendt", () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+
+      expect(
+        screen.queryByRole("heading", {
+          name: "Oppsummering av forhåndsvarselet",
+        })
+      ).to.not.exist;
+      expect(screen.queryByText("Frist: ", { exact: false })).to.not.exist;
+      expect(
+        screen.queryByText(
+          "Husk å sjekke Gosys og Modia for mer informasjon før du vurderer."
+        )
+      ).to.not.exist;
+    });
+  });
+});

--- a/test/aktivitetskrav/vurdering/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/vurdering/VurderAktivitetskravTest.tsx
@@ -7,17 +7,15 @@ import {
 } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
-import { navEnhet } from "../dialogmote/testData";
+import { navEnhet } from "../../dialogmote/testData";
 import React from "react";
 import { VurderAktivitetskrav } from "@/sider/aktivitetskrav/vurdering/VurderAktivitetskrav";
-import { queryClientWithMockData } from "../testQueryClient";
+import { queryClientWithMockData } from "../../testQueryClient";
 import {
   avventVurdering,
   createAktivitetskrav,
-  forhandsvarselVurdering,
-  generateOppfolgingstilfelle,
   oppfyltVurdering,
-} from "../testDataUtils";
+} from "../../testDataUtils";
 import {
   changeTextInput,
   clickButton,
@@ -25,7 +23,7 @@ import {
   daysFromToday,
   getTextInput,
   getTooLongText,
-} from "../testUtils";
+} from "../../testUtils";
 import {
   AktivitetskravDTO,
   AktivitetskravStatus,
@@ -33,7 +31,6 @@ import {
   CreateAktivitetskravVurderingDTO,
   IkkeAktuellArsak,
   OppfyltVurderingArsak,
-  SendForhandsvarselDTO,
   UnntakVurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { expect } from "chai";
@@ -42,56 +39,32 @@ import dayjs from "dayjs";
 import {
   getIkkeAktuellDocument,
   getOppfyltDocument,
-  getSendForhandsvarselDocument,
   getUnntakDocument,
-} from "./varselDocuments";
+} from "../varselDocuments";
 import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
-import { personOppgaveUbehandletVurderStans } from "../../mock/ispersonoppgave/personoppgaveMock";
-import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
-import { apiMock } from "../stubs/stubApi";
-import {
-  stubVurderAktivitetskravApi,
-  stubVurderAktivitetskravForhandsvarselApi,
-} from "../stubs/stubIsaktivitetskrav";
+import { personOppgaveUbehandletVurderStans } from "../../../mock/ispersonoppgave/personoppgaveMock";
+import { ARBEIDSTAKER_DEFAULT } from "../../../mock/common/mockConstants";
+import { apiMock } from "../../stubs/stubApi";
+import { stubVurderAktivitetskravApi } from "../../stubs/stubIsaktivitetskrav";
 import nock from "nock";
 import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { NotificationContext } from "@/context/notification/NotificationContext";
-import { Brevmal } from "@/data/aktivitetskrav/forhandsvarselTexts";
+import {
+  aktivitetskrav,
+  buttonTexts,
+  enKortBeskrivelse,
+  enLangBeskrivelse,
+  forhandsvarselAktivitetskrav,
+  oppfolgingstilfelle,
+  tabTexts,
+  tilfelleEnd,
+  tilfelleStart,
+} from "./vurderingTestUtils";
 
 let queryClient: QueryClient;
 let apiMockScope: any;
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
-const aktivitetskrav = createAktivitetskrav(
-  daysFromToday(5),
-  AktivitetskravStatus.NY
-);
-const forhandsvarselAktivitetskrav = createAktivitetskrav(
-  daysFromToday(5),
-  AktivitetskravStatus.FORHANDSVARSEL,
-  [forhandsvarselVurdering]
-);
-const tilfelleStart = daysFromToday(-50);
-const tilfelleEnd = daysFromToday(50);
-const oppfolgingstilfelle = generateOppfolgingstilfelle(
-  tilfelleStart,
-  tilfelleEnd
-);
-
-const buttonTexts = {
-  [AktivitetskravStatus.AVVENT]: "Avvent",
-  [AktivitetskravStatus.IKKE_AKTUELL]: "Ikke aktuell",
-};
-
-const tabTexts = {
-  [AktivitetskravStatus.UNNTAK]: "Sett unntak",
-  [AktivitetskravStatus.OPPFYLT]: "Er i aktivitet",
-  [AktivitetskravStatus.FORHANDSVARSEL]: "Send forhåndsvarsel",
-  [AktivitetskravStatus.IKKE_OPPFYLT]: "Ikke oppfylt",
-};
-
-const enLangBeskrivelse = "Her er en beskrivelse" + "t".repeat(900);
-const enKortBeskrivelse = "Her er en beskrivelse" + "t".repeat(150);
 
 const renderVurderAktivitetskrav = (aktivitetskravDto: AktivitetskravDTO) =>
   render(
@@ -369,173 +342,6 @@ describe("VurderAktivitetskrav", () => {
         .exist;
     });
   });
-  describe("Send forhåndsvarsel", () => {
-    it("Does not show AVVENT or FORHANDSVARSEL choice when forhandsvarsel is sent", () => {
-      renderVurderAktivitetskrav(forhandsvarselAktivitetskrav);
-
-      expect(screen.queryByRole("tab", { name: "Sett unntak" })).to.exist;
-      expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
-      expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.not
-        .exist;
-      expect(screen.queryByRole("tab", { name: "Ikke oppfylt" })).to.not.exist;
-      expect(screen.queryByRole("button", { name: "Avvent" })).to.not.exist;
-    });
-
-    it("Viser select for valg av mal med 'Med arbeidsgiver' forhåndsvalgt", () => {
-      renderVurderAktivitetskrav(aktivitetskrav);
-      clickTab(tabTexts["FORHANDSVARSEL"]);
-
-      const velgMalSelect = screen.getByRole("combobox");
-      expect(
-        within(velgMalSelect).getByRole("option", { name: "Har arbeidsgiver" })
-      ).to.exist;
-      expect(
-        within(velgMalSelect).getByRole("option", {
-          name: "Har ikke arbeidsgiver",
-        })
-      ).to.exist;
-      expect(screen.getByDisplayValue("Har arbeidsgiver")).to.exist;
-      expect(screen.queryByDisplayValue("Har ikke arbeidsgiver")).to.not.exist;
-    });
-
-    it("Send forhåndsvarsel with beskrivelse filled in, and reset form after submit", async () => {
-      renderVurderAktivitetskrav(aktivitetskrav);
-      stubVurderAktivitetskravForhandsvarselApi(apiMockScope);
-      const beskrivelseLabel = "Begrunnelse (obligatorisk)";
-
-      clickTab(tabTexts["FORHANDSVARSEL"]);
-
-      expect(
-        screen.getByRole("heading", {
-          name: "Send forhåndsvarsel",
-        })
-      ).to.exist;
-
-      expect(screen.getByRole("textbox", { name: beskrivelseLabel })).to.exist;
-      expect(screen.getByText("Forhåndsvisning")).to.exist;
-
-      const beskrivelseInput = getTextInput(beskrivelseLabel);
-      changeTextInput(beskrivelseInput, enLangBeskrivelse);
-
-      clickButton("Send");
-
-      await waitFor(() => {
-        const sendForhandsvarselMutation = queryClient
-          .getMutationCache()
-          .getAll()[0];
-        const expectedVurdering: SendForhandsvarselDTO = {
-          fritekst: enLangBeskrivelse,
-          document: getSendForhandsvarselDocument(enLangBeskrivelse),
-        };
-        expect(sendForhandsvarselMutation.state.variables).to.deep.equal(
-          expectedVurdering
-        );
-      });
-
-      await waitFor(
-        () => expect(screen.queryByText(enLangBeskrivelse)).to.not.exist
-      );
-    });
-
-    it("Send forhåndsvarsel with mal 'Uten arbeidsgiver'", async () => {
-      renderVurderAktivitetskrav(aktivitetskrav);
-      stubVurderAktivitetskravForhandsvarselApi(apiMockScope);
-      const beskrivelseLabel = "Begrunnelse (obligatorisk)";
-
-      clickTab(tabTexts["FORHANDSVARSEL"]);
-
-      expect(
-        screen.getByRole("heading", {
-          name: "Send forhåndsvarsel",
-        })
-      ).to.exist;
-
-      expect(screen.getByRole("textbox", { name: beskrivelseLabel })).to.exist;
-      expect(screen.getByText("Forhåndsvisning")).to.exist;
-
-      const beskrivelseInput = getTextInput(beskrivelseLabel);
-      changeTextInput(beskrivelseInput, enLangBeskrivelse);
-
-      const velgMalSelect = screen.getByRole("combobox");
-      fireEvent.change(velgMalSelect, {
-        target: { value: "UTEN_ARBEIDSGIVER" },
-      });
-
-      clickButton("Send");
-
-      await waitFor(() => {
-        const sendForhandsvarselMutation = queryClient
-          .getMutationCache()
-          .getAll()[0];
-        const expectedVurdering: SendForhandsvarselDTO = {
-          fritekst: enLangBeskrivelse,
-          document: getSendForhandsvarselDocument(
-            enLangBeskrivelse,
-            Brevmal.UTEN_ARBEIDSGIVER
-          ),
-        };
-        expect(sendForhandsvarselMutation.state.variables).to.deep.equal(
-          expectedVurdering
-        );
-      });
-
-      await waitFor(
-        () => expect(screen.queryByText(enLangBeskrivelse)).to.not.exist
-      );
-    });
-
-    it("IKKE_OPPFYLT is present when status is forhandsvarsel and it is expired", () => {
-      queryClient.setQueryData(
-        personoppgaverQueryKeys.personoppgaver(
-          ARBEIDSTAKER_DEFAULT.personIdent
-        ),
-        () => [personOppgaveUbehandletVurderStans]
-      );
-      renderVurderAktivitetskrav(forhandsvarselAktivitetskrav);
-
-      clickTab(tabTexts["IKKE_OPPFYLT"]);
-
-      expect(
-        screen.getByRole("heading", {
-          name: "Ikke oppfylt",
-        })
-      ).to.exist;
-
-      expect(
-        screen.getByText(/Innstilling må skrives og sendes til NAY i Gosys/)
-      ).to.exist;
-      clickButton("Lagre");
-
-      const vurderIkkeOppfyltMutation = queryClient
-        .getMutationCache()
-        .getAll()[0];
-      const expectedVurdering: CreateAktivitetskravVurderingDTO = {
-        status: AktivitetskravStatus.IKKE_OPPFYLT,
-        arsaker: [],
-      };
-      expect(vurderIkkeOppfyltMutation.state.variables).to.deep.equal(
-        expectedVurdering
-      );
-    });
-    it("Fails to send forhåndsvarsel when no beskrivelse is filled in", async () => {
-      renderVurderAktivitetskrav(aktivitetskrav);
-      clickTab(tabTexts["FORHANDSVARSEL"]);
-      clickButton("Send");
-
-      expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
-    });
-    it("Validerer maks tegn beskrivelse", async () => {
-      renderVurderAktivitetskrav(aktivitetskrav);
-      clickTab(tabTexts["FORHANDSVARSEL"]);
-
-      const tooLongBeskrivelse = getTooLongText(1000);
-      const beskrivelseInput = getTextInput("Begrunnelse (obligatorisk)");
-      changeTextInput(beskrivelseInput, tooLongBeskrivelse);
-      clickButton("Send");
-
-      expect(await screen.findByText("1 tegn for mye")).to.exist;
-    });
-  });
   describe("Ikke aktuell", () => {
     it("Validerer maks tegn beskrivelse", async () => {
       renderVurderAktivitetskrav(aktivitetskrav);
@@ -646,39 +452,6 @@ describe("VurderAktivitetskrav", () => {
       expect(screen.queryByRole("img", { name: "Advarsel" })).to.not.exist;
       expect(screen.queryByRole("img", { name: "Suksess" })).to.not.exist;
       expect(screen.queryByRole("img", { name: "Info" })).to.not.exist;
-    });
-  });
-  describe("ForhandsvarselOppsummering", () => {
-    it("Viser oppsummering når forhåndsvarsel er sendt", () => {
-      renderVurderAktivitetskrav(forhandsvarselAktivitetskrav);
-
-      expect(
-        screen.getByRole("heading", {
-          name: "Oppsummering av forhåndsvarselet",
-        })
-      ).to.exist;
-      expect(screen.getByText("Frist: ", { exact: false })).to.exist;
-      expect(
-        screen.getByText(
-          "Husk å sjekke Gosys og Modia for mer informasjon før du vurderer."
-        )
-      ).to.exist;
-    });
-
-    it("Viser ikke oppsummering når forhåndsvarsel ikke er sendt", () => {
-      renderVurderAktivitetskrav(aktivitetskrav);
-
-      expect(
-        screen.queryByRole("heading", {
-          name: "Oppsummering av forhåndsvarselet",
-        })
-      ).to.not.exist;
-      expect(screen.queryByText("Frist: ", { exact: false })).to.not.exist;
-      expect(
-        screen.queryByText(
-          "Husk å sjekke Gosys og Modia for mer informasjon før du vurderer."
-        )
-      ).to.not.exist;
     });
   });
 });

--- a/test/aktivitetskrav/vurdering/vurderingTestUtils.ts
+++ b/test/aktivitetskrav/vurdering/vurderingTestUtils.ts
@@ -1,0 +1,38 @@
+import {
+  createAktivitetskrav,
+  forhandsvarselVurdering,
+  generateOppfolgingstilfelle,
+} from "../../testDataUtils";
+import { daysFromToday } from "../../testUtils";
+import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
+
+export const aktivitetskrav = createAktivitetskrav(
+  daysFromToday(5),
+  AktivitetskravStatus.NY
+);
+export const forhandsvarselAktivitetskrav = createAktivitetskrav(
+  daysFromToday(5),
+  AktivitetskravStatus.FORHANDSVARSEL,
+  [forhandsvarselVurdering]
+);
+export const tilfelleStart = daysFromToday(-50);
+export const tilfelleEnd = daysFromToday(50);
+export const oppfolgingstilfelle = generateOppfolgingstilfelle(
+  tilfelleStart,
+  tilfelleEnd
+);
+
+export const buttonTexts = {
+  [AktivitetskravStatus.AVVENT]: "Avvent",
+  [AktivitetskravStatus.IKKE_AKTUELL]: "Ikke aktuell",
+};
+
+export const tabTexts = {
+  [AktivitetskravStatus.UNNTAK]: "Sett unntak",
+  [AktivitetskravStatus.OPPFYLT]: "Er i aktivitet",
+  [AktivitetskravStatus.FORHANDSVARSEL]: "Send forhåndsvarsel",
+  [AktivitetskravStatus.IKKE_OPPFYLT]: "Ikke oppfylt",
+};
+
+export const enLangBeskrivelse = "Her er en beskrivelse" + "t".repeat(900);
+export const enKortBeskrivelse = "Her er en beskrivelse" + "t".repeat(150);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det fattes ikke vedtak når det vurderes `IKKE_AKTUELL` så her må standardteksten som journalføres med vurderingen tilpasses.

Ryddet samtidig litt i `VurderAktivitetskravTest`: Flyttet forhåndsvarsel-tester og felles testdata ut i egne filer.
