### PR TITLE
IS-2698: Add støttetekst manglende medvirkning

### DIFF
--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselAfterDeadline.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselAfterDeadline.tsx
@@ -4,15 +4,10 @@ import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { BellIcon } from "@navikt/aksel-icons";
 import { ManglendeMedvirkningButtons } from "@/sider/manglendemedvirkning/ManglendeMedvirkningButtons";
 import { VurderingResponseDTO } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
+import SupportingTextList from "@/sider/manglendemedvirkning/forhandsvarsel/SupportingTextList";
 
 const texts = {
   title: "Fristen er gått ut",
-  passertAlert: (sentDate: Date) =>
-    `Fristen for forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
-      sentDate
-    )} er gått ut. Trykk på Innstilling om stans-knappen hvis vilkårene i § 8-8 ikke er oppfylt og rett til videre sykepenger skal stanses.`,
-  ikkeAktuell:
-    "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell.",
   frist: "Fristen var: ",
   seSendtVarsel: "Se sendt varsel",
 };
@@ -40,8 +35,7 @@ export default function ForhandsvarselAfterDeadline({ forhandsvarsel }: Props) {
         </Box>
         <BellIcon title="bjelleikon" fontSize="2em" />
       </HStack>
-      <BodyShort>{texts.passertAlert(forhandsvarsel.createdAt)}</BodyShort>
-      <BodyShort>{texts.ikkeAktuell}</BodyShort>
+      <SupportingTextList isBeforeForhandsvarselDeadline={false} />
       <ManglendeMedvirkningButtons isBeforeForhandsvarselDeadline={false} />
     </Box>
   );

--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselBeforeDeadline.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselBeforeDeadline.tsx
@@ -4,6 +4,7 @@ import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { ClockIcon } from "@navikt/aksel-icons";
 import { ManglendeMedvirkningButtons } from "@/sider/manglendemedvirkning/ManglendeMedvirkningButtons";
 import { VurderingResponseDTO } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
+import SupportingTextList from "@/sider/manglendemedvirkning/forhandsvarsel/SupportingTextList";
 
 const texts = {
   title: "Venter på svar fra bruker",
@@ -13,11 +14,7 @@ const texts = {
     oversikten:
       "Personen ligger nå i oversikten og kan finnes under filteret for § 8-8 manglende medvirkning.",
   },
-  sendtInfo:
-    "Dersom du har mottatt nye opplysninger og vurdert at bruker likevel oppfyller § 8-8, klikker du på Oppfylt-knappen.",
-  ikkeAktuell:
-    "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell.",
-  ikkeStans: "Du kan ikke stanse før fristen er gått ut.",
+  ikkeStans: "Du kan ikke stanse før fristen i forhåndsvarselet er gått ut.",
   frist: "Fristen går ut: ",
   seSendtVarsel: "Se sendt varsel",
 };
