### PR TITLE
IS-2601: Use new endpoint, put aktivveilder first

### DIFF
--- a/mock/syfooversiktsrv/mockSyfooversiktsrv.ts
+++ b/mock/syfooversiktsrv/mockSyfooversiktsrv.ts
@@ -19,10 +19,9 @@ export const mockSyfooversiktsrv = (server: any) => {
   );
 
   server.post(
-    `${SYFOOVERSIKTSRV_PERSONTILDELING_ROOT}/registrer`,
+    `${SYFOOVERSIKTSRV_PERSONTILDELING_ROOT}/personer/single`,
     (req: express.Request, res: express.Response) => {
-      const body = req.body;
-      const { veilederIdent } = body.tilknytninger[0];
+      const { veilederIdent } = req.body;
       veilederBrukerKnytningMock = {
         ...veilederBrukerKnytningMock,
         tildeltVeilederident: veilederIdent,

--- a/src/components/TildeltVeileder.tsx
+++ b/src/components/TildeltVeileder.tsx
@@ -9,6 +9,7 @@ import {
 } from "@navikt/ds-react";
 import { useGetVeilederBrukerKnytning } from "@/data/veilederbrukerknytning/useGetVeilederBrukerKnytning";
 import {
+  useAktivVeilederinfoQuery,
   useVeiledereForValgtEnhetQuery,
   useVeilederInfoQuery,
 } from "@/data/veilederinfo/veilederinfoQueryHooks";
@@ -65,7 +66,12 @@ interface ChangeTildeltVeilederModalProps {
   handleClose: () => void;
 }
 
-const toVeilederOptions = (veiledere: Veileder[]) => {
+const toVeilederOption = (veileder: Veileder) => ({
+  value: veileder.ident,
+  label: `${veileder.etternavn}, ${veileder.fornavn}`,
+});
+
+const toVeilederOptions = (veiledere: Veileder[], aktivVeileder: Veileder) => {
   const sortedVeiledere = veiledere.sort((veilederA, veilederB) => {
     const etternavn1 = veilederA.etternavn.toLowerCase();
     const etternavn2 = veilederB.etternavn.toLowerCase();
@@ -77,10 +83,12 @@ const toVeilederOptions = (veiledere: Veileder[]) => {
       : etternavn1.localeCompare(etternavn2);
   });
 
-  return sortedVeiledere.map((veileder) => ({
-    value: veileder.ident,
-    label: `${veileder.etternavn}, ${veileder.fornavn}`,
-  }));
+  return [
+    toVeilederOption(aktivVeileder),
+    ...sortedVeiledere
+      .filter((veileder) => veileder.ident !== aktivVeileder.ident)
+      .map(toVeilederOption),
+  ];
 };
 
 const StyledCombobox = styled(UNSAFE_Combobox)`
@@ -95,6 +103,8 @@ function ChangeTildeltVeilederModal({
 }: ChangeTildeltVeilederModalProps) {
   const [isError, setIsError] = useState(false);
   const { valgtEnhet } = useValgtEnhet();
+  const { data: aktivVeileder, isLoading: henterAktivVeileder } =
+    useAktivVeilederinfoQuery();
   const tildelVeileder = useTildelVeileder();
   const [selectedVeilederIdent, setSelectedVeilederIdent] = useState<
     string | undefined
@@ -105,7 +115,11 @@ function ChangeTildeltVeilederModal({
     data: veiledere,
   } = useVeiledereForValgtEnhetQuery();
 
-  const options = toVeilederOptions(veiledere || []);
+  const henterVeilederData = henterAktivVeileder || henterVeiledere;
+  const harVeiledere = !!veiledere && !!aktivVeileder;
+  const options = harVeiledere
+    ? toVeilederOptions(veiledere, aktivVeileder)
+    : [];
 
   const selectedOptions = () => {
     const selectedOption = options.find(
@@ -160,7 +174,7 @@ function ChangeTildeltVeilederModal({
         </Alert>
         <StyledCombobox
           shouldAutocomplete
-          isLoading={henterVeiledere}
+          isLoading={henterVeilederData}
           label={`${texts.modal.combobox.label} ${valgtEnhet}`}
           description={
             <>

--- a/src/components/TildeltVeileder.tsx
+++ b/src/components/TildeltVeileder.tsx
@@ -47,10 +47,10 @@ interface VeilederNavnProps {
 }
 
 function VeilederNavn({ tildeltVeilederident }: VeilederNavnProps) {
-  const veilederInfoQuery = useVeilederInfoQuery(tildeltVeilederident);
-  const veilederInfo = veilederInfoQuery.data;
+  const { isLoading, data: veilederInfo } =
+    useVeilederInfoQuery(tildeltVeilederident);
 
-  return veilederInfoQuery.isSuccess ? (
+  return !isLoading ? (
     <span>
       {veilederInfo
         ? `${veilederInfo?.fulltNavn()} (${tildeltVeilederident})`

--- a/src/data/veilederbrukerknytning/useTildelVeileder.ts
+++ b/src/data/veilederbrukerknytning/useTildelVeileder.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useValgtEnhet } from "@/context/ValgtEnhetContext";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { SYFOOVERSIKTSRV_PERSONTILDELING_ROOT } from "@/apiConstants";
 import { post } from "@/api/axios";
@@ -7,20 +6,16 @@ import { veilederBrukerKnytningQueryKeys } from "@/data/veilederbrukerknytning/u
 
 export const useTildelVeileder = () => {
   const personident = useValgtPersonident();
-  const { valgtEnhet } = useValgtEnhet();
   const queryClient = useQueryClient();
 
-  const path = `${SYFOOVERSIKTSRV_PERSONTILDELING_ROOT}/registrer`;
+  const path = `${SYFOOVERSIKTSRV_PERSONTILDELING_ROOT}/personer/single`;
   const postTildelVeileder = (veilederIdent: string) => {
     const veilederBrukerKnytning: VeilederBrukerKnytning = {
       veilederIdent: veilederIdent,
       fnr: personident,
-      enhet: valgtEnhet,
     };
 
-    return post(path, {
-      tilknytninger: [veilederBrukerKnytning],
-    });
+    return post(path, veilederBrukerKnytning);
   };
 
   return useMutation({
@@ -37,5 +32,4 @@ export const useTildelVeileder = () => {
 interface VeilederBrukerKnytning {
   veilederIdent: string;
   fnr: string;
-  enhet: string;
 }


### PR DESCRIPTION
Endrer til å bruke nytt [endepunkt](https://github.com/navikt/syfooversiktsrv/pull/427) for å registrere veilederknytning for enkeltperson.
Legger aktiv veilder øverst i lista med veiledere som kan velges.