### PR TITLE
IS-2620: Add page for sent forhandsvarsel

### DIFF
--- a/mock/ismanglendemedvirkning/mockIsmanglendemedvirkning.ts
+++ b/mock/ismanglendemedvirkning/mockIsmanglendemedvirkning.ts
@@ -3,14 +3,10 @@ import { ISMANGLENDEMEDVIRKNING_ROOT } from "../../src/apiConstants";
 import { NAV_PERSONIDENT_HEADER } from "../util/requestUtil";
 
 import { generateUUID } from "../../src/utils/uuidUtils";
-import {
-  ARBEIDSTAKER_DEFAULT,
-  VEILEDER_DEFAULT,
-} from "../common/mockConstants";
+import { VEILEDER_DEFAULT } from "../common/mockConstants";
 import {
   NewVurderingRequestDTO,
   VurderingResponseDTO,
-  VurderingType,
 } from "../../src/data/manglendemedvirkning/manglendeMedvirkningTypes";
 
 let manglendeMedvirkningVurderinger: VurderingResponseDTO[] = [];
@@ -56,18 +52,4 @@ export const mockIsmanglendemedvirkning = (server: any) => {
       res.status(201).send(JSON.stringify(sentVurdering));
     }
   );
-};
-
-const mockVurdering = {
-  uuid: generateUUID(),
-  personident: ARBEIDSTAKER_DEFAULT.personIdent,
-  createdAt: new Date(),
-  type: VurderingType.FORHANDSVARSEL,
-  begrunnelse: "Dette er en begrunnelse",
-  document: [],
-  varsel: {
-    uuid: generateUUID(),
-    createdAt: new Date(),
-    svarfrist: new Date(),
-  },
 };

--- a/src/routers/AppRouter.tsx
+++ b/src/routers/AppRouter.tsx
@@ -39,7 +39,12 @@ import DialogmoteEndreReferatContainer from "@/sider/dialogmoter/components/refe
 import { Arbeidsuforhet } from "@/sider/arbeidsuforhet/Arbeidsuforhet";
 import { ArbeidsuforhetIkkeAktuellSide } from "@/sider/arbeidsuforhet/ikkeaktuell/ArbeidsuforhetIkkeAktuellSide";
 import SenOppfolgingSide from "@/sider/senoppfolging/SenOppfolgingSide";
-import ManglendeMedvirkningSide from "@/sider/manglendemedvirkning/ManglendeMedvirkningSide";
+import ManglendeMedvirkningSide, {
+  ManglendeMedvirkningIkkeAktuellSide,
+  ManglendeMedvirkningOppfyltSide,
+  ManglendeMedvirkningStansSide,
+} from "@/sider/manglendemedvirkning/ManglendeMedvirkningSide";
+import ManglendeMedvirkning from "@/sider/manglendemedvirkning/ManglendeMedvirkning";
 
 export const appRoutePath = "/sykefravaer";
 
@@ -54,6 +59,9 @@ export const arbeidsuforhetPath = `${appRoutePath}/arbeidsuforhet`;
 export const frisktilarbeidPath = `${appRoutePath}/frisktilarbeid`;
 export const senOppfolgingPath = `${appRoutePath}/senoppfolging`;
 export const manglendeMedvirkningPath = `${appRoutePath}/manglendemedvirkning`;
