### PR TITLE
IS-2251: Change title of Arbeidsuforhet

### DIFF
--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -93,7 +93,7 @@ const vedtakMenypunkt = {
 };
 
 const arbeidsuforhetMenypunkt = {
-  navn: "Arbeidsuførhet",
+  navn: "Forhåndsvarsel §8-4",
   sti: "arbeidsuforhet",
   menypunkt: Menypunkter.ARBEIDSUFORHET,
 };

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetOppfylt.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetOppfylt.tsx
@@ -8,7 +8,7 @@ const texts = {
   success:
     "Vurderingen om at bruker oppfyller § 8-4 er lagret i historikken og blir journalført automatisk.",
   error:
-    "Trykk på 'Arbeidsuførhet'-menypunktet for å komme til skjema for forhåndsvarsel.",
+    "Trykk på 'Forhåndsvarsel §8-4'-menypunktet for å komme til skjema for forhåndsvarsel.",
 };
 
 export const ArbeidsuforhetOppfylt = (): ReactElement => {

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide.tsx
@@ -10,7 +10,7 @@ import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuf
 import { ArbeidsuforhetOppfylt } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfylt";
 
 const texts = {
-  title: "Arbeidsuførhet",
+  title: "Forhåndsvarsel §8-4",
 };
 
 export const ArbeidsuforhetOppfyltSide = (): ReactElement => {

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -10,7 +10,7 @@ import { VurderingHistorikk } from "@/sider/arbeidsuforhet/historikk/VurderingHi
 import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
 
 const texts = {
-  title: "Arbeidsuførhet",
+  title: "Forhåndsvarsel §8-4",
 };
 
 export const ArbeidsuforhetSide = (): ReactElement => {

--- a/test/arbeidsuforhet/ArbeidsuforhetOppfyltTest.tsx
+++ b/test/arbeidsuforhet/ArbeidsuforhetOppfyltTest.tsx
@@ -114,7 +114,7 @@ describe("OppfyltSide", () => {
 
       expect(
         screen.getByText(
-          "Trykk på 'Arbeidsuførhet'-menypunktet for å komme til skjema for forhåndsvarsel."
+          "Trykk på 'Forhåndsvarsel §8-4'-menypunktet for å komme til skjema for forhåndsvarsel."
         )
       ).to.exist;
     });

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -184,6 +184,7 @@ describe("GlobalNavigasjon", () => {
 
     renderGlobalNavigasjon();
 
-    expect(screen.getByRole("link", { name: "Arbeidsuførhet 1" })).to.exist;
+    expect(screen.getByRole("link", { name: "Forhåndsvarsel §8-4 1" })).to
+      .exist;
   });
 });


### PR DESCRIPTION
"Arbeidsuforhet" -> "Forhåndsvarsel §8-4"
Det er mer presist å kalle det forhåndsvarsel, siden det kun er det som er funksjonaliteten der i dag.

<details><summary>Bilder</summary>
<p>
Før:

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/91b16c9c-d2c5-4d74-9862-06dac64c6b5c)

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/569f9da1-3d93-46d7-8780-f91671ad3689)


Etter:
![image](https://github.com/navikt/syfomodiaperson/assets/40055758/46aae72c-2f2f-44a8-a24c-3bede89ac579)

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/ef3951f8-200a-495c-9690-2409adb85b9a)

</p>
</details> 