### PR TITLE
IS-2171: Split sent forhandsvarsel page in two

### DIFF
--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { Alert, Box, Button, Heading } from "@navikt/ds-react";
+import { ButtonRow } from "@/components/Layout";
+import { VisBrev } from "@/components/VisBrev";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { BellIcon } from "@navikt/aksel-icons";
+
+const texts = {
+  title: "Venter på svar fra bruker",
+  passertAlert: (sentDate: Date) =>
+    `Forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+      sentDate
+    )} er gått ut!`,
+  isPassert: "Tiden har gått ut på forhåndsvarselet.",
+  passertInfo: "Tiden har gått ut og du kan nå gå videre med å sende avslag.",
+  seSendtBrev: "Se sendt brev",
+  oppfylt: "Oppfylt",
+  avslag: "Avslag",
+  frist: "Fristen er utgått!",
+};
+
+export const ForhandsvarselAfterDeadline = () => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const forhandsvarsel = data[0];
+
+  return (
+    <div>
+      <Alert variant="warning" className="mb-2">
+        {texts.passertAlert(forhandsvarsel.createdAt)}
+      </Alert>
+      <Box background="surface-default" padding="3" className="mb-2">
+        <div className="flex items-center">
+          <Heading className="mt-2 mb-4" level="2" size="small">
+            {texts.title}
+          </Heading>
+          <b className="ml-auto mr-4">{texts.frist}</b>
+          <BellIcon title="bjelleikon" fontSize="2em" />
+        </div>
+        <p>{texts.passertInfo}</p>
+        <ButtonRow className="flex">
+          <VisBrev document={forhandsvarsel.document} />
+          <Button variant="secondary" className="ml-auto">
+            {texts.oppfylt}
+          </Button>
+          <Button variant="secondary">{texts.avslag}</Button>
+        </ButtonRow>
+      </Box>
+    </div>
+  );
+};

--- a/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { Alert, Box, Button, Heading } from "@navikt/ds-react";
+import { ButtonRow } from "@/components/Layout";
+import { VisBrev } from "@/components/VisBrev";
+import { addWeeks, tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { ClockIcon } from "@navikt/aksel-icons";
+
+const texts = {
+  title: "Venter på svar fra bruker",
+  sentAlert: {
+    isSent: (sentDate: Date) =>
+      `Forhåndsvarselet er sendt ${tilLesbarDatoMedArUtenManedNavn(sentDate)}.`,
+    passert:
+      "Når fristen er passert vil det dukke opp en hendelse i oversikten.",
+  },
+  isPassert: "Tiden har gått ut på forhåndsvarselet.",
+  sendtInfo:
+    "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag.",
+  passertInfo: "Tiden har gått ut og du kan nå gå videre med å sende avslag.",
+  seSendtBrev: "Se sendt brev",
+  oppfylt: "Oppfylt",
+  avslag: "Avslag",
+  frist: "Fristen går ut: ",
+};
+
+export const ForhandsvarselBeforeDeadline = () => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const forhandsvarsel = data[0];
+  const frist = addWeeks(forhandsvarsel.createdAt, 3);
+
+  return (
+    <div>
+      <Alert variant="success" className="mb-2">
+        <p className="mb-0">
+          {texts.sentAlert.isSent(forhandsvarsel.createdAt)}
+        </p>
+        <p>{texts.sentAlert.passert}</p>
+      </Alert>
+      <Box background="surface-default" padding="3" className="mb-2">
+        <div className="flex items-center">
+          <Heading className="mt-2 mb-4" level="2" size="small">
+            {texts.title}
+          </Heading>
+          <div className="ml-auto mr-4">
+            <b>{texts.frist}</b>
+            <span>{tilLesbarDatoMedArUtenManedNavn(frist)}</span>
+          </div>
+          <ClockIcon title="klokkeikon" fontSize="2em" />
+        </div>
+        <p>{texts.sendtInfo}</p>
+        <ButtonRow className="flex">
+          <VisBrev document={forhandsvarsel.document} />
+          <Button variant="secondary" className="ml-auto">
+            {texts.oppfylt}
+          </Button>
+          <Button variant="secondary" disabled>
+            {texts.avslag}
+          </Button>
+        </ButtonRow>
+      </Box>
+    </div>
+  );
+};

--- a/src/sider/arbeidsuforhet/ForhandsvarselSendt.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselSendt.tsx
@@ -1,50 +1,23 @@
 import React from "react";
