### PR TITLE
IS-2119: Remove virksomhet-grouping for sykmeldinger

### DIFF
--- a/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
@@ -4,7 +4,6 @@ import {
   arbeidsgivernavnEllerArbeidssituasjon,
   erEkstraInformasjonISykmeldingen,
   stringMedAlleGraderingerFraSykmeldingPerioder,
-  sykmeldingerGruppertEtterVirksomhet,
   sykmeldingerInnenforOppfolgingstilfelle,
   sykmeldingerSortertNyestTilEldstPeriode,
   sykmeldingerUtenArbeidsgiver,
@@ -126,7 +125,6 @@ export const SykmeldingTittelbeskrivelse = ({
 
 interface UtvidbarSykmeldingProps {
   sykmelding: SykmeldingOldFormat;
-  label?: string;
 }
 
 function logAccordionOpened(isOpen: boolean) {
@@ -141,8 +139,12 @@ function logAccordionOpened(isOpen: boolean) {
   }
 }
 
-const UtvidbarSykmelding = ({ sykmelding, label }: UtvidbarSykmeldingProps) => {
-  const title = label ? label : "Sykmelding uten arbeidsgiver";
+const UtvidbarSykmelding = ({ sykmelding }: UtvidbarSykmeldingProps) => {
+  const arbeidsgiverEllerSituasjon =
+    arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
+  const title = arbeidsgiverEllerSituasjon
+    ? arbeidsgiverEllerSituasjon
+    : "Sykmelding uten arbeidsgiver";
   return (
     <ExpansionCard aria-label={title} onToggle={logAccordionOpened}>
       <StyledExpantionCardHeader className="w-full">
@@ -175,30 +177,15 @@ export const SykmeldingerForVirksomhet = () => {
     );
   const sykmeldingerSortertPaaStartDato =
     sykmeldingerSortertNyestTilEldstPeriode(sykmeldingerIOppfolgingstilfellet);
-  const sykmeldingerSortertPaaVirksomhet = sykmeldingerGruppertEtterVirksomhet(
-    sykmeldingerSortertPaaStartDato
-  );
 
   return (
     <div className="mb-10 [&>*]:mb-2">
       <Heading size="small" level="3">
         {texts.sykmeldinger.header}
       </Heading>
-      {Object.keys(sykmeldingerSortertPaaVirksomhet).map((key) => {
-        return sykmeldingerSortertPaaVirksomhet[key].map(
-          (sykmelding, index) => {
-            const arbeidsgiverEllerSituasjon =
-              arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
-            return (
-              <UtvidbarSykmelding
-                sykmelding={sykmelding}
-                label={arbeidsgiverEllerSituasjon}
-                key={index}
-              />
-            );
-          }
-        );
-      })}
+      {sykmeldingerSortertPaaStartDato.map((sykmelding, index) => (
+        <UtvidbarSykmelding sykmelding={sykmelding} key={index} />
+      ))}
     </div>
   );
 };
@@ -215,9 +202,9 @@ export const SykmeldingerUtenArbeidsgiver = ({
       <Heading size="small" level="3">
         {texts.sykmeldinger.headerUtenArbeidsgiver}
       </Heading>
-      {sykmeldingerSortertPaUtstedelsesdato.map((sykmelding, index) => {
-        return <UtvidbarSykmelding sykmelding={sykmelding} key={index} />;
-      })}
+      {sykmeldingerSortertPaUtstedelsesdato.map((sykmelding, index) => (
+        <UtvidbarSykmelding sykmelding={sykmelding} key={index} />
+      ))}
     </div>
   );
 };

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -253,28 +253,6 @@ export function sykmeldingerSortertNyestTilEldstPeriode(
   });
 }
 
-interface SykmeldingerPerVirksomhet {
-  [virksomhetsnummer: string]: SykmeldingOldFormat[];
-}
-
-export const sykmeldingerGruppertEtterVirksomhet = (
-  sykmeldinger: SykmeldingOldFormat[]
-): SykmeldingerPerVirksomhet => {
-  return sykmeldinger.reduce((memo: SykmeldingerPerVirksomhet, sykmelding) => {
-    const virksomhetsnummer =
-      sykmelding.mottakendeArbeidsgiver?.virksomhetsnummer ??
-      "Ukjent virksomhet";
-    const memo2 = { ...memo };
-    if (virksomhetsnummer) {
-      if (!memo2[virksomhetsnummer]) {
-        memo2[virksomhetsnummer] = [];
-      }
-      memo2[virksomhetsnummer] = [...memo2[virksomhetsnummer], sykmelding];
-    }
-    return memo2;
-  }, {});
-};
-
 const sykmeldingperioderMedGradering = (
   sykmeldingperioder: SykmeldingPeriodeDTO[]
 ) => {

--- a/test/components/UtdragFraSykefravaeretTest.tsx
+++ b/test/components/UtdragFraSykefravaeretTest.tsx
@@ -38,7 +38,8 @@ describe("UtdragFraSykefravaeret", () => {
     expect(within(firstExpansionCard).getByText("Sykmelder:")).to.exist;
     expect(within(firstExpansionCard).getByText("Lego Las Legesen")).to.exist;
     expect(within(firstExpansionCard).getByText("Arbeidsgiver:")).to.exist;
-    expect(within(firstExpansionCard).getByText("BRANN OG BIL AS")).to.exist;
+    expect(within(firstExpansionCard).getByText("Virksomhet uten leder AS")).to
+      .exist;
   });
 
   it("Viser sykmeldinger som både er sendt og ikke tatt i bruk", () => {
@@ -47,7 +48,7 @@ describe("UtdragFraSykefravaeret", () => {
     const sykmeldingExpansionCards = screen.getAllByRole("region");
     expect(sykmeldingExpansionCards.length).to.equal(2);
 
-    expect(within(sykmeldingExpansionCards[0]).getByText("Ikke tatt i bruk")).to
+    expect(within(sykmeldingExpansionCards[1]).getByText("Ikke tatt i bruk")).to
       .exist;
   });
 });

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -14,7 +14,6 @@ import {
   latestSykmeldingForVirksomhet,
   newAndActivatedSykmeldinger,
   stringMedAlleGraderingerFraSykmeldingPerioder,
-  sykmeldingerGruppertEtterVirksomhet,
   sykmeldingerInnenforOppfolgingstilfelle,
   sykmeldingerSortertNyestTilEldstPeriode,
   sykmeldingperioderSortertEldstTilNyest,
@@ -633,77 +632,6 @@ describe("sykmeldingUtils", () => {
       expect(
         sykmeldingerSortertPaaUtstedelsesdato[4].mulighetForArbeid.perioder[0].fom.getTime()
       ).to.equal(new Date("2019-01-01").getTime());
-    });
-  });
-
-  describe("sykmeldingerGruppertEtterVirksomhet", () => {
-    it("skal returnere en liste med én liste av sykmeldinger per virksomhet", () => {
-      const sykmeldinger: SykmeldingOldFormat[] = [
-        {
-          ...baseSykmelding,
-          mottakendeArbeidsgiver: {
-            navn: "Arbeidsgiver",
-            virksomhetsnummer: "1",
-            juridiskOrgnummer: "1",
-          },
-        },
-        {
-          ...baseSykmelding,
-          mottakendeArbeidsgiver: {
-            navn: "Arbeidsgiver",
-            virksomhetsnummer: "2",
-            juridiskOrgnummer: "2",
-          },
-        },
-        {
-          ...baseSykmelding,
-          mottakendeArbeidsgiver: {
-            navn: "Arbeidsgiver",
-            virksomhetsnummer: "2",
-            juridiskOrgnummer: "2",
-          },
-        },
-        {
-          ...baseSykmelding,
-          mottakendeArbeidsgiver: {
-            navn: "Arbeidsgiver",
-            virksomhetsnummer: "3",
-            juridiskOrgnummer: "3",
-          },
-        },
-        {
-          ...baseSykmelding,
-          mottakendeArbeidsgiver: {
-            navn: "Arbeidsgiver",
-            virksomhetsnummer: "1",
-            juridiskOrgnummer: "1",
-          },
-        },
-        {
-          ...baseSykmelding,
-          mottakendeArbeidsgiver: {
-            navn: "Arbeidsgiver",
-            virksomhetsnummer: "1",
-            juridiskOrgnummer: "1",
-          },
-        },
-      ];
-
-      const sykmeldingerSortertPaaVirksomhetsnummer =
-        sykmeldingerGruppertEtterVirksomhet(sykmeldinger);
-
-      expect(
-        Object.keys(sykmeldingerSortertPaaVirksomhetsnummer).length
-      ).to.equal(3);
-      expect(
-        Object.keys(sykmeldingerSortertPaaVirksomhetsnummer["1"]).length
-      ).to.equal(3);
-      expect(
-        Object.keys(sykmeldingerSortertPaaVirksomhetsnummer["2"]).length
-      ).to.equal(2);
-      expect(
-        Object.keys(sykmeldingerSortertPaaVirksomhetsnummer["3"]).length
-      ).to.equal(1);
     });
   });
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Se https://jira.adeo.no/browse/FAGSYSTEM-320013 og https://jira.adeo.no/browse/FAGSYSTEM-316186.
Når sykmeldt har flere arbeidsgivere, grupperes de inn på virksomhetsnummer. Innenfor hver virksomhet var sykmeldingene sortert, men ettersom det var en key-value mapping på virksomhetsnummer så ble rekkefølgen på sykmeldingene vilkårlig på tvers av arbeidsgivere, ettersom vi i dag ikke har noen visuell visning av grupperingen på arbeidsgiver.

Veilederne som har meldt inn saken har egentlig alle sykmeldinger tilgjengelig, men de lå lenger ned i lista ettersom en "gammel" arbeidsgiver endte opp øverst i sorteringen.

