### PR TITLE
IS-2146: Endre storrelse pa page headings til large

### DIFF
--- a/src/components/Sidetopp.tsx
+++ b/src/components/Sidetopp.tsx
@@ -10,7 +10,7 @@ interface Props {
 const Sidetopp = ({ tittel }: Props) => {
   return (
     <header>
-      <Heading spacing size="xlarge" id={SIDETOPP_ID} className="text-center">
+      <Heading spacing size="large" id={SIDETOPP_ID}>
         {tittel}
       </Heading>
     </header>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endrer sidetitler fra `xlarge` til `large` og flytter overskrift til venstre.

### Screenshots 📸✨
Før
![Screenshot 2024-04-30 at 09 21 02](https://github.com/navikt/syfomodiaperson/assets/11747383/26f8b2d9-7401-4138-9618-bd1158bd9795)
![Screenshot 2024-04-30 at 09 21 17](https://github.com/navikt/syfomodiaperson/assets/11747383/ed0474af-9a51-48c1-b12b-f4eb99c35dcf)

Etter
![Screenshot 2024-04-30 at 09 18 05](https://github.com/navikt/syfomodiaperson/assets/11747383/3fa6d66a-092c-4536-98f8-bc57249a5570)
![Screenshot 2024-04-30 at 09 17 52](https://github.com/navikt/syfomodiaperson/assets/11747383/c96d7a19-c59d-4931-8bba-e9b7a9010b4d)

