### PR TITLE
IS-2316: Set tom-date automatically to maksdato when maksdato is before 12 weeks

### DIFF
--- a/mock/syfoperson/persondataMock.ts
+++ b/mock/syfoperson/persondataMock.ts
@@ -3,6 +3,7 @@ import {
   ARBEIDSTAKER_DEFAULT_FULL_NAME,
 } from "../common/mockConstants";
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
+import { weeksFromToday } from "../../test/testUtils";
 
 export const brukerinfoMock: BrukerinfoDTO = {
   navn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
@@ -21,11 +22,13 @@ export const diskresjonskodeMock: "6" | "7" | "" = "";
 
 export const isEgenansattMock = false;
 
+export const maksdato = weeksFromToday(13).toString();
+
 export const maksdatoMock = {
   maxDate: {
     id: "123",
     fnr: ARBEIDSTAKER_DEFAULT.personIdent,
-    forelopig_beregnet_slutt: "2023-12-01",
+    forelopig_beregnet_slutt: maksdato,
     utbetalt_tom: "2024-07-01",
     gjenstaende_sykedager: "70",
     opprettet: "2023-01-01T12:00:00.000000",

--- a/src/sider/frisktilarbeid/FattVedtak.tsx
+++ b/src/sider/frisktilarbeid/FattVedtak.tsx
@@ -42,7 +42,7 @@ export const FattVedtak = (): ReactElement => {
   const [fattVedtakStarted, setFattVedtakStarted] = useState(false);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col [&>*]:mb-4">
       <Box
         background="surface-default"
         padding="6"

--- a/src/sider/frisktilarbeid/FattVedtakSkjema.tsx
+++ b/src/sider/frisktilarbeid/FattVedtakSkjema.tsx
@@ -1,8 +1,10 @@
-import React, { useState } from "react";
+import React, { ReactNode, useState } from "react";
 import {
+  Alert,
   Box,
   Button,
   DatePicker,
+  HelpText,
   Textarea,
   useDatepicker,
 } from "@navikt/ds-react";
@@ -18,6 +20,7 @@ import { VedtakRequestDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 import dayjs from "dayjs";
 import { behandlerNavn } from "@/utils/behandlerUtils";
 import { useFriskmeldingTilArbeidsformidlingDocument } from "@/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument";
+import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 
 const begrunnelseMaxLength = 5000;
 
@@ -28,9 +31,35 @@ const texts = {
   previewContentLabel: "Forhåndsvis vedtaket",
   primaryButton: "Fatt vedtak",
   velgBehandlerLegend: "Velg behandler",
-  tilDatoLabel: "Til dato (automatisk justert 12 uker frem)",
-  tilDatoDescription: "Dette er datoen vedtaket slutter",
+  tilDatoLabel: "Til dato",
+  tilDatoDescription: (tilDatoIsMaxDato: boolean) =>
+    tilDatoIsMaxDato
+      ? "Automatisk justert til maksdato"
+      : "Automatisk justert 12 uker frem",
+  tilDatoHelpText: "Dette er datoen vedtaket slutter",
+  maksdatoWarning: (dato: string) =>
+    `Foreløpig beregnet maksdato er tidligere enn 12 uker frem: ${dato}`,
 };
+
+function calculateTomDate(fomDato: Date, maksDato: Date | undefined): Date {
+  const twelveWeeksFromFomDato = addWeeks(fomDato, 12);
+  if (!maksDato || dayjs(twelveWeeksFromFomDato).isBefore(dayjs(maksDato))) {
+    return twelveWeeksFromFomDato;
+  } else {
+    return maksDato;
+  }
+}
+
+function DatepickerLabel(): ReactNode {
+  return (
+    <>
+      {texts.tilDatoLabel}
+      <HelpText className="ml-2" placement="right">
+        {texts.tilDatoHelpText}
+      </HelpText>
+    </>
+  );
+}
 
 export interface FattVedtakSkjemaValues {
   fraDato: Date;
@@ -43,6 +72,7 @@ export const FattVedtakSkjema = () => {
   const fattVedtak = useFattVedtak();
   const { getBehandlermeldingDocument, getVedtakDocument } =
     useFriskmeldingTilArbeidsformidlingDocument();
+  const { data: maksDato } = useMaksdatoQuery();
   const methods = useForm<FattVedtakSkjemaValues>();
   const {
     register,
@@ -52,7 +82,13 @@ export const FattVedtakSkjema = () => {
   } = methods;
 
   const fraDato: Date | undefined = watch("fraDato");
-  const tilDato = fraDato ? addWeeks(fraDato, 12) : undefined;
+  const tilDato = fraDato
+    ? calculateTomDate(fraDato, maksDato?.maxDate?.forelopig_beregnet_slutt)
+    : undefined;
+
+  const tilDatoIsMaxDato = dayjs(tilDato).isSame(
+    dayjs(maksDato?.maxDate?.forelopig_beregnet_slutt)
+  );
 
   const submit = (values: FattVedtakSkjemaValues) => {
     const vedtakRequestDTO: VedtakRequestDTO = {
@@ -82,14 +118,21 @@ export const FattVedtakSkjema = () => {
         <form onSubmit={handleSubmit(submit)} className="flex flex-col gap-8">
           <div className="flex flex-col gap-6">
             <VedtakFraDato />
-            <DatePicker {...tilDatoDatePicker.datepickerProps}>
-              <DatePicker.Input
-                value={tilDato ? dayjs(tilDato).format("DD.MM.YYYY") : ""}
-                label={texts.tilDatoLabel}
-                description={texts.tilDatoDescription}
-                readOnly
-              />
-            </DatePicker>
+            <div>
+              {tilDatoIsMaxDato && (
+                <Alert variant="warning" size="small" className="w-fit mb-2">
+                  {texts.maksdatoWarning(dayjs(tilDato).format("DD.MM.YYYY"))}
+                </Alert>
+              )}
+              <DatePicker {...tilDatoDatePicker.datepickerProps}>
+                <DatePicker.Input
+                  value={tilDato ? dayjs(tilDato).format("DD.MM.YYYY") : ""}
+                  label={<DatepickerLabel />}
+                  description={texts.tilDatoDescription(tilDatoIsMaxDato)}
+                  readOnly
+                />
+              </DatePicker>
+            </div>
             <VelgBehandler
               legend={texts.velgBehandlerLegend}
               onBehandlerSelected={setSelectedBehandler}

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -10,10 +10,14 @@ import {
 import { ValgtEnhetProvider } from "@/context/ValgtEnhetContext";
 import { egenansattQueryKeys } from "@/data/egenansatt/egenansattQueryHooks";
 import { ARBEIDSTAKER_DEFAULT } from "../../../mock/common/mockConstants";
-import { brukerinfoMock } from "../../../mock/syfoperson/persondataMock";
+import {
+  brukerinfoMock,
+  maksdato,
+} from "../../../mock/syfoperson/persondataMock";
 import { diskresjonskodeQueryKeys } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
 import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { daysFromToday } from "../../testUtils";
+import dayjs from "dayjs";
 
 let queryClient: any;
 
@@ -158,7 +162,7 @@ describe("PersonkortHeader", () => {
     renderPersonkortHeader();
 
     expect(screen.getByText("Maksdato:")).to.exist;
-    expect(screen.getByText("01.12.2023")).to.exist;
+    expect(screen.getByText(dayjs(maksdato).format("DD.MM.YYYY"))).to.exist;
     expect(screen.getByText("Utbetalt tom:")).to.exist;
     expect(screen.getByText("01.07.2024")).to.exist;
   });

--- a/test/data/maksdatoQueryTest.tsx
+++ b/test/data/maksdatoQueryTest.tsx
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import { testQueryClient } from "../testQueryClient";
 import { stubMaxdateApi } from "../stubs/stubEsyfovarsel";
 import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
-import { maksdatoMock } from "../../mock/syfoperson/persondataMock";
+import { maksdato, maksdatoMock } from "../../mock/syfoperson/persondataMock";
 
 let queryClient: any;
 let apiMockScope: any;
@@ -21,7 +21,7 @@ describe("maksdatoQuery", () => {
   });
 
   it("loads maksdatoDTO for valgt personident", async () => {
-    stubMaxdateApi(apiMockScope, "2023-12-01");
+    stubMaxdateApi(apiMockScope, maksdato);
     const wrapper = queryHookWrapper(queryClient);
 
     const { result } = renderHook(() => useMaksdatoQuery(), {

--- a/test/frisktilarbeid/FriskmeldingTilArbeidsformidlingTest.tsx
+++ b/test/frisktilarbeid/FriskmeldingTilArbeidsformidlingTest.tsx
@@ -61,8 +61,7 @@ describe("FriskmeldingTilArbeidsformidling", () => {
       expect(screen.getByRole("heading", { name: "Forberedelser" })).to.exist;
 
       expect(getTextInput("Friskmeldingen gjelder fra")).to.exist;
-      expect(getTextInput("Til dato (automatisk justert 12 uker frem)")).to
-        .exist;
+      expect(screen.getByRole("textbox", { name: /Til dato/ })).to.exist;
       expect(screen.getByRole("group", { name: "Velg behandler" })).to.exist;
       expect(getTextInput("Begrunnelse")).to.exist;
       expect(screen.getByRole("button", { name: "Fatt vedtak" })).to.exist;

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -34,3 +34,7 @@ export const getTooLongText = (max: number) => "t".repeat(max + 1);
 export const daysFromToday = (days: number): Date => {
   return dayjs(new Date()).add(days, "days").toDate();
 };
+
+export const weeksFromToday = (weeks: number): Date => {
+  return dayjs(new Date()).add(weeks, "weeks").toDate();
+};


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Beregner Tom-dato basert på maksdato dersom den er tidligere enn 12 uker
- Gir en warning hvis den går til maks
- Flyttet litt på tekster, blant annet ved å legge inn i Helptext (etter samtale med Peter)

### Screenshots 📸✨
Før:

<img width="475" alt="Screenshot 2024-05-02 at 20 25 33" src="https://github.com/navikt/syfomodiaperson/assets/37441744/e3851d6b-aea8-4676-ac65-2a17f7d24931">

Etter:
https://github.com/navikt/syfomodiaperson/assets/37441744/d2e89e93-2dc8-4874-8640-a5d68a674c64

