### PR TITLE
IS-2150: Show korriger button when papirsykmelding

### DIFF
--- a/src/sider/sykmeldinger/container/DinSykmeldingContainer.tsx
+++ b/src/sider/sykmeldinger/container/DinSykmeldingContainer.tsx
@@ -68,7 +68,7 @@ const DinSykmeldingSide = (): ReactElement => {
             dinSykmelding={dinSykmelding}
             arbeidsgiversSykmelding={arbeidsgiversSykmelding}
           />
-          {!dinSykmelding?.papirsykmelding && <EndreSykmelding />}
+          {dinSykmelding?.papirsykmelding && <EndreSykmelding />}
           <LenkeTilDineSykmeldinger />
         </Panel>
       </SideLaster>


### PR DESCRIPTION
Fiks bug hvor knappen for å korrigere en sykmelding kun ble vist på ikke-papirsykmeldinger.