### PR TITLE
Do minor fixes in arbeidsuforhet code

### DIFF
--- a/mock/isarbeidsuforhet/mockIsarbeidsuforhet.ts
+++ b/mock/isarbeidsuforhet/mockIsarbeidsuforhet.ts
@@ -31,6 +31,14 @@ export const mockIsarbeidsuforhet = (server: any) => {
     (req: express.Request, res: express.Response) => {
       const body: VurderingRequestDTO = req.body;
       const personident = req.headers[NAV_PERSONIDENT_HEADER];
+      const varsel =
+        body.type === "FORHANDSVARSEL"
+          ? {
+              uuid: generateUUID(),
+              createdAt: new Date(),
+              svarfrist: new Date(),
+            }
+          : undefined;
       const sentVurdering: VurderingResponseDTO = {
         uuid: generateUUID(),
         personident:
@@ -40,7 +48,7 @@ export const mockIsarbeidsuforhet = (server: any) => {
         type: body.type,
         begrunnelse: body.begrunnelse,
         document: body.document,
-        varsel: undefined,
+        varsel,
       };
       arbeidsuforhetVurderinger = [sentVurdering, ...arbeidsuforhetVurderinger];
       res.status(201).send(JSON.stringify(sentVurdering));

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -2,7 +2,6 @@ import React, { ReactElement } from "react";
 import Side from "@/sider/Side";
 import Sidetopp from "@/components/Sidetopp";
 import SideLaster from "@/components/SideLaster";
-import { NotificationProvider } from "@/context/notification/NotificationContext";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import * as Tredelt from "@/sider/TredeltSide";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
@@ -17,25 +16,23 @@ const texts = {
 };
 
 export const ArbeidsuforhetSide = (): ReactElement => {
-  const { data } = useArbeidsuforhetVurderingQuery();
+  const { data, isLoading, isError } = useArbeidsuforhetVurderingQuery();
   const sisteVurdering = data[0];
 
   return (
     <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.ARBEIDSUFORHET}>
       <Sidetopp tittel={texts.title} />
-      <SideLaster henter={false} hentingFeilet={false}>
+      <SideLaster henter={isLoading} hentingFeilet={isError}>
         <Tredelt.Container>
           <Tredelt.FirstColumn>
-            <NotificationProvider>
-              <div className="mb-4">
-                {!!sisteVurdering &&
-                sisteVurdering.type === VurderingType.FORHANDSVARSEL ? (
-                  <ForhandsvarselSendt />
-                ) : (
-                  <SendForhandsvarselSkjema />
-                )}
-              </div>
-            </NotificationProvider>
+            <div className="mb-4">
+              {!!sisteVurdering &&
+              sisteVurdering.type === VurderingType.FORHANDSVARSEL ? (
+                <ForhandsvarselSendt />
+              ) : (
+                <SendForhandsvarselSkjema />
+              )}
+            </div>
             <VurderingHistorikk />
           </Tredelt.FirstColumn>
           <Tredelt.SecondColumn>

--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -14,8 +14,8 @@ const texts = {
     `Forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
       sentDate
     )} er gått ut! Du kan nå gi avslag på Arbeidsuførhet.`,
-  oppfylt: "Oppfylt",
   avslag: "Avslag",
+  oppfylt: "Oppfylt",
   seSendtBrev: "Se sendt brev",
 };
 

--- a/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
@@ -16,14 +16,11 @@ const texts = {
     passert:
       "Når fristen er passert vil det dukke opp en hendelse i oversikten.",
   },
-  isPassert: "Tiden har gått ut på forhåndsvarselet.",
   sendtInfo:
     "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag.",
-  passertInfo: "Tiden har gått ut og du kan nå gå videre med å sende avslag.",
-  seSendtBrev: "Se sendt brev",
+  frist: "Fristen går ut: ",
   oppfylt: "Oppfylt",
   avslag: "Avslag",
-  frist: "Fristen går ut: ",
 };
 
 export const ForhandsvarselBeforeDeadline = () => {

--- a/test/arbeidsuforhet/ArbeidsuforhetForhandsvarselTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetForhandsvarselTest.tsx
@@ -4,7 +4,6 @@ import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import React from "react";
 import { expect } from "chai";
 import nock from "nock";
-import { NotificationContext } from "@/context/notification/NotificationContext";
 import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
 import { stubArbeidsuforhetForhandsvarselApi } from "../stubs/stubIsarbeidsuforhet";
 import {
@@ -26,11 +25,7 @@ const renderForhandsvarselSkjema = () =>
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <NotificationContext.Provider
-          value={{ notification: undefined, setNotification: () => void 0 }}
-        >
-          <SendForhandsvarselSkjema />
-        </NotificationContext.Provider>
+        <SendForhandsvarselSkjema />
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>
   );

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -6,7 +6,6 @@ import { screen } from "@testing-library/react";
 import { navEnhet } from "../dialogmote/testData";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { expect } from "chai";
-import { NotificationContext } from "@/context/notification/NotificationContext";
 import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
 import { VurderingResponseDTO } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
@@ -30,11 +29,7 @@ const renderForhandsvarselSendt = () => {
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <NotificationContext.Provider
-          value={{ notification: undefined, setNotification: () => void 0 }}
-        >
-          <ForhandsvarselSendt />
-        </NotificationContext.Provider>
+        <ForhandsvarselSendt />
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
     `${appRoutePath}/arbeidsuforhet`,


### PR DESCRIPTION
Vis spinner når henting av arbeidsuforhet laster, så vi ikke viser forhåndsvarselskjema en liten stund før vi bytter til en annen side. Fjern NotificationProvider som ikke er i bruk, fra test og ArbeidsuforhetSide.
Fjern litt ubrukte tekster.
Opprett varsel i lokal mock når det gjøres en forhåndsvarselvurdering.

<details>
<summary>Med og uten isLoading for å vise spinner:</summary>
Før:

https://github.com/navikt/syfomodiaperson/assets/40055758/434391d7-0d62-4d73-9079-c234e49f6146

Etter:

https://github.com/navikt/syfomodiaperson/assets/40055758/047db2da-cfcb-4920-9ef8-b47be7588a8c
</details>