### PR TITLE
IS-2293: Add page for arbeidsuforhet avslag

### DIFF
--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -26,6 +26,7 @@ import { SykepengesoknadSide } from "@/sider/sykepengsoknader/container/Sykepeng
 import { ArbeidsuforhetSide } from "@/sider/arbeidsuforhet/ArbeidsuforhetSide";
 import { ArbeidsuforhetOppfyltSide } from "@/sider/arbeidsuforhet/ArbeidsuforhetOppfyltSide";
 import { Nokkelinformasjon } from "@/sider/nokkelinformasjon/Nokkelinformasjon";
+import { ArbeidsuforhetAvslagSide } from "@/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslagSide";
 
 export const appRoutePath = "/sykefravaer";
 
@@ -33,6 +34,7 @@ export const dialogmoteRoutePath = `${appRoutePath}/dialogmote`;
 export const dialogmoteUnntakRoutePath = `${appRoutePath}/dialogmoteunntak`;
 export const moteoversiktRoutePath = `${appRoutePath}/moteoversikt`;
 export const arbeidsuforhetOppfyltPath = `${appRoutePath}/arbeidsuforhet/oppfylt`;
+export const arbeidsuforhetAvslagPath = `${appRoutePath}/arbeidsuforhet/avslag`;
 export const arbeidsuforhetPath = `${appRoutePath}/arbeidsuforhet`;
 
 const AktivBrukerRouter = (): ReactElement => {
@@ -97,6 +99,10 @@ const AktivBrukerRouter = (): ReactElement => {
           <Route
             path={arbeidsuforhetOppfyltPath}
             element={<ArbeidsuforhetOppfyltSide />}
+          />
+          <Route
+            path={arbeidsuforhetAvslagPath}
+            element={<ArbeidsuforhetAvslagSide />}
           />
           <Route
             path={`${appRoutePath}/sykepengesoknader/:sykepengesoknadId`}

--- a/src/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslag.tsx
+++ b/src/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslag.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement } from "react";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { Navigate } from "react-router-dom";
+import { arbeidsuforhetPath } from "@/routers/AppRouter";
+
+const texts = {
+  placeholder: "Her kommer det et skjema!",
+};
+
+export const ArbeidsuforhetAvslag = (): ReactElement => {
+  const { data } = useArbeidsuforhetVurderingQuery();
+  const sisteVurdering = data[0];
+  const isForhandsvarselExpired = sisteVurdering.varsel?.isExpired;
+
+  return !isForhandsvarselExpired ? (
+    <Navigate to={arbeidsuforhetPath} />
+  ) : (
+    <p>{texts.placeholder}</p>
+  );
+};

--- a/src/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslagSide.tsx
+++ b/src/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslagSide.tsx
@@ -1,0 +1,35 @@
+import React, { ReactElement } from "react";
+import Side from "@/sider/Side";
+import Sidetopp from "@/components/Sidetopp";
+import SideLaster from "@/components/SideLaster";
+import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
+import * as Tredelt from "@/sider/TredeltSide";
+import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
+import { VurderingHistorikk } from "@/sider/arbeidsuforhet/historikk/VurderingHistorikk";
+import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { ArbeidsuforhetAvslag } from "@/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslag";
+
+const texts = {
+  title: "Arbeidsuførhet",
+};
+
+export const ArbeidsuforhetAvslagSide = (): ReactElement => {
+  const { isLoading, isError } = useArbeidsuforhetVurderingQuery();
+
+  return (
+    <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.ARBEIDSUFORHET}>
+      <Sidetopp tittel={texts.title} />
+      <SideLaster henter={isLoading} hentingFeilet={isError}>
+        <Tredelt.Container>
+          <Tredelt.FirstColumn>
+            <ArbeidsuforhetAvslag />
+            <VurderingHistorikk />
+          </Tredelt.FirstColumn>
+          <Tredelt.SecondColumn>
+            <UtdragFraSykefravaeret />
+          </Tredelt.SecondColumn>
+        </Tredelt.Container>
+      </SideLaster>
+    </Side>
+  );
+};

