### PR TITLE
IS-2237: Use aksel-buttons for dialogmøtestatus

### DIFF
--- a/src/components/IconHeader.tsx
+++ b/src/components/IconHeader.tsx
@@ -1,17 +1,5 @@
-import {
-  FlexColumn,
-  FlexRow,
-  H2NoMargins,
-  JustifyContentType,
-  PaddingSize,
-} from "@/components/Layout";
 import React, { ReactNode } from "react";
-import styled from "styled-components";
-
-const Icon = styled.img`
-  margin-right: 1em;
-  width: 3em;
-`;
+import { Heading } from "@navikt/ds-react";
 
 interface IconHeaderProps {
   icon: string;
@@ -27,12 +15,14 @@ export const IconHeader = ({
   subtitle,
 }: IconHeaderProps) => {
   return (
-    <FlexRow bottomPadding={PaddingSize.MD}>
-      <Icon src={icon} alt={altIcon} />
-      <FlexColumn justifyContent={JustifyContentType.CENTER}>
-        <H2NoMargins>{header}</H2NoMargins>
+    <div className="flex flex-row items-center">
+      <img className="mr-4 w-12" src={icon} alt={altIcon} />
+      <div className="flex flex-col gap-1">
+        <Heading level="2" size="medium">
+          {header}
+        </Heading>
         {typeof subtitle === "string" ? <p>{subtitle}</p> : subtitle}
-      </FlexColumn>
-    </FlexRow>
+      </div>
+    </div>
   );
 };

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -56,10 +56,6 @@ export const FlexRow = styled.div<RowProps>`
     props.justifyContent || JustifyContentType.FLEX_START};
 `;
 
-export const H2NoMargins = styled.h2`
-  margin: 0;
-`;
-
 interface ButtonRowProps {
   topPadding?: PaddingSize;
   bottomPadding?: PaddingSize;

--- a/src/components/dialogmote/DeltakereSvarInfo.tsx
+++ b/src/components/dialogmote/DeltakereSvarInfo.tsx
@@ -218,7 +218,7 @@ const EkspanderbartSvarPanel = ({
   tittel,
   children,
 }: EkspanderbartSvarPanelProps) => (
-  <ExpansionCard size="small" aria-label={tittel} className="mb-4">
+  <ExpansionCard size="small" aria-label={tittel}>
     <ExpansionCard.Header>
       <ExpansionCard.Title size="small">
         <div className="flex gap-1 items-center">
@@ -287,7 +287,7 @@ export const DeltakereSvarInfo = ({ dialogmote }: DeltakereSvarInfoProps) => {
   const customTitle = noNarmesteLeder ? texts.noNarmesteleder : undefined;
 
   return (
-    <div className="flex flex-col w-full">
+    <div className="flex flex-col w-full gap-4">
       <DeltakerSvarPanel
         deltakerLabel={texts.naermesteLeder}
         deltakerNavn={narmesteLederNavn ?? ""}

--- a/src/sider/mote/components/DialogmotePanel.tsx
+++ b/src/sider/mote/components/DialogmotePanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const DialogmotePanel = ({ children, ...rest }: Props): ReactElement => {
   return (
-    <Box background="surface-default" className="flex flex-col mb-4 p-8">
+    <Box background="surface-default" className="flex flex-col mb-2 p-6 gap-6">
       <IconHeader altIcon="moteikon" {...rest} />
       {children}
     </Box>

--- a/src/sider/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/sider/mote/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -1,7 +1,6 @@
+import React, { ReactNode } from "react";
 import { MoteIkonBlaaImage } from "../../../../../img/ImageComponents";
 import { DialogmotePanel } from "../DialogmotePanel";
-import React, { ReactNode } from "react";
-import { FlexRow, PaddingSize } from "../../../../components/Layout";
 import {
   DialogmoteDTO,
   DialogmoteStatus,
@@ -9,14 +8,12 @@ import {
 import { tilDatoMedUkedagOgManedNavnOgKlokkeslett } from "@/utils/datoUtils";
 import { Link } from "react-router-dom";
 import { dialogmoteRoutePath } from "@/routers/AppRouter";
-import { Normaltekst } from "nav-frontend-typografi";
 import { DeltakereSvarInfo } from "@/components/dialogmote/DeltakereSvarInfo";
 import dayjs from "dayjs";
 import { useDialogmoteReferat } from "@/hooks/dialogmote/useDialogmoteReferat";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { narmesteLederForVirksomhet } from "@/utils/ledereUtils";
 import { NoNarmesteLederAlert } from "@/sider/mote/components/innkalling/NoNarmestLederAlert";
-import Knapp, { Hovedknapp } from "nav-frontend-knapper";
 import VurderOppgaveForDialogmotesvarKnapp from "@/sider/mote/components/innkalling/VurderOppgaveForDialogmotesvarKnapp";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { PersonOppgave } from "@/data/personoppgave/types/PersonOppgave";
@@ -24,6 +21,7 @@ import {
   isAktivtDialogmote,
   isPersonoppgaveCompletedAfterLastMoteEndring,
 } from "@/utils/dialogmoteUtils";
+import { BodyShort, Button } from "@navikt/ds-react";
 
 const texts = {
   innkallingSendtTrackingContext: "Møtelandingsside: Sendt innkalling",
@@ -43,8 +41,8 @@ const Subtitle = (dialogmote: DialogmoteDTO): ReactNode => {
 
   return (
     <>
-      <Normaltekst>{`${texts.moteTid}: ${moteDatoTid}`}</Normaltekst>
-      <Normaltekst>{`${texts.moteSted}: ${dialogmote.sted}`}</Normaltekst>
+      <BodyShort size="small">{`${texts.moteTid}: ${moteDatoTid}`}</BodyShort>
+      <BodyShort size="small">{`${texts.moteSted}: ${dialogmote.sted}`}</BodyShort>
     </>
   );
 };
@@ -101,35 +99,36 @@ export const DialogmoteMoteStatusPanel = ({ dialogmote }: Props) => {
       subtitle={Subtitle(dialogmote)}
       header={headerText(dialogmote)}
     >
-      {noNarmesteLeder && (
-        <FlexRow bottomPadding={PaddingSize.MD}>
-          <NoNarmesteLederAlert />
-        </FlexRow>
-      )}
-
-      <FlexRow>
-        <DeltakereSvarInfo dialogmote={dialogmote} />
-      </FlexRow>
-
+      {noNarmesteLeder && <NoNarmesteLederAlert />}
+      <DeltakereSvarInfo dialogmote={dialogmote} />
       {skalVurderes && (
-        <FlexRow topPadding={PaddingSize.MD}>
-          <VurderOppgaveForDialogmotesvarKnapp
-            personOppgave={personOppgaveForMote}
-          />
-        </FlexRow>
+        <VurderOppgaveForDialogmotesvarKnapp
+          personOppgave={personOppgaveForMote}
+        />
       )}
-
-      <FlexRow topPadding={PaddingSize.MD}>
-        <Link to={`${dialogmoteRoutePath}/${dialogmote.uuid}/endre`}>
-          <Knapp>{texts.endreMote}</Knapp>
-        </Link>
-        <Link to={`${dialogmoteRoutePath}/${dialogmote.uuid}/avlys`}>
-          <Knapp>{texts.avlysMote}</Knapp>
-        </Link>
-        <Link to={`${dialogmoteRoutePath}/${dialogmote.uuid}/referat`}>
-          <Hovedknapp>{referatKnappText}</Hovedknapp>
-        </Link>
-      </FlexRow>
+      <div className="flex gap-6">
+        <Button
+          as={Link}
+          to={`${dialogmoteRoutePath}/${dialogmote.uuid}/referat`}
+          variant="primary"
+        >
+          {referatKnappText}
+        </Button>
+        <Button
+          as={Link}
+          to={`${dialogmoteRoutePath}/${dialogmote.uuid}/endre`}
+          variant="secondary"
+        >
+          {texts.endreMote}
+        </Button>
+        <Button
+          as={Link}
+          to={`${dialogmoteRoutePath}/${dialogmote.uuid}/avlys`}
+          variant="secondary"
+        >
+          {texts.avlysMote}
+        </Button>
+      </div>
     </DialogmotePanel>
   );
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Disse knappene har irritert meg lenge, så tenkte jeg kunne oppgradere til Aksel-knapper. Innebærer også litt styling-endringer her og der, og fjerne bruk av styled-komponents og `FlexRow`. Tenker generelt at margin burde brukes for spacing der man dytter ting vekk utenfor elementet, ikke padding.

Hva er gjort:
- Flytta rekkefølge på knappene - håper det er greit å gjøre uten store konsekvenser.
- Nye knapper
- Dersom `Sted: ` hadde lang tekst, så flyttet den teksten under kalender-ikonet
- Bruker samme margin mellom alle elementer, og ikke padding til å skape space mellom ting
- Bytter ut eldre tekst-komponenter med Aksel-komponenter

### Screenshots 📸✨
Før:
<img width="733" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/f455a836-775d-4a97-8d0f-703466ac5360">

Etter:
<img width="737" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/4d84efbd-6376-44bf-b283-cd6108519482">

