### PR TITLE
IS-2069: Add ekspertbistand standardtekst

### DIFF
--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -253,6 +253,7 @@ export enum StandardtekstKey {
   MIDLERTIDIG_LONNSTILSKUDD = "MIDLERTIDIG_LONNSTILSKUDD",
   OKONOMISK_STOTTE = "OKONOMISK_STOTTE",
   INGEN_RETTIGHETER = "INGEN_RETTIGHETER",
+  EKSPERTBISTAND = "EKSPERTBISTAND",
 }
 
 export interface StandardTekst {
@@ -311,6 +312,11 @@ const referatStandardTekster: StandardTekst[] = [
     key: StandardtekstKey.MIDLERTIDIG_LONNSTILSKUDD,
     label: "Midlertidig lønnstilskudd",
     text: "Arbeidsgiveren din kan få et tilskudd til lønnen hvis det er fare for at du ikke kommer tilbake etter tolv måneder med full eller gradert sykmelding. Med lønnstilskudd skal du utføre vanlige oppgaver, men du trenger ikke gjøre dem med full intensitet.",
+  },
+  {
+    key: StandardtekstKey.EKSPERTBISTAND,
+    label: "Ekspertbistand",
+    text: "Dette tiltaket kan være aktuelt når du har en arbeidsgiver, men har utfordringer med å være i jobben. Målet er at du skal komme tilbake til jobb, eller annet arbeid hos samme eller en annen arbeidsgiver. Eksperten skal bidra til å kartlegge og avklare utfordringene på arbeidsplassen som fører til sykefravær, og foreslå tiltak som gjør deg i stand til å utføre arbeidet ditt. Det er arbeidsgiveren din som søker om tilskuddet.",
   },
   {
     key: StandardtekstKey.OKONOMISK_STOTTE,
@@ -374,6 +380,11 @@ const referatStandardTeksterNynorsk: StandardTekst[] = [
     key: StandardtekstKey.MIDLERTIDIG_LONNSTILSKUDD,
     label: "Mellombels lønstilskot",
     text: "Arbeidsgivaren din kan få tilskot til løna dersom det er fare for at du ikkje kjem tilbake etter tolv månader med full eller gradert sjukmelding. Med lønstilskot skal du utføre vanlege oppgåver, men du treng ikkje gjere dei med full intensitet.",
+  },
+  {
+    key: StandardtekstKey.EKSPERTBISTAND,
+    label: "Ekspertbistand",
+    text: "Dette tiltaket kan være aktuelt når du har en arbeidsgiver, men har utfordringer med å være i jobben. Målet er at du skal komme tilbake til jobb, eller annet arbeid hos samme eller en annen arbeidsgiver. Eksperten skal bidra til å kartlegge og avklare utfordringene på arbeidsplassen som fører til sykefravær, og foreslå tiltak som gjør deg i stand til å utføre arbeidet ditt. Det er arbeidsgiveren din som søker om tilskuddet.",
   },
   {
     key: StandardtekstKey.OKONOMISK_STOTTE,

--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -315,7 +315,7 @@ const referatStandardTekster: StandardTekst[] = [
   },
   {
     key: StandardtekstKey.EKSPERTBISTAND,
-    label: "Ekspertbistand",
+    label: "Tilskudd til ekspertbistand",
     text: "Dette tiltaket kan være aktuelt når du har en arbeidsgiver, men har utfordringer med å være i jobben. Målet er at du skal komme tilbake til jobb, eller annet arbeid hos samme eller en annen arbeidsgiver. Eksperten skal bidra til å kartlegge og avklare utfordringene på arbeidsplassen som fører til sykefravær, og foreslå tiltak som gjør deg i stand til å utføre arbeidet ditt. Det er arbeidsgiveren din som søker om tilskuddet.",
   },
   {
@@ -383,8 +383,8 @@ const referatStandardTeksterNynorsk: StandardTekst[] = [
   },
   {
     key: StandardtekstKey.EKSPERTBISTAND,
-    label: "Ekspertbistand",
-    text: "Dette tiltaket kan være aktuelt når du har en arbeidsgiver, men har utfordringer med å være i jobben. Målet er at du skal komme tilbake til jobb, eller annet arbeid hos samme eller en annen arbeidsgiver. Eksperten skal bidra til å kartlegge og avklare utfordringene på arbeidsplassen som fører til sykefravær, og foreslå tiltak som gjør deg i stand til å utføre arbeidet ditt. Det er arbeidsgiveren din som søker om tilskuddet.",
+    label: "Tilskot til ekspertbistand",
+    text: "Dette tiltaket kan vere aktuelt når du har ein arbeidsgivar, men har utfordringar med å vere i arbeid. Målet er at du skal kome tilbake til det same arbeidet, eller anna arbeid hos same eller ein annan arbeidsgivar. Eksperten skal bidra til å kartleggje og avklare utfordringane på arbeidsplassen som fører til sjukefråvær, og foreslå tiltak som gjer deg i stand til å utføre arbeidet ditt. Det er arbeidsgivaren din som søker om tilskot.",
   },
   {
     key: StandardtekstKey.OKONOMISK_STOTTE,

--- a/test/dialogmote/dialogmoteTextsTest.ts
+++ b/test/dialogmote/dialogmoteTextsTest.ts
@@ -18,6 +18,7 @@ const expectedStandardtekstKeys = [
   "MIDLERTIDIG_LONNSTILSKUDD",
   "OKONOMISK_STOTTE",
   "INGEN_RETTIGHETER",
+  "EKSPERTBISTAND",
 ];
 
 describe("dialogmoteTexts", () => {
@@ -29,13 +30,15 @@ describe("dialogmoteTexts", () => {
   });
 
   it("referattekster har tekster for alle standardtekst-nøkler", () => {
-    expectedStandardtekstKeys.forEach((key) => {
-      expect(
-        getReferatTexts(Malform.BOKMAL).standardTekster.some(
-          (standardTekst) => standardTekst.key === key
-        ),
-        `mangler standardtekst for nøkkel ${key}`
-      ).to.be.true;
+    [Malform.BOKMAL, Malform.NYNORSK].forEach((malform) => {
+      expectedStandardtekstKeys.forEach((key) => {
+        expect(
+          getReferatTexts(malform).standardTekster.some(
+            (standardTekst) => standardTekst.key === key
+          ),
+          `mangler ${malform} standardtekst for nøkkel ${key}`
+        ).to.be.true;
+      });
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger til mulighet for å velge standardtekst om ekspertbistand i referatet. Se tilhørende PR med link i [dialogmote-frontend](https://github.com/navikt/dialogmote-frontend/pull/554)

Gjenstår:
- [x] Nynorsk-versjon av teksten

### Screenshots 📸✨

![image](https://github.com/navikt/syfomodiaperson/assets/79838644/ba2844ec-717c-488f-8770-71e09b8355c9)

