### PR TITLE
IS-2217: Add flexjar for arbeidsuforhet and remove from aktivitetskrav

### DIFF
--- a/src/components/flexjar/Flexjar.tsx
+++ b/src/components/flexjar/Flexjar.tsx
@@ -42,7 +42,7 @@ export const Flexjar = ({ side }: FlexjarProps) => {
   const [emojiType, setEmojiType] = useState<EmojiType>();
   const sendFeedback = useFlexjarFeedback();
   const { setStoredValue: setFeedbackDate } = useLocalStorageState<Date>(
-    StoreKey.FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE
+    StoreKey.FLEXJAR_ARBEIDSUFORHET_FEEDBACK_DATE
   );
 
   useEffect(() => {
@@ -95,7 +95,6 @@ export const Flexjar = ({ side }: FlexjarProps) => {
     <div className="flex flex-col sticky bottom-0 items-end z-[100]">
       <Button
         variant="primary-neutral"
-        size="small"
         iconPosition="right"
         icon={isApen ? <ChevronDownIcon /> : <ChevronUpIcon />}
         onClick={clickFeedbackPanel}

--- a/src/hooks/useLocalStorageState.ts
+++ b/src/hooks/useLocalStorageState.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 export enum StoreKey {
   FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE = "flexjarAktivitetskravFeedbackDate",
+  FLEXJAR_ARBEIDSUFORHET_FEEDBACK_DATE = "flexjarArbeidsuforhetFeedbackDate",
   MALFORM = "malform",
 }
 

--- a/src/sider/Side.tsx
+++ b/src/sider/Side.tsx
@@ -29,7 +29,7 @@ interface SideProps {
 const Side = ({ tittel, aktivtMenypunkt, children }: SideProps) => {
   const { data: diskresjonskode } = useDiskresjonskodeQuery();
   const { storedValue: flexjarFeedbackDate } = useLocalStorageState<Date>(
-    StoreKey.FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE
+    StoreKey.FLEXJAR_ARBEIDSUFORHET_FEEDBACK_DATE
   );
 
   const hasGivenFeedback = !!flexjarFeedbackDate;
@@ -43,7 +43,7 @@ const Side = ({ tittel, aktivtMenypunkt, children }: SideProps) => {
   const { toggles } = useFeatureToggles();
   const showFlexjar =
     toggles.isFlexjarEnabled &&
-    aktivtMenypunkt === Menypunkter.AKTIVITETSKRAV &&
+    aktivtMenypunkt === Menypunkter.ARBEIDSUFORHET &&
     diskresjonskode !== "6" &&
     diskresjonskode !== "7" &&
     !hasGivenFeedback;

--- a/test/flexjar/FlexjarTest.tsx
+++ b/test/flexjar/FlexjarTest.tsx
@@ -35,6 +35,7 @@ describe("Flexjar", () => {
   });
   afterEach(() => {
     nock.cleanAll();
+    localStorage.setItem(StoreKey.FLEXJAR_ARBEIDSUFORHET_FEEDBACK_DATE, "");
   });
 
   it("renders only feedback button", () => {
@@ -146,7 +147,8 @@ describe("Flexjar", () => {
     clickButton("Horribel");
     clickButton("Send tilbakemelding");
 
-    expect(localStorage.getItem(StoreKey.FLEXJAR_AKTIVITETSKRAV_FEEDBACK_DATE))
-      .to.not.be.null;
+    expect(
+      localStorage.getItem(StoreKey.FLEXJAR_ARBEIDSUFORHET_FEEDBACK_DATE)
+    ).to.not.equal("");
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjerner fra aktivitetskrav, som vi ble enige om. 
Økte knappen til regular size, og så kan vi endre farge etterhvert tenker jeg. Alt av amplitude-greier burde bli riktig når vi filterer på URL/sidetittel. MEN noen skjær i sjøen ettersom siden kanskje etterhvert endrer navn, og `/oppfylt` er en egen route - må bare passe på dette i amplitude-målingene.

### Screenshots 📸✨

<img width="1119" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/9b9e68d8-88cb-4118-8b04-74a3ff14da27">

<img width="458" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/bde80d48-d8a1-4bec-8c3a-7cd5031adb71">

