### PR TITLE
Invalidate arbeidsuforhet queries after mutate

### DIFF
--- a/mock/isarbeidsuforhet/arbeidsuforhetMock.ts
+++ b/mock/isarbeidsuforhet/arbeidsuforhetMock.ts
@@ -10,7 +10,8 @@ import {
 import { VurderingType } from "../../src/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { getForhandsvarsel84Texts } from "../../src/data/arbeidsuforhet/forhandsvarsel84Texts";
 
-const defaultBegrunnelse = "Du har ikke rett på sykepenger";
+const defaultForhandsvarselBegrunnelse = "Du har nok ikke rett på sykepenger";
+const defaultOppfyltBegrunnelse = "Du har rett på sykepenger";
 
 const getSendForhandsvarselDocument = (
   begrunnelse: string,
@@ -77,17 +78,14 @@ export const mockArbeidsuforhetvurdering = [
   {
     uuid: "123",
     personident: ARBEIDSTAKER_DEFAULT.personIdent,
-    createdAt: new Date(),
+    createdAt: daysFromToday(-100),
     veilederident: VEILEDER_DEFAULT.ident,
-    type: VurderingType.FORHANDSVARSEL,
-    begrunnelse: defaultBegrunnelse,
-    varsel: {
-      uuid: "123",
-      document: getSendForhandsvarselDocument(
-        defaultBegrunnelse,
-        daysFromToday(21)
-      ),
-      createdAt: new Date(),
-    },
+    type: VurderingType.OPPFYLT,
+    begrunnelse: defaultOppfyltBegrunnelse,
+    document: getSendForhandsvarselDocument(
+      defaultOppfyltBegrunnelse,
+      daysFromToday(-79)
+    ),
+    varsel: undefined,
   },
 ];

--- a/mock/isarbeidsuforhet/mockIsarbeidsuforhet.ts
+++ b/mock/isarbeidsuforhet/mockIsarbeidsuforhet.ts
@@ -2,7 +2,10 @@ import express = require("express");
 import { ISARBEIDSUFORHET_ROOT } from "../../src/apiConstants";
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
 import { mockArbeidsuforhetvurdering } from "./arbeidsuforhetMock";
-import { ForhandsvarselRequestDTO } from "../../src/data/arbeidsuforhet/arbeidsuforhetTypes";
+import {
+  ForhandsvarselRequestDTO,
+  VurderingType,
+} from "../../src/data/arbeidsuforhet/arbeidsuforhetTypes";
 
 export const mockIsarbeidsuforhet = (server: any) => {
   server.get(
@@ -20,11 +23,13 @@ export const mockIsarbeidsuforhet = (server: any) => {
     `${ISARBEIDSUFORHET_ROOT}/arbeidsuforhet/forhandsvarsel`,
     (req: express.Request, res: express.Response) => {
       const body: ForhandsvarselRequestDTO = req.body;
-      const forhandsvarsel = {
+      const sentForhandsvarsel = {
+        ...mockArbeidsuforhetvurdering[0],
+        type: VurderingType.FORHANDSVARSEL,
         begrunnelse: body.begrunnelse,
         document: body.document,
       };
-      res.sendStatus(201);
+      res.status(201).send(JSON.stringify(sentForhandsvarsel));
     }
   );
 };

--- a/src/data/arbeidsuforhet/useSendForhandsvarsel.ts
+++ b/src/data/arbeidsuforhet/useSendForhandsvarsel.ts
@@ -14,11 +14,10 @@ export const useSendForhandsvarsel = () => {
 
   return useMutation({
     mutationFn: postForhandsvarsel,
-    onSuccess: (data) => {
-      queryClient.setQueryData(
-        arbeidsuforhetQueryKeys.arbeidsuforhet(personident),
-        data
-      );
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: arbeidsuforhetQueryKeys.arbeidsuforhet(personident),
+      });
     },
   });
 };


### PR DESCRIPTION
Fordi man bare mottar det opprettede forhåndsvarselet når man gjør et post-kall, funker det ikke å bare dytte det inn i queryData for arbeidsuførhet.
Da er det like greit å bare invalidere og hente data på nytt.


Før:
![send84feil](https://github.com/navikt/syfomodiaperson/assets/40055758/21d4bb85-511a-4856-833b-bc2712e2ba31)

Etter:
![send84riktig](https://github.com/navikt/syfomodiaperson/assets/40055758/cee85da1-c780-4e3b-9f64-e9f5581bc88e)
