### PR TITLE
IS-2264: Add ny vurdering button to arbeidsuforhet

### DIFF
--- a/src/context/notification/NotificationContext.tsx
+++ b/src/context/notification/NotificationContext.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 
 export interface Notification {
-  message: string;
+  message: ReactNode;
 }
 
 type NotificationProviderProps = {

--- a/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
+++ b/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
@@ -1,23 +1,20 @@
-import React, { ReactElement } from "react";
+import React, { ReactElement, useState } from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
-import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
-import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
-import { AvslagSent } from "@/sider/arbeidsuforhet/AvslagSent";
+import { NyVurdering } from "@/sider/arbeidsuforhet/NyVurdering";
+import { StartetVurdering } from "@/sider/arbeidsuforhet/StartetVurdering";
 
 export const Arbeidsuforhet = (): ReactElement => {
   const { data } = useArbeidsuforhetVurderingQuery();
   const sisteVurdering = data[0];
   const isForhandsvarsel =
     sisteVurdering?.type === VurderingType.FORHANDSVARSEL;
-  const isOppfylt = sisteVurdering?.type === VurderingType.OPPFYLT;
-  const isAvslag = sisteVurdering?.type === VurderingType.AVSLAG;
+  const [showStartetVurdering, setShowStartetVurdering] =
+    useState<boolean>(false);
 
-  return (
-    <div className="mb-2">
-      {(!sisteVurdering || isOppfylt) && <SendForhandsvarselSkjema />}
-      {isForhandsvarsel && <ForhandsvarselSendt />}
-      {isAvslag && <AvslagSent />}
-    </div>
+  return showStartetVurdering || isForhandsvarsel ? (
+    <StartetVurdering />
+  ) : (
+    <NyVurdering handleClick={() => setShowStartetVurdering(true)} />
   );
 };

--- a/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetSide.tsx
@@ -8,6 +8,7 @@ import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { VurderingHistorikk } from "@/sider/arbeidsuforhet/historikk/VurderingHistorikk";
 import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
+import { NotificationProvider } from "@/context/notification/NotificationContext";
 
 const texts = {
   title: "Arbeidsuførhet",
@@ -22,7 +23,9 @@ export const ArbeidsuforhetSide = (): ReactElement => {
       <SideLaster henter={isLoading} hentingFeilet={isError}>
         <Tredelt.Container>
           <Tredelt.FirstColumn>
-            <Arbeidsuforhet />
+            <NotificationProvider>
+              <Arbeidsuforhet />
+            </NotificationProvider>
             <VurderingHistorikk />
           </Tredelt.FirstColumn>
           <Tredelt.SecondColumn>

--- a/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
+++ b/src/sider/arbeidsuforhet/ForhandsvarseAfterDeadline.tsx
@@ -12,6 +12,8 @@ import {
   VurderingRequestDTO,
   VurderingType,
 } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { useNotification } from "@/context/notification/NotificationContext";
+import { AvslagSent } from "@/sider/arbeidsuforhet/AvslagSent";
 
 const texts = {
   title: "Fristen er gått ut",
@@ -28,6 +30,7 @@ export const ForhandsvarselAfterDeadline = () => {
   const { data } = useArbeidsuforhetVurderingQuery();
   const forhandsvarsel = data[0];
   const sendVurdering = useSendVurderingArbeidsuforhet();
+  const { setNotification } = useNotification();
 
   const handleAvslag = () => {
     const vurderingRequestDTO: VurderingRequestDTO = {
@@ -35,7 +38,14 @@ export const ForhandsvarselAfterDeadline = () => {
       begrunnelse: "",
       document: [],
     };
-    sendVurdering.mutate(vurderingRequestDTO);
+
+    sendVurdering.mutate(vurderingRequestDTO, {
+      onSuccess: () => {
+        setNotification({
+          message: <AvslagSent />,
+        });
+      },
+    });
   };
 
   return (

--- a/src/sider/arbeidsuforhet/NyVurdering.tsx
+++ b/src/sider/arbeidsuforhet/NyVurdering.tsx
@@ -1,0 +1,59 @@
+import React, { ReactElement } from "react";
+import { BodyShort, Box, Button, Heading } from "@navikt/ds-react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import {
+  VurderingResponseDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { useNotification } from "@/context/notification/NotificationContext";
+
+const texts = {
+  title: "Arbeidsuførhet",
+  siste: "Siste vurdering",
+  button: "Start ny vurdering",
+};
+
+const lastVurderingText = (vurderinger: VurderingResponseDTO[]) => {
+  if (vurderinger.length === 0) {
+    return "Ingen vurderinger har blitt gjort, trykk på 'Start ny vurdering' for å sende forhåndsvarsel";
+  }
+
+  const lastVurdering = vurderinger[0];
+  const lastForhandsvarsel = vurderinger.find(
+    (vurdering) => vurdering.type === VurderingType.FORHANDSVARSEL
+  );
+  const lastVurderingType = lastVurdering?.type.toLowerCase();
+
+  return `Forrige forhåndsvarsel på 8-4 ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+    lastForhandsvarsel?.createdAt
+  )} og ${lastVurderingType} ${tilLesbarDatoMedArUtenManedNavn(
+    lastVurdering?.createdAt
+  )}`;
+};
+
+interface NyVurderingProps {
+  handleClick: () => void;
+}
+
+export const NyVurdering = ({
+  handleClick,
+}: NyVurderingProps): ReactElement => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const { notification } = useNotification();
+
+  return (
+    <>
+      {notification && notification.message}
+      <Box background="surface-default" padding="6" className="mb-2">
+        <Heading className="mb-4" level="2" size="medium">
+          {texts.siste}
+        </Heading>
+        <BodyShort className="mb-4">{`${lastVurderingText(data)}`}</BodyShort>
+        <Button onClick={handleClick} variant="secondary">
+          {texts.button}
+        </Button>
+      </Box>
+    </>
+  );
+};

--- a/src/sider/arbeidsuforhet/StartetVurdering.tsx
+++ b/src/sider/arbeidsuforhet/StartetVurdering.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { SendForhandsvarselSkjema } from "@/sider/arbeidsuforhet/SendForhandsvarselSkjema";
+import { ForhandsvarselSendt } from "@/sider/arbeidsuforhet/ForhandsvarselSendt";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+
+export const StartetVurdering = () => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const sisteVurdering = data[0];
+  const isForhandsvarsel =
+    sisteVurdering?.type === VurderingType.FORHANDSVARSEL;
+
+  return isForhandsvarsel ? (
+    <ForhandsvarselSendt />
+  ) : (
+    <SendForhandsvarselSkjema />
+  );
+};

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -18,6 +18,7 @@ import { createForhandsvarsel } from "./arbeidsuforhetTestData";
 import { renderWithRouter } from "../testRouterUtils";
 import { arbeidsuforhetPath } from "@/routers/AppRouter";
 import { clickButton } from "../testUtils";
+import { NotificationContext } from "@/context/notification/NotificationContext";
 
 let queryClient: QueryClient;
 
@@ -34,7 +35,11 @@ const renderForhandsvarselSendt = () => {
       <ValgtEnhetContext.Provider
         value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
       >
-        <ForhandsvarselSendt />
+        <NotificationContext.Provider
+          value={{ notification: undefined, setNotification: () => void 0 }}
+        >
+          <ForhandsvarselSendt />
+        </NotificationContext.Provider>
       </ValgtEnhetContext.Provider>
     </QueryClientProvider>,
     arbeidsuforhetPath,


### PR DESCRIPTION
Knappen sender veileder til skjemaet for forhåndsvarsel. Avslag-siden fjernes og erstattes med en alert over knappen, som blir borte når man beveger seg bort fra siden.
I tillegg til knappen viser vi når siste forhåndsvarsel og oppfylt/avslag ble sendt.
Endrer også testene til arbeidsuforhet, med assertions på at ting ikke vises, siden noen komponenter i teorien kan vises samtidig, men ikke skal det i praksis.


https://github.com/navikt/syfomodiaperson/assets/40055758/d8bc0b5c-f850-4578-b380-05b27d8758c6