-import { Alert, Box, Button, Heading } from "@navikt/ds-react";
-import { ButtonRow } from "@/components/Layout";
-import { useArbeidsuforhetVarselDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVarselDocument";
-import { VisBrev } from "@/components/VisBrev";
-
-const texts = {
-  title: "Venter på svar fra bruker",
-  iSendt: "Forhåndsvarselet er sendt til bruker",
-  isPassert: "Tiden har gått ut på forhåndsvarselet.",
-  sendtInfo:
-    "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag.",
-  passertInfo: "Tiden har gått ut og du kan nå gå videre med å sende avslag.",
-  seSendtBrev: "Se sendt brev",
-  oppfylt: "Oppfylt",
-  avslag: "Avslag",
-  frist: "Fristen går ut:",
-};
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { addWeeks } from "@/utils/datoUtils";
+import { ForhandsvarselBeforeDeadline } from "@/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline";
+import { ForhandsvarselAfterDeadline } from "@/sider/arbeidsuforhet/ForhandsvarseAfterDeadline";
+import dayjs from "dayjs";
 
 export const ForhandsvarselSendt = () => {
-  const { getForhandsvarselDocument } = useArbeidsuforhetVarselDocument();
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const forhandsvarsel = data[0];
+  const frist = addWeeks(new Date(forhandsvarsel.createdAt), 3);
+  const isBeforeFrist = dayjs().isBefore(frist, "day");
 
   return (
     <div>
-      <Alert variant="success" className="mb-2">
-        {texts.iSendt}
-      </Alert>
-      <Box background="surface-default" padding="3" className="mb-2">
-        <Heading className="mt-4 mb-4" level="2" size="small">
-          {texts.title}
-        </Heading>
-        <p>{texts.sendtInfo}</p>
-        <ButtonRow className="flex">
-          <VisBrev
-            document={getForhandsvarselDocument({
-              begrunnelse: "Her må begrunnelsen være",
-              frist: new Date(),
-            })}
-          />
-          <Button variant="secondary" className="ml-auto">
-            {texts.oppfylt}
-          </Button>
-          <Button variant="secondary" disabled>
-            {texts.avslag}
-          </Button>
-        </ButtonRow>
-      </Box>
+      {isBeforeFrist ? (
+        <ForhandsvarselBeforeDeadline />
+      ) : (
+        <ForhandsvarselAfterDeadline />
+      )}
     </div>
   );
 };

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { queryClientWithMockData } from "../testQueryClient";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  VEILEDER_DEFAULT,
+} from "../../mock/common/mockConstants";
+import { render, screen } from "@testing-library/react";
+import { navEnhet } from "../dialogmote/testData";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { expect } from "chai";
+import { NotificationContext } from "@/context/notification/NotificationContext";
+import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
+import {
+  VurderingResponseDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { getSendForhandsvarselDocument } from "./documents";
+import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { addWeeks, tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+
+let queryClient: QueryClient;
+
+const mockArbeidsuforhetVurderinger = (vurderinger: VurderingResponseDTO[]) => {
+  queryClient.setQueryData(
+    arbeidsuforhetQueryKeys.arbeidsuforhet(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => vurderinger
+  );
+};
+
+const renderForhandsvarselSendt = () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <NotificationContext.Provider
+          value={{ notification: undefined, setNotification: () => void 0 }}
+        >
+          <ForhandsvarselSendt />
+        </NotificationContext.Provider>
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("ForhandsvarselSendt", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Show correct component", () => {
+    it("show ForhandsvarselBeforeDeadline when createdAt is less than three weeks ago", () => {
+      const createdAt = new Date();
+      const forhandsvarselBeforeFrist: VurderingResponseDTO = {
+        uuid: "123",
+        personident: ARBEIDSTAKER_DEFAULT.personIdent,
+        createdAt: createdAt,
+        veilederident: VEILEDER_DEFAULT.ident,
+        type: VurderingType.FORHANDSVARSEL,
+        begrunnelse: "begrunnelse",
+        document: getSendForhandsvarselDocument("begrunnelse"),
+        varsel: {
+          uuid: "654",
+          createdAt: createdAt,
+        },
+      };
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderForhandsvarselSendt();
+
+      expect(
+        screen.getByText(
+          `Forhåndsvarselet er sendt ${tilLesbarDatoMedArUtenManedNavn(
+            createdAt
+          )}.`
+        )
+      ).to.exist;
+      expect(screen.getByText("Venter på svar fra bruker")).to.exist;
+      expect(screen.getByText("Fristen går ut:")).to.exist;
+      expect(
+        screen.getByText(
+          "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag."
+        )
+      ).to.exist;
+      expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
+      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
+      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
+        "disabled",
+        true
+      );
+    });
+
+    it("show ForhandsvarselAfterDeadline when createdAt is three weeks ago", () => {
+      const createdAt = addWeeks(new Date(), -3);
+      const forhandsvarselBeforeFrist: VurderingResponseDTO = {
+        uuid: "123",
+        personident: ARBEIDSTAKER_DEFAULT.personIdent,
+        createdAt: createdAt,
+        veilederident: VEILEDER_DEFAULT.ident,
+        type: VurderingType.FORHANDSVARSEL,
+        begrunnelse: "begrunnelse",
+        document: getSendForhandsvarselDocument("begrunnelse"),
+        varsel: {
+          uuid: "654",
+          createdAt: createdAt,
+        },
+      };
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderForhandsvarselSendt();
+
+      expect(
+        screen.getByText(
+          `Forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+            createdAt
+          )} er gått ut!`
+        )
+      ).to.exist;
+      expect(screen.getByText("Venter på svar fra bruker")).to.exist;
+      expect(screen.getByText("Fristen er utgått!")).to.exist;
+      expect(screen.getByRole("img", { name: "bjelleikon" })).to.exist;
+      expect(
+        screen.getByText(
+          "Tiden har gått ut og du kan nå gå videre med å sende avslag."
+        )
+      ).to.exist;
+      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
+      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
+        "disabled",
+        false
+      );
+    });
+  });
+});


### PR DESCRIPTION
Det er nå en komponent for passert frist og en for ikke passert.
De har en del forskjeller, så da er det greit å slippe mange ifer.

Knappene er ikke helt i henhold til skissene, men det er en lapp på å fikse det.
Det mangler også queries som knappene kan bruke for å faktisk sende oppfylt/avslag til backend.

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/76e1c082-d857-49e5-b384-898003ce5c96)

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/0aff4f15-addc-4c60-b8e1-7d1449438d6d)
