### PR TITLE
IS-2126: Add possibility of beskrivelse to oppfolgingsgrunn ANNET

### DIFF
--- a/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
+++ b/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
@@ -77,7 +77,7 @@ export const OppfolgingsoppgaveModal = ({ isOpen, toggleOpen }: Props) => {
     const oppfolgingsoppgaveDto: OppfolgingsoppgaveRequestDTO = {
       oppfolgingsgrunn: values.oppfolgingsgrunn,
       tekst:
-        values.oppfolgingsgrunn == Oppfolgingsgrunn.ANNET
+        values.oppfolgingsgrunn === Oppfolgingsgrunn.ANNET
           ? undefined
           : values.beskrivelse,
       frist: values.frist,
@@ -98,7 +98,7 @@ export const OppfolgingsoppgaveModal = ({ isOpen, toggleOpen }: Props) => {
   });
 
   const isOppfolgingsgrunnAnnet =
-    watch("oppfolgingsgrunn") == Oppfolgingsgrunn.ANNET;
+    watch("oppfolgingsgrunn") === Oppfolgingsgrunn.ANNET;
 
   return (
     <form onSubmit={handleSubmit(submit)}>

--- a/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
+++ b/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
@@ -26,6 +26,8 @@ const texts = {
   header: "Oppfølgingsoppgave",
   guidelines:
     "Denne oppgaven skal kun brukes etter formålet, altså ikke til andre oppgaver enn det oppfølgingsgrunnen tilsier. Innbyggeren kan få innsyn i det du skriver her.",
+  annetChosenAlert:
+    "Denne oppgaven skal kun brukes til sykefraværsoppfølging, altså ikke oppgaver knyttet til andre ytelser eller formål. Innbyggeren kan få innsyn i det du skriver her.",
   save: "Lagre",
   close: "Avbryt",
   missingOppfolgingsgrunn: "Vennligst angi oppfølgingsgrunn.",
@@ -95,8 +97,8 @@ export const OppfolgingsoppgaveModal = ({ isOpen, toggleOpen }: Props) => {
     fromDate: new Date(),
   });
 
-  const isBeskrivelseInputVisible =
-    watch("oppfolgingsgrunn") !== Oppfolgingsgrunn.ANNET;
+  const isOppfolgingsgrunnAnnet =
+    watch("oppfolgingsgrunn") == Oppfolgingsgrunn.ANNET;
 
   return (
     <form onSubmit={handleSubmit(submit)}>
@@ -147,17 +149,25 @@ export const OppfolgingsoppgaveModal = ({ isOpen, toggleOpen }: Props) => {
               </option>
             ))}
           </Select>
-          {isBeskrivelseInputVisible && (
-            <Textarea
-              label={texts.beskrivelseLabel}
-              size="small"
-              value={watch("beskrivelse")}
-              maxLength={MAX_LENGTH_BESKRIVELSE}
-              {...register("beskrivelse", {
-                maxLength: MAX_LENGTH_BESKRIVELSE,
-              })}
-            ></Textarea>
+
+          {isOppfolgingsgrunnAnnet && (
+            <Alert inline variant="warning">
+              <BodyLong textColor="subtle" size="small">
+                {texts.annetChosenAlert}
+              </BodyLong>
+            </Alert>
           )}
+
+          <Textarea
+            label={texts.beskrivelseLabel}
+            size="small"
+            value={watch("beskrivelse")}
+            maxLength={MAX_LENGTH_BESKRIVELSE}
+            {...register("beskrivelse", {
+              maxLength: MAX_LENGTH_BESKRIVELSE,
+            })}
+          ></Textarea>
+
           <DatePicker {...datepickerProps} strategy="fixed">
             <DatePicker.Input {...inputProps} label={texts.datepickerLabel} />
           </DatePicker>

--- a/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
+++ b/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
@@ -96,26 +96,7 @@ describe("Oppfolgingsoppgave", () => {
     beforeEach(() => {
       stubOppfolgingsoppgaveApi(apiMockScope, undefined);
     });
-    it("renders oppfolgingsoppgave without beskrivelse textarea when annet is oppfolgingsgrunn", async () => {
-      renderOppfolgingsoppgave();
 
-      const openModalButton = await screen.findByRole("button", {
-        hidden: true,
-        name: openOppfolgingsoppgaveButtonText,
-      });
-      userEvent.click(openModalButton);
-
-      const selectOppfolgingsgrunn = await screen.findByLabelText(
-        "Hvilken oppfølgingsgrunn har du? (obligatorisk)"
-      );
-      fireEvent.change(selectOppfolgingsgrunn, {
-        target: { value: Oppfolgingsgrunn.ANNET },
-      });
-
-      await waitFor(
-        () => expect(screen.queryByLabelText("Beskrivelse")).to.not.exist
-      );
-    });
     it("renders oppfolgingsoppgave input with radio group, textarea, datepicker and save and cancel buttons", async () => {
       renderOppfolgingsoppgave();
 

--- a/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
+++ b/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
@@ -167,5 +167,47 @@ describe("Oppfolgingsoppgave", () => {
         ).to.deep.equal(expectedOppfolgingsoppgave);
       });
     });
+    it("shown extra alert when ANNET oppfolgingsgrunn is chosen", async () => {
+      renderOppfolgingsoppgave();
+
+      const openModalButton = await screen.findByRole("button", {
+        hidden: true,
+        name: openOppfolgingsoppgaveButtonText,
+      });
+      userEvent.click(openModalButton);
+
+      const selectOppfolgingsgrunn = await screen.findByLabelText(
+        "Hvilken oppfølgingsgrunn har du? (obligatorisk)"
+      );
+      fireEvent.change(selectOppfolgingsgrunn, {
+        target: { value: Oppfolgingsgrunn.ANNET },
+      });
+      expect(
+        screen.queryByText(
+          "Denne oppgaven skal kun brukes til sykefraværsoppfølging, altså ikke oppgaver knyttet til andre ytelser eller formål. Innbyggeren kan få innsyn i det du skriver her."
+        )
+      ).to.exist;
+    });
+    it("does not show extra alert when ANNET oppfolgingsgrunn is NOT chosen", async () => {
+      renderOppfolgingsoppgave();
+
+      const openModalButton = await screen.findByRole("button", {
+        hidden: true,
+        name: openOppfolgingsoppgaveButtonText,
+      });
+      userEvent.click(openModalButton);
+
+      const selectOppfolgingsgrunn = await screen.findByLabelText(
+        "Hvilken oppfølgingsgrunn har du? (obligatorisk)"
+      );
+      fireEvent.change(selectOppfolgingsgrunn, {
+        target: { value: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER },
+      });
+      expect(
+        screen.queryByText(
+          "Denne oppgaven skal kun brukes til sykefraværsoppfølging, altså ikke oppgaver knyttet til andre ytelser eller formål. Innbyggeren kan få innsyn i det du skriver her."
+        )
+      ).to.not.exist;
+    });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til mulighet for å legge ved beskrivelse når oppfølgingsgrunn er `ANNET`
- Virker veldig overflødig med 2 alerts slik det ser ut nå, men er visst slik det må se ut foreløpig. Bekreftet at vi går for denne løsningen i første omgang med Stine og Peter.

### Screenshots 📸✨
https://github.com/navikt/syfomodiaperson/assets/11747383/76caaba8-bb94-41c5-b401-e2e8ccd85289



