### PR TITLE
IS-2143: Move 8-4 buttons to correct position

### DIFF
--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -38,12 +38,10 @@ export const ForhandsvarselAfterDeadline = () => {
           <BellIcon title="bjelleikon" fontSize="2em" />
         </div>
         <p>{texts.passertInfo}</p>
-        <ButtonRow className="flex">
+        <ButtonRow>
+          <Button variant="primary">{texts.avslag}</Button>
+          <Button variant="secondary">{texts.oppfylt}</Button>
           <VisBrev document={forhandsvarsel.document} />
-          <Button variant="secondary" className="ml-auto">
-            {texts.oppfylt}
-          </Button>
-          <Button variant="secondary">{texts.avslag}</Button>
         </ButtonRow>
       </Box>
     </div>

--- a/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
@@ -49,14 +49,12 @@ export const ForhandsvarselBeforeDeadline = () => {
           <ClockIcon title="klokkeikon" fontSize="2em" />
         </div>
         <p>{texts.sendtInfo}</p>
-        <ButtonRow className="flex">
-          <VisBrev document={forhandsvarsel.document} />
-          <Button variant="secondary" className="ml-auto">
-            {texts.oppfylt}
-          </Button>
-          <Button variant="secondary" disabled>
+        <ButtonRow>
+          <Button variant="primary" disabled>
             {texts.avslag}
           </Button>
+          <Button variant="secondary">{texts.oppfylt}</Button>
+          <VisBrev document={forhandsvarsel.document} />
         </ButtonRow>
       </Box>
     </div>

--- a/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
+++ b/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
@@ -89,8 +89,8 @@ export const SendForhandsvarselSkjema = () => {
           <SkjemaInnsendingFeil error={sendForhandsvarsel.error} />
         )}
         <ButtonRow className="flex">
-          <Button variant="secondary" type="button">
-            {texts.avbrytButtonText}
+          <Button loading={sendForhandsvarsel.isPending} type="submit">
+            {texts.sendVarselButtonText}
           </Button>
           <Forhandsvisning
             contentLabel={texts.forhandsvisningLabel}
@@ -102,12 +102,8 @@ export const SendForhandsvarselSkjema = () => {
             }
             title={texts.forhandsvisningLabel}
           />
-          <Button
-            loading={sendForhandsvarsel.isPending}
-            type="submit"
-            className="ml-auto"
-          >
-            {texts.sendVarselButtonText}
+          <Button variant="secondary" type="button" className="ml-auto">
+            {texts.avbrytButtonText}
           </Button>
         </ButtonRow>
       </form>

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -85,12 +85,12 @@ describe("ForhandsvarselSendt", () => {
         )
       ).to.exist;
       expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
-      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
-      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
       expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
         "disabled",
         true
       );
+      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
     });
 
     it("show ForhandsvarselAfterDeadline when createdAt is three weeks ago", () => {
@@ -128,12 +128,12 @@ describe("ForhandsvarselSendt", () => {
           "Tiden har gått ut og du kan nå gå videre med å sende avslag."
         )
       ).to.exist;
-      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
-      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
       expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
         "disabled",
         false
       );
+      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
     });
   });
 });


### PR DESCRIPTION
Flytter de i henhold til skissene.
Gjør "avslag"-knappene primary.
Flytter på rekkefølgen til assertions i ForhandsvarselSendtTest sånn at det matcher rekkefølgen til knappene.

Før:
![knapper_before](https://github.com/navikt/syfomodiaperson/assets/40055758/6341e2c4-5d9b-4f4b-b0fc-a76121fcef68)

Etter:
![knapper_after](https://github.com/navikt/syfomodiaperson/assets/40055758/f8ca70b2-903a-48bf-a4c4-3e0a93151e64)
