### PR TITLE
IS-2200: Add route for ArbeidsuforhetOppfyltSide

### DIFF
--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -25,12 +25,14 @@ import * as Amplitude from "@/utils/amplitude";
 import Motelandingsside from "@/sider/mote/Motelandingsside";
 import { SykepengesoknadSide } from "@/sider/sykepengsoknader/container/SykepengesoknadSide";
 import { ArbeidsuforhetSide } from "@/sider/arbeidsuforhet/ArbeidsuforhetSide";
+import { ArbeidsuforhetOppfyltSide } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide";
 
 export const appRoutePath = "/sykefravaer";
 
 export const dialogmoteRoutePath = `${appRoutePath}/dialogmote`;
 export const dialogmoteUnntakRoutePath = `${appRoutePath}/dialogmoteunntak`;
 export const moteoversiktRoutePath = `${appRoutePath}/moteoversikt`;
+export const arbeidsuforhetOppfyltPath = `${appRoutePath}/arbeidsuforhet/oppfylt`;
 
 const AktivBrukerRouter = (): ReactElement => {
   Amplitude.logViewportAndScreenSize();
@@ -93,6 +95,10 @@ const AktivBrukerRouter = (): ReactElement => {
           <Route
             path={`${appRoutePath}/arbeidsuforhet`}
             element={<ArbeidsuforhetSide />}
+          />
+          <Route
+            path={arbeidsuforhetOppfyltPath}
+            element={<ArbeidsuforhetOppfyltSide />}
           />
           <Route
             path={`${appRoutePath}/sykepengesoknader/:sykepengesoknadId`}

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetOppfylt.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetOppfylt.tsx
@@ -1,0 +1,36 @@
+import React, { ReactElement } from "react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { Alert } from "@navikt/ds-react";
+import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+
+const texts = {
+  success:
+    "Begrunnelsen din på at bruker oppfyller § 8-4 er lagret i historikken.",
+  error:
+    "Trykk på 'Forhåndsvarsel'-menypunktet for å komme til skjema for forhåndsvarsel!",
+};
+
+export const ArbeidsuforhetOppfylt = (): ReactElement => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const sisteVurdering = data[0];
+  const isForhandsvarsel =
+    sisteVurdering?.type === VurderingType.FORHANDSVARSEL;
+  const isOppfylt = sisteVurdering?.type === VurderingType.OPPFYLT;
+  const isAvslag = sisteVurdering?.type === VurderingType.AVSLAG;
+
+  return (
+    <div>
+      {isForhandsvarsel && <p>Placeholder</p>}
+      {isOppfylt && (
+        <Alert variant="success" className="mb-2">
+          {texts.success}
+        </Alert>
+      )}
+      {isAvslag && (
+        <Alert variant="error" className="mb-2">
+          {texts.error}
+        </Alert>
+      )}
+    </div>
+  );
+};

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement } from "react";
+import Side from "@/sider/Side";
+import Sidetopp from "@/components/Sidetopp";
+import SideLaster from "@/components/SideLaster";
+import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
+import * as Tredelt from "@/sider/TredeltSide";
+import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
+import { VurderingHistorikk } from "@/sider/arbeidsuforhet/historikk/VurderingHistorikk";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { ArbeidsuforhetOppfylt } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfylt";
+
+const texts = {
+  title: "Forhåndsvarsel §8-4",
+};
+
+export const ArbeidsuforhetOppfyltSide = (): ReactElement => {
+  const { isLoading, isError } = useArbeidsuforhetVurderingQuery();
+
+  return (
+    <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.ARBEIDSUFORHET}>
+      <Sidetopp tittel={texts.title} />
+      <SideLaster henter={isLoading} hentingFeilet={isError}>
+        <Tredelt.Container>
+          <Tredelt.FirstColumn>
+            <ArbeidsuforhetOppfylt />
+            <VurderingHistorikk />
+          </Tredelt.FirstColumn>
+          <Tredelt.SecondColumn>
+            <UtdragFraSykefravaeret />
+          </Tredelt.SecondColumn>
+        </Tredelt.Container>
+      </SideLaster>
+    </Side>
+  );
+};

