### PR TITLE
IS-2610: Add red notification dot when ubehandlet friskmelding til arbeidsformidling

### DIFF
--- a/mock/isfrisktilarbeid/mockIsfrisktilarbeid.ts
+++ b/mock/isfrisktilarbeid/mockIsfrisktilarbeid.ts
@@ -8,6 +8,7 @@ import {
   VedtakResponseDTO,
 } from "../../src/data/frisktilarbeid/frisktilarbeidTypes";
 import dayjs from "dayjs";
+import { addWeeks } from "@/utils/datoUtils";
 
 let vedtak: VedtakResponseDTO[] = [];
 
@@ -64,4 +65,16 @@ export const mockIsfrisktilarbeid = (server: any) => {
             );
     }
   );
+};
+
+export const defaultVedtak: VedtakResponseDTO = {
+  uuid: "123",
+  createdAt: new Date(),
+  veilederident: "Z999999",
+  begrunnelse: "En begrunnelse",
+  fom: new Date(),
+  tom: addWeeks(new Date(), 12),
+  document: [],
+  ferdigbehandletAt: undefined,
+  ferdigbehandletBy: undefined,
 };

--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -17,6 +17,7 @@ import { EventType, logEvent } from "@/utils/amplitude";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { useArbeidsuforhetVurderingQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { useSenOppfolgingKandidatQuery } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
+import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
 
 export enum Menypunkter {
   AKTIVITETSKRAV = "AKTIVITETSKRAV",
@@ -105,6 +106,7 @@ export const GlobalNavigasjon = ({
   const { data: aktivitetskrav } = useAktivitetskravQuery();
   const { data: arbeidsuforhetVurderinger } = useArbeidsuforhetVurderingQuery();
   const { data: senOppfolgingKandidat } = useSenOppfolgingKandidatQuery();
+  const { data: friskmeldingTilArbeidsformidlingVedtak } = useVedtakQuery();
   const { toggles } = useFeatureToggles();
 
   const oppfolgingsplanerLPSMedPersonOppgave = oppfolgingsplanerLPS.map(
@@ -180,7 +182,8 @@ export const GlobalNavigasjon = ({
           oppfolgingsplanerLPSMedPersonOppgave,
           aktivitetskrav,
           arbeidsuforhetVurderinger,
-          senOppfolgingKandidat
+          senOppfolgingKandidat,
+          friskmeldingTilArbeidsformidlingVedtak
         );
 
         const isVedtakMenypunkt = menypunkt === Menypunkter.VEDTAK;

--- a/src/styles/_antallNytt.less
+++ b/src/styles/_antallNytt.less
@@ -24,7 +24,7 @@
 }
 
 .antallNytt {
-  width: 1.5em;
+  min-width: 1.5em;
   height: 1.5em;
   display: inline-block;
   border-radius: 50%;

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -25,6 +25,7 @@ import {
   SenOppfolgingKandidatResponseDTO,
   SenOppfolgingStatus,
 } from "@/data/senoppfolging/senOppfolgingTypes";
+import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 
 const getNumberOfMoteOppgaver = (
   motebehov: MotebehovVeilederDTO[],
@@ -124,6 +125,17 @@ function getNumberOfActiveSenOppfolgingOppgaver(
     : 0;
 }
 
+function getNumberOfFriskmeldingTilArbeidsformidlingOppgaver(
+  friskmeldingTilArbeidsformidlingVedtak: VedtakResponseDTO[]
+): number {
+  const sisteVedtak = friskmeldingTilArbeidsformidlingVedtak[0];
+  return !!sisteVedtak &&
+    !sisteVedtak.ferdigbehandletAt &&
+    !sisteVedtak.ferdigbehandletAt
+    ? 1
+    : 0;
+}
+
 export const numberOfTasks = (
   menypunkt: Menypunkter,
   motebehov: MotebehovVeilederDTO[],
@@ -132,7 +144,8 @@ export const numberOfTasks = (
   oppfolgingsplanerlps: OppfolgingsplanLPSMedPersonoppgave[],
   aktivitetskrav: AktivitetskravDTO[],
   arbeidsuforhetVurderinger: VurderingResponseDTO[],
-  senOppfolgingKandidatOppgaver: SenOppfolgingKandidatResponseDTO[]
+  senOppfolgingKandidatOppgaver: SenOppfolgingKandidatResponseDTO[],
+  friskmeldingTilArbeidsformidlingVedtak: VedtakResponseDTO[]
 ): number => {
   switch (menypunkt) {
     case Menypunkter.DIALOGMOTE:
@@ -159,6 +172,9 @@ export const numberOfTasks = (
         senOppfolgingKandidatOppgaver
       );
     case Menypunkter.FRISKTILARBEID:
+      return getNumberOfFriskmeldingTilArbeidsformidlingOppgaver(
+        friskmeldingTilArbeidsformidlingVedtak
+      );
     case Menypunkter.NOKKELINFORMASJON:
     case Menypunkter.SYKEPENGESOKNADER:
     case Menypunkter.VEDTAK:

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -131,7 +131,7 @@ function getNumberOfFriskmeldingTilArbeidsformidlingOppgaver(
   const sisteVedtak = friskmeldingTilArbeidsformidlingVedtak[0];
   return !!sisteVedtak &&
     !sisteVedtak.ferdigbehandletAt &&
-    !sisteVedtak.ferdigbehandletAt
+    !sisteVedtak.ferdigbehandletBy
     ? 1
     : 0;
 }

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -36,6 +36,8 @@ import {
   ferdigbehandletKandidatMock,
   senOppfolgingKandidatMock,
 } from "../../mock/ismeroppfolging/mockIsmeroppfolging";
+import { vedtakQueryKeys } from "@/data/frisktilarbeid/vedtakQuery";
+import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: QueryClient;
@@ -269,5 +271,60 @@ describe("GlobalNavigasjon", () => {
 
     expect(screen.getByRole("link", { name: "Snart slutt på sykepengene" })).to
       .exist;
+  });
+
+  it('viser en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ikke ferdigbehandlet', () => {
+    const vedtak: VedtakResponseDTO[] = [
+      {
+        uuid: "123",
+        createdAt: new Date(),
+        veilederident: "Z999999",
+        begrunnelse: "En begrunnelse",
+        fom: new Date(),
+        tom: addWeeks(new Date(), 12),
+        document: [],
+        ferdigbehandletAt: undefined,
+        ferdigbehandletBy: undefined,
+      },
+    ];
+    queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => vedtak);
+    queryClient.setQueryData(
+      unleashQueryKeys.toggles(navEnhet.id, ""),
+      () => mockUnleashResponse
+    );
+    renderGlobalNavigasjon();
+
+    expect(
+      screen.getByRole("link", { name: "Friskmelding til arbeidsformidling 1" })
+    ).to.exist;
+  });
+
+  it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ferdigbehandlet', () => {
+    const ferdigbehandletVedtak: VedtakResponseDTO[] = [
+      {
+        uuid: "123",
+        createdAt: new Date(),
+        veilederident: "Z999999",
+        begrunnelse: "En begrunnelse",
+        fom: new Date(),
+        tom: addWeeks(new Date(), 12),
+        document: [],
+        ferdigbehandletAt: new Date(),
+        ferdigbehandletBy: "Z999999",
+      },
+    ];
+    queryClient.setQueryData(
+      vedtakQueryKeys.vedtak(fnr),
+      () => ferdigbehandletVedtak
+    );
+    queryClient.setQueryData(
+      unleashQueryKeys.toggles(navEnhet.id, ""),
+      () => mockUnleashResponse
+    );
+    renderGlobalNavigasjon();
+
+    expect(
+      screen.getByRole("link", { name: "Friskmelding til arbeidsformidling" })
+    ).to.exist;
   });
 });

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -38,6 +38,7 @@ import {
 } from "../../mock/ismeroppfolging/mockIsmeroppfolging";
 import { vedtakQueryKeys } from "@/data/frisktilarbeid/vedtakQuery";
 import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
+import { defaultVedtak } from "../../mock/isfrisktilarbeid/mockIsfrisktilarbeid";
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: QueryClient;
@@ -274,20 +275,9 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ikke ferdigbehandlet', () => {
-    const vedtak: VedtakResponseDTO[] = [
-      {
-        uuid: "123",
-        createdAt: new Date(),
-        veilederident: "Z999999",
-        begrunnelse: "En begrunnelse",
-        fom: new Date(),
-        tom: addWeeks(new Date(), 12),
-        document: [],
-        ferdigbehandletAt: undefined,
-        ferdigbehandletBy: undefined,
-      },
-    ];
-    queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => vedtak);
+    queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => [
+      defaultVedtak,
+    ]);
     queryClient.setQueryData(
       unleashQueryKeys.toggles(navEnhet.id, ""),
       () => mockUnleashResponse
@@ -300,23 +290,46 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ferdigbehandlet', () => {
-    const ferdigbehandletVedtak: VedtakResponseDTO[] = [
-      {
-        uuid: "123",
-        createdAt: new Date(),
-        veilederident: "Z999999",
-        begrunnelse: "En begrunnelse",
-        fom: new Date(),
-        tom: addWeeks(new Date(), 12),
-        document: [],
-        ferdigbehandletAt: new Date(),
-        ferdigbehandletBy: "Z999999",
-      },
-    ];
+    const ferdigbehandletVedtak: VedtakResponseDTO = {
+      ...defaultVedtak,
+      ferdigbehandletAt: new Date(),
+      ferdigbehandletBy: "Z999999",
+    };
+    queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => [
+      ferdigbehandletVedtak,
+    ]);
     queryClient.setQueryData(
-      vedtakQueryKeys.vedtak(fnr),
-      () => ferdigbehandletVedtak
+      unleashQueryKeys.toggles(navEnhet.id, ""),
+      () => mockUnleashResponse
     );
+    renderGlobalNavigasjon();
+
+    expect(
+      screen.getByRole("link", { name: "Friskmelding til arbeidsformidling" })
+    ).to.exist;
+  });
+
+  it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når bare ett av ferdigbehandletfeltene finnes', () => {
+    const ferdigbehandletVedtak: VedtakResponseDTO = {
+      ...defaultVedtak,
+      ferdigbehandletAt: new Date(),
+    };
+    queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => [
+      ferdigbehandletVedtak,
+    ]);
+    queryClient.setQueryData(
+      unleashQueryKeys.toggles(navEnhet.id, ""),
+      () => mockUnleashResponse
+    );
+    renderGlobalNavigasjon();
+
+    expect(
+      screen.getByRole("link", { name: "Friskmelding til arbeidsformidling" })
+    ).to.exist;
+  });
+
+  it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ingen vedtak', () => {
+    queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => []);
     queryClient.setQueryData(
       unleashQueryKeys.toggles(navEnhet.id, ""),
       () => mockUnleashResponse


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Nå vises en rød prikk hvis det er sendt inn vedtak som ikke er behandlet enda. Da kan veileder enkelt se at her er det noe ubehandlet Friskmelding til arbeidsformidling når de går inn på en person.

### Screenshots 📸✨
Verdt å legge merke til at når man har klikket seg gjennom sidene på FTA mange ganger lokalt (som jeg har gjort før innspillingen av videoen), så kommer man ikke til "Nytt vedtak"-siden fordi denne styres av en useState som aldri flippes tilbake til `false`. Tror ingen reelle caser vil komme hit dog, da må en veileder først ferdigbehandle et vedtak, så sende ut et nytt et med en gang, og ferdigbehandle det også på samme person. 

https://github.com/user-attachments/assets/41fa15db-11b6-469a-8f47-394075b69de7


