### PR TITLE
IS-2188: Update texts and styling for arbeidsuforhet-pages

### DIFF
--- a/mock/isarbeidsuforhet/arbeidsuforhetMock.ts
+++ b/mock/isarbeidsuforhet/arbeidsuforhetMock.ts
@@ -11,7 +11,7 @@ import {
   VurderingResponseDTO,
   VurderingType,
 } from "../../src/data/arbeidsuforhet/arbeidsuforhetTypes";
-import { getForhandsvarsel84Texts } from "../../src/data/arbeidsuforhet/forhandsvarsel84Texts";
+import { getForhandsvarselArbeidsuforhetTexts } from "../../src/data/arbeidsuforhet/forhandsvarselArbeidsuforhetTexts";
 
 const defaultOppfyltBegrunnelse = "Du har rett på sykepenger";
 
@@ -19,7 +19,7 @@ const getSendForhandsvarselDocument = (
   begrunnelse: string,
   frist: Date
 ): DocumentComponentDto[] => {
-  const sendForhandsvarselTexts = getForhandsvarsel84Texts({
+  const sendForhandsvarselTexts = getForhandsvarselArbeidsuforhetTexts({
     frist,
   });
   return [

--- a/src/components/VisBrev.tsx
+++ b/src/components/VisBrev.tsx
@@ -13,16 +13,18 @@ const texts = {
 
 interface VarselBrevProps {
   document: DocumentComponentDto[];
+  buttonText?: string;
 }
 
-export const VisBrev = ({ document }: VarselBrevProps) => {
+export const VisBrev = ({ document, buttonText }: VarselBrevProps) => {
   const [visBrev, setVisBrev] = useState(false);
+  const text = buttonText ? buttonText : texts.visBrev;
 
   const handleButtonClick = () => {
     setVisBrev(true);
     Amplitude.logEvent({
       type: EventType.ButtonClick,
-      data: { tekst: texts.visBrev, url: window.location.href },
+      data: { tekst: text, url: window.location.href },
     });
   };
 
@@ -35,7 +37,7 @@ export const VisBrev = ({ document }: VarselBrevProps) => {
         size="small"
         icon={<EyeWithPupilIcon aria-hidden />}
       >
-        {texts.visBrev}
+        {text}
       </Button>
       <ForhandsvisningModal
         contentLabel={texts.visBrevLabel}

--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -93,7 +93,7 @@ const vedtakMenypunkt = {
 };
 
 const arbeidsuforhetMenypunkt = {
-  navn: "Forhåndsvarsel §8-4",
+  navn: "Arbeidsuførhet",
   sti: "arbeidsuforhet",
   menypunkt: Menypunkter.ARBEIDSUFORHET,
 };

--- a/src/data/arbeidsuforhet/forhandsvarselArbeidsuforhetTexts.ts
+++ b/src/data/arbeidsuforhet/forhandsvarselArbeidsuforhetTexts.ts
@@ -1,12 +1,12 @@
 import { tilDatoMedManedNavn } from "../../utils/datoUtils";
 
-type Forhandsvarsel84TextsOptions = {
+type ForhandsvarselArbeidsuforhetTextsOptions = {
   frist: Date;
 };
 
-export const getForhandsvarsel84Texts = ({
+export const getForhandsvarselArbeidsuforhetTexts = ({
   frist,
-}: Forhandsvarsel84TextsOptions) => ({
+}: ForhandsvarselArbeidsuforhetTextsOptions) => ({
   varselInfo: {
     header: "NAV vurderer å avslå sykepengene dine",
     introWithFristDate: `NAV vurderer å avslå sykepengene dine fra og med ${tilDatoMedManedNavn(
@@ -23,6 +23,9 @@ export const getForhandsvarsel84Texts = ({
       frist
     )}.`,
     etterFrist: "Etter denne datoen vil NAV vurdere å avslå sykepengene dine.",
+    friskmeldt: `Dersom du blir friskmeldt før ${tilDatoMedManedNavn(
+      frist
+    )} kan du se bort fra dette brevet.`,
     kontaktOss:
       "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
   },

--- a/src/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument.ts
+++ b/src/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument.ts
@@ -5,9 +5,9 @@ import {
   createHeaderH3,
   createParagraph,
 } from "@/utils/documentComponentUtils";
-import { getForhandsvarsel84Texts } from "@/data/arbeidsuforhet/forhandsvarsel84Texts";
 import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import { getForhandsvarselArbeidsuforhetTexts } from "@/data/arbeidsuforhet/forhandsvarselArbeidsuforhetTexts";
 
 type ForhandsvarselDocumentValues = {
   begrunnelse: string;
@@ -29,7 +29,7 @@ export const useArbeidsuforhetVurderingDocument = (): {
 
   const getForhandsvarselDocument = (values: ForhandsvarselDocumentValues) => {
     const { begrunnelse, frist } = values;
-    const sendForhandsvarselTexts = getForhandsvarsel84Texts({
+    const sendForhandsvarselTexts = getForhandsvarselArbeidsuforhetTexts({
       frist,
     });
 
@@ -49,6 +49,7 @@ export const useArbeidsuforhetVurderingDocument = (): {
         sendForhandsvarselTexts.duKanUttaleDeg.tilbakemeldingWithFristDate
       ),
       createParagraph(sendForhandsvarselTexts.duKanUttaleDeg.etterFrist),
+      createParagraph(sendForhandsvarselTexts.duKanUttaleDeg.friskmeldt),
       createParagraph(sendForhandsvarselTexts.duKanUttaleDeg.kontaktOss),
 
       createHeaderH3(sendForhandsvarselTexts.lovhjemmel.header),
@@ -69,7 +70,7 @@ export const useArbeidsuforhetVurderingDocument = (): {
     }
 
     const documentComponents = [
-      createHeaderH1("Vurdering av arbeidsuførhet"),
+      createHeaderH1("Vurdering av § 8-4 arbeidsuførhet"),
       getIntroGjelder(),
       createParagraph(getVurderingText(type)),
     ];
@@ -95,7 +96,7 @@ const getVurderingText = (
   const vurdertDato = tilDatoMedManedNavn(new Date());
   switch (type) {
     case VurderingType.OPPFYLT: {
-      return `Det ble vurdert oppfylt den ${vurdertDato}`;
+      return `Det ble vurdert oppfylt den ${vurdertDato}.`;
     }
     case VurderingType.AVSLAG: {
       return `Det ble vurdert avslag den ${vurdertDato}.`;

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -33,6 +33,7 @@ export const dialogmoteRoutePath = `${appRoutePath}/dialogmote`;
 export const dialogmoteUnntakRoutePath = `${appRoutePath}/dialogmoteunntak`;
 export const moteoversiktRoutePath = `${appRoutePath}/moteoversikt`;
 export const arbeidsuforhetOppfyltPath = `${appRoutePath}/arbeidsuforhet/oppfylt`;
+export const arbeidsuforhetPath = `${appRoutePath}/arbeidsuforhet`;
 
 const AktivBrukerRouter = (): ReactElement => {
   Amplitude.logViewportAndScreenSize();
@@ -92,10 +93,7 @@ const AktivBrukerRouter = (): ReactElement => {
             path={`${appRoutePath}/sykepengesoknader`}
             element={<SykepengesoknaderSide />}
           />
-          <Route
-            path={`${appRoutePath}/arbeidsuforhet`}
-            element={<ArbeidsuforhetSide />}
-          />
+          <Route path={arbeidsuforhetPath} element={<ArbeidsuforhetSide />} />
           <Route
             path={arbeidsuforhetOppfyltPath}
             element={<ArbeidsuforhetOppfyltSide />}

--- a/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
+++ b/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
@@ -14,7 +14,7 @@ export const Arbeidsuforhet = (): ReactElement => {
   const isAvslag = sisteVurdering?.type === VurderingType.AVSLAG;
 
   return (
-    <div>
+    <div className="mb-2">
       {(!sisteVurdering || isOppfylt) && <SendForhandsvarselSkjema />}
       {isForhandsvarsel && <ForhandsvarselSendt />}
       {isAvslag && <AvslagSent />}

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetOppfylt.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetOppfylt.tsx
@@ -6,9 +6,9 @@ import { OppfyltForm } from "@/sider/arbeidsuforhet/OppfyltForm";
 
 const texts = {
   success:
-    "Begrunnelsen din på at bruker oppfyller § 8-4 er lagret i historikken.",
+    "Vurderingen om at bruker oppfyller § 8-4 er lagret i historikken og blir journalført automatisk.",
   error:
-    "Trykk på 'Forhåndsvarsel'-menypunktet for å komme til skjema for forhåndsvarsel!",
+    "Trykk på 'Arbeidsuførhet'-menypunktet for å komme til skjema for forhåndsvarsel.",
 };
 
 export const ArbeidsuforhetOppfylt = (): ReactElement => {

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide.tsx
@@ -10,7 +10,7 @@ import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuf
 import { ArbeidsuforhetOppfylt } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfylt";
 
 const texts = {
-  title: "Forhåndsvarsel §8-4",
+  title: "Arbeidsuførhet",
 };
 
 export const ArbeidsuforhetOppfyltSide = (): ReactElement => {

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -10,7 +10,7 @@ import { VurderingHistorikk } from "@/sider/arbeidsuforhet/historikk/VurderingHi
 import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
 
 const texts = {
-  title: "Forhåndsvarsel §8-4",
+  title: "Arbeidsuførhet",
 };
 
 export const ArbeidsuforhetSide = (): ReactElement => {
@@ -22,9 +22,7 @@ export const ArbeidsuforhetSide = (): ReactElement => {
       <SideLaster henter={isLoading} hentingFeilet={isError}>
         <Tredelt.Container>
           <Tredelt.FirstColumn>
-            <div className="mb-4">
-              <Arbeidsuforhet />
-            </div>
+            <Arbeidsuforhet />
             <VurderingHistorikk />
           </Tredelt.FirstColumn>
           <Tredelt.SecondColumn>

--- a/src/sider/arbeidsuforhet/AvslagSent.tsx
+++ b/src/sider/arbeidsuforhet/AvslagSent.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Box } from "@navikt/ds-react";
+import { Box, Heading, List } from "@navikt/ds-react";
 
 const texts = {
   title: "Husk å opprette oppgave i Gosys",
@@ -13,13 +13,15 @@ const texts = {
 
 export const AvslagSent = () => {
   return (
-    <Box background="surface-default" padding="6">
-      <h1>{texts.title}</h1>
-      <ol>
+    <Box background="surface-default" padding="4">
+      <Heading className="mb-4" level="2" size="medium">
+        {texts.title}
+      </Heading>
+      <List as="ol" size="small">
         {texts.todo.map((todo, index) => (
-          <li key={index}>{todo}</li>
+          <List.Item key={index}>{todo}</List.Item>
         ))}
-      </ol>
+      </List>
     </Box>
   );
 };

--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
-import { BodyShort, Box, Button, Heading } from "@navikt/ds-react";
+import { BodyShort, Box, Button, Detail, Heading } from "@navikt/ds-react";
 import { ButtonRow } from "@/components/Layout";
 import { VisBrev } from "@/components/VisBrev";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
@@ -14,14 +14,14 @@ import {
 } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 
 const texts = {
-  title: "Fristen er utgått!",
+  title: "Fristen er gått ut",
   passertAlert: (sentDate: Date) =>
-    `Forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+    `Fristen for forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
       sentDate
-    )} er gått ut! Du kan nå gi avslag på Arbeidsuførhet.`,
+    )} er gått ut. Trykk på Avslag-knappen hvis vilkårene i § 8-4 ikke er oppfylt og rett til videre sykepenger skal avslås.`,
   avslag: "Avslag",
   oppfylt: "Oppfylt",
-  seSendtBrev: "Se sendt brev",
+  seSendtVarsel: "Se sendt varsel",
 };
 
 export const ForhandsvarselAfterDeadline = () => {
@@ -39,19 +39,17 @@ export const ForhandsvarselAfterDeadline = () => {
   };
 
   return (
-    <Box background="surface-default" padding="3" className="mb-2">
+    <Box background="surface-default" padding="4" className="mb-2 [&>*]:mb-4">
       <div className="flex items-center">
-        <Heading className="mt-2 mb-4" level="2" size="small">
+        <Heading level="2" size="medium">
           {texts.title}
         </Heading>
-        <b className="ml-auto mr-4">
+        <Detail weight="semibold" className="ml-auto mr-4 text-lg">
           {tilLesbarDatoMedArUtenManedNavn(forhandsvarsel.varsel?.svarfrist)}
-        </b>
+        </Detail>
         <BellIcon title="bjelleikon" fontSize="2em" />
       </div>
-      <BodyShort className="mt-4 mb-8">
-        {texts.passertAlert(forhandsvarsel.createdAt)}
-      </BodyShort>
+      <BodyShort>{texts.passertAlert(forhandsvarsel.createdAt)}</BodyShort>
       <ButtonRow>
         <Button
           variant="primary"
@@ -63,7 +61,10 @@ export const ForhandsvarselAfterDeadline = () => {
         <Button as={Link} to={arbeidsuforhetOppfyltPath} variant="secondary">
           {texts.oppfylt}
         </Button>
-        <VisBrev document={forhandsvarsel.document} />
+        <VisBrev
+          document={forhandsvarsel.document}
+          buttonText={texts.seSendtVarsel}
+        />
       </ButtonRow>
     </Box>
   );

--- a/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarselBeforeDeadline.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
-import { Alert, Box, Button, Heading } from "@navikt/ds-react";
+import { Alert, BodyLong, Box, Button, Heading } from "@navikt/ds-react";
 import { ButtonRow } from "@/components/Layout";
 import { VisBrev } from "@/components/VisBrev";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
@@ -17,10 +17,11 @@ const texts = {
       "Når fristen er passert vil det dukke opp en hendelse i oversikten.",
   },
   sendtInfo:
-    "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag.",
+    "Dersom du har mottatt nye opplysninger og vurdert at bruker likevel oppfyller § 8-4, klikker du på Oppfylt-knappen. Du kan ikke avslå før fristen er gått ut.",
   frist: "Fristen går ut: ",
   oppfylt: "Oppfylt",
   avslag: "Avslag",
+  seSendtVarsel: "Se sendt varsel",
 };
 
 export const ForhandsvarselBeforeDeadline = () => {
@@ -36,9 +37,9 @@ export const ForhandsvarselBeforeDeadline = () => {
         </p>
         <p>{texts.sentAlert.passert}</p>
       </Alert>
-      <Box background="surface-default" padding="3" className="mb-2">
+      <Box background="surface-default" padding="4" className="[&>*]:mb-4">
         <div className="flex items-center">
-          <Heading className="mt-2 mb-4" level="2" size="small">
+          <Heading level="2" size="medium">
             {texts.title}
           </Heading>
           <div className="ml-auto mr-4">
@@ -47,7 +48,7 @@ export const ForhandsvarselBeforeDeadline = () => {
           </div>
           <ClockIcon title="klokkeikon" fontSize="2em" />
         </div>
-        <p>{texts.sendtInfo}</p>
+        <BodyLong>{texts.sendtInfo}</BodyLong>
         <ButtonRow>
           <Button variant="primary" disabled>
             {texts.avslag}
@@ -55,7 +56,10 @@ export const ForhandsvarselBeforeDeadline = () => {
           <Button as={Link} to={arbeidsuforhetOppfyltPath} variant="secondary">
             {texts.oppfylt}
           </Button>
-          <VisBrev document={forhandsvarsel.document} />
+          <VisBrev
+            document={forhandsvarsel.document}
+            buttonText={texts.seSendtVarsel}
+          />
         </ButtonRow>
       </Box>
     </div>

--- a/src/sider/arbeidsuforhet/OppfyltForm.tsx
+++ b/src/sider/arbeidsuforhet/OppfyltForm.tsx
@@ -1,6 +1,12 @@
 import React from "react";
-import { BodyShort, Box, Button, Heading, Textarea } from "@navikt/ds-react";
-import { ButtonRow } from "@/components/Layout";
+import {
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  List,
+  Textarea,
+} from "@navikt/ds-react";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
 import { useForm } from "react-hook-form";
@@ -10,21 +16,26 @@ import {
 } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { useArbeidsuforhetVurderingDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument";
 import { useSendVurderingArbeidsuforhet } from "@/data/arbeidsuforhet/useSendVurderingArbeidsuforhet";
+import { Link } from "react-router-dom";
+import { arbeidsuforhetPath } from "@/routers/AppRouter";
+import { ButtonRow } from "@/components/Layout";
 
 const texts = {
-  title: "Skriv en kort begrunnelse for hvorfor bruker oppfyller § 8-4",
-  info: "Det du skriver her blir liggende i historikken på brukeren og bruker vil få innsyn i notatet om de har behov.",
+  title: "Oppfyller bruker vilkårene likevel?",
+  info: "Skriv en kort begrunnelse for hvorfor bruker oppfyller vilkårene i § 8-4.",
   begrunnelseLabel: "Begrunnelse (obligatorisk)",
-  begrunnelseDescription: "Åpne forhåndsvisning for å se innstillingen.",
+  begrunnelseDescription:
+    "Åpne forhåndsvisning for å se vurderingen. Når du trykker Lagre journalføres vurderingen automatisk.",
   forDuGarVidere: {
-    head: "Før du går videre bør du gjøre følgende",
+    head: "Før du går videre bør du gjøre følgende:",
     step1: "Informere bruker om utfallet av vurderingen.",
     step2:
-      "Informere NAV Arbeid og ytelser via Gosys dersom det var de som initierte vurderingen av arbeidsuførheten",
+      "Besvare Gosys-oppgaven dersom NAV Arbeid og ytelser ba om vurderingen.",
   },
-  forhandsvisningLabel: "Forhåndsvis brev",
+  forhandsvisningLabel: "Forhåndsvis vurderingen",
   missingBegrunnelse: "Vennligst angi begrunnelse",
-  sendVarselButtonText: "Send",
+  sendVarselButtonText: "Lagre",
+  avbrytButton: "Avbryt",
 };
 
 const defaultValues = { begrunnelse: "" };
@@ -58,14 +69,13 @@ export const OppfyltForm = () => {
   };
 
   return (
-    <Box background="surface-default" padding="3" className="mb-2">
-      <form onSubmit={handleSubmit(submit)}>
-        <Heading className="mt-4 mb-4" level="2" size="small">
+    <Box background="surface-default" padding="4" className="mb-2">
+      <form onSubmit={handleSubmit(submit)} className="[&>*]:mb-4">
+        <Heading level="2" size="medium">
           {texts.title}
         </Heading>
-        <BodyShort className="mb-4">{texts.info}</BodyShort>
+        <BodyShort>{texts.info}</BodyShort>
         <Textarea
-          className="mb-8"
           {...register("begrunnelse", {
             maxLength: begrunnelseMaxLength,
             required: texts.missingBegrunnelse,
@@ -81,11 +91,10 @@ export const OppfyltForm = () => {
         {sendVurdering.isError && (
           <SkjemaInnsendingFeil error={sendVurdering.error} />
         )}
-        <b>{texts.forDuGarVidere.head}</b>
-        <ol>
-          <li>{texts.forDuGarVidere.step1}</li>
-          <li>{texts.forDuGarVidere.step2}</li>
-        </ol>
+        <List as="ol" size="small" title={texts.forDuGarVidere.head}>
+          <List.Item>{texts.forDuGarVidere.step1}</List.Item>
+          <List.Item>{texts.forDuGarVidere.step2}</List.Item>
+        </List>
         <ButtonRow>
           <Button loading={sendVurdering.isPending} type="submit">
             {texts.sendVarselButtonText}
@@ -98,8 +107,10 @@ export const OppfyltForm = () => {
                 type,
               })
             }
-            title={texts.forhandsvisningLabel}
           />
+          <Button as={Link} to={arbeidsuforhetPath} variant="secondary">
+            {texts.avbrytButton}
+          </Button>
         </ButtonRow>
       </form>
     </Box>

--- a/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
+++ b/src/sider/arbeidsuforhet/SendForhandsvarselSkjema.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { addWeeks } from "@/utils/datoUtils";
 import { ButtonRow } from "@/components/Layout";
-import { Box, Button, Heading, Textarea } from "@navikt/ds-react";
+import { Box, Button, Heading, List, Textarea } from "@navikt/ds-react";
 import { useForm } from "react-hook-form";
 import { useArbeidsuforhetVurderingDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
@@ -62,18 +62,18 @@ export const SendForhandsvarselSkjema = () => {
   return (
     <Box background="surface-default" padding="6">
       <form onSubmit={handleSubmit(submit)}>
-        <Heading className="mt-4 mb-4" level="2" size="small">
+        <Heading className="mb-4" level="2" size="medium">
           {texts.title}
         </Heading>
-        <ul className="pl-8">
+        <List as="ul" size="small">
           {texts.helptexts.map((text, index) => (
-            <li key={index} className="mb-2">
+            <List.Item key={index} className="mb-2">
               {text}
-            </li>
+            </List.Item>
           ))}
-        </ul>
+        </List>
         <Textarea
-          className="mb-8"
+          className="mb-8 mt-8"
           {...register("begrunnelse", {
             maxLength: begrunnelseMaxLength,
             required: texts.missingBeskrivelse,
@@ -103,7 +103,6 @@ export const SendForhandsvarselSkjema = () => {
                 frist: forhandsvarselFrist,
               })
             }
-            title={texts.forhandsvisningLabel}
           />
         </ButtonRow>
       </form>

--- a/src/sider/arbeidsuforhet/historikk/VurderingHistorikk.tsx
+++ b/src/sider/arbeidsuforhet/historikk/VurderingHistorikk.tsx
@@ -64,7 +64,7 @@ export const VurderingHistorikk = () => {
     <Box
       padding="6"
       background="surface-default"
-      className="flex flex-col gap-8 mb-4"
+      className="flex flex-col gap-8 mb-2"
     >
       <div>
         <Heading level="2" size="medium">

--- a/test/arbeidsuforhet/ArbeidsuforhetForhandsvarselTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetForhandsvarselTest.tsx
@@ -110,7 +110,7 @@ describe("Forhandsvarselskjema arbeidsuforhet", () => {
       })[0];
       expect(
         within(forhandsvisningForhandsvarsel).getByRole("heading", {
-          name: "Forhåndsvis forhåndsvarselet",
+          name: "NAV vurderer å avslå sykepengene dine",
           hidden: true,
         })
       ).to.exist;

--- a/test/arbeidsuforhet/ArbeidsuforhetOppfyltTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetOppfyltTest.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { queryClientWithMockData } from "../testQueryClient";
 import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { navEnhet } from "../dialogmote/testData";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { expect } from "chai";
@@ -17,6 +17,8 @@ import {
   createVurdering,
 } from "./arbeidsuforhetTestData";
 import { ArbeidsuforhetOppfylt } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfylt";
+import { renderWithRouter } from "../testRouterUtils";
+import { arbeidsuforhetOppfyltPath } from "@/routers/AppRouter";
 
 let queryClient: QueryClient;
 
@@ -28,14 +30,16 @@ const mockArbeidsuforhetVurderinger = (vurderinger: VurderingResponseDTO[]) => {
 };
 
 const renderArbeidsuforhetOppfyltSide = () => {
-  render(
+  renderWithRouter(
     <QueryClientProvider client={queryClient}>
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
         <ArbeidsuforhetOppfylt />
       </ValgtEnhetContext.Provider>
-    </QueryClientProvider>
+    </QueryClientProvider>,
+    arbeidsuforhetOppfyltPath,
+    [arbeidsuforhetOppfyltPath]
   );
 };
 
@@ -57,7 +61,7 @@ describe("OppfyltSide", () => {
 
       expect(
         screen.getByText(
-          "Skriv en kort begrunnelse for hvorfor bruker oppfyller § 8-4"
+          "Skriv en kort begrunnelse for hvorfor bruker oppfyller vilkårene i § 8-4."
         )
       ).to.exist;
     });
@@ -74,7 +78,7 @@ describe("OppfyltSide", () => {
 
       expect(
         screen.getByText(
-          "Skriv en kort begrunnelse for hvorfor bruker oppfyller § 8-4"
+          "Skriv en kort begrunnelse for hvorfor bruker oppfyller vilkårene i § 8-4."
         )
       ).to.exist;
     });
@@ -92,7 +96,7 @@ describe("OppfyltSide", () => {
 
       expect(
         screen.getByText(
-          "Begrunnelsen din på at bruker oppfyller § 8-4 er lagret i historikken."
+          "Vurderingen om at bruker oppfyller § 8-4 er lagret i historikken og blir journalført automatisk."
         )
       ).to.exist;
     });
@@ -110,7 +114,7 @@ describe("OppfyltSide", () => {
 
       expect(
         screen.getByText(
-          "Trykk på 'Forhåndsvarsel'-menypunktet for å komme til skjema for forhåndsvarsel!"
+          "Trykk på 'Arbeidsuførhet'-menypunktet for å komme til skjema for forhåndsvarsel."
         )
       ).to.exist;
     });

--- a/test/arbeidsuforhet/ArbeidsuforhetTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetTest.tsx
@@ -18,7 +18,7 @@ import {
 } from "./arbeidsuforhetTestData";
 import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
 import { renderWithRouter } from "../testRouterUtils";
-import { appRoutePath } from "@/routers/AppRouter";
+import { arbeidsuforhetPath } from "@/routers/AppRouter";
 
 let queryClient: QueryClient;
 
@@ -38,8 +38,8 @@ const renderArbeidsuforhetSide = () => {
         <Arbeidsuforhet />
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
-    `${appRoutePath}/arbeidsuforhet`,
-    [`${appRoutePath}/arbeidsuforhet`]
+    arbeidsuforhetPath,
+    [arbeidsuforhetPath]
   );
 };
 
@@ -97,7 +97,7 @@ describe("ArbeidsuforhetSide", () => {
 
       renderArbeidsuforhetSide();
 
-      expect(screen.getByText("Fristen er utgått!")).to.exist;
+      expect(screen.getByText("Fristen er gått ut")).to.exist;
     });
 
     it("show avslag page if status is avslag", () => {

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -16,7 +16,7 @@ import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQue
 import { addWeeks, tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { createForhandsvarsel } from "./arbeidsuforhetTestData";
 import { renderWithRouter } from "../testRouterUtils";
-import { appRoutePath } from "@/routers/AppRouter";
+import { arbeidsuforhetPath } from "@/routers/AppRouter";
 import { clickButton } from "../testUtils";
 
 let queryClient: QueryClient;
@@ -37,8 +37,8 @@ const renderForhandsvarselSendt = () => {
         <ForhandsvarselSendt />
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
-    `${appRoutePath}/arbeidsuforhet`,
-    [`${appRoutePath}/arbeidsuforhet`]
+    arbeidsuforhetPath,
+    [arbeidsuforhetPath]
   );
 };
 
@@ -69,7 +69,7 @@ describe("ForhandsvarselSendt", () => {
       expect(screen.getByText("Fristen går ut:")).to.exist;
       expect(
         screen.getByText(
-          "Om du får svar fra bruker, og hen oppfyller kravene om 8-4 etter din vurdering, klikker du på “oppfylt”-knappen under. Om ikke må du vente til tiden går ut før du kan gi avslag."
+          "Dersom du har mottatt nye opplysninger og vurdert at bruker likevel oppfyller § 8-4, klikker du på Oppfylt-knappen. Du kan ikke avslå før fristen er gått ut."
         )
       ).to.exist;
       expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
@@ -78,7 +78,7 @@ describe("ForhandsvarselSendt", () => {
         true
       );
       expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
-      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
+      expect(screen.getByRole("button", { name: "Se sendt varsel" })).to.exist;
     });
 
     it("show ForhandsvarselAfterDeadline when svarfrist is today (expired)", () => {
@@ -92,15 +92,15 @@ describe("ForhandsvarselSendt", () => {
 
       renderForhandsvarselSendt();
 
-      expect(screen.getByText("Fristen er utgått!")).to.exist;
+      expect(screen.getByText("Fristen er gått ut")).to.exist;
       expect(screen.getByText(tilLesbarDatoMedArUtenManedNavn(new Date()))).to
         .exist;
       expect(screen.getByRole("img", { name: "bjelleikon" })).to.exist;
       expect(
         screen.getByText(
-          `Forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+          `Fristen for forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
             createdAt
-          )} er gått ut! Du kan nå gi avslag på Arbeidsuførhet.`
+          )} er gått ut. Trykk på Avslag-knappen hvis vilkårene i § 8-4 ikke er oppfylt og rett til videre sykepenger skal avslås.`
         )
       ).to.exist;
       expect(screen.getByRole("button", { name: "Avslag" })).to.have.property(
@@ -108,7 +108,7 @@ describe("ForhandsvarselSendt", () => {
         false
       );
       expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
-      expect(screen.getByRole("button", { name: "Se hele brevet" })).to.exist;
+      expect(screen.getByRole("button", { name: "Se sendt varsel" })).to.exist;
     });
 
     it("send avslag after frist is utgatt", async () => {

--- a/test/arbeidsuforhet/OppfyltFormTest.tsx
+++ b/test/arbeidsuforhet/OppfyltFormTest.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import { queryClientWithMockData } from "../testQueryClient";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { screen, waitFor, within } from "@testing-library/react";
 import { navEnhet } from "../dialogmote/testData";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { expect } from "chai";
@@ -12,18 +12,22 @@ import {
 import { changeTextInput, clickButton, getTextInput } from "../testUtils";
 import { OppfyltForm } from "@/sider/arbeidsuforhet/OppfyltForm";
 import { getSendVurderingDocument } from "./documents";
+import { renderWithRouter } from "../testRouterUtils";
+import { arbeidsuforhetOppfyltPath } from "@/routers/AppRouter";
 
 let queryClient: QueryClient;
 
 const renderOppfyltForm = () => {
-  render(
+  renderWithRouter(
     <QueryClientProvider client={queryClient}>
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
         <OppfyltForm />
       </ValgtEnhetContext.Provider>
-    </QueryClientProvider>
+    </QueryClientProvider>,
+    arbeidsuforhetOppfyltPath,
+    [arbeidsuforhetOppfyltPath]
   );
 };
 
@@ -39,23 +43,26 @@ describe("OppfyltForm", () => {
       renderOppfyltForm();
 
       expect(screen.getByText(begrunnelseLabel)).to.exist;
-      expect(screen.getByText("Åpne forhåndsvisning for å se innstillingen."))
-        .to.exist;
+      expect(
+        screen.getByText(
+          "Åpne forhåndsvisning for å se vurderingen. Når du trykker Lagre journalføres vurderingen automatisk."
+        )
+      ).to.exist;
       expect(
         screen.getByRole("textbox", {
           name: begrunnelseLabel,
         })
       ).to.exist;
-      expect(screen.getByText("Før du går videre bør du gjøre følgende")).to
+      expect(screen.getByText("Før du går videre bør du gjøre følgende:")).to
         .exist;
       expect(screen.getByText("Informere bruker om utfallet av vurderingen."))
         .to.exist;
       expect(
         screen.getByText(
-          "Informere NAV Arbeid og ytelser via Gosys dersom det var de som initierte vurderingen av arbeidsuførheten"
+          "Besvare Gosys-oppgaven dersom NAV Arbeid og ytelser ba om vurderingen."
         )
       ).to.exist;
-      expect(screen.getByRole("button", { name: "Send" })).to.exist;
+      expect(screen.getByRole("button", { name: "Lagre" })).to.exist;
       expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
     });
   });
@@ -64,7 +71,7 @@ describe("OppfyltForm", () => {
     it("Gives error when trying to send vurdering without begrunnelse", async () => {
       renderOppfyltForm();
 
-      clickButton("Send");
+      clickButton("Lagre");
 
       expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
     });
@@ -76,7 +83,7 @@ describe("OppfyltForm", () => {
       const berunnelseInput = getTextInput(begrunnelseLabel);
 
       changeTextInput(berunnelseInput, begrunnelse);
-      clickButton("Send");
+      clickButton("Lagre");
 
       await waitFor(() => {
         const useSendVurderingArbeidsuforhet = queryClient
@@ -108,7 +115,7 @@ describe("OppfyltForm", () => {
       })[0];
       expect(
         within(forhandsvisningVurdering).getByRole("heading", {
-          name: "Forhåndsvis brev",
+          name: "Vurdering av § 8-4 arbeidsuførhet",
           hidden: true,
         })
       ).to.exist;

--- a/test/arbeidsuforhet/documents.ts
+++ b/test/arbeidsuforhet/documents.ts
@@ -3,19 +3,19 @@ import {
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
 import { addWeeks, tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { getForhandsvarsel84Texts } from "@/data/arbeidsuforhet/forhandsvarsel84Texts";
 import {
   ARBEIDSTAKER_DEFAULT,
   ARBEIDSTAKER_DEFAULT_FULL_NAME,
   VEILEDER_DEFAULT,
 } from "../../mock/common/mockConstants";
+import { getForhandsvarselArbeidsuforhetTexts } from "@/data/arbeidsuforhet/forhandsvarselArbeidsuforhetTexts";
 
 const expectedFristDate = addWeeks(new Date(), 3);
 
 export const getSendForhandsvarselDocument = (
   begrunnelse: string
 ): DocumentComponentDto[] => {
-  const sendForhandsvarselTexts = getForhandsvarsel84Texts({
+  const sendForhandsvarselTexts = getForhandsvarselArbeidsuforhetTexts({
     frist: expectedFristDate,
   });
   return [
@@ -50,6 +50,10 @@ export const getSendForhandsvarselDocument = (
       type: DocumentComponentType.PARAGRAPH,
     },
     {
+      texts: [sendForhandsvarselTexts.duKanUttaleDeg.friskmeldt],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
       texts: [sendForhandsvarselTexts.duKanUttaleDeg.kontaktOss],
       type: DocumentComponentType.PARAGRAPH,
     },
@@ -77,7 +81,7 @@ export const getSendVurderingDocument = (
 ): DocumentComponentDto[] => {
   return [
     {
-      texts: ["Vurdering av arbeidsuførhet"],
+      texts: ["Vurdering av § 8-4 arbeidsuførhet"],
       type: DocumentComponentType.HEADER_H1,
     },
     {
@@ -87,7 +91,9 @@ export const getSendVurderingDocument = (
       type: DocumentComponentType.PARAGRAPH,
     },
     {
-      texts: [`Det ble vurdert oppfylt den ${tilDatoMedManedNavn(new Date())}`],
+      texts: [
+        `Det ble vurdert oppfylt den ${tilDatoMedManedNavn(new Date())}.`,
+      ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -184,7 +184,6 @@ describe("GlobalNavigasjon", () => {
 
     renderGlobalNavigasjon();
 
-    expect(screen.getByRole("link", { name: "Forhåndsvarsel §8-4 1" })).to
-      .exist;
+    expect(screen.getByRole("link", { name: "Arbeidsuførhet 1" })).to.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Inkluderer også IS-2206 og IS-2229.
Har gjort en del tekstendringer etter prat med Stine, og kosmetiske styling-endringer slik at ting ser mer likt ut og bruker Aksel i større grad:
- Endret sidetittel og menypunkt fra `Forhåndsvarsel § 8-4` til `Arbeidsuførhet`
- Endret fra "Se sendt brev" til "Se sendt varsel" på knapp for å vise forhåndsvarselet man har sendt ut
- Lagt til en ny setning om friskmelding før fristen i forhåndsvarselbrevet
- Fjernet tittler på forhåndsvisingmodal, slik at det er mer likt som dialogmelding- og aktivitetskravmodalene
- Bruker [List](https://aksel.nav.no/komponenter/core/list) fra Aksel i stedet for ol, ul og li tags
- Tekstendringer i flere visninger (se bilder)
- Avbryt-knapp når man kommer til oppfylt-form
- Send-knapp på Oppfylt endres til Lagre
- Styling av overskrifter, fontstørrelser og spacing mellom disse så det er mer likt på tvers av komponenter

<details>
<summary>Klikk her for screenshots</summary>

Forhåndsvarsel før:
<img width="796" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/f04cbbf1-fd1d-4260-a745-984a4e386c82">

Forhåndsvarsel etter:
<img width="754" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/db849ea7-d2d2-44c7-a92b-98ce3102cf98">

Forhåndsvisning forhåndsvarsel før:
<img width="791" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/d0c99349-4cf5-42ef-8485-6966abe37bed">

Forhåndsvisning forhåndsvarsel etter:
<img width="791" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/211f7966-3411-4a3d-b10b-be7bfe09abc9">

Venteside før:
<img width="751" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/c689a65c-5cd5-4ffb-a9f2-7e3a4b9304d4">

Venteside nå:
<img width="748" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/e0902cd2-0a2a-4209-a1d2-79b50e069217">

Oppfyltside før:
<img width="743" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/12f0106c-70bb-4d1e-8d0a-797a0e688d24">

Oppfyltside nå:
<img width="739" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/5d3d3a3a-443d-4eb9-b069-b50a72281630">

Oppfylt forhåndsvisning før:
<img width="432" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/b399c75e-e34c-4744-90ee-34445ee9efe0">

Oppfylt forhåndsvisning nå:
<img width="498" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/81c89da9-4fe4-4b8f-975b-05147bc078a1">

Etter oppfylt før:
<img width="746" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/249a66d9-d22c-497a-9b69-9ae008bfccf6">

Etter oppfylt nå:
<img width="747" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/323fe6ba-b1f1-4560-80d3-1c64f87bb2c9">

Etter fristen før:
<img width="746" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/38c706ff-9d8c-4823-a032-18febb39742d">

Etter fristen nå:
<img width="740" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/2b9b130d-abd7-4706-bf81-2833847124d8">

Etter avslag før:
<img width="757" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/d1a5df46-6b3c-4f17-9e68-6b0ef537723e">

Etter avslag nå:
<img width="751" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/4807f41f-3edc-43b1-b97d-dc96120742af">

</details>

