### PR TITLE
IS-2439: Add diagnosenavn tooltip

### DIFF
--- a/src/sider/nokkelinformasjon/sykmeldingsgrad/SyketilfelleList.tsx
+++ b/src/sider/nokkelinformasjon/sykmeldingsgrad/SyketilfelleList.tsx
@@ -2,15 +2,15 @@ import React from "react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
-import { Radio, RadioGroup } from "@navikt/ds-react";
+import { Radio, RadioGroup, Tooltip } from "@navikt/ds-react";
 import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
 import {
-  getDiagnosekodeFromLatestSykmelding,
+  getDiagnoseFromLatestSykmelding,
   newAndActivatedSykmeldinger,
   sykmeldingerInnenforOppfolgingstilfelle,
 } from "@/utils/sykmeldinger/sykmeldingUtils";
-import styled from "styled-components";
 import { MedisinskrinImage } from "../../../../img/ImageComponents";
+import { SykmeldingDiagnose } from "@/data/sykmelding/types/SykmeldingOldFormat";
 
 const texts = {
   title: "Siste sykefravær",
@@ -20,15 +20,6 @@ interface SyketilfelleListProps {
   changeSelectedTilfelle: (value: OppfolgingstilfelleDTO) => void;
 }
 
-const KodeSpan = styled.span`
-  margin-left: 0.2em;
-`;
-
-const TilfelleBox = styled.div`
-  display: flex;
-  align-items: center;
-`;
-
 export const SyketilfelleList = ({
   changeSelectedTilfelle,
 }: SyketilfelleListProps) => {
@@ -37,14 +28,14 @@ export const SyketilfelleList = ({
 
   const tenLatestTilfeller = tilfellerDescendingStart?.slice(0, 10);
 
-  const getDiagnosekode = (tilfelle: OppfolgingstilfelleDTO): string => {
+  const getDiagnose = (
+    tilfelle: OppfolgingstilfelleDTO
+  ): SykmeldingDiagnose | undefined => {
     const newAndUsedSykmeldinger = newAndActivatedSykmeldinger(sykmeldinger);
     const sykmeldingerIOppfolgingstilfellet =
       sykmeldingerInnenforOppfolgingstilfelle(newAndUsedSykmeldinger, tilfelle);
 
-    return getDiagnosekodeFromLatestSykmelding(
-      sykmeldingerIOppfolgingstilfellet
-    );
+    return getDiagnoseFromLatestSykmelding(sykmeldingerIOppfolgingstilfellet);
   };
 
   const tilfelleText = (tilfelle: OppfolgingstilfelleDTO) => {
@@ -66,18 +57,21 @@ export const SyketilfelleList = ({
       >
         {tenLatestTilfeller.map(
           (tilfelle: OppfolgingstilfelleDTO, index: number) => {
+            const diagnose = getDiagnose(tilfelle);
             return (
-              <TilfelleBox key={index}>
+              <div className="flex items-center" key={index}>
                 <Radio key={index} value={tilfelle}>
                   {tilfelleText(tilfelle)}
                 </Radio>
-                <>
-                  <div className="ml-2">
-                    <img src={MedisinskrinImage} alt="Medisinskrin" />
-                  </div>
-                  <KodeSpan>{getDiagnosekode(tilfelle)}</KodeSpan>
-                </>
-              </TilfelleBox>
+                {diagnose?.diagnosekode && (
+                  <Tooltip content={diagnose.diagnose ?? "Ukjent diagnosenavn"}>
+                    <div className="ml-2">
+                      <img src={MedisinskrinImage} alt="Medisinskrin" />
+                      <span className="ml-1">{diagnose.diagnosekode}</span>
+                    </div>
+                  </Tooltip>
+                )}
+              </div>
             );
           }
         )}

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -1,6 +1,7 @@
 import { senesteTom, tidligsteFom } from "../periodeUtils";
 import {
   ArbeidssituasjonType,
+  SykmeldingDiagnose,
   SykmeldingOldFormat,
   SykmeldingPeriodeDTO,
   SykmeldingStatus,
@@ -327,13 +328,10 @@ export const skalVisesSomTidligereSykmelding = (sykmld: SykmeldingOldFormat) =>
     new Date()
   ) >= 3;
 
-export const getDiagnosekodeFromLatestSykmelding = (
+export const getDiagnoseFromLatestSykmelding = (
   sykmeldinger: SykmeldingOldFormat[]
-) => {
+): SykmeldingDiagnose | undefined => {
   const latestSykmelding =
     sykmeldingerSortertNyestTilEldstPeriode(sykmeldinger)[0];
-  const latestDiagnosekode =
-    latestSykmelding?.diagnose?.hoveddiagnose?.diagnosekode;
-
-  return latestDiagnosekode || "";
+  return latestSykmelding?.diagnose?.hoveddiagnose;
 };

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -10,7 +10,7 @@ import {
   erMeldingTilArbeidsgiverInformasjon,
   erMulighetForArbeidInformasjon,
   finnAvventendeSykmeldingTekst,
-  getDiagnosekodeFromLatestSykmelding,
+  getDiagnoseFromLatestSykmelding,
   latestSykmeldingForVirksomhet,
   newAndActivatedSykmeldinger,
   stringMedAlleGraderingerFraSykmeldingPerioder,
@@ -967,9 +967,9 @@ describe("sykmeldingUtils", () => {
         },
       };
 
-      const diagnosekode = getDiagnosekodeFromLatestSykmelding([sykmelding]);
+      const diagnose = getDiagnoseFromLatestSykmelding([sykmelding]);
 
-      expect(diagnosekode).to.equal(wantedDiagnosekode);
+      expect(diagnose?.diagnosekode).to.equal(wantedDiagnosekode);
     });
 
     it("Returns diagnosekode from latest sykmelding in list", () => {
@@ -999,26 +999,24 @@ describe("sykmeldingUtils", () => {
         },
       };
 
-      const diagnosekode = getDiagnosekodeFromLatestSykmelding([
+      const diagnose = getDiagnoseFromLatestSykmelding([
         latestSykmelding,
         oldestSykmelding,
       ]);
 
-      expect(diagnosekode).to.equal(wantedDiagnosekode);
+      expect(diagnose?.diagnosekode).to.equal(wantedDiagnosekode);
     });
 
     it("Returns empty string if no sykmeldinger in list", () => {
-      const diagnosekode = getDiagnosekodeFromLatestSykmelding([]);
+      const diagnose = getDiagnoseFromLatestSykmelding([]);
 
-      expect(diagnosekode).to.equal("");
+      expect(diagnose?.diagnosekode).to.equal(undefined);
     });
 
     it("Returns empty string if latest sykmelding doesn't have diagnose", () => {
-      const diagnosekode = getDiagnosekodeFromLatestSykmelding([
-        baseSykmelding,
-      ]);
+      const diagnose = getDiagnoseFromLatestSykmelding([baseSykmelding]);
 
-      expect(diagnosekode).to.equal("");
+      expect(diagnose?.diagnosekode).to.equal(undefined);
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser diagnosenavn i Tooltip ved hover, etter ønske på Yammer.
I dag er det sånn at det bare er siste diagnose for oppfølgingstilfellet, aka man kan ha hatt én diagnose i alle sykmeldingene i et oppfølgingstilfelle bortsett fra det siste, men da vil likevel den siste diagnosen "oppsummere" tilfellet.

### Screenshots 📸✨

<img width="415" alt="image" src="https://github.com/navikt/syfomodiaperson/assets/37441744/6ed245ac-2630-4f45-8306-201dd1cf7058">
