### PR TITLE
IS-1958: combine sykmeldinger with and without arbeidsgiver

### DIFF
--- a/mock/syfosmregister/sykmeldingerMock.ts
+++ b/mock/syfosmregister/sykmeldingerMock.ts
@@ -1461,11 +1461,6 @@ export const sykmeldingerMock = [
       ],
     },
     legekontorOrgnummer: "223456789",
-    arbeidsgiver: {
-      navn: "LOMMEN BARNEHAVE",
-      yrkesbetegnelse: "Barnehageassistent",
-      stillingsprosent: 100,
-    },
     sykmeldingsperioder: [
       {
         fom: dayjs(new Date()).subtract(10, "days").toJSON(),

--- a/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
+++ b/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
@@ -1,0 +1,182 @@
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
+import {
+  SykmeldingOldFormat,
+  SykmeldingStatus,
+} from "@/data/sykmelding/types/SykmeldingOldFormat";
+import { EventType } from "@/utils/amplitude";
+import {
+  arbeidsgivernavnEllerArbeidssituasjon,
+  erEkstraInformasjonISykmeldingen,
+  erSykmeldingUtenArbeidsgiver,
+  stringMedAlleGraderingerFraSykmeldingPerioder,
+  sykmeldingerInnenforOppfolgingstilfelle,
+  sykmeldingerSortertNyestTilEldstPeriode,
+  sykmeldingperioderSortertEldstTilNyest,
+} from "@/utils/sykmeldinger/sykmeldingUtils";
+import { ExpansionCard, Heading, Tag } from "@navikt/ds-react";
+import React from "react";
+import SykmeldingUtdragFraSykefravaretVisning from "../motebehov/SykmeldingUtdragFraSykefravaretVisning";
+import * as Amplitude from "@/utils/amplitude";
+import styled from "styled-components";
+import { tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
+import { tidligsteFom, senesteTom } from "@/utils/periodeUtils";
+import { MerInformasjonImage } from "img/ImageComponents";
+import { PapirsykmeldingTag } from "../PapirsykmeldingTag";
+
+const texts = {
+  header: "Sykmeldinger",
+  utenArbeidsgiver: "Uten arbeidsgiver",
+  ny: "Ikke tatt i bruk",
+};
+
+const StyledExpantionCardHeader = styled(ExpansionCard.Header)`
+  .navds-expansioncard__header-content {
+    width: 100%;
+  }
+`;
+
+function logAccordionOpened(isOpen: boolean) {
+  if (isOpen) {
+    Amplitude.logEvent({
+      type: EventType.AccordionOpen,
+      data: {
+        tekst: `Åpne sykmeldinger accordion`,
+        url: window.location.href,
+      },
+    });
+  }
+}
+
+const Info = ({ label, text }: { label: string; text: string }) => {
+  return (
+    <div className="text-base font-normal">
+      <b>{label}</b>
+      <span>{text}</span>
+    </div>
+  );
+};
+
+interface UtvidbarSykmeldingProps {
+  sykmelding: SykmeldingOldFormat;
+}
+
+const UtvidbarSykmelding = ({ sykmelding }: UtvidbarSykmeldingProps) => {
+  const arbeidsgiverEllerSituasjon =
+    arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
+  const title = arbeidsgiverEllerSituasjon
+    ? arbeidsgiverEllerSituasjon
+    : "Sykmelding uten arbeidsgiver";
+  return (
+    <ExpansionCard aria-label={title} onToggle={logAccordionOpened}>
+      <StyledExpantionCardHeader className="w-full">
+        <ExpansionCard.Title
+          as="div"
+          className="flex justify-between m-0 text-base"
+        >
+          <SykmeldingTittelbeskrivelse sykmelding={sykmelding} />
+        </ExpansionCard.Title>
+      </StyledExpantionCardHeader>
+      <ExpansionCard.Content>
+        <SykmeldingUtdragFraSykefravaretVisning sykmelding={sykmelding} />
+      </ExpansionCard.Content>
+    </ExpansionCard>
+  );
+};
+
+interface UtvidbarTittelProps {
+  sykmelding: SykmeldingOldFormat;
+}
+
+const SykmeldingTittelbeskrivelse = ({ sykmelding }: UtvidbarTittelProps) => {
+  const sykmeldingPerioderSortertEtterDato =
+    sykmeldingperioderSortertEldstTilNyest(
+      sykmelding.mulighetForArbeid.perioder
+    );
+
+  const periode = `${tilLesbarPeriodeMedArstall(
+    tidligsteFom(sykmelding.mulighetForArbeid.perioder),
+    senesteTom(sykmelding.mulighetForArbeid.perioder)
+  )}: `;
+  const graderinger = stringMedAlleGraderingerFraSykmeldingPerioder(
+    sykmeldingPerioderSortertEtterDato
+  );
+  const diagnose = `${sykmelding.diagnose.hoveddiagnose?.diagnosekode} (${sykmelding.diagnose.hoveddiagnose?.diagnose})`;
+  const erViktigInformasjon = erEkstraInformasjonISykmeldingen(sykmelding);
+  const sykmelder = sykmelding.bekreftelse.sykmelder;
+  const arbeidsgiver = arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
+  const erIkkeTattIBruk = sykmelding.status === SykmeldingStatus.NY;
+  const erUtenArbeidsgiver = erSykmeldingUtenArbeidsgiver(sykmelding);
+
+  return (
+    <div className="w-full flex flex-col">
+      <div className="flex justify-between mb-2">
+        <div>
+          {periode}
+          {graderinger}
+        </div>
+        <div className="flex gap-4">
+          {erIkkeTattIBruk && (
+            <Tag variant="warning" size="small">
+              {texts.ny}
+            </Tag>
+          )}
+          {erUtenArbeidsgiver && (
+            <Tag variant="info" size="small">
+              {texts.utenArbeidsgiver}
+            </Tag>
+          )}
+          {erViktigInformasjon && (
+            <img
+              height={18}
+              alt="Viktig informasjon"
+              src={MerInformasjonImage}
+            />
+          )}
+        </div>
+      </div>
+      {sykmelding.diagnose.hoveddiagnose && (
+        <Info label={"Diagnose: "} text={diagnose} />
+      )}
+      {sykmelder && <Info label={"Sykmelder: "} text={sykmelder} />}
+      {arbeidsgiver && <Info label={"Arbeidsgiver: "} text={arbeidsgiver} />}
+      {sykmelding.yrkesbetegnelse && (
+        <Info
+          label={"Stilling fra sykmelding: "}
+          text={sykmelding.yrkesbetegnelse}
+        />
+      )}
+      {sykmelding.papirsykmelding && <PapirsykmeldingTag />}
+    </div>
+  );
+};
+
+export default function Sykmeldinger() {
+  const { sykmeldinger } = useSykmeldingerQuery();
+  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
+
+  const aktuelleSykmeldinger = sykmeldinger.filter(
+    (sykmelding) =>
+      sykmelding.status === SykmeldingStatus.SENDT ||
+      sykmelding.status === SykmeldingStatus.NY ||
+      erSykmeldingUtenArbeidsgiver(sykmelding)
+  );
+  const sykmeldingerIOppfolgingstilfellet =
+    sykmeldingerInnenforOppfolgingstilfelle(
+      aktuelleSykmeldinger,
+      latestOppfolgingstilfelle
+    );
+  const sykmeldingerSortertPaaStartDato =
+    sykmeldingerSortertNyestTilEldstPeriode(sykmeldingerIOppfolgingstilfellet);
+
+  return (
+    <div className="mb-10 [&>*]:mb-2">
+      <Heading size="small" level="3">
+        {texts.header}
+      </Heading>
+      {sykmeldingerSortertPaaStartDato.map((sykmelding, index) => (
+        <UtvidbarSykmelding sykmelding={sykmelding} key={index} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragFraSykefravaeret.tsx
@@ -1,40 +1,14 @@
 import React from "react";
-import SykmeldingUtdragFraSykefravaretVisning from "../motebehov/SykmeldingUtdragFraSykefravaretVisning";
-import {
-  arbeidsgivernavnEllerArbeidssituasjon,
-  erEkstraInformasjonISykmeldingen,
-  stringMedAlleGraderingerFraSykmeldingPerioder,
-  sykmeldingerInnenforOppfolgingstilfelle,
-  sykmeldingerSortertNyestTilEldstPeriode,
-  sykmeldingerUtenArbeidsgiver,
-  sykmeldingperioderSortertEldstTilNyest,
-} from "@/utils/sykmeldinger/sykmeldingUtils";
 import { finnMiljoStreng } from "@/utils/miljoUtil";
-import { tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
-import { senesteTom, tidligsteFom } from "@/utils/periodeUtils";
 import styled from "styled-components";
-import {
-  SykmeldingOldFormat,
-  SykmeldingStatus,
-} from "@/data/sykmelding/types/SykmeldingOldFormat";
-import { MerInformasjonImage } from "../../../img/ImageComponents";
 import { UtdragOppfolgingsplaner } from "./UtdragOppfolgingsplaner";
 import { SpinnsynLenke } from "@/components/vedtak/SpinnsynLenke";
-import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
-import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
-import { PapirsykmeldingTag } from "@/components/PapirsykmeldingTag";
-import { ExpansionCard, Heading, Link, Panel, Tag } from "@navikt/ds-react";
-import * as Amplitude from "@/utils/amplitude";
-import { EventType } from "@/utils/amplitude";
+import { Box, Heading, Link } from "@navikt/ds-react";
+import Sykmeldinger from "./Sykmeldinger";
 
 const texts = {
   header: "Utdrag fra sykefraværet",
-  sykmeldinger: {
-    header: "Sykmeldinger",
-    headerUtenArbeidsgiver: "Sykmeldinger uten arbeidsgiver",
-    ny: "Ikke tatt i bruk",
-  },
   samtalereferat: {
     header: "Samtalereferat",
     lenkeTekst: "Samtalereferat",
@@ -42,171 +16,6 @@ const texts = {
   vedtak: {
     header: "Vedtak",
   },
-  apneSykmelding: "Åpne sykmelding",
-};
-
-const StyledExpantionCardHeader = styled(ExpansionCard.Header)`
-  .navds-expansioncard__header-content {
-    width: 100%;
-  }
-`;
-
-const Info = ({ label, text }: { label: string; text: string }) => {
-  return (
-    <div className="text-base font-normal">
-      <b>{label}</b>
-      <span>{text}</span>
-    </div>
-  );
-};
-
-interface UtvidbarTittelProps {
-  sykmelding: SykmeldingOldFormat;
-}
-
-export const SykmeldingTittelbeskrivelse = ({
-  sykmelding,
-}: UtvidbarTittelProps) => {
-  const sykmeldingPerioderSortertEtterDato =
-    sykmeldingperioderSortertEldstTilNyest(
-      sykmelding.mulighetForArbeid.perioder
-    );
-
-  const periode = `${tilLesbarPeriodeMedArstall(
-    tidligsteFom(sykmelding.mulighetForArbeid.perioder),
-    senesteTom(sykmelding.mulighetForArbeid.perioder)
-  )}: `;
-  const graderinger = stringMedAlleGraderingerFraSykmeldingPerioder(
-    sykmeldingPerioderSortertEtterDato
-  );
-  const diagnose = `${sykmelding.diagnose.hoveddiagnose?.diagnosekode} (${sykmelding.diagnose.hoveddiagnose?.diagnose})`;
-  const erViktigInformasjon = erEkstraInformasjonISykmeldingen(sykmelding);
-  const sykmelder = sykmelding.bekreftelse.sykmelder;
-  const arbeidsgiver = arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
-  const erIkkeTattIBruk = sykmelding.status === SykmeldingStatus.NY;
-
-  return (
-    <div className="w-full flex flex-col">
-      <div className="flex justify-between mb-2">
-        <div>
-          {periode}
-          {graderinger}
-        </div>
-        <div className="flex gap-4">
-          {erIkkeTattIBruk && (
-            <Tag variant="warning" size="small">
-              {texts.sykmeldinger.ny}
-            </Tag>
-          )}
-          {erViktigInformasjon && (
-            <img
-              height={18}
-              alt="Viktig informasjon"
-              src={MerInformasjonImage}
-            />
-          )}
-        </div>
-      </div>
-      {sykmelding.diagnose.hoveddiagnose && (
-        <Info label={"Diagnose: "} text={diagnose} />
-      )}
-      {sykmelder && <Info label={"Sykmelder: "} text={sykmelder} />}
-      {arbeidsgiver && <Info label={"Arbeidsgiver: "} text={arbeidsgiver} />}
-      {sykmelding.yrkesbetegnelse && (
-        <Info
-          label={"Stilling fra sykmelding: "}
-          text={sykmelding.yrkesbetegnelse}
-        />
-      )}
-      {sykmelding.papirsykmelding && <PapirsykmeldingTag />}
-    </div>
-  );
-};
-
-interface UtvidbarSykmeldingProps {
-  sykmelding: SykmeldingOldFormat;
-}
-
-function logAccordionOpened(isOpen: boolean) {
-  if (isOpen) {
-    Amplitude.logEvent({
-      type: EventType.AccordionOpen,
-      data: {
-        tekst: `Åpne sykmeldinger accordion`,
-        url: window.location.href,
-      },
-    });
-  }
-}
-
-const UtvidbarSykmelding = ({ sykmelding }: UtvidbarSykmeldingProps) => {
-  const arbeidsgiverEllerSituasjon =
-    arbeidsgivernavnEllerArbeidssituasjon(sykmelding);
-  const title = arbeidsgiverEllerSituasjon
-    ? arbeidsgiverEllerSituasjon
-    : "Sykmelding uten arbeidsgiver";
-  return (
-    <ExpansionCard aria-label={title} onToggle={logAccordionOpened}>
-      <StyledExpantionCardHeader className="w-full">
-        <ExpansionCard.Title
-          as="div"
-          className="flex justify-between m-0 text-base"
-        >
-          <SykmeldingTittelbeskrivelse sykmelding={sykmelding} />
-        </ExpansionCard.Title>
-      </StyledExpantionCardHeader>
-      <ExpansionCard.Content>
-        <SykmeldingUtdragFraSykefravaretVisning sykmelding={sykmelding} />
-      </ExpansionCard.Content>
-    </ExpansionCard>
-  );
-};
-
-export const SykmeldingerForVirksomhet = () => {
-  const { sykmeldinger } = useSykmeldingerQuery();
-  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
-  const aktuelleSykmeldinger = sykmeldinger.filter(
-    (sykmelding) =>
-      sykmelding.status === SykmeldingStatus.SENDT ||
-      sykmelding.status === SykmeldingStatus.NY
-  );
-  const sykmeldingerIOppfolgingstilfellet =
-    sykmeldingerInnenforOppfolgingstilfelle(
-      aktuelleSykmeldinger,
-      latestOppfolgingstilfelle
-    );
-  const sykmeldingerSortertPaaStartDato =
-    sykmeldingerSortertNyestTilEldstPeriode(sykmeldingerIOppfolgingstilfellet);
-
-  return (
-    <div className="mb-10 [&>*]:mb-2">
-      <Heading size="small" level="3">
-        {texts.sykmeldinger.header}
-      </Heading>
-      {sykmeldingerSortertPaaStartDato.map((sykmelding, index) => (
-        <UtvidbarSykmelding sykmelding={sykmelding} key={index} />
-      ))}
-    </div>
-  );
-};
-
-interface SykmeldingerUtenArbeidsgiverProps {
-  sykmeldingerSortertPaUtstedelsesdato: SykmeldingOldFormat[];
-}
-
-export const SykmeldingerUtenArbeidsgiver = ({
-  sykmeldingerSortertPaUtstedelsesdato,
-}: SykmeldingerUtenArbeidsgiverProps) => {
-  return (
-    <div className="mb-10 [&>*]:mb-2">
-      <Heading size="small" level="3">
-        {texts.sykmeldinger.headerUtenArbeidsgiver}
-      </Heading>
-      {sykmeldingerSortertPaUtstedelsesdato.map((sykmelding, index) => (
-        <UtvidbarSykmelding sykmelding={sykmelding} key={index} />
-      ))}
-    </div>
-  );
 };
 
 const SamtalereferatWrapper = styled.div`
@@ -231,39 +40,19 @@ export const Samtalereferat = () => {
 };
 
 const UtdragFraSykefravaeret = () => {
-  const { sykmeldinger } = useSykmeldingerQuery();
-  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
-
-  const innsendteSykmeldingerUtenArbeidsgiver =
-    sykmeldingerUtenArbeidsgiver(sykmeldinger);
-  const sykmeldingerIOppfolgingstilfellet =
-    sykmeldingerInnenforOppfolgingstilfelle(
-      innsendteSykmeldingerUtenArbeidsgiver,
-      latestOppfolgingstilfelle
-    );
-  const sykmeldingerSortertPaSykmeldingsperiode =
-    sykmeldingerSortertNyestTilEldstPeriode(sykmeldingerIOppfolgingstilfellet);
-
   return (
-    <Panel className="mb-4 h-min">
+    <Box padding="4" background="surface-default" className="mb-4 h-min">
       <Heading level="2" size="medium" className="mb-4">
         {texts.header}
       </Heading>
       <UtdragOppfolgingsplaner />
-      <SykmeldingerForVirksomhet />
-      {sykmeldingerSortertPaSykmeldingsperiode?.length > 0 && (
-        <SykmeldingerUtenArbeidsgiver
-          sykmeldingerSortertPaUtstedelsesdato={
-            sykmeldingerSortertPaSykmeldingsperiode
-          }
-        />
-      )}
+      <Sykmeldinger />
       <Samtalereferat />
       <Heading size="small" level="3">
         {texts.vedtak.header}
       </Heading>
       <SpinnsynLenke />
-    </Panel>
+    </Box>
   );
 };
 

--- a/test/components/UtdragFraSykefravaeretTest.tsx
+++ b/test/components/UtdragFraSykefravaeretTest.tsx
@@ -3,8 +3,13 @@ import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFr
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { expect, describe, it, vi, beforeAll, afterAll } from "vitest";
-import { ARBEIDSTAKER_DEFAULT_FULL_NAME } from "../../mock/common/mockConstants";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  ARBEIDSTAKER_DEFAULT_FULL_NAME,
+} from "../../mock/common/mockConstants";
 import { queryClientWithMockData } from "../testQueryClient";
+import { sykmeldingerQueryKeys } from "@/data/sykmelding/sykmeldingQueryHooks";
+import { sykmeldingerMock } from "mock/syfosmregister/sykmeldingerMock";
 
 let queryClient: QueryClient;
 
@@ -59,5 +64,24 @@ describe("UtdragFraSykefravaeret", () => {
 
     expect(within(sykmeldingExpansionCards[1]).getByText("Ikke tatt i bruk")).to
       .exist;
+  });
+
+  it("Viser sykmelding uten arbeidsgiver tag", () => {
+    queryClient.setQueryData(
+      sykmeldingerQueryKeys.sykmeldinger(ARBEIDSTAKER_DEFAULT.personIdent),
+      () =>
+        sykmeldingerMock.filter(
+          (sykmelding) =>
+            sykmelding.id === "8361e922-2c92-4aa8-811d-e53ca958dc6a"
+        )
+    );
+
+    renderUtdragFraSykefravaeret();
+
+    const sykmeldingExpansionCards = screen.getAllByRole("region");
+    expect(sykmeldingExpansionCards.length).to.equal(1);
+
+    expect(within(sykmeldingExpansionCards[0]).getByText("Uten arbeidsgiver"))
+      .to.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Vi har kombinert alle sykemeldingene, både med og uten arbeidsgiver, og viser disse i kronologisk rekkefølge i "utdrag fra sykefraværet". De kortene uten arbeidsgiver har fått en tag med navn "uten arbeidsgiver". 

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/83199557-2cea-41ee-935e-cf89a8fc5301)
