### PR TITLE
IS-2220: Show 8-4 form when new sykmelding

### DIFF
--- a/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
+++ b/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
@@ -1,23 +1,60 @@
 import React, { ReactElement } from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
-import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import {
+  VurderingResponseDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
 import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
 import { AvslagSent } from "@/sider/arbeidsuforhet/AvslagSent";
+import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
+import {
+  getSykmeldingStartdato,
+  sykmeldingerSortertNyestTilEldstPeriode,
+} from "@/utils/sykmeldinger/sykmeldingUtils";
+import dayjs from "dayjs";
+import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat";
+
+const newSykmeldingAfterLastVurdering = (
+  sykmeldinger: SykmeldingOldFormat[],
+  latestVurdering: VurderingResponseDTO
+) => {
+  const sortedSykmeldinger =
+    !!sykmeldinger &&
+    sykmeldinger.length > 0 &&
+    sykmeldingerSortertNyestTilEldstPeriode(sykmeldinger);
+  const newestSykmelding = sortedSykmeldinger[0];
+  const startDateOfNewestSykmelding =
+    !!newestSykmelding?.mulighetForArbeid?.perioder &&
+    newestSykmelding?.mulighetForArbeid?.perioder.length > 0 &&
+    getSykmeldingStartdato(newestSykmelding);
+  const dateOfLastVurdering = latestVurdering?.createdAt;
+  return (
+    !!startDateOfNewestSykmelding &&
+    dayjs(startDateOfNewestSykmelding).isAfter(dateOfLastVurdering)
+  );
+};
 
 export const Arbeidsuforhet = (): ReactElement => {
   const { data } = useArbeidsuforhetVurderingQuery();
+  const { sykmeldinger } = useSykmeldingerQuery();
   const sisteVurdering = data[0];
   const isForhandsvarsel =
     sisteVurdering?.type === VurderingType.FORHANDSVARSEL;
   const isOppfylt = sisteVurdering?.type === VurderingType.OPPFYLT;
   const isAvslag = sisteVurdering?.type === VurderingType.AVSLAG;
+  const isSykmeldingAfterLastVurdering = newSykmeldingAfterLastVurdering(
+    sykmeldinger,
+    sisteVurdering
+  );
 
   return (
     <div className="mb-2">
-      {(!sisteVurdering || isOppfylt) && <SendForhandsvarselSkjema />}
+      {(!sisteVurdering || isOppfylt || isSykmeldingAfterLastVurdering) && (
+        <SendForhandsvarselSkjema />
+      )}
       {isForhandsvarsel && <ForhandsvarselSendt />}
-      {isAvslag && <AvslagSent />}
+      {!isSykmeldingAfterLastVurdering && isAvslag && <AvslagSent />}
     </div>
   );
 };


### PR DESCRIPTION
Nå vises bekreftelse på avslag frem til det kommer en sykmelding med startdato etter at avslaget ble opprettet.
Da kan veiledere vurdere å sende nytt forhåndsvarsel fordi det er mer informasjon (og antakeligvis et helt nytt tilfelle).
Legger også på litt ekstra validering i testene i ArbeidsuforhetTest: Siden de ulike komponentene i teorien kan vises samtidig, er det greit å validere at ting ikke vises.


https://github.com/navikt/syfomodiaperson/assets/40055758/a51702c3-23c7-4b80-9090-215644963893

