### PR TITLE
Change sorting of LPS plans

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=true
+legacy-peer-deps=true

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Applikasjonen har en mock som kan brukes lokalt. Her mockes diverse endepunkter,
 Du må ha Node v18 og npm v9 installert.
 
 - For å kjøre koden lokalt:
-  - `$ npm install --legacy-peer-deps`
+  - `$ npm install`
   - `$ npm start`
   - Eventuelt kan komandoene kjøres fra `package.json` i intellij.
 - Kjør tester med `npm test` eller `npm test:watch`
@@ -26,7 +26,7 @@ Ved første kjøring:
 
 ```sh
 $ cp .env.template .env # for å sette opp lokale miljøvariabler
-$ npm install --legacy-peer-deps # installerer avhengigheter
+$ npm install # installerer avhengigheter
 ```
 
 ## Redis Cache

--- a/mock/ereg/virksomhetMock.ts
+++ b/mock/ereg/virksomhetMock.ts
@@ -5,8 +5,11 @@ import {
   VIRKSOMHET_PONTYPANDY,
   VIRKSOMHET_UTEN_NARMESTE_LEDER,
 } from "../common/mockConstants";
+import { EregOrganisasjonResponseDTO } from "@/data/virksomhet/types/EregOrganisasjonResponseDTO";
 