--- a/test/arbeidsuforhet/ArbeidsuforhetOppfyltTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetOppfyltTest.tsx
@@ -1,0 +1,110 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { queryClientWithMockData } from "../testQueryClient";
+import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
+import { render, screen } from "@testing-library/react";
+import { navEnhet } from "../dialogmote/testData";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { expect } from "chai";
+import {
+  VurderingResponseDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { addWeeks } from "@/utils/datoUtils";
+import {
+  createForhandsvarsel,
+  createVurdering,
+} from "./arbeidsuforhetTestData";
+import { ArbeidsuforhetOppfylt } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfylt";
+
+let queryClient: QueryClient;
+
+const mockArbeidsuforhetVurderinger = (vurderinger: VurderingResponseDTO[]) => {
+  queryClient.setQueryData(
+    arbeidsuforhetQueryKeys.arbeidsuforhet(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => vurderinger
+  );
+};
+
+const renderArbeidsuforhetOppfyltSide = () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <ArbeidsuforhetOppfylt />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("OppfyltSide", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Show correct info", () => {
+    it("show form if latest arbeidsuforhet status is forhandsvarsel and frist is utgatt", () => {
+      const forhandsvarselAfterFrist = createForhandsvarsel({
+        createdAt: new Date(),
+        svarfrist: addWeeks(new Date(), -3),
+      });
+      const vurderinger = [forhandsvarselAfterFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetOppfyltSide();
+
+      expect(screen.getByText("Placeholder")).to.exist;
+    });
+
+    it("show form if latest arbeidsuforhet status is forhandsvarsel and frist is not utgatt", () => {
+      const forhandsvarselBeforeFrist = createForhandsvarsel({
+        createdAt: new Date(),
+        svarfrist: addWeeks(new Date(), 3),
+      });
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetOppfyltSide();
+
+      expect(screen.getByText("Placeholder")).to.exist;
+    });
+
+    it("show succes if latest arbeidsuforhet status is Oppfylt", () => {
+      const forhandsvarselBeforeFrist = createVurdering({
+        type: VurderingType.OPPFYLT,
+        begrunnelse: "begrunnelse",
+        createdAt: new Date(),
+      });
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetOppfyltSide();
+
+      expect(
+        screen.getByText(
+          "Begrunnelsen din på at bruker oppfyller § 8-4 er lagret i historikken."
+        )
+      ).to.exist;
+    });
+
+    it("show error if latest arbeidsuforhet status is Avslag", () => {
+      const forhandsvarselBeforeFrist = createVurdering({
+        type: VurderingType.AVSLAG,
+        begrunnelse: "begrunnelse",
+        createdAt: new Date(),
+      });
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetOppfyltSide();
+
+      expect(
+        screen.getByText(
+          "Trykk på 'Forhåndsvarsel'-menypunktet for å komme til skjema for forhåndsvarsel!"
+        )
+      ).to.exist;
+    });
+  });
+});

--- a/test/arbeidsuforhet/arbeidsuforhetTestData.ts
+++ b/test/arbeidsuforhet/arbeidsuforhetTestData.ts
@@ -51,7 +51,7 @@ export const createVurdering = ({
     veilederident: VEILEDER_DEFAULT.ident,
     type,
     begrunnelse,
-    document: [],
+    document: getSendForhandsvarselDocument(begrunnelse),
     varsel: undefined,
   };
 };


### PR DESCRIPTION
Da blir det lettere å håndtere tilstanden på arbeidsuforhet-siden.
Klar til å legge til skjema for oppfylt, der det nå er placeholder.

Forhåndsvarsel:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/caa43ed1-d042-4e80-9f00-5e5cc82f5e69)

Oppfylt:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/f2ebf5f2-c4bf-4301-aa5b-4297ca4ccaf9)

Avslag:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/a87f60ba-3dde-4fd0-a695-f7f78a613c0f)
