### PR TITLE
IS-2289: Don't show question undertekst as user response in soknad

### DIFF
--- a/src/sider/sykepengsoknader/soknad-felles-oppsummering/OppsummeringTall.tsx
+++ b/src/sider/sykepengsoknader/soknad-felles-oppsummering/OppsummeringTall.tsx
@@ -40,10 +40,8 @@ const OppsummeringTall = ({
   tag,
   overskriftsnivaa,
   svartype,
-  undertekst,
 }: OppsummeringSporsmalProps): ReactElement => {
   const text = getSvartypeText(svartype);
-  const label = undertekst || text;
   return (
     <OppsummeringSporsmalscontainer tag={tag}>
       <OppsummeringSporsmalstekst overskriftsnivaa={overskriftsnivaa}>
@@ -54,7 +52,7 @@ const OppsummeringTall = ({
           const verdi = verdiAdjustedIfBelop(svarverdi, svartype);
           return (
             <p className="oppsummering__tekst" key={getKey(tag, index)}>
-              {verdi} {label}
+              {verdi} {text}
             </p>
           );
         })}


### PR DESCRIPTION
Det er forvirrende når "eksempel 12" ser ut som en del av svaret til innbygger.
Derfor bruker vi nå kun svaret fra bruker i visningen, med "prosent/timer" bak, uavhengig av om undertekst finnes på spørsmålet.

<details>
  <summary>Bilder</summary>
  Før:

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/0b9b206c-06a5-46dd-b99f-4e58a470bbe9)

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/5279e880-6fe5-42eb-adca-28eb75748067)


Etter: 

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/3727b65b-eaea-4df0-b804-90b152ea3791)

![image](https://github.com/navikt/syfomodiaperson/assets/40055758/47070d38-d7a3-4840-b723-69054205ab7f)

</details>