### PR TITLE
IS-2617: add demo link

### DIFF
--- a/src/sider/senoppfolging/OvingssideLink.tsx
+++ b/src/sider/senoppfolging/OvingssideLink.tsx
@@ -1,0 +1,31 @@
+import { Box, Heading, HelpText } from "@navikt/ds-react";
+import React from "react";
+import { EksternLenke } from "@/components/EksternLenke";
+
+const texts = {
+  heading: "Øvingsside for Snart slutt på sykepengene",
+  link: "Se nyeste versjon av svarskjemaet her",
+  helpTextTitle: "Hvorfor kan øvingssiden avvike fra den sykmeldtes svar?",
+  helpText: "Bruker kan ha svart på en tidligere versjon av svarskjemaet.",
+};
+
+const demoUrl =
+  "https://demo.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene";
+
+export default function OvingssideLink() {
+  return (
+    <Box
+      background="surface-default"
+      padding="6"
+      className="flex flex-col gap-4 mb-2"
+    >
+      <div className="flex items-center gap-2">
+        <Heading level="2" size="medium">
+          {texts.heading}
+        </Heading>
+        <HelpText title={texts.helpTextTitle}>{texts.helpText}</HelpText>
+      </div>
+      <EksternLenke href={demoUrl}>{texts.link}</EksternLenke>
+    </Box>
+  );
+}

--- a/src/sider/senoppfolging/OvingssideLink.tsx
+++ b/src/sider/senoppfolging/OvingssideLink.tsx
@@ -1,12 +1,12 @@
-import { Box, Heading, HelpText } from "@navikt/ds-react";
+import { BodyShort, Box, Heading } from "@navikt/ds-react";
 import React from "react";
 import { EksternLenke } from "@/components/EksternLenke";
 
 const texts = {
-  heading: "Øvingsside for Snart slutt på sykepengene",
+  heading: "Sykmeldtes svarskjema",
   link: "Se nyeste versjon av svarskjemaet her",
-  helpTextTitle: "Hvorfor kan øvingssiden avvike fra den sykmeldtes svar?",
-  helpText: "Bruker kan ha svart på en tidligere versjon av svarskjemaet.",
+  linkDesc:
+    "Lenken tar deg til en øvingsside der du trygt kan klikke deg rundt i skjemaet som den sykmeldte svarer på.",
 };
 
 const demoUrl =
@@ -19,13 +19,15 @@ export default function OvingssideLink() {
       padding="6"
       className="flex flex-col gap-4 mb-2"
     >
-      <div className="flex items-center gap-2">
-        <Heading level="2" size="medium">
-          {texts.heading}
-        </Heading>
-        <HelpText title={texts.helpTextTitle}>{texts.helpText}</HelpText>
+      <Heading level="2" size="medium">
+        {texts.heading}
+      </Heading>
+      <div>
+        <EksternLenke href={demoUrl}>{texts.link}</EksternLenke>
+        <BodyShort size="small" className="my-2">
+          {texts.linkDesc}
+        </BodyShort>
       </div>
-      <EksternLenke href={demoUrl}>{texts.link}</EksternLenke>
     </Box>
   );
 }

--- a/src/sider/senoppfolging/SenOppfolging.tsx
+++ b/src/sider/senoppfolging/SenOppfolging.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/data/senoppfolging/senOppfolgingTypes";
 import { VeiledningRutine } from "@/sider/senoppfolging/VeiledningRutine";
 import { NewVurderingForm } from "@/sider/senoppfolging/NewVurderingForm";
+import OvingssideLink from "@/sider/senoppfolging/OvingssideLink";
 
 const texts = {
   ikkeVarslet: {
@@ -45,6 +46,7 @@ export default function SenOppfolging(): ReactElement {
       </Tredelt.FirstColumn>
       <Tredelt.SecondColumn>
         <VeiledningRutine />
+        <OvingssideLink />
       </Tredelt.SecondColumn>
     </Tredelt.Container>
   ) : (

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -152,4 +152,27 @@ describe("Sen oppfolging", () => {
       begrunnelse: "En flott begrunnelse",
     });
   });
+
+  it("Viser link til ovingsside for snart slutt pa sykepengene", () => {
+    mockSenOppfolgingSvar();
+    mockSenOppfolgingKandidat(senOppfolgingKandidatMock);
+    renderSenOppfolging();
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Øvingsside for Snart slutt på sykepengene",
+      })
+    ).to.exist;
+    expect(
+      screen.getByText(
+        "Bruker kan ha svart på en tidligere versjon av svarskjemaet."
+      )
+    ).to.exist;
+    const link = screen.getByRole("link", {
+      name: "Se nyeste versjon av svarskjemaet her Ekstern lenke",
+    });
+    expect(link.getAttribute("href")).to.contain(
+      "https://demo.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene"
+    );
+  });
 });

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -160,13 +160,8 @@ describe("Sen oppfolging", () => {
 
     expect(
       screen.getByRole("heading", {
-        name: "Øvingsside for Snart slutt på sykepengene",
+        name: "Sykmeldtes svarskjema",
       })
-    ).to.exist;
-    expect(
-      screen.getByText(
-        "Bruker kan ha svart på en tidligere versjon av svarskjemaet."
-      )
     ).to.exist;
     const link = screen.getByRole("link", {
       name: "Se nyeste versjon av svarskjemaet her Ekstern lenke",
@@ -174,5 +169,10 @@ describe("Sen oppfolging", () => {
     expect(link.getAttribute("href")).to.contain(
       "https://demo.ekstern.dev.nav.no/syk/meroppfolging/snart-slutt-pa-sykepengene"
     );
+    expect(
+      screen.getByText(
+        "Lenken tar deg til en øvingsside der du trygt kan klikke deg rundt i skjemaet som den sykmeldte svarer på."
+      )
+    ).to.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til link til esyfo sin demo av svarskjemaet. 

### Screenshots 📸✨
<img width="1197" alt="image" src="https://github.com/user-attachments/assets/1884616b-e392-4b0a-aa95-1c9267b144b0">

For å forstå tråden under lar jeg bare disse gamle screenshottene ligge litt lengre: 
<img width="1435" alt="image" src="https://github.com/user-attachments/assets/9d0f08a3-2ec1-44b8-ab65-58a6ed77215d">

Hjelpetekst:
<img width="581" alt="image" src="https://github.com/user-attachments/assets/c918e89a-85b0-4579-8377-74d65fe3790c">
