### PR TITLE
IS-2214: Add functionality for 8-4-avslag

### DIFF
--- a/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
+++ b/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
@@ -1,0 +1,23 @@
+import React, { ReactElement } from "react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
+import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
+import { AvslagSent } from "@/sider/arbeidsuforhet/AvslagSent";
+
+export const Arbeidsuforhet = (): ReactElement => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const sisteVurdering = data[0];
+  const isForhandsvarsel =
+    sisteVurdering?.type === VurderingType.FORHANDSVARSEL;
+  const isOppfylt = sisteVurdering?.type === VurderingType.OPPFYLT;
+  const isAvslag = sisteVurdering?.type === VurderingType.AVSLAG;
+
+  return (
+    <div>
+      {(!sisteVurdering || isOppfylt) && <SendForhandsvarselSkjema />}
+      {isForhandsvarsel && <ForhandsvarselSendt />}
+      {isAvslag && <AvslagSent />}
+    </div>
+  );
+};

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -5,19 +5,16 @@ import SideLaster from "@/components/SideLaster";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import * as Tredelt from "@/sider/TredeltSide";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
-import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
-import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
-import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { VurderingHistorikk } from "@/sider/arbeidsuforhet/historikk/VurderingHistorikk";
+import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
 
 const texts = {
   title: "Forhåndsvarsel §8-4",
 };
 
 export const ArbeidsuforhetSide = (): ReactElement => {
-  const { data, isLoading, isError } = useArbeidsuforhetVurderingQuery();
-  const sisteVurdering = data[0];
+  const { isLoading, isError } = useArbeidsuforhetVurderingQuery();
 
   return (
     <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.ARBEIDSUFORHET}>
@@ -26,12 +23,7 @@ export const ArbeidsuforhetSide = (): ReactElement => {
         <Tredelt.Container>
           <Tredelt.FirstColumn>
             <div className="mb-4">
-              {!!sisteVurdering &&
-              sisteVurdering.type === VurderingType.FORHANDSVARSEL ? (
-                <ForhandsvarselSendt />
-              ) : (
-                <SendForhandsvarselSkjema />
-              )}
+              <Arbeidsuforhet />
             </div>
             <VurderingHistorikk />
           </Tredelt.FirstColumn>

--- a/src/sider/arbeidsuforhet/AvslagSent.tsx
+++ b/src/sider/arbeidsuforhet/AvslagSent.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box } from "@navikt/ds-react";
+
+const texts = {
+  title: "Husk å opprette oppgave i Gosys",
+  todo: [
+    "Gå inn i Gosys",
+    "Lag innstilling i forvaltningsnotat",
+    "Lag oppgave",
+    "Send til NAY",
+  ],
+};
+
+export const AvslagSent = () => {
+  return (
+    <Box background="surface-default" padding="6">
+      <h1>{texts.title}</h1>
+      <ol>
+        {texts.todo.map((todo, index) => (
+          <li key={index}>{todo}</li>
+        ))}
+      </ol>
+    </Box>
+  );
+};

--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -7,6 +7,11 @@ import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { BellIcon } from "@navikt/aksel-icons";
 import { Link } from "react-router-dom";
 import { arbeidsuforhetOppfyltPath } from "@/routers/AppRouter";
+import { useSendVurderingArbeidsuforhet } from "@/data/arbeidsuforhet/useSendVurderingArbeidsuforhet";
+import {
+  VurderingRequestDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 
 const texts = {
   title: "Fristen er utgått!",
@@ -22,6 +27,16 @@ const texts = {
 export const ForhandsvarselAfterDeadline = () => {
   const { data } = useArbeidsuforhetVurderingQuery();
   const forhandsvarsel = data[0];
+  const sendVurdering = useSendVurderingArbeidsuforhet();
+
+  const handleAvslag = () => {
+    const vurderingRequestDTO: VurderingRequestDTO = {
+      type: VurderingType.AVSLAG,
+      begrunnelse: "",
+      document: [],
+    };
+    sendVurdering.mutate(vurderingRequestDTO);
+  };
 
   return (
     <Box background="surface-default" padding="3" className="mb-2">
@@ -38,7 +53,13 @@ export const ForhandsvarselAfterDeadline = () => {
         {texts.passertAlert(forhandsvarsel.createdAt)}
       </BodyShort>
       <ButtonRow>
-        <Button variant="primary">{texts.avslag}</Button>
+        <Button
+          variant="primary"
+          onClick={handleAvslag}
+          loading={sendVurdering.isPending}
+        >
+          {texts.avslag}
+        </Button>
         <Button as={Link} to={arbeidsuforhetOppfyltPath} variant="secondary">
           {texts.oppfylt}
         </Button>

--- a/test/arbeidsuforhet/ArbeidsuforhetTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetTest.tsx
@@ -1,0 +1,117 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { queryClientWithMockData } from "../testQueryClient";
+import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
+import { screen } from "@testing-library/react";
+import { navEnhet } from "../dialogmote/testData";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { expect } from "chai";
+import {
+  VurderingResponseDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { addWeeks } from "@/utils/datoUtils";
+import {
+  createForhandsvarsel,
+  createVurdering,
+} from "./arbeidsuforhetTestData";
+import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
+import { renderWithRouter } from "../testRouterUtils";
+import { appRoutePath } from "@/routers/AppRouter";
+
+let queryClient: QueryClient;
+
+const mockArbeidsuforhetVurderinger = (vurderinger: VurderingResponseDTO[]) => {
+  queryClient.setQueryData(
+    arbeidsuforhetQueryKeys.arbeidsuforhet(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => vurderinger
+  );
+};
+
+const renderArbeidsuforhetSide = () => {
+  renderWithRouter(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <Arbeidsuforhet />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>,
+    `${appRoutePath}/arbeidsuforhet`,
+    [`${appRoutePath}/arbeidsuforhet`]
+  );
+};
+
+describe("ArbeidsuforhetSide", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Show correct info", () => {
+    it("show forhandsvarsel form if no there are no existing vurderinger", () => {
+      const vurderinger = [];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetSide();
+
+      expect(screen.getByText("Send forhåndsvarsel")).to.exist;
+      expect(screen.getByRole("button", { name: "Send" })).to.exist;
+    });
+
+    it("show forhandsvarsel form if latest arbeidsuforhet status is oppfylt", () => {
+      const oppfyltVurdering = createVurdering({
+        type: VurderingType.OPPFYLT,
+        begrunnelse: "begrunnelse",
+        createdAt: new Date(),
+      });
+      const vurderinger = [oppfyltVurdering];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetSide();
+
+      expect(screen.getByText("Send forhåndsvarsel")).to.exist;
+      expect(screen.getByRole("button", { name: "Send" })).to.exist;
+    });
+
+    it("show sent forhandsvarsel page if status is forhandsvarsel and frist is not utgatt", () => {
+      const forhandsvarselBeforeFrist = createForhandsvarsel({
+        createdAt: new Date(),
+        svarfrist: addWeeks(new Date(), 3),
+      });
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetSide();
+
+      expect(screen.getByText("Venter på svar fra bruker")).to.exist;
+    });
+
+    it("show sent forhandsvarsel page if status is forhandsvarsel and frist is utgatt", () => {
+      const forhandsvarselBeforeFrist = createForhandsvarsel({
+        createdAt: new Date(),
+        svarfrist: addWeeks(new Date(), -3),
+      });
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetSide();
+
+      expect(screen.getByText("Fristen er utgått!")).to.exist;
+    });
+
+    it("show avslag page if status is avslag", () => {
+      const avslag = createVurdering({
+        type: VurderingType.AVSLAG,
+        begrunnelse: "begrunnelse",
+        createdAt: new Date(),
+      });
+      const vurderinger = [avslag];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetSide();
+
+      expect(screen.getByText("Husk å opprette oppgave i Gosys")).to.exist;
+    });
+  });
+});


### PR DESCRIPTION
Ved klikk på avslag-knappen, når fristen på forhåndsvarselet er utgått, send en avslag-vurdering til isarbeidsuforhet.
Når siste status på arbeidsuforhet er avslag, vises en side med de neste stegene i prosessen.
Siden for veien videre skal fjernes etter hvert, f.eks. ved ny sykmelding, men det er ikke implementert enda.


https://github.com/navikt/syfomodiaperson/assets/40055758/816a3f6b-68aa-47e6-90a1-add5f7603f9c