@@ -54,9 +51,8 @@ export default function ForhandsvarselBeforeDeadline({
           </Box>
           <ClockIcon title="klokkeikon" fontSize="2em" />
         </HStack>
-        <BodyShort>{texts.sendtInfo}</BodyShort>
-        <BodyShort>{texts.ikkeAktuell}</BodyShort>
         <BodyShort>{texts.ikkeStans}</BodyShort>
+        <SupportingTextList isBeforeForhandsvarselDeadline={true} />
         <ManglendeMedvirkningButtons isBeforeForhandsvarselDeadline={true} />
       </Box>
     </Box>

--- a/src/sider/manglendemedvirkning/forhandsvarsel/SupportingTextList.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/SupportingTextList.tsx
@@ -1,0 +1,55 @@
+import { List } from "@navikt/ds-react";
+import React from "react";
+
+const texts = {
+  listTitle: "Følgende alternativer er tilgjengelig:",
+  stans: {
+    bold: "Stans",
+    text: " dersom vilkårene i § 8-8 ikke er oppfylt og rett til videre sykepenger skal stanses.",
+  },
+  oppfylt: {
+    bold: "Oppfylt",
+    text: " dersom bruker har startet å medvirke, og oppfyller medvirkningsplikten.",
+  },
+  unntak: {
+    bold: "Unntak",
+    text: " dersom bruker har rimelig grunn til ikke å medvirke, og dermed er unntatt medvirkningsplikten.",
+  },
+  ikkeAktuell: {
+    bold: "Ikke aktuell",
+    text: " dersom det ikke lenger er aktuelt å vurdere medvirkningsplikten, for eksempel ved friskmelding.",
+  },
+};
+
+interface Props {
+  isBeforeForhandsvarselDeadline: boolean;
+}
+
+export default function SupportingTextList({
+  isBeforeForhandsvarselDeadline,
+}: Props) {
+  return (
+    <List as="ul" title={texts.listTitle}>
+      {isBeforeForhandsvarselDeadline ? (
+        ""
+      ) : (
+        <List.Item>
+          <span className="font-semibold">{texts.stans.bold}</span>
+          {texts.stans.text}
+        </List.Item>
+      )}
+      <List.Item>
+        <span className="font-semibold">{texts.oppfylt.bold}</span>
+        {texts.oppfylt.text}
+      </List.Item>
+      <List.Item>
+        <span className="font-semibold">{texts.unntak.bold}</span>
+        {texts.unntak.text}
+      </List.Item>
+      <List.Item>
+        <span className="font-semibold">{texts.ikkeAktuell.bold}</span>
+        {texts.ikkeAktuell.text}
+      </List.Item>
+    </List>
+  );
+}

--- a/test/manglendemedvirkning/ForhandsvarselTest.tsx
+++ b/test/manglendemedvirkning/ForhandsvarselTest.tsx
@@ -122,16 +122,26 @@ describe("Manglendemedvirkning Forhandsvarsel", () => {
       expect(screen.getByText("Fristen går ut:")).to.exist;
       expect(
         screen.getByText(
-          "Dersom du har mottatt nye opplysninger og vurdert at bruker likevel oppfyller § 8-8, klikker du på Oppfylt-knappen."
+          "Du kan ikke stanse før fristen i forhåndsvarselet er gått ut."
+        )
+      ).to.exist;
+      expect(screen.getByText("Følgende alternativer er tilgjengelig:")).to
+        .exist;
+      expect(
+        screen.getByText(
+          "dersom bruker har startet å medvirke, og oppfyller medvirkningsplikten."
         )
       ).to.exist;
       expect(
         screen.getByText(
-          "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell."
+          "dersom bruker har rimelig grunn til ikke å medvirke, og dermed er unntatt medvirkningsplikten."
         )
       ).to.exist;
-      expect(screen.getByText("Du kan ikke stanse før fristen er gått ut.")).to
-        .exist;
+      expect(
+        screen.getByText(
+          "dersom det ikke lenger er aktuelt å vurdere medvirkningsplikten, for eksempel ved friskmelding."
+        )
+      ).to.exist;
       expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
       expect(
         screen.getByRole("button", { name: "Innstilling om stans" })
@@ -159,16 +169,26 @@ describe("Manglendemedvirkning Forhandsvarsel", () => {
       expect(screen.getByText(tilLesbarDatoMedArUtenManedNavn(svarfrist))).to
         .exist;
       expect(screen.getByRole("img", { name: "bjelleikon" })).to.exist;
+      expect(screen.getByText("Følgende alternativer er tilgjengelig:")).to
+        .exist;
       expect(
         screen.getByText(
-          `Fristen for forhåndsvarselet som ble sendt ut ${tilLesbarDatoMedArUtenManedNavn(
-            createdAt
-          )} er gått ut. Trykk på Innstilling om stans-knappen hvis vilkårene i § 8-8 ikke er oppfylt og rett til videre sykepenger skal stanses.`
+          "dersom vilkårene i § 8-8 ikke er oppfylt og rett til videre sykepenger skal stanses."
         )
       ).to.exist;
       expect(
         screen.getByText(
-          "Velg Ikke aktuell-knappen dersom personen har blitt friskmeldt etter at forhåndsvarselet ble sendt ut, eller av andre årsaker ikke er aktuell."
+          "dersom bruker har startet å medvirke, og oppfyller medvirkningsplikten."
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          "dersom bruker har rimelig grunn til ikke å medvirke, og dermed er unntatt medvirkningsplikten."
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          "dersom det ikke lenger er aktuelt å vurdere medvirkningsplikten, for eksempel ved friskmelding."
         )
       ).to.exist;
       expect(screen.getByRole("button", { name: "Innstilling om stans" })).to


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til støttetekst på knappene 'innstilling om stans', 'oppfylt', 'unntak' og 'ikke aktuell' i hovedbilde. 

### Screenshots 📸✨
Før forhåndsvarselet har gått ut:
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/b6c5f390-6f37-427a-aa7c-7c51d8497738">

Etter forhåndsvarselet har gått ut:
<img width="1254" alt="image" src="https://github.com/user-attachments/assets/2809e9ee-8297-4afe-a6e8-5e48b1543758">