### PR TITLE
IS-2277: Viser navn på veileder som opprettet møte

### DIFF
--- a/src/sider/dialogmoter/components/innkalling/DialogmoteMoteStatusPanel.tsx
+++ b/src/sider/dialogmoter/components/innkalling/DialogmoteMoteStatusPanel.tsx
@@ -22,6 +22,7 @@ import {
   isPersonoppgaveCompletedAfterLastMoteEndring,
 } from "@/utils/dialogmoteUtils";
 import { BodyShort, Button } from "@navikt/ds-react";
+import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 
 const texts = {
   innkallingSendtTrackingContext: "Møtelandingsside: Sendt innkalling",
@@ -34,15 +35,20 @@ const texts = {
   fortsettReferat: "Fortsett på referatet",
   moteTid: "Møtetidspunkt",
   moteSted: "Sted",
+  veileder: "Veileder",
 };
 
 const Subtitle = (dialogmote: DialogmoteDTO): ReactNode => {
   const moteDatoTid = tilDatoMedUkedagOgManedNavnOgKlokkeslett(dialogmote.tid);
+  const { data: veileder } = useVeilederInfoQuery(dialogmote.opprettetAv);
 
   return (
     <>
       <BodyShort size="small">{`${texts.moteTid}: ${moteDatoTid}`}</BodyShort>
       <BodyShort size="small">{`${texts.moteSted}: ${dialogmote.sted}`}</BodyShort>
+      <BodyShort size="small">{`${
+        texts.veileder
+      }: ${veileder?.fulltNavn()}`}</BodyShort>
     </>
   );
 };

--- a/test/dialogmote/DialogmoteMoteStatusPanelTest.tsx
+++ b/test/dialogmote/DialogmoteMoteStatusPanelTest.tsx
@@ -10,9 +10,10 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { expect } from "chai";
 import { daysFromToday, getButton } from "../testUtils";
-import { testQueryClient } from "../testQueryClient";
+import { queryClientWithMockData } from "../testQueryClient";
+import { VEILEDER_DEFAULT } from "../../mock/common/mockConstants";
 
-const queryClient = testQueryClient();
+const queryClient = queryClientWithMockData();
 
 const renderDialogmoteMoteStatusPanel = (dialogmote: DialogmoteDTO) =>
   render(
@@ -99,6 +100,28 @@ describe("DialogmoteMoteStatusPanel", () => {
     renderDialogmoteMoteStatusPanel(endretDialogmote);
 
     expect(screen.getByRole("heading", { name: "Endringen er sendt" })).to
+      .exist;
+  });
+  it("Viser navn på veileder for innkalt dialogmøte", () => {
+    const innkaltDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      tid: new Date().toISOString(),
+      opprettetAv: VEILEDER_DEFAULT.ident,
+    };
+    renderDialogmoteMoteStatusPanel(innkaltDialogmote);
+
+    expect(screen.getByText(`Veileder: ${VEILEDER_DEFAULT.fulltNavn()}`)).to
+      .exist;
+  });
+  it("Viser navn på veileder for endret dialogmøte", () => {
+    const endretDialogmote: DialogmoteDTO = {
+      ...dialogmote,
+      status: DialogmoteStatus.NYTT_TID_STED,
+      opprettetAv: VEILEDER_DEFAULT.ident,
+    };
+    renderDialogmoteMoteStatusPanel(endretDialogmote);
+
+    expect(screen.getByText(`Veileder: ${VEILEDER_DEFAULT.fulltNavn()}`)).to
       .exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Status-panel som vises ved aktivt møte (innkalling/endring) viser navn på veileder som opprettet møte.
Gjenstår å avklare om det blir riktigst å vise den som opprettet møtet her, eller om vi burde vise veilederen som er tildelt møtet. Evt begge (hvis de er forskjellige)

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/437eae26-4116-4277-9c48-3ba3d0083647)
