### PR TITLE
IS-2183: Use tabs in sent forhandsvarsel page

### DIFF
--- a/mock/isarbeidsuforhet/mockIsarbeidsuforhet.ts
+++ b/mock/isarbeidsuforhet/mockIsarbeidsuforhet.ts
@@ -3,6 +3,7 @@ import { ISARBEIDSUFORHET_ROOT } from "../../src/apiConstants";
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
 import { mockArbeidsuforhetvurdering } from "./arbeidsuforhetMock";
 import {
+  VarselDTO,
   VurderingRequestDTO,
   VurderingResponseDTO,
 } from "../../src/data/arbeidsuforhet/arbeidsuforhetTypes";
@@ -31,6 +32,14 @@ export const mockIsarbeidsuforhet = (server: any) => {
     (req: express.Request, res: express.Response) => {
       const body: VurderingRequestDTO = req.body;
       const personident = req.headers[NAV_PERSONIDENT_HEADER];
+      const varsel: VarselDTO | undefined =
+        body.type === "FORHANDSVARSEL"
+          ? {
+              uuid: generateUUID(),
+              svarfrist: new Date(),
+              createdAt: new Date(),
+            }
+          : undefined;
       const sentVurdering: VurderingResponseDTO = {
         uuid: generateUUID(),
         personident:
@@ -40,7 +49,7 @@ export const mockIsarbeidsuforhet = (server: any) => {
         type: body.type,
         begrunnelse: body.begrunnelse,
         document: body.document,
-        varsel: undefined,
+        varsel,
       };
       arbeidsuforhetVurderinger = [sentVurdering, ...arbeidsuforhetVurderinger];
       res.status(201).send(JSON.stringify(sentVurdering));

--- a/src/data/arbeidsuforhet/arbeidsuforhetTypes.ts
+++ b/src/data/arbeidsuforhet/arbeidsuforhetTypes.ts
@@ -12,7 +12,7 @@ export enum VurderingType {
   AVSLAG = "AVSLAG",
 }
 
-interface VarselDTO {
+export interface VarselDTO {
   uuid: string;
   createdAt: Date;
   svarfrist: Date;

--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
-import { Alert, Box, Button, Heading } from "@navikt/ds-react";
-import { ButtonRow } from "@/components/Layout";
+import { Alert, Box, Heading } from "@navikt/ds-react";
 import { VisBrev } from "@/components/VisBrev";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { BellIcon } from "@navikt/aksel-icons";
@@ -38,11 +37,7 @@ export const ForhandsvarselAfterDeadline = () => {
           <BellIcon title="bjelleikon" fontSize="2em" />
         </div>
         <p>{texts.passertInfo}</p>
-        <ButtonRow>
-          <Button variant="primary">{texts.avslag}</Button>
-          <Button variant="secondary">{texts.oppfylt}</Button>
-          <VisBrev document={forhandsvarsel.document} />
-        </ButtonRow>
+        <VisBrev document={forhandsvarsel.document} />
       </Box>
     </div>
   );

--- a/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
-import { Alert, Box, Button, Heading } from "@navikt/ds-react";
-import { ButtonRow } from "@/components/Layout";
+import { Alert, Box, Heading } from "@navikt/ds-react";
 import { VisBrev } from "@/components/VisBrev";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { ClockIcon } from "@navikt/aksel-icons";
@@ -49,13 +48,7 @@ export const ForhandsvarselBeforeDeadline = () => {
           <ClockIcon title="klokkeikon" fontSize="2em" />
         </div>
         <p>{texts.sendtInfo}</p>
-        <ButtonRow>
-          <Button variant="primary" disabled>
-            {texts.avslag}
-          </Button>
-          <Button variant="secondary">{texts.oppfylt}</Button>
-          <VisBrev document={forhandsvarsel.document} />
-        </ButtonRow>
+        <VisBrev document={forhandsvarsel.document} />
       </Box>
     </div>
   );

--- a/src/sider/arbeidsuforhet/ForhandsvarselSendt.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselSendt.tsx
@@ -2,7 +2,9 @@ import React from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { ForhandsvarselBeforeDeadline } from "@/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline";
 import { ForhandsvarselAfterDeadline } from "@/sider/arbeidsuforhet/ForhandsvarseAfterDeadline";
+import { Box } from "@navikt/ds-react";
 import dayjs from "dayjs";
+import { VurderArbeidsuforhetTabs } from "@/sider/arbeidsuforhet/VurderArbeidsuforhetTabs";
 
 export const ForhandsvarselSendt = () => {
   const { data } = useArbeidsuforhetVurderingQuery();
@@ -17,6 +19,9 @@ export const ForhandsvarselSendt = () => {
       ) : (
         <ForhandsvarselAfterDeadline />
       )}
+      <Box background="surface-default" padding="3" className="mb-2">
+        <VurderArbeidsuforhetTabs />
+      </Box>
     </div>
   );
 };

--- a/src/sider/arbeidsuforhet/VurderArbeidsuforhetTabs.tsx
+++ b/src/sider/arbeidsuforhet/VurderArbeidsuforhetTabs.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import styled from "styled-components";
+import { Tabs } from "@navikt/ds-react";
+import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import dayjs from "dayjs";
+import { VurderingSkjema } from "@/sider/arbeidsuforhet/VurderingSkjema";
+
+const texts = {
+  oppfylt: "Oppfylt",
+  avslag: "Avslag",
+};
+
+const StyledTabs = styled(Tabs)`
+  margin-top: 1rem;
+  width: 100%;
+
+  .navds-tabs__tablist-wrapper {
+    width: max-content;
+  }
+`;
+
+enum Tab {
+  OPPFYLT = "OPPFYLT",
+  AVSLAG = "AVSLAG",
+}
+
+export const VurderArbeidsuforhetTabs = () => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const forhandsvarsel = data[0];
+  const frist = forhandsvarsel.varsel?.svarfrist;
+  const isBeforeFrist = dayjs().isBefore(frist, "day");
+
+  return (
+    <StyledTabs defaultValue={Tab.OPPFYLT}>
+      <Tabs.List>
+        <Tabs.Tab value={Tab.OPPFYLT} label={texts.oppfylt} />
+        {!isBeforeFrist && <Tabs.Tab value={Tab.AVSLAG} label={texts.avslag} />}
+      </Tabs.List>
+      <Tabs.Panel value={Tab.OPPFYLT}>
+        <VurderingSkjema type={VurderingType.OPPFYLT} />
+      </Tabs.Panel>
+      {!isBeforeFrist && (
+        <Tabs.Panel value={Tab.AVSLAG}>
+          <VurderingSkjema type={VurderingType.AVSLAG} />
+        </Tabs.Panel>
+      )}
+    </StyledTabs>
+  );
+};

--- a/src/sider/arbeidsuforhet/VurderingSkjema.tsx
+++ b/src/sider/arbeidsuforhet/VurderingSkjema.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Button, Heading, Textarea } from "@navikt/ds-react";
+import { ButtonRow } from "@/components/Layout";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { Forhandsvisning } from "@/components/Forhandsvisning";
+import { useForm } from "react-hook-form";
+import {
+  VurderingRequestDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { useArbeidsuforhetVurderingDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument";
+import { useSendVurderingArbeidsuforhet } from "@/data/arbeidsuforhet/useSendVurderingArbeidsuforhet";
+
+const texts = {
+  title: (type: VurderingType) => {
+    return type === VurderingType.OPPFYLT
+      ? "Skriv en kort begrunnelse for hvorfor bruker oppfyller 8-4"
+      : "Skriv en kort begrunnelse for hvorfor bruker ikke oppfyller 8-4";
+  },
+  info: "Det du skriver her blir liggende i historikken på brukeren og et brev med begrunnelse blir sendt til bruker for deg.",
+  beskrivelseLabel: "Begrunnelse (obligatorisk)",
+  begrunnelseDescription: "Åpne forhåndsvisning for å se hele varselet.",
+  forhandsvisning: "Forhåndsvisning",
+  forhandsvisningLabel: "Forhåndsvis brev",
+  missingBeskrivelse: "Vennligst angi begrunnelse",
+  sendVarselButtonText: "Send",
+};
+
+const defaultValues = { begrunnelse: "" };
+const begrunnelseMaxLength = 1000;
+
+interface SkjemaValues {
+  begrunnelse: string;
+}
+
+interface VurderingSkjemaProps {
+  type: VurderingType;
+}
+
+export const VurderingSkjema = ({ type }: VurderingSkjemaProps) => {
+  const sendVurdering = useSendVurderingArbeidsuforhet();
+  const { getVurderingDocument } = useArbeidsuforhetVurderingDocument();
+  const {
+    register,
+    watch,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<SkjemaValues>({ defaultValues });
+
+  const submit = (values: SkjemaValues) => {
+    const vurderingRequestDTO: VurderingRequestDTO = {
+      type,
+      begrunnelse: values.begrunnelse,
+      document: getVurderingDocument({
+        begrunnelse: values.begrunnelse,
+        type,
+      }),
+    };
+    sendVurdering.mutate(vurderingRequestDTO);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(submit)}>
+      <Heading className="mt-4 mb-4" level="2" size="small">
+        {texts.title(type)}
+      </Heading>
+      <p>{texts.info}</p>
+      <Textarea
+        className="mb-8"
+        {...register("begrunnelse", {
+          maxLength: begrunnelseMaxLength,
+          required: texts.missingBeskrivelse,
+        })}
+        value={watch("begrunnelse")}
+        label={texts.beskrivelseLabel}
+        description={texts.begrunnelseDescription}
+        error={errors.begrunnelse?.message}
+        size="small"
+        minRows={6}
+        maxLength={begrunnelseMaxLength}
+      />
+      {sendVurdering.isError && (
+        <SkjemaInnsendingFeil error={sendVurdering.error} />
+      )}
+      <ButtonRow>
+        <Button loading={sendVurdering.isPending} type="submit">
+          {texts.sendVarselButtonText}
+        </Button>
+        <Forhandsvisning
+          contentLabel={texts.forhandsvisningLabel}
+          getDocumentComponents={() =>
+            getVurderingDocument({
+              begrunnelse: watch("begrunnelse"),
+              type,
+            })
+          }
+          title={texts.forhandsvisningLabel}
+        />
+      </ButtonRow>
+    </form>
+  );
+};

--- a/test/arbeidsuforhet/ArbeidsuforhetForhandsvarselTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetForhandsvarselTest.tsx
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import nock from "nock";
 import { NotificationContext } from "@/context/notification/NotificationContext";
 import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
-import { stubArbeidsuforhetForhandsvarselApi } from "../stubs/stubIsarbeidsuforhet";
+import { stubArbeidsuforhetVurderingApi } from "../stubs/stubIsarbeidsuforhet";
 import {
   VurderingRequestDTO,
   VurderingType,
@@ -66,7 +66,7 @@ describe("Forhandsvarselskjema arbeidsuforhet", () => {
     it("Send forhåndsvarsel with begrunnelse filled in, without reseting the form", async () => {
       const begrunnelse = "Dette er en begrunnelse!";
       renderForhandsvarselSkjema();
-      stubArbeidsuforhetForhandsvarselApi(apiMockScope);
+      stubArbeidsuforhetVurderingApi(apiMockScope);
       const begrunnelseLabel = "Begrunnelse (obligatorisk)";
 
       expect(
@@ -103,7 +103,7 @@ describe("Forhandsvarselskjema arbeidsuforhet", () => {
     it("Forhåndsvis brev with begrunnelse", async () => {
       const begrunnelse = "Dette er en begrunnelse!";
       renderForhandsvarselSkjema();
-      stubArbeidsuforhetForhandsvarselApi(apiMockScope);
+      stubArbeidsuforhetVurderingApi(apiMockScope);
       const begrunnelseLabel = "Begrunnelse (obligatorisk)";
 
       const begrunnelseInput = getTextInput(begrunnelseLabel);

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -85,12 +85,9 @@ describe("ForhandsvarselSendt", () => {
         )
       ).to.exist;
       expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
-      expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
-        "disabled",
-        true
-      );
-      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
       expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Oppfylt" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Avslag" })).to.not.exist;
     });
 
     it("show ForhandsvarselAfterDeadline when svarfrist is today (expired)", () => {
@@ -129,12 +126,9 @@ describe("ForhandsvarselSendt", () => {
           "Tiden har gått ut og du kan nå gå videre med å sende avslag."
         )
       ).to.exist;
-      expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
-        "disabled",
-        false
-      );
-      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
       expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Oppfylt" })).to.exist;
+      expect(screen.queryByRole("tab", { name: "Avslag" })).to.exist;
     });
   });
 });

--- a/test/arbeidsuforhet/VurderingSkjemaTest.tsx
+++ b/test/arbeidsuforhet/VurderingSkjemaTest.tsx
@@ -1,0 +1,150 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { queryClientWithMockData } from "../testQueryClient";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { navEnhet } from "../dialogmote/testData";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { expect } from "chai";
+import { NotificationContext } from "@/context/notification/NotificationContext";
+import {
+  VurderingRequestDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { VurderingSkjema } from "@/sider/arbeidsuforhet/VurderingSkjema";
+import { changeTextInput, clickButton, getTextInput } from "../testUtils";
+import { stubArbeidsuforhetVurderingApi } from "../stubs/stubIsarbeidsuforhet";
+import { getSendVurderingDocument } from "./documents";
+import { apiMock } from "../stubs/stubApi";
+import nock from "nock";
+
+let queryClient: QueryClient;
+let apiMockScope: any;
+
+const renderVurderingSkjema = (type: VurderingType) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <NotificationContext.Provider
+          value={{ notification: undefined, setNotification: () => void 0 }}
+        >
+          <VurderingSkjema type={type} />
+        </NotificationContext.Provider>
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("VurderingSkjema", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+    apiMockScope = apiMock();
+  });
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("Show correct title", () => {
+    it("shows 'oppfyller'-title when oppfylt type is chosen", () => {
+      renderVurderingSkjema(VurderingType.OPPFYLT);
+
+      expect(
+        screen.getByText(
+          "Skriv en kort begrunnelse for hvorfor bruker oppfyller 8-4"
+        )
+      ).to.exist;
+    });
+
+    it("shows 'ikke oppfyller'-title when avslag type is chosen", () => {
+      renderVurderingSkjema(VurderingType.AVSLAG);
+
+      expect(
+        screen.getByText(
+          "Skriv en kort begrunnelse for hvorfor bruker ikke oppfyller 8-4"
+        )
+      ).to.exist;
+    });
+  });
+
+  describe("Form components", () => {
+    it("shows textarea and buttons", () => {
+      const begrunnelseLabel = "Begrunnelse (obligatorisk)";
+
+      renderVurderingSkjema(VurderingType.OPPFYLT);
+
+      expect(screen.getByText(begrunnelseLabel)).to.exist;
+      expect(screen.getByText("Åpne forhåndsvisning for å se hele varselet."))
+        .to.exist;
+      expect(
+        screen.getByRole("textbox", {
+          name: begrunnelseLabel,
+        })
+      ).to.exist;
+      expect(screen.getByRole("button", { name: "Send" })).to.exist;
+      expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
+    });
+  });
+
+  describe("Send vurdering", () => {
+    it("Gives error when trying to send vurdering without begrunnelse", async () => {
+      renderVurderingSkjema(VurderingType.OPPFYLT);
+
+      clickButton("Send");
+
+      expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
+    });
+
+    it("Send vurdering with begrunnelse filled in, without reseting the form", async () => {
+      const begrunnelse = "Dette er en begrunnelse!";
+      renderVurderingSkjema(VurderingType.OPPFYLT);
+      stubArbeidsuforhetVurderingApi(apiMockScope);
+      const begrunnelseLabel = "Begrunnelse (obligatorisk)";
+      const beskrivelseInput = getTextInput(begrunnelseLabel);
+
+      changeTextInput(beskrivelseInput, begrunnelse);
+      clickButton("Send");
+
+      await waitFor(() => {
+        const useSendVurderingArbeidsuforhet = queryClient
+          .getMutationCache()
+          .getAll()[0];
+        const expectedVurdering: VurderingRequestDTO = {
+          type: VurderingType.OPPFYLT,
+          begrunnelse: begrunnelse,
+          document: getSendVurderingDocument(begrunnelse),
+        };
+        expect(useSendVurderingArbeidsuforhet.state.variables).to.deep.equal(
+          expectedVurdering
+        );
+      });
+      expect(screen.queryByText(begrunnelse)).to.exist;
+    });
+
+    it("Forhåndsvis brev with begrunnelse", async () => {
+      const begrunnelse = "Dette er en begrunnelse!";
+      renderVurderingSkjema(VurderingType.OPPFYLT);
+      stubArbeidsuforhetVurderingApi(apiMockScope);
+      const begrunnelseLabel = "Begrunnelse (obligatorisk)";
+      const begrunnelseInput = getTextInput(begrunnelseLabel);
+
+      changeTextInput(begrunnelseInput, begrunnelse);
+      clickButton("Forhåndsvisning");
+
+      const forhandsvisningVurdering = screen.getAllByRole("dialog", {
+        hidden: true,
+      })[0];
+      expect(
+        within(forhandsvisningVurdering).getByRole("heading", {
+          name: "Forhåndsvis brev",
+          hidden: true,
+        })
+      ).to.exist;
+      getSendVurderingDocument(begrunnelse)
+        .flatMap((documentComponent) => documentComponent.texts)
+        .forEach((text) => {
+          expect(within(forhandsvisningVurdering).getByText(text)).to.exist;
+        });
+    });
+  });
+});

