### PR TITLE
IS-2227: Show alert after arbeidsuforhet avslag

### DIFF
--- a/src/sider/arbeidsuforhet/AvslagSent.tsx
+++ b/src/sider/arbeidsuforhet/AvslagSent.tsx
@@ -1,27 +1,20 @@
 import React from "react";
-import { Box, Heading, List } from "@navikt/ds-react";
+import { Alert } from "@navikt/ds-react";
 
 const texts = {
-  title: "Husk å opprette oppgave i Gosys",
-  todo: [
-    "Gå inn i Gosys",
-    "Lag innstilling i forvaltningsnotat",
-    "Lag oppgave",
-    "Send til NAY",
-  ],
+  title: "Du har gitt avslag i modia og oppgaven er fjernet fra oversikten.",
+  nb: "NB!",
+  nextStep:
+    "Husk å lage innstilling i forvaltningsnotat i Gosys og lage oppgave og sende til NAY.",
 };
 
 export const AvslagSent = () => {
   return (
-    <Box background="surface-default" padding="4">
-      <Heading className="mb-4" level="2" size="medium">
-        {texts.title}
-      </Heading>
-      <List as="ol" size="small">
-        {texts.todo.map((todo, index) => (
-          <List.Item key={index}>{todo}</List.Item>
-        ))}
-      </List>
-    </Box>
+    <Alert variant="success" className="mb-2">
+      <p>{texts.title}</p>
+      <p>
+        <b>{texts.nb}</b> {texts.nextStep}
+      </p>
+    </Alert>
   );
 };

--- a/test/arbeidsuforhet/ArbeidsuforhetTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetTest.tsx
@@ -111,7 +111,11 @@ describe("ArbeidsuforhetSide", () => {
 
       renderArbeidsuforhetSide();
 
-      expect(screen.getByText("Husk å opprette oppgave i Gosys")).to.exist;
+      expect(
+        screen.getByText(
+          "Du har gitt avslag i modia og oppgaven er fjernet fra oversikten."
+        )
+      ).to.exist;
     });
   });
 });


### PR DESCRIPTION
Vis alert i stedet for bare tekst, slik at det er tydelig at avslaget var vellykket.
Vis fortsatt informasjon om det neste veilederen må gjøre.

Før:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/a94e9901-7704-49c7-84af-6a5616446c5e)

Etter:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/7dadd317-05f1-4481-804c-57e8c987b6ac)
