### PR TITLE
IS-2181: Remove Avbryt button from forhandsvarsel

### DIFF
--- a/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
+++ b/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
@@ -24,7 +24,6 @@ const texts = {
   forhandsvisningLabel: "Forhåndsvis forhåndsvarselet",
   missingBeskrivelse: "Vennligst angi begrunnelse",
   sendVarselButtonText: "Send",
-  avbrytButtonText: "Avbryt",
 };
 
 const forhandsvarselFrist = addWeeks(new Date(), 3);
@@ -88,7 +87,7 @@ export const SendForhandsvarselSkjema = () => {
         {sendForhandsvarsel.isError && (
           <SkjemaInnsendingFeil error={sendForhandsvarsel.error} />
         )}
-        <ButtonRow className="flex">
+        <ButtonRow>
           <Button loading={sendForhandsvarsel.isPending} type="submit">
             {texts.sendVarselButtonText}
           </Button>
@@ -102,9 +101,6 @@ export const SendForhandsvarselSkjema = () => {
             }
             title={texts.forhandsvisningLabel}
           />
-          <Button variant="secondary" type="button" className="ml-auto">
-            {texts.avbrytButtonText}
-          </Button>
         </ButtonRow>
       </form>
     </Box>


### PR DESCRIPTION
Den er ikke i bruk i dag, og gir ikke noen verdi.
Den kan evt. legges på igjen senere hvis det er et ønske om å avbryte prosessen for å være sikker på at teksten er fjernet.

Før:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/6ac01492-3628-47fd-9c43-39e58f24cb12)


Etter:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/3cce2fb7-bd4d-42bc-a444-bb1dc19837a5)

