### PR TITLE
IS-2077: Add mal for NAV utland in forhandsvarsel aktivitetskrav

### DIFF
--- a/mock/isaktivitetskrav/aktivitetskravMock.ts
+++ b/mock/isaktivitetskrav/aktivitetskravMock.ts
@@ -102,7 +102,11 @@ const getForhandsvarselDocument = (
     },
     {
       type: DocumentComponentType.PARAGRAPH,
-      texts: [sendForhandsvarselTexts.varselInfo.introWithFristDate],
+      texts: [sendForhandsvarselTexts.varselInfo.intro],
+    },
+    {
+      type: DocumentComponentType.PARAGRAPH,
+      texts: [sendForhandsvarselTexts.varselInfo.stans],
     },
   ];
 

--- a/src/data/aktivitetskrav/forhandsvarselTexts.ts
+++ b/src/data/aktivitetskrav/forhandsvarselTexts.ts
@@ -3,6 +3,7 @@ import { tilDatoMedManedNavn } from "../../utils/datoUtils";
 export enum Brevmal {
   MED_ARBEIDSGIVER = "MED_ARBEIDSGIVER",
   UTEN_ARBEIDSGIVER = "UTEN_ARBEIDSGIVER",
+  UTLAND = "UTLAND",
 }
 
 type ForhandsvarselTextsOptions = {
@@ -16,7 +17,8 @@ export const getForhandsvarselTexts = ({
 }: ForhandsvarselTextsOptions) => ({
   varselInfo: {
     header: "Varsel om stans av sykepenger",
-    introWithFristDate: `Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
+    intro: introText(mal),
+    stans: `Ut fra opplysningene NAV har i saken har vi vurdert at du ikke oppfyller vilkårene for å unntas aktivitetsplikten. Vi vurderer å stanse sykepengene dine fra og med ${tilDatoMedManedNavn(
       frist
     )}.`,
   },
@@ -30,11 +32,8 @@ export const getForhandsvarselTexts = ({
   },
   giOssTilbakemelding: {
     header: "Gi oss tilbakemelding",
-    tilbakemeldingWithFristDate: `Vi ber om tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
-      frist
-    )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`,
-    kontaktOss:
-      "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.",
+    tilbakemeldingWithFristDate: tilbakemeldingText(mal, frist),
+    kontaktOss: kontaktOssText(mal),
   },
   lovhjemmel: {
     header: "Lovhjemmel",
@@ -45,13 +44,52 @@ export const getForhandsvarselTexts = ({
       " så tidlig som mulig, og senest innen 8 uker. Dette gjelder ikke når medisinske grunner klart er til hinder for slik aktivitet," +
       " eller arbeidsrelaterte aktiviteter ikke kan gjennomføres på arbeidsplassen.»",
   },
+  utland: {
+    dokumentasjon:
+      "Legen må bruke blokkbokstaver eller skrive på maskin. Sender du medisinsk dokumentasjon på et annet språk enn norsk eller engelsk, vil vi bruke mer tid på saksbehandlingen fordi vi må oversette dokumentene. Dersom du velger å få dokumenter oversatt før de sendes oss må du legge ved original dokumentasjon.",
+  },
 });
 
 const tiltak3Text = (mal: Brevmal): string => {
   switch (mal) {
     case Brevmal.MED_ARBEIDSGIVER:
+    case Brevmal.UTLAND:
       return "Du kan få unntak fra aktivitetsplikten dersom arbeidsgiveren din gir en skriftlig begrunnelse for hvorfor det ikke er mulig å legge til rette for at du kan jobbe, eller dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
     case Brevmal.UTEN_ARBEIDSGIVER:
       return "Du kan få unntak fra aktivitetsplikten dersom din lege dokumenterer at medisinske grunner klart er til hinder for arbeidsrelatert aktivitet.";
+  }
+};
+
+const kontaktOssText = (mal: Brevmal): string => {
+  switch (mal) {
+    case Brevmal.MED_ARBEIDSGIVER:
+    case Brevmal.UTEN_ARBEIDSGIVER:
+      return "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 55 55 33 33.";
+    case Brevmal.UTLAND:
+      return "Kontakt oss gjerne på nav.no/skriv-til-oss eller telefon 21 07 37 00.";
+  }
+};
+
+const introText = (mal: Brevmal): string => {
+  switch (mal) {
+    case Brevmal.MED_ARBEIDSGIVER:
+    case Brevmal.UTEN_ARBEIDSGIVER:
+      return "Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet.";
+    case Brevmal.UTLAND:
+      return "Du har nå vært sykmeldt i mer enn åtte uker. Da har du plikt til å være i aktivitet. Vi gjør oppmerksom på det er vanlig praksis i Norge å være sykmeldt gradert mens man jobber gradert. Det er også vanlig praksis å kombinere jobb, eventuelt gradert jobb, med behandling.";
+  }
+};
+
+const tilbakemeldingText = (mal: Brevmal, frist: Date): string => {
+  switch (mal) {
+    case Brevmal.MED_ARBEIDSGIVER:
+    case Brevmal.UTLAND:
+      return `Vi ber om tilbakemelding fra deg, arbeidsgiveren din eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
+        frist
+      )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`;
+    case Brevmal.UTEN_ARBEIDSGIVER:
+      return `Vi ber om tilbakemelding fra deg eller den som har sykmeldt deg innen ${tilDatoMedManedNavn(
+        frist
+      )}. Etter denne datoen vil NAV vurdere å stanse sykepengene dine.`;
   }
 };

--- a/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
+++ b/src/hooks/aktivitetskrav/useAktivitetskravVarselDocument.ts
@@ -46,7 +46,8 @@ export const useAktivitetskravVarselDocument = (): {
 
     const documentComponents = [
       createHeaderH1(sendForhandsvarselTexts.varselInfo.header),
-      createParagraph(sendForhandsvarselTexts.varselInfo.introWithFristDate),
+      createParagraph(sendForhandsvarselTexts.varselInfo.intro),
+      createParagraph(sendForhandsvarselTexts.varselInfo.stans),
     ];
 
     if (begrunnelse) {
@@ -59,8 +60,16 @@ export const useAktivitetskravVarselDocument = (): {
         sendForhandsvarselTexts.unngaStansInfo.tiltak1,
         sendForhandsvarselTexts.unngaStansInfo.tiltak2,
         sendForhandsvarselTexts.unngaStansInfo.tiltak3
-      ),
+      )
+    );
 
+    if (mal === Brevmal.UTLAND) {
+      documentComponents.push(
+        createParagraph(sendForhandsvarselTexts.utland.dokumentasjon)
+      );
+    }
+
+    documentComponents.push(
       createHeaderH3(sendForhandsvarselTexts.giOssTilbakemelding.header),
       createParagraph(
         sendForhandsvarselTexts.giOssTilbakemelding.tilbakemeldingWithFristDate

--- a/src/sider/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/sider/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -37,6 +37,7 @@ const brevMalTexts: {
 } = {
   [Brevmal.MED_ARBEIDSGIVER]: "Har arbeidsgiver",
   [Brevmal.UTEN_ARBEIDSGIVER]: "Har ikke arbeidsgiver",
+  [Brevmal.UTLAND]: "Bosatt i utlandet",
 };
 
 const forhandsvarselFrist = addWeeks(new Date(), 3);

--- a/test/aktivitetskrav/varselDocuments.ts
+++ b/test/aktivitetskrav/varselDocuments.ts
@@ -132,13 +132,17 @@ export const getSendForhandsvarselDocument = (
     frist: expectedFristDate,
     mal,
   });
-  return [
+  const documentComponents = [
     {
       texts: [sendForhandsvarselTexts.varselInfo.header],
       type: DocumentComponentType.HEADER_H1,
     },
     {
-      texts: [sendForhandsvarselTexts.varselInfo.introWithFristDate],
+      texts: [sendForhandsvarselTexts.varselInfo.intro],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: [sendForhandsvarselTexts.varselInfo.stans],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
@@ -157,6 +161,16 @@ export const getSendForhandsvarselDocument = (
       ],
       type: DocumentComponentType.BULLET_POINTS,
     },
+  ];
+
+  if (mal === Brevmal.UTLAND) {
+    documentComponents.push({
+      texts: [sendForhandsvarselTexts.utland.dokumentasjon],
+      type: DocumentComponentType.PARAGRAPH,
+    });
+  }
+
+  documentComponents.push(
     {
       texts: [sendForhandsvarselTexts.giOssTilbakemelding.header],
       type: DocumentComponentType.HEADER_H3,
@@ -186,6 +200,8 @@ export const getSendForhandsvarselDocument = (
     {
       texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.fulltNavn(), "NAV"],
       type: DocumentComponentType.PARAGRAPH,
-    },
-  ];
+    }
+  );
+
+  return documentComponents;
 };

--- a/test/aktivitetskrav/vurdering/AktivitetskravForhandsvarselTest.tsx
+++ b/test/aktivitetskrav/vurdering/AktivitetskravForhandsvarselTest.tsx
@@ -181,6 +181,53 @@ describe("VurderAktivitetskrav forhåndsvarsel", () => {
       );
     });
 
+    it("Send forhåndsvarsel with mal 'Bosatt i Norge'", async () => {
+      renderVurderAktivitetskrav(aktivitetskrav);
+      stubVurderAktivitetskravForhandsvarselApi(apiMockScope);
+      const beskrivelseLabel = "Begrunnelse (obligatorisk)";
+
+      clickTab(tabTexts["FORHANDSVARSEL"]);
+
+      expect(
+        screen.getByRole("heading", {
+          name: "Send forhåndsvarsel",
+        })
+      ).to.exist;
+
+      expect(screen.getByRole("textbox", { name: beskrivelseLabel })).to.exist;
+      expect(screen.getByText("Forhåndsvisning")).to.exist;
+
+      const beskrivelseInput = getTextInput(beskrivelseLabel);
+      changeTextInput(beskrivelseInput, enLangBeskrivelse);
+
+      const velgMalSelect = screen.getByRole("combobox");
+      fireEvent.change(velgMalSelect, {
+        target: { value: "UTLAND" },
+      });
+
+      clickButton("Send");
+
+      await waitFor(() => {
+        const sendForhandsvarselMutation = queryClient
+          .getMutationCache()
+          .getAll()[0];
+        const expectedVurdering: SendForhandsvarselDTO = {
+          fritekst: enLangBeskrivelse,
+          document: getSendForhandsvarselDocument(
+            enLangBeskrivelse,
+            Brevmal.UTLAND
+          ),
+        };
+        expect(sendForhandsvarselMutation.state.variables).to.deep.equal(
+          expectedVurdering
+        );
+      });
+
+      await waitFor(
+        () => expect(screen.queryByText(enLangBeskrivelse)).to.not.exist
+      );
+    });
+
     it("IKKE_OPPFYLT is present when status is forhandsvarsel and it is expired", () => {
       queryClient.setQueryData(
         personoppgaverQueryKeys.personoppgaver(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til ny mal for NAV utland. Det besto av å legge til noen setninger her og der, og endre telefonnummer.
I tillegg var det en feil i brevet til de uten arbeidsgiver som vi får fikset her. 

La også til et avsnitt mellom `intro` og `stans`-tekstene, sånn at det kommer tydelig frem at vi vurderer å stanse sykepengene.

### Screenshots 📸✨

<img width="631" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/be90880c-ef66-4b84-8576-0a18e6530e2a">
<img width="645" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/b457dd5f-7f6c-43ec-bdc2-c2b2d81d9ef5">

