### PR TITLE
IS-2293: Add form for 8-4-avslag

### DIFF
--- a/src/data/arbeidsuforhet/arbeidsuforhetDocumentTexts.ts
+++ b/src/data/arbeidsuforhet/arbeidsuforhetDocumentTexts.ts
@@ -38,11 +38,11 @@ export const getForhandsvarselArbeidsuforhetTexts = ({
   },
 });
 
-export const getAvslagArbeidsuforhetTexts = (fom: Date) => ({
+export const getAvslagArbeidsuforhetTexts = (fom: Date | undefined) => ({
   header: "NAV har avslått sykepengene dine",
-  fom: `NAV har avslått din søknad om sykepenger fra og med ${tilDatoMedManedNavn(
-    fom
-  )}.`,
+  fom: `NAV har avslått din søknad om sykepenger fra og med ${
+    !!fom ? tilDatoMedManedNavn(fom) : ""
+  }.`,
   intro:
     "For å få sykepenger må du ha en sykdom eller skade som gjør at du ikke kan klarer å være i arbeid, eller at du bare klarer å gjøre deler av arbeidet ditt.",
   hjemmel:

--- a/src/data/arbeidsuforhet/arbeidsuforhetTypes.ts
+++ b/src/data/arbeidsuforhet/arbeidsuforhetTypes.ts
@@ -4,6 +4,7 @@ export interface VurderingRequestDTO {
   type: VurderingType;
   begrunnelse: string;
   document: DocumentComponentDto[];
+  gjelderFom?: string;
 }
 
 export enum VurderingType {

--- a/src/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument.ts
+++ b/src/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument.ts
@@ -18,7 +18,7 @@ type ForhandsvarselDocumentValues = {
 
 type AvslagDocumentValues = {
   begrunnelse: string;
-  fom: Date;
+  fom: Date | undefined;
 };
 
 export const useArbeidsuforhetVurderingDocument = (): {

--- a/src/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslag.tsx
+++ b/src/sider/arbeidsuforhet/avslag/ArbeidsuforhetAvslag.tsx
@@ -2,10 +2,7 @@ import React, { ReactElement } from "react";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { Navigate } from "react-router-dom";
 import { arbeidsuforhetPath } from "@/routers/AppRouter";
-
-const texts = {
-  placeholder: "Her kommer det et skjema!",
-};
+import { AvslagForm } from "@/sider/arbeidsuforhet/avslag/AvslagForm";
 
 export const ArbeidsuforhetAvslag = (): ReactElement => {
   const { data } = useArbeidsuforhetVurderingQuery();
@@ -15,6 +12,6 @@ export const ArbeidsuforhetAvslag = (): ReactElement => {
   return !isForhandsvarselExpired ? (
     <Navigate to={arbeidsuforhetPath} />
   ) : (
-    <p>{texts.placeholder}</p>
+    <AvslagForm />
   );
 };

--- a/src/sider/arbeidsuforhet/avslag/AvslagDatePicker.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagDatePicker.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { DatePicker, useDatepicker } from "@navikt/ds-react";
+import { useController } from "react-hook-form";
+import { ArbeidsuforhetAvslagSkjemaValues } from "@/sider/arbeidsuforhet/avslag/AvslagForm";
+
+const texts = {
+  label: "Avslaget gjelder fra",
+  missingDate: "Vennligst angi dato",
+};
+
+export const AvslagDatePicker = () => {
+  const { field, fieldState } = useController<
+    ArbeidsuforhetAvslagSkjemaValues,
+    "fom"
+  >({
+    name: "fom",
+    rules: {
+      required: texts.missingDate,
+    },
+  });
+  const { datepickerProps, inputProps } = useDatepicker({
+    onDateChange: (date: Date | undefined) => {
+      field.onChange(date);
+    },
+  });
+
+  return (
+    <DatePicker {...datepickerProps} strategy="fixed">
+      <DatePicker.Input
+        {...inputProps}
+        size="small"
+        label={texts.label}
+        error={fieldState.error?.message}
+      />
+    </DatePicker>
+  );
+};

--- a/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { useSendVurderingArbeidsuforhet } from "@/data/arbeidsuforhet/useSendVurderingArbeidsuforhet";
+import { useArbeidsuforhetVurderingDocument } from "@/hooks/arbeidsuforhet/useArbeidsuforhetVurderingDocument";
+import { FormProvider, useForm } from "react-hook-form";
+import {
+  VurderingRequestDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import {
+  BodyShort,
+  Box,
+  Button,
+  Heading,
+  List,
+  Textarea,
+} from "@navikt/ds-react";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { ButtonRow } from "@/components/Layout";
+import { Forhandsvisning } from "@/components/Forhandsvisning";
+import { Link } from "react-router-dom";
+import { arbeidsuforhetPath } from "@/routers/AppRouter";
+import { AvslagDatePicker } from "@/sider/arbeidsuforhet/avslag/AvslagDatePicker";
+import dayjs from "dayjs";
+
+const texts = {
+  title: "Skriv innstilling til NAY",
+  begrunnelseLabel: "Innstilling om avslag (obligatorisk)",
+  info1:
+    "Skriv kort hvilke opplysninger som ligger til grunn for avslaget, samt din vurdering av hvorfor vilkåret ikke er oppfylt og vurdering av eventuelle nye opplysninger.",
+  info2:
+    "Hvis du har vurdert ordningen friskmelding til arbeidsformidling: skriv hvorfor ordningen ikke er aktuell og legg inn henvisning til §8-5.",
+  afterSendInfo: {
+    title: "Videre må du huske å:",
+    gosysoppgave: "Sende oppgave til NAY i Gosys.",
+    stoppknapp:
+      "Gi beskjed om avslag til ny saksbehandlingsløsning via Stoppknappen under fanen Sykmeldinger i Modia.",
+  },
+  buttonDescription:
+    "Når du trykker “Gi avslag” blir innstillingen journalført og kan sees i Gosys.",
+  forhandsvisningLabel: "Forhåndsvis innstillingen",
+  missingBegrunnelse: "Vennligst angi begrunnelse",
+  sendVarselButtonText: "Gi avslag",
+  avbrytButton: "Avbryt",
+};
+
+const begrunnelseMaxLength = 5000;
+
+export interface ArbeidsuforhetAvslagSkjemaValues {
+  begrunnelse: string;
+  fom: Date;
+}
+
+export const AvslagForm = () => {
+  const sendVurdering = useSendVurderingArbeidsuforhet();
+  const { getAvslagDocument } = useArbeidsuforhetVurderingDocument();
+  const formMethods = useForm<ArbeidsuforhetAvslagSkjemaValues>();
+  const {
+    register,
+    watch,
+    formState: { errors },
+    handleSubmit,
+  } = formMethods;
+
+  const submit = (values: ArbeidsuforhetAvslagSkjemaValues) => {
+    const vurderingRequestDTO: VurderingRequestDTO = {
+      type: VurderingType.AVSLAG,
+      begrunnelse: values.begrunnelse,
+      document: getAvslagDocument({
+        begrunnelse: values.begrunnelse,
+        fom: values.fom,
+      }),
+      gjelderFom: dayjs(values.fom).format("YYYY-MM-DD"),
+    };
+    sendVurdering.mutate(vurderingRequestDTO);
+  };
+
+  return (
+    <Box background="surface-default" padding="4" className="mb-2">
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit(submit)} className="[&>*]:mb-4">
+          <Heading level="2" size="medium">
+            {texts.title}
+          </Heading>
+          <AvslagDatePicker />
+          <BodyShort>
+            <p>{texts.info1}</p>
+            <p>{texts.info2}</p>
+          </BodyShort>
+          <Textarea
+            {...register("begrunnelse", {
+              maxLength: begrunnelseMaxLength,
+              required: texts.missingBegrunnelse,
+            })}
+            value={watch("begrunnelse")}
+            label={texts.begrunnelseLabel}
+            error={errors.begrunnelse?.message}
+            size="small"
+            minRows={6}
+            maxLength={begrunnelseMaxLength}
+          />
+          {sendVurdering.isError && (
+            <SkjemaInnsendingFeil error={sendVurdering.error} />
+          )}
+          <List as="ul" title={texts.afterSendInfo.title}>
+            <List.Item className="ml-8">
+              {texts.afterSendInfo.gosysoppgave}
+            </List.Item>
+            <List.Item className="ml-8">
+              {texts.afterSendInfo.stoppknapp}
+            </List.Item>
+          </List>
+          <BodyShort>{texts.buttonDescription}</BodyShort>
+          <ButtonRow>
+            <Button loading={sendVurdering.isPending} type="submit">
+              {texts.sendVarselButtonText}
+            </Button>
+            <Button as={Link} to={arbeidsuforhetPath} variant="secondary">
+              {texts.avbrytButton}
+            </Button>
+            <Forhandsvisning
+              contentLabel={texts.forhandsvisningLabel}
+              getDocumentComponents={() =>
+                getAvslagDocument({
+                  begrunnelse: watch("begrunnelse"),
+                  fom: watch("fom"),
+                })
+              }
+            />
+          </ButtonRow>
+        </form>
+      </FormProvider>
+    </Box>
+  );
+};

--- a/test/arbeidsuforhet/avslag/ArbeidsuforhetAvslagTest.tsx
+++ b/test/arbeidsuforhet/avslag/ArbeidsuforhetAvslagTest.tsx
@@ -59,7 +59,7 @@ describe("AvslagSide", () => {
 
       renderArbeidsuforhetAvslagSide();
 
-      expect(screen.getByText("Her kommer det et skjema!")).to.exist;
+      expect(screen.getByText("Skriv innstilling til NAY")).to.exist;
     });
 
     it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is forhandsvarsel and frist is not utgatt", () => {
@@ -72,7 +72,7 @@ describe("AvslagSide", () => {
 
       renderArbeidsuforhetAvslagSide();
 
-      expect(screen.queryByText("Her kommer det et skjema!")).to.not.exist;
+      expect(screen.queryByText("Skriv innstilling til NAY")).to.not.exist;
     });
 
     it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is Avslag", () => {
@@ -86,7 +86,7 @@ describe("AvslagSide", () => {
 
       renderArbeidsuforhetAvslagSide();
 
-      expect(screen.queryByText("Her kommer det et skjema!")).to.not.exist;
+      expect(screen.queryByText("Skriv innstilling til NAY")).to.not.exist;
     });
 
     it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is Oppfylt", () => {
@@ -100,7 +100,7 @@ describe("AvslagSide", () => {
 
       renderArbeidsuforhetAvslagSide();
 
-      expect(screen.queryByText("Her kommer det et skjema!")).to.not.exist;
+      expect(screen.queryByText("Skriv innstilling til NAY")).to.not.exist;
     });
   });
 });

--- a/test/arbeidsuforhet/avslag/AvslagFormTest.tsx
+++ b/test/arbeidsuforhet/avslag/AvslagFormTest.tsx
@@ -1,0 +1,142 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { screen, waitFor, within } from "@testing-library/react";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { expect } from "chai";
+import {
+  VurderingRequestDTO,
+  VurderingType,
+} from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { arbeidsuforhetOppfyltPath } from "@/routers/AppRouter";
+import { AvslagForm } from "@/sider/arbeidsuforhet/avslag/AvslagForm";
+import { renderWithRouter } from "../../testRouterUtils";
+import { navEnhet } from "../../dialogmote/testData";
+import { queryClientWithMockData } from "../../testQueryClient";
+import { changeTextInput, clickButton, getTextInput } from "../../testUtils";
+import { getAvslagVurderingDocument } from "../documents";
+import { toDatePrettyPrint } from "@/utils/datoUtils";
+
+let queryClient: QueryClient;
+
+const renderAvslagForm = () => {
+  renderWithRouter(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <AvslagForm />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>,
+    arbeidsuforhetOppfyltPath,
+    [arbeidsuforhetOppfyltPath]
+  );
+};
+
+describe("OppfyltForm", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Form components", () => {
+    it("shows date picker, textarea, and buttons", () => {
+      const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
+
+      renderAvslagForm();
+
+      expect(screen.getByText("Avslaget gjelder fra")).to.exist;
+      expect(
+        screen.getByText("Skriv kort hvilke opplysninger", { exact: false })
+      ).to.exist;
+      expect(
+        screen.getByText("friskmelding til arbeidsformidling:", {
+          exact: false,
+        })
+      ).to.exist;
+      expect(screen.getByText(begrunnelseLabel)).to.exist;
+      expect(
+        screen.getByRole("textbox", {
+          name: begrunnelseLabel,
+        })
+      ).to.exist;
+      expect(screen.getByText("Videre må du huske å:")).to.exist;
+      expect(screen.getByRole("button", { name: "Gi avslag" })).to.exist;
+      expect(screen.getByRole("button", { name: "Avbryt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
+    });
+  });
+
+  describe("Send avslag", () => {
+    it("Gives errors when trying to send vurdering without date and begrunnelse", async () => {
+      renderAvslagForm();
+
+      clickButton("Gi avslag");
+
+      await waitFor(() => {
+        expect(screen.queryByText("Vennligst angi begrunnelse")).to.not.exist;
+      });
+      expect(await screen.findByText("Vennligst angi dato")).to.exist;
+      expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
+    });
+
+    it("Send vurdering with date and begrunnelse filled in, without reseting the form", async () => {
+      renderAvslagForm();
+      const begrunnelse = "Dette er en begrunnelse!";
+      const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
+      const dateAsString = "2024-01-01";
+      const date = new Date(dateAsString);
+      const dateLabel = "Avslaget gjelder fra";
+      const dateInput = getTextInput(dateLabel);
+      const begrunnelseInput = getTextInput(begrunnelseLabel);
+
+      changeTextInput(dateInput, toDatePrettyPrint(date) as string);
+      changeTextInput(begrunnelseInput, begrunnelse);
+      clickButton("Gi avslag");
+
+      await waitFor(() => {
+        const useSendVurderingArbeidsuforhet = queryClient
+          .getMutationCache()
+          .getAll()[0];
+        const expectedVurdering: VurderingRequestDTO = {
+          type: VurderingType.AVSLAG,
+          begrunnelse: begrunnelse,
+          document: getAvslagVurderingDocument(begrunnelse, date),
+          gjelderFom: dateAsString,
+        };
+        expect(useSendVurderingArbeidsuforhet.state.variables).to.deep.equal(
+          expectedVurdering
+        );
+      });
+    });
+
+    it("Forhåndsvis brev with begrunnelse", async () => {
+      renderAvslagForm();
+      const begrunnelse = "Dette er en begrunnelse!";
+      const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
+      const dateAsString = "2024-01-01";
+      const date = new Date(dateAsString);
+      const dateLabel = "Avslaget gjelder fra";
+      const dateInput = getTextInput(dateLabel);
+      const begrunnelseInput = getTextInput(begrunnelseLabel);
+
+      changeTextInput(dateInput, toDatePrettyPrint(date) as string);
+      changeTextInput(begrunnelseInput, begrunnelse);
+
+      clickButton("Forhåndsvisning");
+
+      const forhandsvisningVurdering = screen.getAllByRole("dialog", {
+        hidden: true,
+      })[1];
+      expect(
+        within(forhandsvisningVurdering).getByRole("heading", {
+          name: "NAV har avslått sykepengene dine",
+          hidden: true,
+        })
+      ).to.exist;
+      getAvslagVurderingDocument(begrunnelse, date)
+        .flatMap((documentComponent) => documentComponent.texts)
+        .forEach((text) => {
+          expect(within(forhandsvisningVurdering).getByText(text)).to.exist;
+        });
+    });
+  });
+});

--- a/test/arbeidsuforhet/documents.ts
+++ b/test/arbeidsuforhet/documents.ts
@@ -106,3 +106,43 @@ export const getOppfyltVurderingDocument = (
     },
   ];
 };
+
+export const getAvslagVurderingDocument = (
+  begrunnelse: string,
+  fom: Date | undefined
+): DocumentComponentDto[] => {
+  return [
+    {
+      texts: ["NAV har avslått sykepengene dine"],
+      type: DocumentComponentType.HEADER_H1,
+    },
+    {
+      texts: [
+        `NAV har avslått din søknad om sykepenger fra og med ${
+          !!fom ? tilDatoMedManedNavn(fom) : ""
+        }.`,
+      ],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [
+        "For å få sykepenger må du ha en sykdom eller skade som gjør at du ikke kan klarer å være i arbeid, eller at du bare klarer å gjøre deler av arbeidet ditt.",
+      ],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [`${begrunnelse}`],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [
+        "Vi har brukt folketrygdloven § 8-4 første ledd når vi har behandlet saken din.",
+      ],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [`${VEILEDER_DEFAULT.fulltNavn()}`],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+  ];
+};


### PR DESCRIPTION
Veileder trenger å kunne fylle ut dato og begrunnelse, og få det lagret i Joark, slik at de kan henvise til det senere i kommunikasjon med NAY. Etter hvert skal "avslag"-knappen sende veileder til dette skjemaet.
Det mangler også en bekreftelse til veileder på at avslaget er innsendt.


https://github.com/navikt/syfomodiaperson/assets/40055758/82ea2b0d-c423-41ab-b131-56f288af3af5

