### PR TITLE
IS-1703: Dialogmøtesvar-historikk innkallinger

### DIFF
--- a/mock/isdialogmote/dialogmoterMock.ts
+++ b/mock/isdialogmote/dialogmoterMock.ts
@@ -41,9 +41,9 @@ const createVarsel = ({
         uuid: uuid + 2,
         createdAt: "2021-05-26T12:56:26.271381",
         varselType: varselType,
-        lestDato: undefined,
+        lestDato: "2021-05-26T12:56:26.271381",
         fritekst: "Ipsum lorum",
-        svar,
+        ...(svar ? { svar } : {}),
         document: [
           {
             type: DocumentComponentType.PARAGRAPH,
@@ -75,9 +75,9 @@ const createVarsel = ({
         uuid: uuid + 4,
         createdAt: "2021-05-26T12:56:26.271381",
         varselType: varselType,
-        lestDato: undefined,
+        lestDato: "2021-05-26T12:56:26.271381",
         fritekst: "Ipsum lorum",
-        svar,
+        ...(svar ? { svar } : {}),
         document: [
           {
             type: DocumentComponentType.PARAGRAPH,

--- a/mock/isdialogmote/dialogmoterMock.ts
+++ b/mock/isdialogmote/dialogmoterMock.ts
@@ -1,9 +1,14 @@
 import {
+  DialogmotedeltakerArbeidsgiverVarselDTO,
+  DialogmotedeltakerArbeidstakerVarselDTO,
   DialogmotedeltakerBehandlerDTO,
+  DialogmotedeltakerBehandlerVarselDTO,
+  DialogmotedeltakerVarselDTO,
   DialogmoteDTO,
   DialogmoteStatus,
   MotedeltakerVarselType,
   SvarType,
+  VarselSvarDTO,
 } from "../../src/data/dialogmote/types/dialogmoteTypes";
 import { BehandlerType } from "../../src/data/behandler/BehandlerDTO";
 import {
@@ -17,18 +22,183 @@ import { getReferatTexts } from "../../src/data/dialogmote/dialogmoteTexts";
 import dayjs from "dayjs";
 import { DocumentComponentType } from "../../src/data/documentcomponent/documentComponentTypes";
 import { Malform } from "../../src/context/malform/MalformContext";
+import { addDays } from "../../src/utils/datoUtils";
+
+type VarselOpts = {
+  varselType: MotedeltakerVarselType.INNKALT | MotedeltakerVarselType.AVLYST;
+  uuid: string;
+  svar?: VarselSvarDTO;
+};
+
+const createVarsel = ({
+  svar,
+  uuid,
+  varselType,
+}: VarselOpts): DialogmotedeltakerVarselDTO => {
+  switch (varselType) {
+    case MotedeltakerVarselType.INNKALT: {
+      return {
+        uuid: uuid + 2,
+        createdAt: "2021-05-26T12:56:26.271381",
+        varselType: varselType,
+        lestDato: undefined,
+        fritekst: "Ipsum lorum",
+        svar,
+        document: [
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            title: "Tittel innkalling",
+            texts: [],
+          },
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            title: "Møtetid:",
+            texts: ["5. mai 2021"],
+          },
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            texts: ["Brødtekst"],
+          },
+          {
+            type: DocumentComponentType.LINK,
+            texts: ["https://nav.no/"],
+          },
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            texts: ["Med vennlig hilsen", "NAV Staden", "Kari Saksbehandler"],
+          },
+        ],
+      };
+    }
+    case MotedeltakerVarselType.AVLYST: {
+      return {
+        uuid: uuid + 4,
+        createdAt: "2021-05-26T12:56:26.271381",
+        varselType: varselType,
+        lestDato: undefined,
+        fritekst: "Ipsum lorum",
+        svar,
+        document: [
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            title: "Avlysning",
+            texts: [],
+          },
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            title: "Møtetid:",
+            texts: ["5. mai 2021"],
+          },
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            texts: ["Brødtekst"],
+          },
+          {
+            type: DocumentComponentType.LINK,
+            texts: ["https://nav.no/"],
+          },
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            texts: ["Med vennlig hilsen", "NAV Staden", "Kari Saksbehandler"],
+          },
+        ],
+      };
+    }
+  }
+};
 
 export const createDialogmote = (
   uuid: string,
   moteStatus: DialogmoteStatus,
-  varselType: MotedeltakerVarselType,
-  moteTid: string,
+  moteTid: Date,
   behandler?: DialogmotedeltakerBehandlerDTO
 ) => {
+  const arbeidstakerVarselList: DialogmotedeltakerArbeidstakerVarselDTO[] = [
+    {
+      ...createVarsel({
+        svar: {
+          svarTidspunkt: addDays(moteTid, -3).toJSON(),
+          svarType: SvarType.KOMMER,
+        },
+        uuid,
+        varselType: MotedeltakerVarselType.INNKALT,
+      }),
+      digitalt: true,
+    },
+  ];
+  const arbeidsgiverVarselList: DialogmotedeltakerArbeidsgiverVarselDTO[] = [
+    {
+      ...createVarsel({
+        svar: {
+          svarTidspunkt: addDays(moteTid, -3).toJSON(),
+          svarTekst: "Passer ikke denne dagen.",
+          svarType: SvarType.NYTT_TID_STED,
+        },
+        uuid,
+        varselType: MotedeltakerVarselType.INNKALT,
+      }),
+      status: "",
+    },
+  ];
+  const behandlerVarselList: DialogmotedeltakerBehandlerVarselDTO[] = [
+    {
+      uuid: uuid + 5,
+      createdAt: "2021-05-26T12:56:26.271381",
+      varselType: MotedeltakerVarselType.INNKALT,
+      fritekst: "Ipsum lorum behandler",
+      document: [],
+      svar: [
+        {
+          uuid: uuid + 6,
+          createdAt: "2021-12-05T14:56:26.282386",
+          svarType: SvarType.KOMMER,
+          tekst: "Jeg kommer i møtet.",
+        },
+        {
+          uuid: uuid + 7,
+          createdAt: "2021-12-04T13:56:26.282386",
+          svarType: SvarType.NYTT_TID_STED,
+          tekst: "Jeg vil endre møtet!",
+        },
+        {
+          uuid: uuid + 8,
+          createdAt: "2021-12-03T12:56:26.282386",
+          svarType: SvarType.KOMMER_IKKE,
+          tekst: "Jeg kommer IKKE!!!!!! i møtet.",
+        },
+      ],
+    },
+  ];
+
+  if (moteStatus === DialogmoteStatus.AVLYST) {
+    arbeidstakerVarselList.push({
+      ...createVarsel({
+        uuid,
+        varselType: MotedeltakerVarselType.AVLYST,
+      }),
+      digitalt: true,
+    });
+    arbeidsgiverVarselList.push({
+      ...createVarsel({
+        uuid,
+        varselType: MotedeltakerVarselType.AVLYST,
+      }),
+      status: "",
+    });
+    behandlerVarselList.push({
+      uuid: uuid + 5,
+      createdAt: addDays(moteTid, -4).toJSON(),
+      varselType: MotedeltakerVarselType.AVLYST,
+      fritekst: "Ipsum lorum behandler",
+      document: [],
+      svar: [],
+    });
+  }
+
   const dialogMote: DialogmoteDTO = {
     uuid: uuid,
-    createdAt: "2021-05-26T12:56:26.238385",
-    updatedAt: "2021-05-26T12:56:26.238385",
+    createdAt: addDays(moteTid, -4).toJSON(),
+    updatedAt: addDays(moteTid, -4).toJSON(),
     status: moteStatus,
     opprettetAv: VEILEDER_IDENT_DEFAULT,
     tildeltVeilederIdent: VEILEDER_IDENT_DEFAULT,
@@ -36,103 +206,23 @@ export const createDialogmote = (
     arbeidstaker: {
       personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
       type: "ARBEIDSTAKER",
-      varselList: [
-        {
-          uuid: uuid + 2,
-          createdAt: "2021-05-26T12:56:26.271381",
-          varselType: varselType,
-          digitalt: true,
-          lestDato: "2021-05-26T12:56:26.271381",
-          fritekst: "Ipsum lorum arbeidstaker",
-          document: [
-            {
-              type: DocumentComponentType.PARAGRAPH,
-              title: "Tittel innkalling",
-              texts: [],
-            },
-            {
-              type: DocumentComponentType.PARAGRAPH,
-              title: "Møtetid:",
-              texts: ["5. mai 2021"],
-            },
-            {
-              type: DocumentComponentType.PARAGRAPH,
-              texts: ["Brødtekst"],
-            },
-            {
-              type: DocumentComponentType.LINK,
-              texts: ["https://nav.no/"],
-            },
-            {
-              type: DocumentComponentType.PARAGRAPH,
-              texts: ["Med vennlig hilsen", "NAV Staden", "Kari Saksbehandler"],
-            },
-          ],
-          svar: {
-            svarTidspunkt: "2021-05-26T12:56:26.271381",
-            svarType: SvarType.KOMMER,
-          },
-        },
-      ],
+      varselList: arbeidstakerVarselList,
     },
     arbeidsgiver: {
       virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
       type: "ARBEIDSGIVER",
-      varselList: [
-        {
-          uuid: uuid + 4,
-          createdAt: "2021-05-26T12:56:26.282386",
-          varselType: varselType,
-          lestDato: "2021-05-26T12:56:26.271381",
-          fritekst: "Ipsum lorum arbeidsgiver",
-          document: [],
-          status: "",
-          svar: {
-            svarTidspunkt: "2021-05-26T12:56:26.271381",
-            svarTekst: "Passer ikke denne dagen.",
-            svarType: SvarType.NYTT_TID_STED,
-          },
-        },
-      ],
+      varselList: arbeidsgiverVarselList,
     },
     ...(behandler
       ? {
           behandler: {
             ...behandler,
-            varselList: [
-              {
-                uuid: uuid + 5,
-                createdAt: "2021-12-01T12:56:26.282386",
-                varselType: varselType,
-                fritekst: "Ipsum lorum behandler",
-                document: [],
-                svar: [
-                  {
-                    uuid: uuid + 6,
-                    createdAt: "2021-12-05T14:56:26.282386",
-                    svarType: SvarType.KOMMER,
-                    tekst: "Jeg kommer i møtet.",
-                  },
-                  {
-                    uuid: uuid + 7,
-                    createdAt: "2021-12-04T13:56:26.282386",
-                    svarType: SvarType.NYTT_TID_STED,
-                    tekst: "Jeg vil endre møtet!",
-                  },
-                  {
-                    uuid: uuid + 8,
-                    createdAt: "2021-12-03T12:56:26.282386",
-                    svarType: SvarType.KOMMER_IKKE,
-                    tekst: "Jeg kommer IKKE!!!!!! i møtet.",
-                  },
-                ],
-              },
-            ],
+            varselList: behandlerVarselList,
           },
         }
       : {}),
     sted: "This is a very lang text that has a lot of characters and describes where the meeting will take place.",
-    tid: moteTid,
+    tid: moteTid.toJSON(),
     videoLink: "https://video.nav.no/xyz",
     referatList: [],
   };
@@ -207,27 +297,23 @@ const behandler = (uuid: string): DialogmotedeltakerBehandlerDTO => {
 export const innkaltDialogmote = createDialogmote(
   "5f1e2629-062b-442d-ae1f-3b08e9574cd3",
   DialogmoteStatus.INNKALT,
-  MotedeltakerVarselType.INNKALT,
-  dayjs().add(2, "days").toJSON()
+  dayjs().add(2, "days").toDate()
 );
 export const avlystDialogmote = createDialogmote(
   "2",
   DialogmoteStatus.AVLYST,
-  MotedeltakerVarselType.AVLYST,
-  "2021-01-15T11:52:13.539843"
+  dayjs().subtract(2, "weeks").toDate()
 );
 export const ferdigstiltDialogmote = createDialogmote(
   "3",
   DialogmoteStatus.FERDIGSTILT,
-  MotedeltakerVarselType.REFERAT,
-  "2020-03-21T12:34:23.539843"
+  dayjs().subtract(2, "years").toDate()
 );
 
 export const innkaltDialogmoteMedBehandler = createDialogmote(
   "4",
   DialogmoteStatus.INNKALT,
-  MotedeltakerVarselType.INNKALT,
-  "2021-11-10T14:22:23.539843",
+  dayjs().add(2, "days").toDate(),
   behandler("4")
 );
 

--- a/mock/isdialogmote/mockIsdialogmote.ts
+++ b/mock/isdialogmote/mockIsdialogmote.ts
@@ -9,8 +9,8 @@ import { ISDIALOGMOTE_ROOT } from "../../src/apiConstants";
 import {
   DialogmoteDTO,
   DialogmoteStatus,
-  MotedeltakerVarselType,
 } from "../../src/data/dialogmote/types/dialogmoteTypes";
+import dayjs from "dayjs";
 
 let mockedDialogmoter = dialogmoterMock;
 
@@ -24,8 +24,7 @@ export const mockIsdialogmote = (server: any) => {
           createDialogmote(
             "0",
             DialogmoteStatus.INNKALT,
-            MotedeltakerVarselType.INNKALT,
-            "2021-05-26T12:56:26.238385"
+            dayjs().add(10, "days").toDate()
           ),
         ];
         res.sendStatus(200);

--- a/src/components/dialogmote/motehistorikk/MoteSvarHistorikk.tsx
+++ b/src/components/dialogmote/motehistorikk/MoteSvarHistorikk.tsx
@@ -1,5 +1,6 @@
 import {
   DialogmoteDTO,
+  DialogmoteStatus,
   MotedeltakerVarselType,
 } from "@/data/dialogmote/types/dialogmoteTypes";
 import { FortidenImage } from "../../../../img/ImageComponents";
@@ -61,6 +62,18 @@ const InnkallingSvar = ({ dialogmote }: Props) => {
   );
 };
 
+const getHeaderText = (mote: DialogmoteDTO): string => {
+  const moteDato = tilDatoMedManedNavn(mote.tid);
+  switch (mote.status) {
+    case DialogmoteStatus.AVLYST:
+      return `Avlyst møte ${moteDato}`;
+    case DialogmoteStatus.FERDIGSTILT:
+      return `Møte ${moteDato}`;
+    default:
+      return "";
+  }
+};
+
 interface MoteSvarHistorikkProps {
   historiskeMoter: DialogmoteDTO[];
 }
@@ -81,9 +94,7 @@ export const MoteSvarHistorikk = ({
     <Accordion>
       {historiskeMoter.map((mote, index) => (
         <Accordion.Item key={index}>
-          <Accordion.Header>{`Møte ${tilDatoMedManedNavn(
-            mote.tid
-          )}`}</Accordion.Header>
+          <Accordion.Header>{getHeaderText(mote)}</Accordion.Header>
           <Accordion.Content>
             <DialogmoteStedInfo dialogmote={mote} />
             <DialogmoteVeilederInfo dialogmote={mote} />

--- a/src/components/dialogmote/motehistorikk/MoteSvarHistorikk.tsx
+++ b/src/components/dialogmote/motehistorikk/MoteSvarHistorikk.tsx
@@ -1,0 +1,96 @@
+import {
+  DialogmoteDTO,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import { FortidenImage } from "../../../../img/ImageComponents";
+import { Accordion, BodyLong, Box, Heading, Label } from "@navikt/ds-react";
+import React from "react";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import { DialogmoteVeilederInfo } from "@/components/dialogmote/DialogmoteVeilederInfo";
+import { DialogmoteStedInfo } from "@/components/dialogmote/DialogmoteStedInfo";
+import { ArbeidsgiverSvar } from "@/components/dialogmote/svar/ArbeidsgiverSvar";
+import { ArbeidstakerSvar } from "@/components/dialogmote/svar/ArbeidstakerSvar";
+import { BehandlerSvar } from "@/components/dialogmote/svar/BehandlerSvar";
+
+const texts = {
+  header: "Møtesvarhistorikk",
+  subtitle: "Oversikt over svar på tidligere innkallinger til dialogmøter",
+};
+
+interface Props {
+  dialogmote: DialogmoteDTO;
+}
+
+const InnkallingSvar = ({ dialogmote }: Props) => {
+  const innkallingArbeidstaker = dialogmote.arbeidstaker.varselList.find(
+    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+  );
+  const innkallingArbeidsgiver = dialogmote.arbeidsgiver.varselList.find(
+    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+  );
+  const innkallingBehandler =
+    dialogmote.behandler &&
+    dialogmote.behandler.varselList.find(
+      ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+    );
+
+  return (
+    <div className="mt-4">
+      <Label size="small">{`Innkalling sendt ${tilDatoMedManedNavn(
+        dialogmote.createdAt
+      )} - svar:`}</Label>
+      <div className="flex flex-col gap-4">
+        {innkallingArbeidsgiver && (
+          <ArbeidsgiverSvar
+            varsel={innkallingArbeidsgiver}
+            virksomhetsnummer={dialogmote.arbeidsgiver.virksomhetsnummer}
+            defaultClosed
+          />
+        )}
+        {innkallingArbeidstaker && (
+          <ArbeidstakerSvar varsel={innkallingArbeidstaker} defaultClosed />
+        )}
+        {innkallingBehandler && (
+          <BehandlerSvar
+            varsel={innkallingBehandler}
+            behandlerNavn={dialogmote.behandler.behandlerNavn}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface MoteSvarHistorikkProps {
+  historiskeMoter: DialogmoteDTO[];
+}
+
+export const MoteSvarHistorikk = ({
+  historiskeMoter,
+}: MoteSvarHistorikkProps) => (
+  <Box background="surface-default" className="p-8">
+    <div className="flex flex-row mb-4">
+      <img src={FortidenImage} alt="moteikon" className="w-12 mr-4" />
+      <div className="flex flex-col">
+        <Heading level="2" size="medium" className="">
+          {texts.header}
+        </Heading>
+        <BodyLong size="small">{texts.subtitle}</BodyLong>
+      </div>
+    </div>
+    <Accordion>
+      {historiskeMoter.map((mote, index) => (
+        <Accordion.Item key={index}>
+          <Accordion.Header>{`Møte ${tilDatoMedManedNavn(
+            mote.tid
+          )}`}</Accordion.Header>
+          <Accordion.Content>
+            <DialogmoteStedInfo dialogmote={mote} />
+            <DialogmoteVeilederInfo dialogmote={mote} />
+            <InnkallingSvar dialogmote={mote} />
+          </Accordion.Content>
+        </Accordion.Item>
+      ))}
+    </Accordion>
+  </Box>
+);

--- a/src/components/dialogmote/svar/ArbeidsgiverSvar.tsx
+++ b/src/components/dialogmote/svar/ArbeidsgiverSvar.tsx
@@ -14,9 +14,14 @@ const texts = {
 interface Props {
   varsel: DialogmotedeltakerArbeidsgiverVarselDTO;
   virksomhetsnummer: string;
+  defaultClosed?: boolean;
 }
 
-export const ArbeidsgiverSvar = ({ varsel, virksomhetsnummer }: Props) => {
+export const ArbeidsgiverSvar = ({
+  varsel,
+  virksomhetsnummer,
+  defaultClosed = false,
+}: Props) => {
   const { getCurrentNarmesteLeder } = useLedereQuery();
   const narmesteLederNavn =
     getCurrentNarmesteLeder(virksomhetsnummer)?.narmesteLederNavn || "";
@@ -33,7 +38,7 @@ export const ArbeidsgiverSvar = ({ varsel, virksomhetsnummer }: Props) => {
         label: texts.label,
         body: `${capitalizeAllWords(narmesteLederNavn)}, ${svarTittelTekst}`,
       }}
-      defaultOpen={!!svar}
+      defaultOpen={!defaultClosed && !!svar}
     >
       <SvarDetaljer svarTekst={svar?.svarTekst} />
     </EkspanderbartSvarPanel>

--- a/src/components/dialogmote/svar/ArbeidstakerSvar.tsx
+++ b/src/components/dialogmote/svar/ArbeidstakerSvar.tsx
@@ -13,9 +13,10 @@ const texts = {
 
 interface Props {
   varsel: DialogmotedeltakerArbeidstakerVarselDTO;
+  defaultClosed?: boolean;
 }
 
-export const ArbeidstakerSvar = ({ varsel }: Props) => {
+export const ArbeidstakerSvar = ({ varsel, defaultClosed = false }: Props) => {
   const bruker = useNavBrukerData();
 
   const svar = varsel?.svar;
@@ -30,7 +31,7 @@ export const ArbeidstakerSvar = ({ varsel }: Props) => {
         label: texts.label,
         body: `${capitalizeAllWords(bruker.navn)}, ${svarTittelTekst}`,
       }}
-      defaultOpen={!!svar}
+      defaultOpen={!defaultClosed && !!svar}
     >
       <SvarDetaljer svarTekst={svar?.svarTekst} />
     </EkspanderbartSvarPanel>

--- a/src/components/dialogmote/svar/BehandlerSvar.tsx
+++ b/src/components/dialogmote/svar/BehandlerSvar.tsx
@@ -25,9 +25,14 @@ const begrunnelseHeaderTekst = (
 interface Props {
   varsel: DialogmotedeltakerBehandlerVarselDTO;
   behandlerNavn: string;
+  defaultClosed?: boolean;
 }
 
-export const BehandlerSvar = ({ varsel, behandlerNavn }: Props) => {
+export const BehandlerSvar = ({
+  varsel,
+  behandlerNavn,
+  defaultClosed = false,
+}: Props) => {
   const svarList = varsel.svar;
   const latestSvar: DialogmotedeltakerBehandlerVarselSvarDTO | undefined =
     svarList[0];
@@ -42,7 +47,7 @@ export const BehandlerSvar = ({ varsel, behandlerNavn }: Props) => {
         label: texts.label,
         body: `${behandlerNavn}, ${svarTittelTekst}`,
       }}
-      defaultOpen={!!latestSvar}
+      defaultOpen={!defaultClosed && !!latestSvar}
     >
       {svarList.length > 1 ? (
         <>

--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -16,6 +16,7 @@ import * as Tredelt from "@/sider/TredeltSide";
 import Side from "@/sider/Side";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import { MotehistorikkPanel } from "@/components/dialogmote/motehistorikk/MotehistorikkPanel";
+import { MoteSvarHistorikk } from "@/components/dialogmote/motehistorikk/MoteSvarHistorikk";
 
 const texts = {
   pageTitle: "Møtelandingsside",
@@ -59,7 +60,7 @@ export const Motelandingsside = () => {
     henterDialogmoterFeilet ||
     henterDialogmoteunntakFeilet;
 
-  const isMotehistorikkVisible =
+  const hasMotehistorikk =
     historiskeDialogmoter.length > 0 || dialogmoteunntak.length > 0;
 
   return (
@@ -85,11 +86,14 @@ export const Motelandingsside = () => {
           </Tredelt.FirstColumn>
 
           <Tredelt.SecondColumn>
-            {isMotehistorikkVisible && (
-              <MotehistorikkPanel
-                historiskeMoter={historiskeDialogmoter}
-                dialogmoteunntak={dialogmoteunntak}
-              />
+            {hasMotehistorikk && (
+              <div className="flex flex-col gap-4">
+                <MotehistorikkPanel
+                  historiskeMoter={historiskeDialogmoter}
+                  dialogmoteunntak={dialogmoteunntak}
+                />
+                <MoteSvarHistorikk historiskeMoter={historiskeDialogmoter} />
+              </div>
             )}
           </Tredelt.SecondColumn>
         </Tredelt.Container>

--- a/test/data/dialogmoteQueryHooksTest.tsx
+++ b/test/data/dialogmoteQueryHooksTest.tsx
@@ -11,7 +11,7 @@ import { testQueryClient } from "../testQueryClient";
 let queryClient: any;
 let apiMockScope: any;
 
-describe("dialogmoteQueryHooks tests", () => {
+xdescribe("dialogmoteQueryHooks tests", () => {
   beforeEach(() => {
     queryClient = testQueryClient();
     apiMockScope = apiMock();

--- a/test/data/dialogmoteQueryHooksTest.tsx
+++ b/test/data/dialogmoteQueryHooksTest.tsx
@@ -11,7 +11,7 @@ import { testQueryClient } from "../testQueryClient";
 let queryClient: any;
 let apiMockScope: any;
 
-xdescribe("dialogmoteQueryHooks tests", () => {
+describe("dialogmoteQueryHooks tests", () => {
   beforeEach(() => {
     queryClient = testQueryClient();
     apiMockScope = apiMock();

--- a/test/dialogmote/InnkallingDialogmotePanelTest.tsx
+++ b/test/dialogmote/InnkallingDialogmotePanelTest.tsx
@@ -15,10 +15,7 @@ import { dialogmotekandidatQueryKeys } from "@/data/dialogmotekandidat/dialogmot
 import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
 import { dialogmotekandidatMock } from "../../mock/isdialogmotekandidat/dialogmotekandidatMock";
 import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
-import {
-  DialogmoteStatus,
-  MotedeltakerVarselType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
+import { DialogmoteStatus } from "@/data/dialogmote/types/dialogmoteTypes";
 import {
   createDialogmote,
   createReferat,
@@ -131,18 +128,17 @@ describe("InnkallingDialogmotePanel", () => {
         dialogmotekandidatQueryKeys.kandidat(ARBEIDSTAKER_DEFAULT.personIdent),
         () => dialogmotekandidatMock
       );
-      const createdAt = dayjs(new Date(dialogmotekandidatMock.kandidatAt))
-        .subtract(1, "days")
-        .toISOString();
+      const createdAt = dayjs(
+        new Date(dialogmotekandidatMock.kandidatAt)
+      ).subtract(1, "days");
       const dialogmote = createDialogmote(
         "1",
         DialogmoteStatus.FERDIGSTILT,
-        MotedeltakerVarselType.REFERAT,
-        createdAt
+        createdAt.toDate()
       );
       const dialogmoteFerdigstiltTidligereEnnKandidat = {
         ...dialogmote,
-        referatList: [createReferat(true, createdAt)],
+        referatList: [createReferat(true, createdAt.toISOString())],
       };
       queryClient.setQueryData(
         dialogmoterQueryKeys.dialogmoter(ARBEIDSTAKER_DEFAULT.personIdent),
@@ -160,18 +156,18 @@ describe("InnkallingDialogmotePanel", () => {
         dialogmotekandidatQueryKeys.kandidat(ARBEIDSTAKER_DEFAULT.personIdent),
         () => dialogmotekandidatMock
       );
-      const createdAt = dayjs(new Date(dialogmotekandidatMock.kandidatAt))
-        .add(1, "days")
-        .toISOString();
+      const createdAt = dayjs(new Date(dialogmotekandidatMock.kandidatAt)).add(
+        1,
+        "days"
+      );
       const dialogmote = createDialogmote(
         "1",
         DialogmoteStatus.FERDIGSTILT,
-        MotedeltakerVarselType.REFERAT,
-        createdAt
+        createdAt.toDate()
       );
       const dialogmoteFerdigstiltEtterKandidat = {
         ...dialogmote,
-        referatList: [createReferat(true, createdAt)],
+        referatList: [createReferat(true, createdAt.toISOString())],
       };
       queryClient.setQueryData(
         dialogmoterQueryKeys.dialogmoter(ARBEIDSTAKER_DEFAULT.personIdent),
@@ -188,19 +184,19 @@ describe("InnkallingDialogmotePanel", () => {
         dialogmotekandidatQueryKeys.kandidat(ARBEIDSTAKER_DEFAULT.personIdent),
         () => dialogmotekandidatMock
       );
-      const createdAt = dayjs(new Date(dialogmotekandidatMock.kandidatAt))
-        .add(1, "days")
-        .toISOString();
+      const createdAt = dayjs(new Date(dialogmotekandidatMock.kandidatAt)).add(
+        1,
+        "days"
+      );
       const dialogmote = createDialogmote(
         "1",
         DialogmoteStatus.FERDIGSTILT,
-        MotedeltakerVarselType.REFERAT,
-        createdAt
+        createdAt.toDate()
       );
 
       const dialogmoteMellomlagreReferatEtterKandidat = {
         ...dialogmote,
-        referatList: [createMellomlagretReferat(createdAt)],
+        referatList: [createMellomlagretReferat(createdAt.toISOString())],
       };
       queryClient.setQueryData(
         dialogmoterQueryKeys.dialogmoter(ARBEIDSTAKER_DEFAULT.personIdent),

--- a/test/dialogmote/MoteSvarHistorikkTest.tsx
+++ b/test/dialogmote/MoteSvarHistorikkTest.tsx
@@ -1,0 +1,204 @@
+import {
+  DialogmotedeltakerArbeidsgiverVarselDTO,
+  DialogmotedeltakerArbeidstakerVarselDTO,
+  DialogmoteDTO,
+  DialogmoteStatus,
+  MotedeltakerVarselType,
+  SvarType,
+  VarselSvarDTO,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  ARBEIDSTAKER_DEFAULT_FULL_NAME,
+  ENHET_GRUNERLOKKA,
+  NARMESTE_LEDER_DEFAULT,
+  VEILEDER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
+  VIRKSOMHET_PONTYPANDY,
+} from "../../mock/common/mockConstants";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { MoteSvarHistorikk } from "@/components/dialogmote/motehistorikk/MoteSvarHistorikk";
+import { queryClientWithMockData } from "../testQueryClient";
+import { expect } from "chai";
+import userEvent from "@testing-library/user-event";
+
+let queryClient: QueryClient;
+
+type InnkallingSvar = Pick<VarselSvarDTO, "svarType" | "svarTekst">;
+const innkallingAT = (
+  svar: InnkallingSvar
+): DialogmotedeltakerArbeidstakerVarselDTO => ({
+  uuid: "123",
+  createdAt: "2021-05-26T12:56:26.271381",
+  varselType: MotedeltakerVarselType.INNKALT,
+  digitalt: true,
+  lestDato: "2021-05-26T12:56:26.271381",
+  fritekst: "Ipsum lorum arbeidstaker",
+  document: [],
+  svar: {
+    ...svar,
+    svarTidspunkt: "2021-05-26T12:56:26.271381",
+  },
+});
+const innkallingAG = (
+  svar: InnkallingSvar
+): DialogmotedeltakerArbeidsgiverVarselDTO => ({
+  uuid: "456",
+  createdAt: "2021-05-26T12:56:26.282386",
+  varselType: MotedeltakerVarselType.INNKALT,
+  lestDato: "2021-05-26T12:56:26.271381",
+  fritekst: "Ipsum lorum arbeidsgiver",
+  document: [],
+  status: "Status",
+  svar: {
+    ...svar,
+    svarTidspunkt: "2021-05-26T12:56:26.271381",
+  },
+});
+const ferdigstiltMote: DialogmoteDTO = {
+  uuid: "1",
+  createdAt: "2021-05-26T12:56:26.238385",
+  updatedAt: "2021-05-26T12:56:26.238385",
+  status: DialogmoteStatus.FERDIGSTILT,
+  opprettetAv: VEILEDER_IDENT_DEFAULT,
+  tildeltVeilederIdent: VEILEDER_IDENT_DEFAULT,
+  tildeltEnhet: ENHET_GRUNERLOKKA.nummer,
+  arbeidstaker: {
+    personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
+    type: "ARBEIDSTAKER",
+    varselList: [
+      innkallingAT({
+        svarType: SvarType.KOMMER,
+      }),
+    ],
+  },
+  arbeidsgiver: {
+    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    type: "ARBEIDSGIVER",
+    varselList: [
+      innkallingAG({
+        svarType: SvarType.KOMMER,
+      }),
+    ],
+  },
+  sted: "Sted",
+  tid: "2021-01-15T11:52:13.539843",
+  referatList: [],
+};
+const avlystMote: DialogmoteDTO = {
+  uuid: "10",
+  createdAt: "2020-05-26T12:56:26.238385",
+  updatedAt: "2020-05-26T12:56:26.238385",
+  status: DialogmoteStatus.AVLYST,
+  opprettetAv: VEILEDER_IDENT_DEFAULT,
+  tildeltVeilederIdent: VEILEDER_IDENT_DEFAULT,
+  tildeltEnhet: ENHET_GRUNERLOKKA.nummer,
+  arbeidstaker: {
+    personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
+    type: "ARBEIDSTAKER",
+    varselList: [
+      innkallingAT({
+        svarType: SvarType.KOMMER_IKKE,
+        svarTekst: "Syk",
+      }),
+      {
+        uuid: "abc",
+        createdAt: "2021-05-26T12:56:26.271381",
+        varselType: MotedeltakerVarselType.AVLYST,
+        digitalt: true,
+        lestDato: "2021-05-26T12:56:26.271381",
+        fritekst: "Ipsum lorum arbeidstaker",
+        document: [],
+      },
+    ],
+  },
+  arbeidsgiver: {
+    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    type: "ARBEIDSGIVER",
+    varselList: [
+      innkallingAG({
+        svarType: SvarType.KOMMER,
+      }),
+      {
+        uuid: "def",
+        createdAt: "2021-05-26T12:56:26.282386",
+        varselType: MotedeltakerVarselType.AVLYST,
+        lestDato: "2021-05-26T12:56:26.271381",
+        fritekst: "Ipsum lorum arbeidsgiver",
+        document: [],
+        status: "Status",
+      },
+    ],
+  },
+  sted: "Sted",
+  tid: "2020-03-22T11:52:13.539843",
+  referatList: [],
+};
+
+const renderMoteSvarHistorikk = (historiskeMoter: DialogmoteDTO[]) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MoteSvarHistorikk historiskeMoter={historiskeMoter} />
+    </QueryClientProvider>
+  );
+};
+
+describe("MoteSvarHistorikk", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+  it("viser accordion for hvert møte", () => {
+    renderMoteSvarHistorikk([ferdigstiltMote, avlystMote]);
+
+    const accordions = screen.getAllByRole("button");
+    expect(accordions.length).to.equal(2);
+    expect(accordions[0].textContent).to.contain("Møte 15. januar 2021");
+    expect(accordions[1].textContent).to.contain("Avlyst møte 22. mars 2020");
+  });
+  it("viser sted og veileder for møte", () => {
+    renderMoteSvarHistorikk([ferdigstiltMote]);
+
+    const accordion = screen.getByRole("button", {
+      name: "Møte 15. januar 2021",
+    });
+    userEvent.click(accordion);
+
+    expect(screen.getByText("Sted: Sted")).to.exist;
+    expect(screen.getByText(`Innkalt av: ${VEILEDER_DEFAULT.fulltNavn()}`)).to
+      .exist;
+  });
+  it("viser innkalling med svar for ferdigstilt møte", () => {
+    renderMoteSvarHistorikk([ferdigstiltMote]);
+
+    const accordion = screen.getByRole("button");
+    userEvent.click(accordion);
+
+    assertExpandableWithHeader(
+      `${ARBEIDSTAKER_DEFAULT_FULL_NAME}, kommer - Svar mottatt 26.05.2021`
+    );
+    assertExpandableWithHeader(
+      `${NARMESTE_LEDER_DEFAULT.navn}, kommer - Svar mottatt 26.05.2021`
+    );
+  });
+  it("viser innkalling med svar for avlyst møte", () => {
+    renderMoteSvarHistorikk([avlystMote]);
+
+    const accordion = screen.getByRole("button");
+    userEvent.click(accordion);
+
+    assertExpandableWithHeader(
+      `${NARMESTE_LEDER_DEFAULT.navn}, kommer - Svar mottatt 26.05.2021`
+    );
+    assertExpandableWithHeader(
+      `${ARBEIDSTAKER_DEFAULT_FULL_NAME}, ønsker å avlyse - Svar mottatt 26.05.2021`
+    );
+    expect(screen.getByText("Begrunnelse")).to.exist;
+    expect(screen.getByText("Syk")).to.exist;
+  });
+});
+
+const assertExpandableWithHeader = (header: string) => {
+  expect(screen.getByRole("region", { name: header })).to.exist;
+};


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til panel med møtesvarhistorikk i tredelingen til høyre på dialogmøte-siden. Foreløpig vises kun svar på innkalling for hvert historiske møte, men skal være greit å utvide til å vise svar på evt endringer av tid/sted også.
Har også gjort litt forbedring av dialogmøte-mockdataene.

Gjenstår:
- Tester på komponenten.
- Endelig avklare design, tekster osv - tar gjerne innspill på det. Tanken er for enkelhets skyld å gjenbruke mest mulig av svar-visningen vi har for det aktive møtet.

### Screenshots 📸✨
![image](https://github.com/navikt/syfomodiaperson/assets/79838644/976f0f68-1e56-4d40-b369-df85053d64b0)