-export const eregOrganisasjonResponse = (virksomhetsnavn: string) => {
+export const eregOrganisasjonResponse = (
+  virksomhetsnavn: string
+): EregOrganisasjonResponseDTO => {
   return {
     navn: {
       navnelinje1: virksomhetsnavn,

--- a/mock/ereg/virksomhetMock.ts
+++ b/mock/ereg/virksomhetMock.ts
@@ -5,7 +5,7 @@ import {
   VIRKSOMHET_PONTYPANDY,
   VIRKSOMHET_UTEN_NARMESTE_LEDER,
 } from "../common/mockConstants";
-import { EregOrganisasjonResponseDTO } from "@/data/virksomhet/types/EregOrganisasjonResponseDTO";
+import { EregOrganisasjonResponseDTO } from "../../src/data/virksomhet/types/EregOrganisasjonResponseDTO";
 
 export const eregOrganisasjonResponse = (
   virksomhetsnavn: string

--- a/mock/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock.ts
+++ b/mock/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock.ts
@@ -3,19 +3,21 @@ import {
   ARBEIDSTAKER_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
+import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
 
-const getDefaultOppfolgingsplanLPS = (created: Date) => {
+const getDefaultOppfolgingsplanLPS = (created: Date): OppfolgingsplanLPS => {
   return {
     uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd2",
     fnr: ARBEIDSTAKER_DEFAULT.personIdent,
     virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-    virksomhetsnavn: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
     opprettet: dayjs(created).subtract(1, "days").toJSON(),
     sistEndret: dayjs(created).subtract(1, "days").toJSON(),
   };
 };
 
-export const oppfolgingsplanerLPSMock = (created: Date) => {
+export const oppfolgingsplanerLPSMock = (
+  created: Date
+): OppfolgingsplanLPS[] => {
   return [
     getDefaultOppfolgingsplanLPS(created),
     {

--- a/mock/lpsoppfolgingsplanmottak/mockLpsOppfolgingsplanMottak.ts
+++ b/mock/lpsoppfolgingsplanmottak/mockLpsOppfolgingsplanMottak.ts
@@ -1,6 +1,6 @@
 import express = require("express");
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
-import { LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT } from "@/apiConstants";
+import { LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT } from "../../src/apiConstants";
 import { oppfolgingsplanerLPSMock } from "../lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
 
 const path = require("path");

--- a/mock/lpsoppfolgingsplanmottak/mockLpsOppfolgingsplanMottak.ts
+++ b/mock/lpsoppfolgingsplanmottak/mockLpsOppfolgingsplanMottak.ts
@@ -1,7 +1,7 @@
 import express = require("express");
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
-import { LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT } from "../../src/apiConstants";
-import { oppfolgingsplanerLPSMock } from "../syfooppfolgingsplanservice/oppfolgingsplanLPSMock";
+import { LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT } from "@/apiConstants";
+import { oppfolgingsplanerLPSMock } from "../lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
 
 const path = require("path");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,6 +146,7 @@
         "ts-node": "10.9.2",
         "tsconfig-paths-webpack-plugin": "3.5.2",
         "typescript": "5.4.3",
+        "uuid": "^9.0.1",
         "webpack": "5.91.0",
         "webpack-cli": "4.9.2",
         "webpack-dev-server": "4.11.1",
@@ -15704,6 +15705,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/socks": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
@@ -16927,10 +16937,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -28940,6 +28954,14 @@
         "faye-websocket": "^0.11.3",
         "uuid": "^8.3.2",
         "websocket-driver": "^0.7.4"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
+        }
       }
     },
     "socks": {
@@ -29823,9 +29845,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "dev": true
     },
     "v8-compile-cache-lib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,7 +146,6 @@
         "ts-node": "10.9.2",
         "tsconfig-paths-webpack-plugin": "3.5.2",
         "typescript": "5.4.3",
-        "uuid": "^9.0.1",
         "webpack": "5.91.0",
         "webpack-cli": "4.9.2",
         "webpack-dev-server": "4.11.1",
@@ -16936,19 +16935,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
@@ -29843,12 +29829,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-    },
-    "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "dev": true
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "ts-node": "10.9.2",
     "tsconfig-paths-webpack-plugin": "3.5.2",
     "typescript": "5.4.3",
+    "uuid": "^9.0.1",
     "webpack": "5.91.0",
     "webpack-cli": "4.9.2",
     "webpack-dev-server": "4.11.1",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,6 @@
     "ts-node": "10.9.2",
     "tsconfig-paths-webpack-plugin": "3.5.2",
     "typescript": "5.4.3",
-    "uuid": "^9.0.1",
     "webpack": "5.91.0",
     "webpack-cli": "4.9.2",
     "webpack-dev-server": "4.11.1",

--- a/src/data/oppfolgingsplan/types/OppfolgingsplanLPS.ts
+++ b/src/data/oppfolgingsplan/types/OppfolgingsplanLPS.ts
@@ -4,9 +4,8 @@ export interface OppfolgingsplanLPS {
   uuid: string;
   fnr: string;
   virksomhetsnummer: string;
-  virksomhetsnavn: string;
-  opprettet: Date;
-  sistEndret: Date;
+  opprettet: string;
+  sistEndret: string;
 }
 
 export type OppfolgingsplanLPSMedPersonoppgave = OppfolgingsplanLPS & {

--- a/src/sider/oppfolgingsplan/lps/OppfolgingsplanerOversiktLPS.tsx
+++ b/src/sider/oppfolgingsplan/lps/OppfolgingsplanerOversiktLPS.tsx
@@ -39,7 +39,12 @@ const OppfolgingsplanerOversiktLPS = ({
   );
 
   return (
-    <Box background="surface-default" padding="8" className="mb-2">
+    <Box
+      background="surface-default"
+      padding="8"
+      className="mb-2"
+      data-testid="oppfolgingsplan-lps"
+    >
       <Heading size="small">{virksomhetsnavn}</Heading>
       <p>
         Mottatt:{" "}

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
@@ -94,7 +94,7 @@ const OppfolgingsplanerOversikt = (
       return erIdag(oppfolgingsplanLPS.opprettet);
     })
     .sort((a, b) => {
-      return new Date(a.opprettet).getTime() - new Date(b.opprettet).getTime();
+      return new Date(b.opprettet).getTime() - new Date(a.opprettet).getTime();
     });
 
   const oppfolgingsplanerLPSProcessed = oppfolgingsplanerLPSMedPersonOppgave
@@ -105,7 +105,7 @@ const OppfolgingsplanerOversikt = (
       return erIkkeIdag(oppfolgingsplanLPS.opprettet);
     })
     .sort((a, b) => {
-      return new Date(a.opprettet).getTime() - new Date(b.opprettet).getTime();
+      return new Date(b.opprettet).getTime() - new Date(a.opprettet).getTime();
     });
 
   aktivePlaner.sort((a, b) => {

--- a/test/data/oppfolgingsplanQueryHooksTest.tsx
+++ b/test/data/oppfolgingsplanQueryHooksTest.tsx
@@ -14,9 +14,9 @@ import {
   stubOppfolgingsplanApi,
   stubOppfolgingsplanLPSApi,
 } from "../stubs/stubSyfooppfolgingsplan";
-import { oppfolgingsplanerLPSMock } from "../../mock/syfooppfolgingsplanservice/oppfolgingsplanLPSMock";
 import { dokumentinfoMock } from "../../mock/syfooppfolgingsplanservice/dokumentinfoMock";
 import { testQueryClient } from "../testQueryClient";
+import { oppfolgingsplanerLPSMock } from "../../mock/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
 
 let queryClient: any;
 let apiMockScope: any;

--- a/test/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
+++ b/test/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
@@ -13,12 +13,12 @@ import dayjs from "dayjs";
 import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
 import OppfolgingsplanerOversikt from "@/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt";
 import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
-import { v4 as uuidv4 } from "uuid";
 import {
   PersonOppgave,
   PersonOppgaveType,
 } from "@/data/personoppgave/types/PersonOppgave";
 import { restdatoTilLesbarDato } from "@/utils/datoUtils";
+import { generateUUID } from "@/utils/uuidUtils";
 
 let queryClient: QueryClient;
 
@@ -98,7 +98,7 @@ const createOppfolgingsplanLps = (
   behandlet: boolean
 ): OppfolgingsplanLPS => {
   const oppfolgingsplanLPS = {
-    uuid: uuidv4(),
+    uuid: generateUUID(),
     fnr: ARBEIDSTAKER_DEFAULT.personIdent,
     virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
     opprettet: dayjs().subtract(daysSinceOpprettet, "days").toJSON(),
@@ -125,7 +125,7 @@ const createOppfolgingsplanLpsPersonoppgave = (
   behandlet: boolean
 ): PersonOppgave => {
   return {
-    uuid: uuidv4,
+    uuid: generateUUID(),
     referanseUuid: referanseUuid,
     fnr: ARBEIDSTAKER_DEFAULT.personIdent,
     virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,

--- a/test/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
+++ b/test/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { queryClientWithAktivBruker } from "../testQueryClient";
+import { render, screen, within } from "@testing-library/react";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { navEnhet } from "../dialogmote/testData";
+import React from "react";
+import { expect } from "chai";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  VIRKSOMHET_PONTYPANDY,
+} from "../../mock/common/mockConstants";
+import dayjs from "dayjs";
+import { personoppgaverQueryKeys } from "@/data/personoppgave/personoppgaveQueryHooks";
+import OppfolgingsplanerOversikt from "@/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt";
+import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
+import { v4 as uuidv4 } from "uuid";
+import {
+  PersonOppgave,
+  PersonOppgaveType,
+} from "@/data/personoppgave/types/PersonOppgave";
+import { restdatoTilLesbarDato } from "@/utils/datoUtils";
+
+let queryClient: QueryClient;
+
+const renderOppfolgingsplanerOversikt = (
+  oppfolgingsplanerLPS: OppfolgingsplanLPS[]
+) => {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <OppfolgingsplanerOversikt
+          aktivePlaner={[]}
+          inaktivePlaner={[]}
+          fnr={ARBEIDSTAKER_DEFAULT.personIdent}
+          oppfolgingsplanerLPS={oppfolgingsplanerLPS}
+        />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+describe("Oppfølgingsplaner visning", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithAktivBruker();
+  });
+
+  it("Sorterer ubehandlede oppfølgingsplan-LPSer etter opprettet dato", () => {
+    const olderOppfolgingsplan = createOppfolgingsplanLps(90, false);
+    const newerOppfolgingsplan = createOppfolgingsplanLps(10, false);
+
+    renderOppfolgingsplanerOversikt([
+      olderOppfolgingsplan,
+      newerOppfolgingsplan,
+    ]);
+
+    const olderDate = restdatoTilLesbarDato(olderOppfolgingsplan.opprettet);
+    const newerDate = restdatoTilLesbarDato(newerOppfolgingsplan.opprettet);
+
+    const oppfolgingsplanerLPS = screen.getAllByTestId("oppfolgingsplan-lps");
+
+    expect(oppfolgingsplanerLPS.length).to.equal(2);
+    expect(oppfolgingsplanerLPS[0].textContent).to.contain(newerDate);
+    expect(within(oppfolgingsplanerLPS[0]).getByText("Marker som behandlet")).to
+      .exist;
+    expect(oppfolgingsplanerLPS[1].textContent).to.contain(olderDate);
+    expect(within(oppfolgingsplanerLPS[1]).getByText("Marker som behandlet")).to
+      .exist;
+  });
+
+  it("Sorterer behandlede oppfølgingsplan-LPSer etter opprettet dato", () => {
+    const olderOppfolgingsplan = createOppfolgingsplanLps(90, true);
+    const newerOppfolgingsplan = createOppfolgingsplanLps(10, true);
+
+    renderOppfolgingsplanerOversikt([
+      olderOppfolgingsplan,
+      newerOppfolgingsplan,
+    ]);
+
+    const olderDate = restdatoTilLesbarDato(olderOppfolgingsplan.opprettet);
+    const newerDate = restdatoTilLesbarDato(newerOppfolgingsplan.opprettet);
+
+    const oppfolgingsplanerLPS = screen.getAllByTestId("oppfolgingsplan-lps");
+
+    expect(oppfolgingsplanerLPS.length).to.equal(2);
+    expect(oppfolgingsplanerLPS[0].textContent).to.contain(newerDate);
+    expect(within(oppfolgingsplanerLPS[0]).queryByText("Marker som behandlet"))
+      .to.be.null;
+    expect(oppfolgingsplanerLPS[1].textContent).to.contain(olderDate);
+    expect(within(oppfolgingsplanerLPS[1]).queryByText("Marker som behandlet"))
+      .to.be.null;
+  });
+});
+
+const createOppfolgingsplanLps = (
+  daysSinceOpprettet: number,
+  behandlet: boolean
+): OppfolgingsplanLPS => {
+  const oppfolgingsplanLPS = {
+    uuid: uuidv4(),
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    opprettet: dayjs().subtract(daysSinceOpprettet, "days").toJSON(),
+    sistEndret: new Date().toDateString(),
+  };
+
+  const existingPersonOppgaver =
+    queryClient.getQueryData<PersonOppgave[]>(
+      personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent)
+    ) || [];
+  queryClient.setQueryData(
+    personoppgaverQueryKeys.personoppgaver(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => [
+      ...existingPersonOppgaver,
+      createOppfolgingsplanLpsPersonoppgave(oppfolgingsplanLPS.uuid, behandlet),
+    ]
+  );
+
+  return oppfolgingsplanLPS;
+};
+
+const createOppfolgingsplanLpsPersonoppgave = (
+  referanseUuid: string,
+  behandlet: boolean
+): PersonOppgave => {
+  return {
+    uuid: uuidv4,
+    referanseUuid: referanseUuid,
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    type: PersonOppgaveType.OPPFOLGINGSPLANLPS,
+    behandletTidspunkt: behandlet
+      ? dayjs().subtract(10, "days").toDate()
+      : null,
+    behandletVeilederIdent: behandlet ? "Veilederident" : null,
+    opprettet: new Date(),
+  };
+};

--- a/test/stubs/stubSyfooppfolgingsplan.ts
+++ b/test/stubs/stubSyfooppfolgingsplan.ts
@@ -5,9 +5,9 @@ import {
   SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT,
 } from "@/apiConstants";
 import { oppfolgingsplanMock } from "../../mock/syfooppfolgingsplanservice/oppfolgingsplanMock";
-import { oppfolgingsplanerLPSMock } from "../../mock/syfooppfolgingsplanservice/oppfolgingsplanLPSMock";
 import { dokumentinfoMock } from "../../mock/syfooppfolgingsplanservice/dokumentinfoMock";
 import { historikkoppfolgingsplanMock } from "../../mock/syfooppfolgingsplanservice/historikkoppfolgingsplanMock";
+import { oppfolgingsplanerLPSMock } from "../../mock/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
 
 export const stubOppfolgingsplanApi = (scope: nock.Scope) => {
   return scope


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Jeg la merke til at LPS-planene ble sortert slik at de nyeste kom nederst. nav.no planene kommer øverst. De har altså ulik sortering i oversikten! Her bør nok nyeste planer alltid komme øverst, uavhengig av LPS eller ikke.

Ryddet i tillegg litt opp i typing/DTO som var feil, og noe smårusk.
