### PR TITLE
IS-2219: Fix logic for gjentakende sykefravar

### DIFF
--- a/src/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts
+++ b/src/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts
@@ -15,7 +15,7 @@ import {
 
 export const ARBEIDSGIVERPERIODE_DAYS = 16;
 export const THREE_YEARS_AGO_IN_MONTHS = 36;
-export const MIN_DAYS_IN_LONG_TILFELLE = 4;
+export const MIN_DAYS_IN_LONG_TILFELLE = 3;
 
 const isInactive = (oppfolgingstilfelle: OppfolgingstilfelleDTO) => {
   const today = dayjs(new Date());

--- a/src/utils/oppfolgingstilfelleUtils.ts
+++ b/src/utils/oppfolgingstilfelleUtils.ts
@@ -7,7 +7,10 @@ import {
 import { dagerMellomDatoer } from "@/utils/datoUtils";
 
 const daysInTilfelle = (tilfelle: OppfolgingstilfelleDTO) => {
-  return dagerMellomDatoer(tilfelle.start, tilfelle.end) + 1;
+  return (
+    tilfelle.antallSykedager ??
+    dagerMellomDatoer(tilfelle.start, tilfelle.end) + 1
+  );
 };
 
 const hasManySykefravar = (tilfeller: number, sickdays: number) => {

--- a/test/utils/oppfolgingstilfelleUtilsTest.ts
+++ b/test/utils/oppfolgingstilfelleUtilsTest.ts
@@ -29,7 +29,20 @@ describe("OppfolgingstilfelleUtils", () => {
       expect(isGjentakendeSykefravar(tilfeller)).to.be.false;
     });
 
-    it("is NOT a gjentakende sykefravar if 5 short sykefravar and one long adding up to more than 100 days", () => {
+    it("is NOT a gjentakende sykefravar if 5 short, less than 3 days, sykefravar and one long adding up to more than 100 days", () => {
+      const tilfeller = [
+        generateOppfolgingstilfelle(daysFromToday(-500), daysFromToday(-400)),
+        generateOppfolgingstilfelle(daysFromToday(-300), daysFromToday(-299)),
+        generateOppfolgingstilfelle(daysFromToday(-250), daysFromToday(-249)),
+        generateOppfolgingstilfelle(daysFromToday(-200), daysFromToday(-199)),
+        generateOppfolgingstilfelle(daysFromToday(-150), daysFromToday(-149)),
+        generateOppfolgingstilfelle(daysFromToday(-100), daysFromToday(-99)),
+      ];
+
+      expect(isGjentakendeSykefravar(tilfeller)).to.be.false;
+    });
+
+    it("is a gjentakende sykefravar if 5 almost short, exactly 3 days, sykefravar and one long adding up to more than 100 days", () => {
       const tilfeller = [
         generateOppfolgingstilfelle(daysFromToday(-500), daysFromToday(-400)),
         generateOppfolgingstilfelle(daysFromToday(-300), daysFromToday(-298)),
@@ -39,7 +52,7 @@ describe("OppfolgingstilfelleUtils", () => {
         generateOppfolgingstilfelle(daysFromToday(-100), daysFromToday(-98)),
       ];
 
-      expect(isGjentakendeSykefravar(tilfeller)).to.be.false;
+      expect(isGjentakendeSykefravar(tilfeller)).to.be.true;
     });
 
     it("is a gjentakende sykefravar if 5 sykefravar adding up to 101 days", () => {


### PR DESCRIPTION
Alle tilfeller med minst 3 dager, i stedet for 4, skal være med i beregningen.
Bruk antallSykedager i stedet for å bare beregne lengde fra start til slutt i tilfellet.