--- a/test/arbeidsuforhet/avslag/ArbeidsuforhetAvslagTest.tsx
+++ b/test/arbeidsuforhet/avslag/ArbeidsuforhetAvslagTest.tsx
@@ -1,0 +1,106 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { screen } from "@testing-library/react";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { expect } from "chai";
+import {
+  VurderingResponseDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
+import { addWeeks } from "@/utils/datoUtils";
+import { ArbeidsuforhetAvslag } from "@/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslag";
+import { ARBEIDSTAKER_DEFAULT } from "../../../mock/common/mockConstants";
+import { navEnhet } from "../../dialogmote/testData";
+import { queryClientWithMockData } from "../../testQueryClient";
+import {
+  createForhandsvarsel,
+  createVurdering,
+} from "../arbeidsuforhetTestData";
+import { renderWithRouter } from "../../testRouterUtils";
+import { arbeidsuforhetAvslagPath } from "@/routers/AppRouter";
+
+let queryClient: QueryClient;
+
+const mockArbeidsuforhetVurderinger = (vurderinger: VurderingResponseDTO[]) => {
+  queryClient.setQueryData(
+    arbeidsuforhetQueryKeys.arbeidsuforhet(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => vurderinger
+  );
+};
+
+const renderArbeidsuforhetAvslagSide = () => {
+  renderWithRouter(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <ArbeidsuforhetAvslag />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>,
+    arbeidsuforhetAvslagPath,
+    [arbeidsuforhetAvslagPath]
+  );
+};
+
+describe("AvslagSide", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Show correct info", () => {
+    it("show form if latest arbeidsuforhet status is forhandsvarsel and frist is utgatt", () => {
+      const forhandsvarselAfterFrist = createForhandsvarsel({
+        createdAt: new Date(),
+        svarfrist: addWeeks(new Date(), -3),
+      });
+      const vurderinger = [forhandsvarselAfterFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetAvslagSide();
+
+      expect(screen.getByText("Her kommer det et skjema!")).to.exist;
+    });
+
+    it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is forhandsvarsel and frist is not utgatt", () => {
+      const forhandsvarselBeforeFrist = createForhandsvarsel({
+        createdAt: new Date(),
+        svarfrist: addWeeks(new Date(), 3),
+      });
+      const vurderinger = [forhandsvarselBeforeFrist];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetAvslagSide();
+
+      expect(screen.queryByText("Her kommer det et skjema!")).to.not.exist;
+    });
+
+    it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is Avslag", () => {
+      const avslag = createVurdering({
+        type: VurderingType.AVSLAG,
+        begrunnelse: "begrunnelse",
+        createdAt: new Date(),
+      });
+      const vurderinger = [avslag];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetAvslagSide();
+
+      expect(screen.queryByText("Her kommer det et skjema!")).to.not.exist;
+    });
+
+    it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is Oppfylt", () => {
+      const oppfylt = createVurdering({
+        type: VurderingType.OPPFYLT,
+        begrunnelse: "begrunnelse",
+        createdAt: new Date(),
+      });
+      const vurderinger = [oppfylt];
+      mockArbeidsuforhetVurderinger(vurderinger);
+
+      renderArbeidsuforhetAvslagSide();
+
+      expect(screen.queryByText("Her kommer det et skjema!")).to.not.exist;
+    });
+  });
+});


### PR DESCRIPTION
Vi bruker en egen route for dette, tilsvarende oppfylt, for å separere det fra skjema for forhåndsvarsel.
Det er ingenting som lenker til routen enda, men det skal legges inn på Avslag-knappen i `ForhandsvarselAfterDeadline`.

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/68ec2726-0484-4ab0-a67c-c5ba84e00b0a)
