### PR TITLE
IS-2186: Add getVurderingDocument to arbeidsuforhet document hook

### DIFF
--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -14,7 +14,6 @@ import {
   VarselType,
   VurderingArsak,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import { vurderingArsakTexts } from "@/data/aktivitetskrav/aktivitetskravTexts";
 
@@ -36,8 +35,7 @@ export const useAktivitetskravVarselDocument = (): {
   ): DocumentComponentDto[];
   getVurderingDocument(values: VurderingDocumentValues): DocumentComponentDto[];
 } => {
-  const { getHilsen, getIntroGjelder } = useDocumentComponents();
-  const { data: veilederinfo } = useAktivVeilederinfoQuery();
+  const { getHilsen, getIntroGjelder, getVurdertAv } = useDocumentComponents();
 
   const getForhandsvarselDocument = (values: ForhandsvarselDocumentValues) => {
     const { mal, begrunnelse, frist } = values;
@@ -92,7 +90,7 @@ export const useAktivitetskravVarselDocument = (): {
     }
     documentComponents.push(
       createParagraph(getVedtakText(varselType)),
-      createParagraph(`Vurdert av ${veilederinfo?.navn || ""}`)
+      getVurdertAv()
     );
 
     return documentComponents;

--- a/src/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument.ts
+++ b/src/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument.ts
@@ -6,18 +6,26 @@ import {
   createParagraph,
 } from "@/utils/documentComponentUtils";
 import { getForhandsvarsel84Texts } from "@/data/arbeidsuforhet/forhandsvarsel84Texts";
+import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 
 type ForhandsvarselDocumentValues = {
   begrunnelse: string;
   frist: Date;
 };
 
-export const useArbeidsuforhetVarselDocument = (): {
+type VurderingDocumentValues = {
+  begrunnelse: string;
+  type: VurderingType;
+};
+
+export const useArbeidsuforhetVurderingDocument = (): {
   getForhandsvarselDocument(
     values: ForhandsvarselDocumentValues
   ): DocumentComponentDto[];
+  getVurderingDocument(values: VurderingDocumentValues): DocumentComponentDto[];
 } => {
-  const { getHilsen } = useDocumentComponents();
+  const { getHilsen, getIntroGjelder, getVurdertAv } = useDocumentComponents();
 
   const getForhandsvarselDocument = (values: ForhandsvarselDocumentValues) => {
     const { begrunnelse, frist } = values;
@@ -53,7 +61,44 @@ export const useArbeidsuforhetVarselDocument = (): {
     return documentComponents;
   };
 
+  const getVurderingDocument = (values: VurderingDocumentValues) => {
+    const { type, begrunnelse } = values;
+
+    if (type === VurderingType.FORHANDSVARSEL) {
+      throw new Error("use getForhandsvarselDocument");
+    }
+
+    const documentComponents = [
+      createHeaderH1("Vurdering av arbeidsuførhet"),
+      getIntroGjelder(),
+      createParagraph(getVurderingText(type)),
+    ];
+
+    if (begrunnelse) {
+      documentComponents.push(createParagraph(`Begrunnelse: ${begrunnelse}`));
+    }
+
+    documentComponents.push(getVurdertAv());
+
+    return documentComponents;
+  };
+
   return {
     getForhandsvarselDocument,
+    getVurderingDocument,
   };
+};
+
+const getVurderingText = (
+  type: VurderingType.OPPFYLT | VurderingType.AVSLAG
+) => {
+  const vurdertDato = tilDatoMedManedNavn(new Date());
+  switch (type) {
+    case VurderingType.OPPFYLT: {
+      return `Det ble vurdert oppfylt den ${vurdertDato}`;
+    }
+    case VurderingType.AVSLAG: {
+      return `Det ble vurdert avslag den ${vurdertDato}.`;
+    }
+  }
 };

--- a/src/hooks/useDocumentComponents.ts
+++ b/src/hooks/useDocumentComponents.ts
@@ -14,5 +14,7 @@ export const useDocumentComponents = () => {
     getIntroHei: () => createParagraph(`Hei, ${navBruker.navn}`),
     getIntroGjelder: () =>
       createParagraph(`Gjelder ${navBruker.navn}, f.nr. ${valgtPersonident}`),
+    getVurdertAv: () =>
+      createParagraph(`Vurdert av ${veilederinfo?.navn || ""}`),
   };
 };

--- a/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
+++ b/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
@@ -3,7 +3,7 @@ import { addWeeks } from "@/utils/datoUtils";
 import { ButtonRow } from "@/components/Layout";
 import { Box, Button, Heading, Textarea } from "@navikt/ds-react";
 import { useForm } from "react-hook-form";
-import { useArbeidsuforhetVarselDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVarselDocument";
+import { useArbeidsuforhetVurderingDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { ForhandsvarselRequestDTO } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
@@ -42,7 +42,7 @@ export const SendForhandsvarselSkjema = () => {
     formState: { errors },
     handleSubmit,
   } = useForm<SkjemaValues>({ defaultValues });
-  const { getForhandsvarselDocument } = useArbeidsuforhetVarselDocument();
+  const { getForhandsvarselDocument } = useArbeidsuforhetVurderingDocument();
 
   const submit = (values: SkjemaValues) => {
     const forhandsvarselRequestDTO: ForhandsvarselRequestDTO = {


### PR DESCRIPTION
Inspirert av document vi lager for vurderingene som gjøres i aktivitetskravet og som journalføres so notat der. Der har vi i tillegg en standardtekst om hjemmel som vi kanskje burde ha her også, men da kan legges på senere.
Kan tas i bruk i skjemaene som sender OPPFYLT/AVSLAG til api.