--- a/test/arbeidsuforhet/documents.ts
+++ b/test/arbeidsuforhet/documents.ts
@@ -2,9 +2,13 @@ import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
-import { addWeeks } from "@/utils/datoUtils";
+import { addWeeks, tilDatoMedManedNavn } from "@/utils/datoUtils";
 import { getForhandsvarsel84Texts } from "@/data/arbeidsuforhet/forhandsvarsel84Texts";
-import { VEILEDER_DEFAULT } from "../../mock/common/mockConstants";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  ARBEIDSTAKER_DEFAULT_FULL_NAME,
+  VEILEDER_DEFAULT,
+} from "../../mock/common/mockConstants";
 
 const expectedFristDate = addWeeks(new Date(), 3);
 
@@ -63,6 +67,35 @@ export const getSendForhandsvarselDocument = (
     },
     {
       texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.navn, "NAV"],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+  ];
+};
+
+export const getSendVurderingDocument = (
+  begrunnelse: string
+): DocumentComponentDto[] => {
+  return [
+    {
+      texts: ["Vurdering av arbeidsuførhet"],
+      type: DocumentComponentType.HEADER_H1,
+    },
+    {
+      texts: [
+        `Gjelder ${ARBEIDSTAKER_DEFAULT_FULL_NAME}, f.nr. ${ARBEIDSTAKER_DEFAULT.personIdent}`,
+      ],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [`Det ble vurdert oppfylt den ${tilDatoMedManedNavn(new Date())}`],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [`Begrunnelse: ${begrunnelse}`],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [`Vurdert av ${VEILEDER_DEFAULT.navn}`],
       type: DocumentComponentType.PARAGRAPH,
     },
   ];

--- a/test/stubs/stubIsarbeidsuforhet.ts
+++ b/test/stubs/stubIsarbeidsuforhet.ts
@@ -7,8 +7,8 @@ export const stubAktivitetskravApi = (scope: nock.Scope) => {
     .reply(200, () => undefined);
 };
 
-export const stubArbeidsuforhetForhandsvarselApi = (scope: nock.Scope) => {
+export const stubArbeidsuforhetVurderingApi = (scope: nock.Scope) => {
   return scope
-    .post(new RegExp(`${ISARBEIDSUFORHET_ROOT}/arbeidsuforhet/forhandsvarsel`))
+    .post(new RegExp(`${ISARBEIDSUFORHET_ROOT}/arbeidsuforhet/vurderinger`))
     .reply(201);
 };


### PR DESCRIPTION
Bruk faner i stedet for å sende veiledere til ny side for å sende "oppfylt" eller "avslag".
Kun vis avslag-fanen hvis fristen er utgått.
Viser alert og ekstra informasjon over fanene, slik at veileder vet om fristen har gått ut, og kan se det sendte forhåndsvarselet. Legg til ekstra funksjonalitet i mocken, slik at man får med varsel med svarfrist når det sendes forhåndsvarsel lokalt.


![image](https://github.com/navikt/syfomodiaperson/assets/40055758/7edae099-020c-47df-9ddd-ecef7335bc23)

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/3a169d6a-0299-4c92-9a65-032b8bcf4f81)
