### PR TITLE
IS-1896: Expand deltaker-svar if received svar

### DIFF
--- a/src/components/dialogmote/DeltakereSvarInfo.tsx
+++ b/src/components/dialogmote/DeltakereSvarInfo.tsx
@@ -199,6 +199,7 @@ const DeltakerBehandlerSvarPanel = ({
       icon={<DeltakerSvarIcon svarType={latestSvar?.svarType} />}
       deltaker={texts.behandler}
       tittel={`${behandler.behandlerNavn}, ${svarTittelTekst}`}
+      defaultOpen={!!latestSvar}
     >
       <DeltakerBehandlerSvarDetaljer svarList={svarList} />
     </EkspanderbartSvarPanel>
@@ -210,6 +211,7 @@ interface EkspanderbartSvarPanelProps {
   tittel: string;
   icon: ReactElement;
   children: ReactElement;
+  defaultOpen: boolean;
 }
 
 const EkspanderbartSvarPanel = ({
@@ -217,8 +219,9 @@ const EkspanderbartSvarPanel = ({
   deltaker,
   tittel,
   children,
+  defaultOpen,
 }: EkspanderbartSvarPanelProps) => (
-  <ExpansionCard size="small" aria-label={tittel}>
+  <ExpansionCard size="small" aria-label={tittel} defaultOpen={defaultOpen}>
     <ExpansionCard.Header>
       <ExpansionCard.Title size="small">
         <div className="flex gap-1 items-center">
@@ -259,6 +262,7 @@ const DeltakerSvarPanel = ({
       icon={<DeltakerSvarIcon svarType={svar?.svarType} />}
       deltaker={deltakerLabel}
       tittel={title}
+      defaultOpen={!!svar}
     >
       {svar?.svarTekst ? (
         <SvarDetaljerTekst


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Default open svar-expandable hvis det har kommet svar (uavhengig av om det er skrevet tekst eller ei).
Kunne også bare åpnet dersom det er skrevet noe, men hypotesen er at de uansett vil ekspandere for å sjekke om det står noe der. Her kunne man kanskje løst det med en visuell indikator på om det finnes tekst, men tenker det er enklest å bare begynne med å expande. 

Sjekket i databasen og lengste svar fra arbeidstaker og arbeidsgiver er på 300 tegn (input-begrensning). Fra behandler har vi noen outliers på flere tusen tegn, men de aller flest er under 1000 tegn. Tenker uansett det er greit å beholde muligheten til å collapse.

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/57842cc6-8352-4b5a-8452-486a8c789176)