+export const manglendeMedvirkningOppfyltPath = `${appRoutePath}/manglendemedvirkning/oppfylt`;
+export const manglendeMedvirkningStansPath = `${appRoutePath}/manglendemedvirkning/stans`;
+export const manglendeMedvirkningIkkeAktuellPath = `${appRoutePath}/manglendemedvirkning/ikkeaktuell`;
 
 const AktivBrukerRouter = (): ReactElement => {
   Amplitude.logViewportAndScreenSize();
@@ -153,7 +161,23 @@ const AktivBrukerRouter = (): ReactElement => {
           <Route path={senOppfolgingPath} element={<SenOppfolgingSide />} />
           <Route
             path={manglendeMedvirkningPath}
-            element={<ManglendeMedvirkningSide />}
+            element={
+              <ManglendeMedvirkningSide>
+                <ManglendeMedvirkning />
+              </ManglendeMedvirkningSide>
+            }
+          />
+          <Route
+            path={manglendeMedvirkningOppfyltPath}
+            element={<ManglendeMedvirkningOppfyltSide />}
+          />
+          <Route
+            path={manglendeMedvirkningStansPath}
+            element={<ManglendeMedvirkningStansSide />}
+          />
+          <Route
+            path={manglendeMedvirkningIkkeAktuellPath}
+            element={<ManglendeMedvirkningIkkeAktuellSide />}
           />
           <Route
             path={`${appRoutePath}/sykepengesoknader/:sykepengesoknadId`}

--- a/src/sider/manglendemedvirkning/ManglendeMedvirkning.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedvirkning.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import ForhandsvarselSkjema from "@/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSkjema";
+import { useManglendeMedvirkningVurderingQuery } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
+import { VurderingType } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
+import { Box } from "@navikt/ds-react";
+import ForhandsvarselSendt from "@/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSendt";
+
+export default function ManglendeMedvirkning() {
+  const { data } = useManglendeMedvirkningVurderingQuery();
+  const sisteVurdering = data[0];
+  const isForhandsvarsel =
+    sisteVurdering?.vurderingType === VurderingType.FORHANDSVARSEL;
+
+  return (
+    <Box>
+      {isForhandsvarsel ? (
+        <ForhandsvarselSendt sisteVurdering={sisteVurdering} />
+      ) : (
+        <ForhandsvarselSkjema />
+      )}
+    </Box>
+  );
+}

--- a/src/sider/manglendemedvirkning/ManglendeMedvirkningButtons.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedvirkningButtons.tsx
@@ -1,0 +1,44 @@
+import { Button, HStack } from "@navikt/ds-react";
+import { Link } from "react-router-dom";
+import {
+  manglendeMedvirkningIkkeAktuellPath,
+  manglendeMedvirkningOppfyltPath,
+  manglendeMedvirkningStansPath,
+} from "@/routers/AppRouter";
+import React from "react";
+
+const texts = {
+  avslag: "Innstilling om stans",
+  oppfylt: "Oppfylt",
+  ikkeAktuell: "Ikke aktuell",
+};
+
+interface Props {
+  isBeforeForhandsvarselDeadline: boolean;
+}
+
+export const ManglendeMedvirkningButtons = ({
+  isBeforeForhandsvarselDeadline,
+}: Props) => (
+  <HStack gap="4">
+    {isBeforeForhandsvarselDeadline ? (
+      <Button variant="primary" disabled>
+        {texts.avslag}
+      </Button>
+    ) : (
+      <Button as={Link} to={manglendeMedvirkningStansPath} variant="primary">
+        {texts.avslag}
+      </Button>
+    )}
+    <Button as={Link} to={manglendeMedvirkningOppfyltPath} variant="secondary">
+      {texts.oppfylt}
+    </Button>
+    <Button
+      as={Link}
+      to={manglendeMedvirkningIkkeAktuellPath}
+      variant="secondary"
+    >
+      {texts.ikkeAktuell}
+    </Button>
+  </HStack>
+);

--- a/src/sider/manglendemedvirkning/ManglendeMedvirkningSide.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedvirkningSide.tsx
@@ -3,14 +3,43 @@ import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import Sidetopp from "@/components/Sidetopp";
 import Side from "@/sider/Side";
 import SideLaster from "@/components/SideLaster";
-import ForhandsvarselSide from "@/sider/manglendemedvirkning/ForhandsvarselSide";
 import { useManglendeMedvirkningVurderingQuery } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
 
 const texts = {
   title: "Manglende medvirkning",
 };
 
-export default function ManglendeMedvirkningSide(): ReactElement {
+export function ManglendeMedvirkningOppfyltSide() {
+  return (
+    <ManglendeMedvirkningSide>
+      <div>Oppfylt</div>
+    </ManglendeMedvirkningSide>
+  );
+}
+
+export function ManglendeMedvirkningStansSide() {
+  return (
+    <ManglendeMedvirkningSide>
+      <div>Stans</div>
+    </ManglendeMedvirkningSide>
+  );
+}
+
+export function ManglendeMedvirkningIkkeAktuellSide() {
+  return (
+    <ManglendeMedvirkningSide>
+      <div>Ikke Aktuell</div>
+    </ManglendeMedvirkningSide>
+  );
+}
+
+interface Props {
+  children: ReactElement;
+}
+
+export default function ManglendeMedvirkningSide({
+  children,
+}: Props): ReactElement {
   const { isLoading, isError } = useManglendeMedvirkningVurderingQuery();
   return (
     <Side
@@ -19,7 +48,7 @@ export default function ManglendeMedvirkningSide(): ReactElement {
     >
       <Sidetopp tittel={texts.title} />
       <SideLaster henter={isLoading} hentingFeilet={isError}>
-        <ForhandsvarselSide />
+        {children}
       </SideLaster>
     </Side>
   );

--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselAfterDeadline.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselAfterDeadline.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { BodyShort, Box, Heading, HStack } from "@navikt/ds-react";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { BellIcon } from "@navikt/aksel-icons";
+import { useManglendeMedvirkningVurderingQuery } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
+import { ManglendeMedvirkningButtons } from "@/sider/manglendemedvirkning/ManglendeMedvirkningButtons";
+
+const texts = {
+  title: "Fristen er gått ut",
+  passertAlert: (sentDate: Date) =>
+    `Fristen for forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+      sentDate
+    )} er gått ut. Trykk på Innstilling om stans-knappen hvis vilkårene i § 8-8 ikke er oppfylt og rett til videre sykepenger skal stanses.`,
+  ikkeAktuell:
+    "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell.",
+  frist: "Fristen var: ",
+  seSendtVarsel: "Se sendt varsel",
+};
+
+export default function ForhandsvarselAfterDeadline() {
+  const { data } = useManglendeMedvirkningVurderingQuery();
+  const forhandsvarsel = data[0];
+  const frist = forhandsvarsel?.varsel?.svarfrist;
+
+  return (
+    <Box
+      background="surface-default"
+      padding="6"
+      className="flex flex-col gap-4"
+    >
+      <HStack align="center">
+        <Heading level="2" size="medium">
+          {texts.title}
+        </Heading>
+        <Box className="flex ml-auto mr-2 gap-1">
+          <BodyShort weight="semibold">{texts.frist}</BodyShort>
+          <BodyShort>{tilLesbarDatoMedArUtenManedNavn(frist)}</BodyShort>
+        </Box>
+        <BellIcon title="bjelleikon" fontSize="2em" />
+      </HStack>
+      <BodyShort>{texts.passertAlert(forhandsvarsel.createdAt)}</BodyShort>
+      <BodyShort>{texts.ikkeAktuell}</BodyShort>
+      <ManglendeMedvirkningButtons isBeforeForhandsvarselDeadline={false} />
+    </Box>
+  );
+}

--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselBeforeDeadline.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Alert, BodyShort, Box, Heading, HStack } from "@navikt/ds-react";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { ClockIcon } from "@navikt/aksel-icons";
+import { useManglendeMedvirkningVurderingQuery } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
+import { ManglendeMedvirkningButtons } from "@/sider/manglendemedvirkning/ManglendeMedvirkningButtons";
+
+const texts = {
+  title: "Venter på svar fra bruker",
+  sentAlert: {
+    isSent: (sentDate: Date) =>
+      `Forhåndsvarselet er sendt ${tilLesbarDatoMedArUtenManedNavn(sentDate)}.`,
+    oversikten:
+      "Personen ligger nå i oversikten og kan finnes under filteret for § 8-8 manglende medvirkning.",
+  },
+  sendtInfo:
+    "Dersom du har mottatt nye opplysninger og vurdert at bruker likevel oppfyller § 8-8, klikker du på Oppfylt-knappen.",
+  ikkeAktuell:
+    "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell.",
+  ikkeStans: "Du kan ikke stanse før fristen er gått ut.",
+  frist: "Fristen går ut: ",
+  seSendtVarsel: "Se sendt varsel",
+};
+
+export default function ForhandsvarselBeforeDeadline() {
+  const { data } = useManglendeMedvirkningVurderingQuery();
+  const forhandsvarsel = data[0];
+  const frist = forhandsvarsel?.varsel?.svarfrist;
+
+  return (
+    <Box>
+      <Alert variant="success" className="mb-2">
+        <BodyShort className="mb-0">
+          {texts.sentAlert.isSent(forhandsvarsel.createdAt)}
+        </BodyShort>
+        <BodyShort>{texts.sentAlert.oversikten}</BodyShort>
+      </Alert>
+      <Box
+        background="surface-default"
+        padding="6"
+        className="flex flex-col gap-4"
+      >
+        <HStack align="center">
+          <Heading level="2" size="medium">
+            {texts.title}
+          </Heading>
+          <Box className="flex ml-auto mr-2 gap-1">
+            <BodyShort weight="semibold">{texts.frist}</BodyShort>
+            <BodyShort>{tilLesbarDatoMedArUtenManedNavn(frist)}</BodyShort>
+          </Box>
+          <ClockIcon title="klokkeikon" fontSize="2em" />
+        </HStack>
+        <BodyShort>{texts.sendtInfo}</BodyShort>
+        <BodyShort>{texts.ikkeAktuell}</BodyShort>
+        <BodyShort>{texts.ikkeStans}</BodyShort>
+        <ManglendeMedvirkningButtons isBeforeForhandsvarselDeadline={true} />
+      </Box>
+    </Box>
+  );
+}

--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSendt.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSendt.tsx
@@ -1,0 +1,21 @@
+import { VurderingResponseDTO } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
+import dayjs from "dayjs";
+import React from "react";
+import ForhandsvarselBeforeDeadline from "@/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselBeforeDeadline";
+import ForhandsvarselAfterDeadline from "@/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselAfterDeadline";
+
+interface Props {
+  sisteVurdering: VurderingResponseDTO;
+}
+
+export default function ForhandsvarselSendt({ sisteVurdering }: Props) {
+  const isForhandsvarselExpired = dayjs(
+    sisteVurdering?.varsel?.svarfrist
+  ).isBefore(dayjs(new Date()), "date");
+
+  return isForhandsvarselExpired ? (
+    <ForhandsvarselAfterDeadline />
+  ) : (
+    <ForhandsvarselBeforeDeadline />
+  );
+}

--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSkjema.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSkjema.tsx
@@ -37,7 +37,7 @@ interface SkjemaValues {
   begrunnelse: string;
 }
 
-export default function ForhandsvarselSide() {
+export default function ForhandsvarselSkjema() {
   const personident = useValgtPersonident();
   const sendForhandsvarsel = useSendVurderingManglendeMedvirkning();
   const {

--- a/test/manglendemedvirkning/ManglendeMedvirkningTest.tsx
+++ b/test/manglendemedvirkning/ManglendeMedvirkningTest.tsx
@@ -1,5 +1,8 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { ARBEIDSTAKER_DEFAULT } from "../../mock/common/mockConstants";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  VEILEDER_DEFAULT,
+} from "../../mock/common/mockConstants";
 import { beforeEach, describe, expect, it } from "vitest";
 import { queryClientWithMockData } from "../testQueryClient";
 import { manglendeMedvirkningQueryKeys } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
@@ -10,18 +13,24 @@ import React, { ReactNode } from "react";
 import { changeTextInput, clickButton, getTextInput } from "../testUtils";
 import {
   NewVurderingRequestDTO,
+  VurderingResponseDTO,
   VurderingType,
 } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
-import { addWeeks } from "@/utils/datoUtils";
+import {
+  addDays,
+  addWeeks,
+  tilLesbarDatoMedArUtenManedNavn,
+} from "@/utils/datoUtils";
 import { NotificationProvider } from "@/context/notification/NotificationContext";
 import { renderWithRouter } from "../testRouterUtils";
 import { manglendeMedvirkningPath } from "@/routers/AppRouter";
-import ForhandsvarselSide from "@/sider/manglendemedvirkning/ForhandsvarselSide";
 import { getSendForhandsvarselDocument } from "./vurderingDocuments";
+import ManglendeMedvirkning from "@/sider/manglendemedvirkning/ManglendeMedvirkning";
+import { generateUUID } from "@/utils/uuidUtils";
 
 let queryClient: QueryClient;
 
-const renderManglendemedvirkningSide = (children: ReactNode, path: string) => {
+const renderManglendeMedvirkning = (children: ReactNode, path: string) => {
   return renderWithRouter(
     <QueryClientProvider client={queryClient}>
       <ValgtEnhetContext.Provider
@@ -35,21 +44,40 @@ const renderManglendemedvirkningSide = (children: ReactNode, path: string) => {
   );
 };
 
+function mockVurdering(vurdering?: VurderingResponseDTO) {
+  queryClient.setQueryData(
+    manglendeMedvirkningQueryKeys.manglendeMedvirkning(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
+    () => (vurdering ? [vurdering] : [])
+  );
+}
+
+const defaultVurdering: VurderingResponseDTO = {
+  uuid: generateUUID(),
+  personident: ARBEIDSTAKER_DEFAULT.personIdent,
+  createdAt: new Date(),
+  veilederident: VEILEDER_DEFAULT.ident,
+  vurderingType: VurderingType.FORHANDSVARSEL,
+  begrunnelse: "Dette er en begrunnelse",
+  document: [],
+  varsel: {
+    uuid: generateUUID(),
+    createdAt: new Date(),
+    svarfrist: addWeeks(new Date(), 3),
+  },
+};
+
 describe("Manglendemedvirkning", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
-    queryClient.setQueryData(
-      manglendeMedvirkningQueryKeys.manglendeMedvirkning(
-        ARBEIDSTAKER_DEFAULT.personIdent
-      ),
-      () => []
-    );
   });
 
-  describe("ForhandsvarselSide", () => {
-    it("skal vise forhandsvarsel side", () => {
-      renderManglendemedvirkningSide(
-        <ForhandsvarselSide />,
+  describe("ForhandsvarselSkjema", () => {
+    it("skal vise forhandsvarsel side når ingen tidligere vurderinger", () => {
+      mockVurdering();
+      renderManglendeMedvirkning(
+        <ManglendeMedvirkning />,
         manglendeMedvirkningPath
       );
 
@@ -63,9 +91,22 @@ describe("Manglendemedvirkning", () => {
       expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
     });
 
+    it("viser feil når man sender forhåndsvarsel uten å ha skrevet begrunnelse", async () => {
+      mockVurdering();
+      renderManglendeMedvirkning(
+        <ManglendeMedvirkning />,
+        manglendeMedvirkningPath
+      );
+
+      await clickButton("Send");
+
+      expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
+    });
+
     it("skal sende forhandsvarsel med riktige verdier", async () => {
-      renderManglendemedvirkningSide(
-        <ForhandsvarselSide />,
+      mockVurdering();
+      renderManglendeMedvirkning(
+        <ManglendeMedvirkning />,
         manglendeMedvirkningPath
       );
       const varselSvarfrist = addWeeks(new Date(), 3);
@@ -95,6 +136,87 @@ describe("Manglendemedvirkning", () => {
           document: expectedRequestBody.document,
         });
       });
+    });
+  });
+
+  describe("ForhandsvarselSendt", () => {
+    it("viser ForhandsvarselBeforeDeadline når svarfrist ikke utgått", () => {
+      mockVurdering(defaultVurdering);
+
+      renderManglendeMedvirkning(
+        <ManglendeMedvirkning />,
+        manglendeMedvirkningPath
+      );
+
+      expect(
+        screen.getByText(
+          `Forhåndsvarselet er sendt ${tilLesbarDatoMedArUtenManedNavn(
+            new Date()
+          )}.`
+        )
+      ).to.exist;
+      expect(screen.getByText("Venter på svar fra bruker")).to.exist;
+      expect(screen.getByText("Fristen går ut:")).to.exist;
+      expect(
+        screen.getByText(
+          "Dersom du har mottatt nye opplysninger og vurdert at bruker likevel oppfyller § 8-8, klikker du på Oppfylt-knappen."
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell."
+        )
+      ).to.exist;
+      expect(screen.getByText("Du kan ikke stanse før fristen er gått ut.")).to
+        .exist;
+      expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
+      expect(
+        screen.getByRole("button", { name: "Innstilling om stans" })
+      ).to.have.property("disabled", true);
+      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Ikke aktuell" })).to.exist;
+    });
+
+    it("viser ForhandsvarselAfterDeadline når svarfrist er utgått", () => {
+      const createdAt = addWeeks(new Date(), -3);
+      const svarfrist = addDays(new Date(), -1);
+      const forhandsvarselAfterFrist: VurderingResponseDTO = {
+        ...defaultVurdering,
+        createdAt: createdAt,
+        varsel: {
+          uuid: generateUUID(),
+          createdAt: createdAt,
+          svarfrist: svarfrist,
+        },
+      };
+      mockVurdering(forhandsvarselAfterFrist);
+
+      renderManglendeMedvirkning(
+        <ManglendeMedvirkning />,
+        manglendeMedvirkningPath
+      );
+
+      expect(screen.getByText("Fristen er gått ut")).to.exist;
+      expect(screen.getByText("Fristen var:")).to.exist;
+      expect(screen.getByText(tilLesbarDatoMedArUtenManedNavn(svarfrist))).to
+        .exist;
+      expect(screen.getByRole("img", { name: "bjelleikon" })).to.exist;
+      expect(
+        screen.getByText(
+          `Fristen for forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
+            createdAt
+          )} er gått ut. Trykk på Innstilling om stans-knappen hvis vilkårene i § 8-8 ikke er oppfylt og rett til videre sykepenger skal stanses.`
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell."
+        )
+      ).to.exist;
+      expect(screen.getByRole("button", { name: "Innstilling om stans" })).to
+        .exist;
+      expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
+      expect(screen.getByRole("button", { name: "Ikke aktuell" })).to.exist;
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Egen side som sjekker om det er blitt sendt forhåndsvarsel, og i så fall viser sider for om fristen for varselet er utgått eller ikke. Har også satt opp routes for `/oppfylt`, `/stans` og `/ikkeaktuell` slik at man kan begynne på disse hvis man ønsker i parallell.

Gjort litt opprydninger her på styling og tekster basert på hvordan det så ut i arbeidsuførhet-sidene, som jeg tenker å endre der også i en egen PR. Avklares med Stine også.

### Screenshots 📸✨
Før frist:
<img width="1260" alt="image" src="https://github.com/user-attachments/assets/4508fdc1-664d-497b-8ccc-378fa4e117e4">

Etter frist:
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/b8913c75-4002-421f-b026-754f3ec536ac">


