### PR TITLE
IS-2617: count demo link click amplitude

### DIFF
--- a/src/components/EksternLenke.tsx
+++ b/src/components/EksternLenke.tsx
@@ -1,6 +1,8 @@
 import { ExternalLinkIcon } from "@navikt/aksel-icons";
 import { Link } from "@navikt/ds-react";
 import React, { ReactNode } from "react";
+import * as Amplitude from "@/utils/amplitude";
+import { EventType } from "@/utils/amplitude";
 
 interface Props {
   href: string;
@@ -9,12 +11,23 @@ interface Props {
 }
 
 export function EksternLenke({ href, children, className }: Props) {
+  function countLinkClick() {
+    Amplitude.logEvent({
+      type: EventType.LinkClick,
+      data: {
+        sideUrl: window.location.href,
+        destinasjonUrl: href,
+      },
+    });
+  }
+
   return (
     <Link
       href={href}
       className={className}
       target="_blank"
       rel="noopener noreferrer"
+      onClick={countLinkClick}
     >
       {children}
       <ExternalLinkIcon title="Ekstern lenke" fontSize="1.5em" />

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -17,6 +17,7 @@ export enum EventType {
   IkkeAktuellVurderingArsak = "Ikke aktuell vurdering arsak",
   ViewPortAndScreenResolution = "viewport og skjermstørrelse",
   OptionSelected = "alternativ valgt",
+  LinkClick = "lenke klikket",
 }
 
 type EventPageView = {
@@ -98,6 +99,14 @@ type OptionSelected = {
   };
 };
 
+type LinkClick = {
+  type: EventType.LinkClick;
+  data: {
+    sideUrl: string;
+    destinasjonUrl: string;
+  };
+};
+
 type Event =
   | EventPageView
   | EventButtonClick
@@ -107,7 +116,8 @@ type Event =
   | OppfolgingsgrunnSendt
   | OppfolgingsoppgaveEdited
   | IkkeAktuellVurderingArsak
-  | OptionSelected;
+  | OptionSelected
+  | LinkClick;
 
 export const logEvent = (event: Event) =>
   amplitude.track(event.type, { ...event.data });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Nå teller amplitude alle klikk på eksterne linker. Vi ønsker å se hvor mange som klikker på demo side linken, men la det til på alle eksterne linker samtidig. 

