### PR TITLE
IS-2160: Fatt vedtak med datoer og begrunnelse

### DIFF
--- a/mock/isfrisktilarbeid/mockIsfrisktilarbeid.ts
+++ b/mock/isfrisktilarbeid/mockIsfrisktilarbeid.ts
@@ -1,5 +1,5 @@
 import express = require("express");
-import { ISFRISKTILARBEID_ROOT } from "@/apiConstants";
+import { ISFRISKTILARBEID_ROOT } from "../../src/apiConstants";
 
 export const mockIsfrisktilarbeid = (server: any) => {
   server.post(

--- a/src/sider/frisktilarbeid/FattVedtak.tsx
+++ b/src/sider/frisktilarbeid/FattVedtak.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import { Box, Button, Textarea } from "@navikt/ds-react";
+import { Forhandsvisning } from "@/components/Forhandsvisning";
+import { FormProvider, useForm } from "react-hook-form";
+import { VedtakDatoer } from "@/sider/frisktilarbeid/VedtakDatoer";
+import { addWeeks } from "@/utils/datoUtils";
+
+const begrunnelseMaxLength = 5000;
+
+const texts = {
+  begrunnelseMissing: "Vennligst angi begrunnelse",
+  begrunnelseLabel: "Begrunnelse",
+  begrunnelseDescription: "Åpne forhåndsvisning for å se hele vedtaket",
+  previewContentLabel: "Forhåndsvis vedtaket",
+  primaryButton: "Fatt vedtak",
+};
+
+export interface FattVedtakSkjemaValues {
+  fraDato: string;
+  begrunnelse: string;
+  behandlerRef: string;
+}
+
+export const FattVedtak = () => {
+  const [tilDato, setTilDato] = useState<Date>();
+  const methods = useForm<FattVedtakSkjemaValues>();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = methods;
+
+  const handleFraDatoChanged = (fraDato: Date) => {
+    setTilDato(addWeeks(fraDato, 12));
+  };
+
+  const submit = (values: FattVedtakSkjemaValues) => {
+    console.log(values);
+  };
+
+  return (
+    <Box background="surface-default" padding="6">
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(submit)} className="flex flex-col gap-8">
+          <div className="flex flex-col gap-4">
+            <VedtakDatoer
+              tilDato={tilDato}
+              onFraDatoChanged={handleFraDatoChanged}
+            />
+            <Textarea
+              {...register("begrunnelse", {
+                required: texts.begrunnelseMissing,
+                maxLength: begrunnelseMaxLength,
+              })}
+              minRows={6}
+              maxLength={begrunnelseMaxLength}
+              description={texts.begrunnelseDescription}
+              label={texts.begrunnelseLabel}
+              error={errors.begrunnelse?.message}
+            />
+          </div>
+          <div className="flex gap-4">
+            <Button variant="primary" loading={false} type="submit">
+              {texts.primaryButton}
+            </Button>
+            <Forhandsvisning
+              contentLabel={texts.previewContentLabel}
+              getDocumentComponents={() => []}
+            />
+          </div>
+        </form>
+      </FormProvider>
+    </Box>
+  );
+};

--- a/src/sider/frisktilarbeid/FriskmeldingTilArbeidsformidlingSide.tsx
+++ b/src/sider/frisktilarbeid/FriskmeldingTilArbeidsformidlingSide.tsx
@@ -4,6 +4,7 @@ import Sidetopp from "@/components/Sidetopp";
 import SideLaster from "@/components/SideLaster";
 import * as Tredelt from "@/sider/TredeltSide";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
+import { FattVedtak } from "@/sider/frisktilarbeid/FattVedtak";
 
 const texts = {
   title: "Friskmelding til arbeidsformidling",
@@ -15,7 +16,9 @@ export const FriskmeldingTilArbeidsformidlingSide = (): ReactElement => {
       <Sidetopp tittel={texts.title} />
       <SideLaster henter={false} hentingFeilet={false}>
         <Tredelt.Container>
-          <Tredelt.FirstColumn>Her kommer vedtak-skjema</Tredelt.FirstColumn>
+          <Tredelt.FirstColumn>
+            <FattVedtak />
+          </Tredelt.FirstColumn>
           <Tredelt.SecondColumn>
             Her kommer historikk og link servicerutine
           </Tredelt.SecondColumn>

--- a/src/sider/frisktilarbeid/VedtakDatoer.tsx
+++ b/src/sider/frisktilarbeid/VedtakDatoer.tsx
@@ -34,12 +34,13 @@ export const VedtakDatoer = ({
         onFraDatoChanged(date);
       }
     },
+    fromDate: new Date(),
   });
   const tilDatoDatePicker = useDatepicker();
 
   return (
     <>
-      <DatePicker {...fraDatoDatePicker.datepickerProps} strategy="fixed">
+      <DatePicker {...fraDatoDatePicker.datepickerProps}>
         <DatePicker.Input
           {...fraDatoDatePicker.inputProps}
           label={texts.fraDatoLabel}

--- a/src/sider/frisktilarbeid/VedtakDatoer.tsx
+++ b/src/sider/frisktilarbeid/VedtakDatoer.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import dayjs from "dayjs";
+import { DatePicker, useDatepicker } from "@navikt/ds-react";
+import { useController } from "react-hook-form";
+import { FattVedtakSkjemaValues } from "./FattVedtak";
+
+const texts = {
+  fraDatoMissing: "Vennligst angi dato",
+  fraDatoLabel: "Friskmeldingen gjelder fra",
+  fraDatoDescription: "Dette er datoen vedtaket starter",
+  tilDatoLabel: "Til dato (automatisk justert 12 uker frem)",
+  tilDatoDescription: "Dette er datoen vedtaket slutter",
+};
+
+interface VedtakDatoerProps {
+  tilDato: Date | undefined;
+  onFraDatoChanged: (fom: Date) => void;
+}
+
+export const VedtakDatoer = ({
+  tilDato,
+  onFraDatoChanged,
+}: VedtakDatoerProps) => {
+  const { field, fieldState } = useController<FattVedtakSkjemaValues>({
+    name: "fraDato",
+    rules: {
+      required: texts.fraDatoMissing,
+    },
+  });
+  const fraDatoDatePicker = useDatepicker({
+    onDateChange: (date: Date | undefined) => {
+      if (date) {
+        field.onChange(dayjs(date).format("YYYY-MM-DD"));
+        onFraDatoChanged(date);
+      }
+    },
+  });
+  const tilDatoDatePicker = useDatepicker();
+
+  return (
+    <>
+      <DatePicker {...fraDatoDatePicker.datepickerProps} strategy="fixed">
+        <DatePicker.Input
+          {...fraDatoDatePicker.inputProps}
+          label={texts.fraDatoLabel}
+          description={texts.fraDatoDescription}
+          error={fieldState.error?.message}
+        />
+      </DatePicker>
+      <DatePicker {...tilDatoDatePicker.datepickerProps}>
+        <DatePicker.Input
+          value={tilDato ? dayjs(tilDato).format("DD.MM.YYYY") : ""}
+          label={texts.tilDatoLabel}
+          description={texts.tilDatoDescription}
+          readOnly
+        />
+      </DatePicker>
+    </>
+  );
+};

--- a/test/frisktilarbeid/FattVedtakTest.tsx
+++ b/test/frisktilarbeid/FattVedtakTest.tsx
@@ -1,0 +1,66 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { navEnhet } from "../dialogmote/testData";
+import React from "react";
+import { FattVedtak } from "@/sider/frisktilarbeid/FattVedtak";
+import { queryClientWithMockData } from "../testQueryClient";
+import { expect } from "chai";
+import { clickButton, getTextInput } from "../testUtils";
+
+let queryClient: QueryClient;
+
+const renderFattVedtak = () =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <FattVedtak />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+
+describe("FattVedtak", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  it("viser skjema for å fatte vedtak", () => {
+    renderFattVedtak();
+
+    expect(getTextInput("Friskmeldingen gjelder fra")).to.exist;
+    const tilDatoInput = getTextInput(
+      "Til dato (automatisk justert 12 uker frem)"
+    );
+    expect(tilDatoInput).to.exist;
+    expect(tilDatoInput).to.have.property("readOnly", true);
+    expect(getTextInput("Begrunnelse")).to.exist;
+    expect(screen.getByRole("button", { name: "Fatt vedtak" })).to.exist;
+    expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
+  });
+  it("validerer fra-dato og begrunnelse", async () => {
+    renderFattVedtak();
+
+    clickButton("Fatt vedtak");
+
+    expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
+    expect(await screen.findByText("Vennligst angi dato")).to.exist;
+  });
+  it("åpner forhåndsvisning", () => {
+    renderFattVedtak();
+
+    clickButton("Forhåndsvisning");
+
+    const forhandsvisModal = screen.getAllByRole("dialog", {
+      hidden: true,
+    })[2];
+    expect(forhandsvisModal).to.exist;
+    expect(
+      within(forhandsvisModal).getByRole("button", {
+        name: "Lukk",
+        hidden: true,
+      })
+    ).to.exist;
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Begynt på skjema for å fatte vedtak. Foreløpig bare med dato-inputs og begrunnelse.
Størrelsen på input-feltene er som i skissene foreløpig, selv om vi bruker `small` mange andre steder

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/1507be60-6cb9-4ebc-8554-0b0e361b372b)
