### PR TITLE
IS-2340: Show whole graph when oppfolgingstilfelle bigger than one year

### DIFF
--- a/src/sider/nokkelinformasjon/sykmeldingsgrad/Sykmeldingsgrad.tsx
+++ b/src/sider/nokkelinformasjon/sykmeldingsgrad/Sykmeldingsgrad.tsx
@@ -38,12 +38,20 @@ export const Sykmeldingsgrad = () => {
       selectedOppfolgingstilfelle
     );
 
-  const DAYS_IN_GRAPH = 55 * 7;
-  const sykmeldingsgradPerDay = new Int32Array(DAYS_IN_GRAPH);
-
   const perioderListSortert = sykmeldingerIOppfolgingstilfellet
     .flatMap((sykmelding) => sykmelding.mulighetForArbeid.perioder)
     .sort((a, b) => a.fom.getTime() - b.fom.getTime());
+
+  const varighetOppfolgingstilfelle = dagerMellomDatoer(
+    perioderListSortert[0].fom,
+    perioderListSortert[perioderListSortert.length - 1].tom
+  );
+  const oneYearInDays = 52 * 7;
+  const DAYS_IN_GRAPH =
+    varighetOppfolgingstilfelle > oneYearInDays
+      ? varighetOppfolgingstilfelle
+      : oneYearInDays;
+  const sykmeldingsgradPerDay = new Int32Array(DAYS_IN_GRAPH);
 
   perioderListSortert.forEach((periode) => {
     const dayZero = perioderListSortert[0].fom;

--- a/src/utils/periodeUtils.ts
+++ b/src/utils/periodeUtils.ts
@@ -16,32 +16,14 @@ export const sorterPerioderEldsteForst = (
 
 export const tidligsteFom = (perioder: TilfellePeriode[]): string | Date => {
   return perioder
-    .map((p) => {
-      return p.fom;
-    })
-    .sort((p1, p2) => {
-      if (p1 > p2) {
-        return 1;
-      } else if (p1 < p2) {
-        return -1;
-      }
-      return 0;
-    })[0];
+    .map((p) => p.fom)
+    .sort((p1, p2) => (p1 > p2 ? 1 : p1 < p2 ? -1 : 0))[0];
 };
 
 export const senesteTom = (perioder: TilfellePeriode[]): string | Date => {
   return perioder
-    .map((p) => {
-      return p.tom;
-    })
-    .sort((p1, p2) => {
-      if (p1 < p2) {
-        return 1;
-      } else if (p1 > p2) {
-        return -1;
-      }
-      return 0;
-    })[0];
+    .map((p) => p.tom)
+    .sort((p1, p2) => (p1 < p2 ? 1 : p1 > p2 ? -1 : 0))[0];
 };
 
 export const periodeOverlapperMedPeriode = (

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -247,6 +247,11 @@ export function sykmeldingerSortertNyestTilEldstPeriode(
       const dato2 = new Date(
         tidligsteFom(sykmelding2.mulighetForArbeid.perioder)
       );
+      if (dato1.getTime() === dato2.getTime()) {
+        return sykmelding1.mottattTidspunkt > sykmelding2.mottattTidspunkt
+          ? -1
+          : 1;
+      }
       return dato1 > dato2 ? -1 : 1;
     }
     return 0;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

To ting som var feil her:
1. Det var en fast lengde på grafen, så den var maks 55 uker. Jeg endret til enten 52 uker, eller så langt tilfellet varer.
2. I lista over sykmeldinger, så var det to stk med lik `fom` og `tom`, men ulik `grad`. Den ene ble sendt inn noen minutter etter den andre, men vi hadde ikke tatt høyde for `mottattTidspunkt` i sorteringen, så disse lå feil; den med 20% var skrevet over av den med 40% i grafen (riktig), men lå som nyest av de to i sykmeldingslista (feil).

### Screenshots 📸✨

Fra Jira-sak
<img width="1233" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/8e3d684e-ebaa-499c-a216-dc4bc5297675">


Etterpå
<img width="840" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/ad6b3db5-4c03-4bd9-aa5f-d29b781c437a">


### Sidenote
Burde vi prøvd å pimpe denne litt mer, siden den er så populær? Feks bruke Timeline fra Aksel https://aksel.nav.no/komponenter/core/timeline#timeline-interndemo-pins
