### PR TITLE
IS-2261: Set standard vertical margins between cards

### DIFF
--- a/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
+++ b/src/sider/arbeidsuforhet/Arbeidsuforhet.tsx
@@ -13,7 +13,7 @@ export const Arbeidsuforhet = (): ReactElement => {
     useState<boolean>(false);
 
   return (
-    <div className="mb-2">
+    <div className="mb-4">
       {showStartetVurdering || isForhandsvarsel ? (
         <StartetVurdering />
       ) : (

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -78,7 +78,7 @@ const Historikk = ({
   return (
     <div className="p-4">
       <Select
-        className="w-fit mb-8"
+        className="w-fit mb-4"
         label={"Sykefraværstilfelle"}
         onChange={(event) =>
           setSelectedTilfelleIndex(Number(event.target.value))

--- a/src/sider/mote/components/DialogmotePanel.tsx
+++ b/src/sider/mote/components/DialogmotePanel.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const DialogmotePanel = ({ children, ...rest }: Props): ReactElement => {
   return (
-    <Box background="surface-default" className="flex flex-col mb-2 p-6 gap-6">
+    <Box background="surface-default" className="flex flex-col mb-4 p-6 gap-6">
       <IconHeader altIcon="moteikon" {...rest} />
       {children}
     </Box>

--- a/src/sider/nokkelinformasjon/sykmeldingsgrad/Sykmeldingsgrad.tsx
+++ b/src/sider/nokkelinformasjon/sykmeldingsgrad/Sykmeldingsgrad.tsx
@@ -85,7 +85,7 @@ export const Sykmeldingsgrad = () => {
   };
 
   return (
-    <Box background="surface-default" padding={"4"} className={"mb-8"}>
+    <Box background="surface-default" padding={"4"} className={"mb-4"}>
       <Heading size="medium" level="2">
         {texts.title}
       </Heading>

--- a/src/sider/sykepengsoknader/soknader/SoknaderTeasere.tsx
+++ b/src/sider/sykepengsoknader/soknader/SoknaderTeasere.tsx
@@ -17,7 +17,7 @@ const SoknaderTeasere = ({
   tomListeTekst,
   id,
 }: SoknaderTeasereProps): ReactElement => (
-  <div className="blokk--l">
+  <div className="mb-4">
     <header className="inngangspanelerHeader">
       <h2 className="inngangspanelerHeader__tittel">{tittel}</h2>
     </header>

--- a/src/sider/sykmeldinger/sykmeldinger/SykmeldingTeasere.tsx
+++ b/src/sider/sykmeldinger/sykmeldinger/SykmeldingTeasere.tsx
@@ -20,7 +20,7 @@ const SykmeldingTeasere = ({
   children,
 }: SykmeldingTeasereProps): ReactElement => {
   return (
-    <div className="blokk--l">
+    <div className="mb-4">
       <header className="inngangspanelerHeader">
         <h2 className="inngangspanelerHeader__tittel">{tittel}</h2>
         {children}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Setter standard margin mellom kort til `1 rem` (`16px`)

### Screenshots 📸✨
Eksempelvis siden for nøkkelinformasjon

Før
![Screenshot 2024-04-29 at 12 52 37](https://github.com/navikt/syfomodiaperson/assets/11747383/64bffb9c-12fd-4ae8-8293-06f75f29276a)

Etter
![Screenshot 2024-04-29 at 12 52 50](https://github.com/navikt/syfomodiaperson/assets/11747383/a31110c6-bdb6-4cdd-bca7-5060f4138fd4)
