### PR TITLE
IS-2687: Vise rød prikk når sen oppfolging-kandidat med svar

### DIFF
--- a/src/data/senoppfolging/senOppfolgingTypes.ts
+++ b/src/data/senoppfolging/senOppfolgingTypes.ts
@@ -17,8 +17,20 @@ export interface SenOppfolgingKandidatResponseDTO {
   uuid: string;
   personident: string;
   createdAt: Date;
+  varselAt: Date | undefined;
+  svar: SvarResponseDTO | undefined;
   status: SenOppfolgingStatus;
   vurderinger: SenOppfolgingVurderingResponseDTO[];
+}
+
+export interface SvarResponseDTO {
+  svarAt: Date;
+  onskerOppfolging: OnskerOppfolging;
+}
+
+export enum OnskerOppfolging {
+  JA = "JA",
+  NEI = "NEI",
 }
 
 export interface SenOppfolgingVurderingResponseDTO {

--- a/src/data/senoppfolging/useSenOppfolgingSvarQuery.ts
+++ b/src/data/senoppfolging/useSenOppfolgingSvarQuery.ts
@@ -13,7 +13,7 @@ export const useSenOppfolgingSvarQuery = () => {
   const fnr = useValgtPersonident();
   const path = `${MEROPPFOLGING_BACKEND_ROOT}/senoppfolging/formresponse`;
   const getSenOppfolgingSvar = () =>
-    get<SenOppfolgingFormResponseDTOV2>(path, fnr);
+    get<SenOppfolgingFormResponseDTOV2 | undefined>(path, fnr);
 
   return useQuery({
     queryKey: senOppfolgingSvarQueryKeys.senOppfolgingSvar(fnr),

--- a/src/mocks/ismeroppfolging/mockIsmeroppfolging.ts
+++ b/src/mocks/ismeroppfolging/mockIsmeroppfolging.ts
@@ -1,5 +1,6 @@
 import { ISMEROPPFOLGING_ROOT } from "@/apiConstants";
 import {
+  OnskerOppfolging,
   SenOppfolgingKandidatResponseDTO,
   SenOppfolgingStatus,
   SenOppfolgingVurderingRequestDTO,
@@ -46,6 +47,11 @@ export const senOppfolgingKandidatMock: SenOppfolgingKandidatResponseDTO = {
   createdAt: new Date(),
   personident: ARBEIDSTAKER_DEFAULT.personIdent,
   status: SenOppfolgingStatus.KANDIDAT,
+  varselAt: new Date(),
+  svar: {
+    svarAt: new Date(),
+    onskerOppfolging: OnskerOppfolging.JA,
+  },
   vurderinger: [],
 };
 

--- a/src/sider/senoppfolging/KandidatFormResponse.tsx
+++ b/src/sider/senoppfolging/KandidatFormResponse.tsx
@@ -1,0 +1,31 @@
+import { useSenOppfolgingSvarQuery } from "@/data/senoppfolging/useSenOppfolgingSvarQuery";
+import { Alert, BodyShort, Label, Loader } from "@navikt/ds-react";
+import React from "react";
+
+const texts = {
+  pending: "Henter spørsmål og svar...",
+  error:
+    "Noe gikk galt ved henting av spørsmål og svar. Vennligst prøv igjen senere.",
+};
+
+export function KandidatFormResponse() {
+  const { data, isPending, isError } = useSenOppfolgingSvarQuery();
+
+  if (isPending) {
+    return <Loader size="xlarge" title={texts.pending} />;
+  }
+  if (isError || !data) {
+    return (
+      <Alert size="small" inline variant="error">
+        {texts.error}
+      </Alert>
+    );
+  }
+
+  return data.questionResponses.map((response, index) => (
+    <div key={index}>
+      <Label size="small">{response.questionText}</Label>
+      <BodyShort size="small">{response.answerText}</BodyShort>
+    </div>
+  ));
+}

--- a/src/sider/senoppfolging/KandidatSvar.tsx
+++ b/src/sider/senoppfolging/KandidatSvar.tsx
@@ -1,18 +1,53 @@
-import { SenOppfolgingFormResponseDTOV2 } from "@/data/senoppfolging/senOppfolgingTypes";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
-import { BodyShort, Box, Heading, Label } from "@navikt/ds-react";
+import {
+  Alert,
+  BodyShort,
+  Box,
+  Heading,
+  Label,
+  Loader,
+} from "@navikt/ds-react";
 import React from "react";
+import { useSenOppfolgingSvarQuery } from "@/data/senoppfolging/useSenOppfolgingSvarQuery";
+import { SvarResponseDTO } from "@/data/senoppfolging/senOppfolgingTypes";
 
 const texts = {
   heading: "Sykmeldtes svar",
+  formResponse: {
+    pending: "Henter spørsmål og svar...",
+    error:
+      "Noe gikk galt ved henting av spørsmål og svar. Vennligst prøv igjen senere.",
+  },
 };
 
+function KandidatFormResponse() {
+  const { data, isPending, isError } = useSenOppfolgingSvarQuery();
+
+  if (isPending) {
+    return <Loader size="xlarge" title={texts.formResponse.pending} />;
+  }
+  if (isError || !data) {
+    return (
+      <Alert size="small" inline variant="error">
+        {texts.formResponse.error}
+      </Alert>
+    );
+  }
+
+  return data.questionResponses.map((response, index) => (
+    <div key={index}>
+      <Label size="small">{response.questionText}</Label>
+      <BodyShort size="small">{response.answerText}</BodyShort>
+    </div>
+  ));
+}
+
 interface KandidatSvarProps {
-  svar: SenOppfolgingFormResponseDTOV2;
+  svar: SvarResponseDTO;
 }
 
 export function KandidatSvar({ svar }: KandidatSvarProps) {
-  const svardato = svar && tilLesbarDatoMedArUtenManedNavn(svar.createdAt);
+  const svardato = svar && tilLesbarDatoMedArUtenManedNavn(svar.svarAt);
   return (
     <Box
       background="surface-default"
@@ -21,13 +56,7 @@ export function KandidatSvar({ svar }: KandidatSvarProps) {
     >
       <Heading size="medium">{texts.heading}</Heading>
       <BodyShort size="small">Den sykmeldte svarte {svardato}.</BodyShort>
-      {svar &&
-        svar?.questionResponses.map((response, index) => (
-          <div key={index}>
-            <Label size="small">{response.questionText}</Label>
-            <BodyShort size="small">{response.answerText}</BodyShort>
-          </div>
-        ))}
+      <KandidatFormResponse />
     </Box>
   );
 }

--- a/src/sider/senoppfolging/KandidatSvar.tsx
+++ b/src/sider/senoppfolging/KandidatSvar.tsx
@@ -1,46 +1,12 @@
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
-import {
-  Alert,
-  BodyShort,
-  Box,
-  Heading,
-  Label,
-  Loader,
-} from "@navikt/ds-react";
+import { BodyShort, Box, Heading } from "@navikt/ds-react";
 import React from "react";
-import { useSenOppfolgingSvarQuery } from "@/data/senoppfolging/useSenOppfolgingSvarQuery";
 import { SvarResponseDTO } from "@/data/senoppfolging/senOppfolgingTypes";
+import { KandidatFormResponse } from "@/sider/senoppfolging/KandidatFormResponse";
 
 const texts = {
   heading: "Sykmeldtes svar",
-  formResponse: {
-    pending: "Henter spørsmål og svar...",
-    error:
-      "Noe gikk galt ved henting av spørsmål og svar. Vennligst prøv igjen senere.",
-  },
 };
-
-function KandidatFormResponse() {
-  const { data, isPending, isError } = useSenOppfolgingSvarQuery();
-
-  if (isPending) {
-    return <Loader size="xlarge" title={texts.formResponse.pending} />;
-  }
-  if (isError || !data) {
-    return (
-      <Alert size="small" inline variant="error">
-        {texts.formResponse.error}
-      </Alert>
-    );
-  }
-
-  return data.questionResponses.map((response, index) => (
-    <div key={index}>
-      <Label size="small">{response.questionText}</Label>
-      <BodyShort size="small">{response.answerText}</BodyShort>
-    </div>
-  ));
-}
 
 interface KandidatSvarProps {
   svar: SvarResponseDTO;
@@ -48,6 +14,7 @@ interface KandidatSvarProps {
 
 export function KandidatSvar({ svar }: KandidatSvarProps) {
   const svardato = svar && tilLesbarDatoMedArUtenManedNavn(svar.svarAt);
+
   return (
     <Box
       background="surface-default"

--- a/src/sider/senoppfolging/SenOppfolging.tsx
+++ b/src/sider/senoppfolging/SenOppfolging.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from "react";
 import { BodyShort, Box } from "@navikt/ds-react";
-import { useSenOppfolgingSvarQuery } from "@/data/senoppfolging/useSenOppfolgingSvarQuery";
 import { useSenOppfolgingKandidatQuery } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
 import { KandidatSvar } from "@/sider/senoppfolging/KandidatSvar";
 import { VurdertKandidat } from "@/sider/senoppfolging/VurdertKandidat";
@@ -25,16 +24,16 @@ const texts = {
 };
 
 export default function SenOppfolging(): ReactElement {
-  const { data: svar } = useSenOppfolgingSvarQuery();
   const { data: kandidater } = useSenOppfolgingKandidatQuery();
   const kandidat = kandidater[0];
+  const svar = kandidat?.svar;
   const isFerdigbehandlet =
     kandidat?.status === SenOppfolgingStatus.FERDIGBEHANDLET;
   const ferdigbehandletVurdering = kandidat?.vurderinger.find(
     (vurdering) => vurdering.type === SenOppfolgingVurderingType.FERDIGBEHANDLET
   );
 
-  return svar && kandidat ? (
+  return svar ? (
     <Tredelt.Container>
       <Tredelt.FirstColumn>
         <KandidatSvar svar={svar} />

--- a/src/sider/senoppfolging/SenOppfolgingSide.tsx
+++ b/src/sider/senoppfolging/SenOppfolgingSide.tsx
@@ -4,7 +4,6 @@ import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import Sidetopp from "@/components/Sidetopp";
 import SenOppfolging from "@/sider/senoppfolging/SenOppfolging";
 import SideLaster from "@/components/SideLaster";
-import { useSenOppfolgingSvarQuery } from "@/data/senoppfolging/useSenOppfolgingSvarQuery";
 import { useSenOppfolgingKandidatQuery } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
 
 const texts = {
@@ -12,13 +11,7 @@ const texts = {
 };
 
 export default function SenOppfolgingSide(): ReactElement {
-  const { isError: hentSvarFeilet, isPending: henterSvar } =
-    useSenOppfolgingSvarQuery();
-  const { isError: hentKandidatFeilet, isPending: henterKandidat } =
-    useSenOppfolgingKandidatQuery();
-
-  const isPending = henterKandidat || henterSvar;
-  const isError = hentKandidatFeilet || hentSvarFeilet;
+  const { isError, isPending } = useSenOppfolgingKandidatQuery();
 
   return (
     <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.SENOPPFOLGING}>

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -119,11 +119,15 @@ const getNumberOfArbeidsuforhetOppgaver = (
 };
 
 function getNumberOfActiveSenOppfolgingOppgaver(
-  senOppfolgingKandidat: SenOppfolgingKandidatResponseDTO[]
+  senOppfolgingKandidatResponseDTO: SenOppfolgingKandidatResponseDTO[]
 ) {
-  return senOppfolgingKandidat[0]?.status === SenOppfolgingStatus.KANDIDAT
-    ? 1
-    : 0;
+  const senOppfolgingKandidat: SenOppfolgingKandidatResponseDTO | undefined =
+    senOppfolgingKandidatResponseDTO[0];
+  const isActiveSenOppfolgingOppgave =
+    senOppfolgingKandidat?.status === SenOppfolgingStatus.KANDIDAT &&
+    !!senOppfolgingKandidat.svar;
+
+  return isActiveSenOppfolgingOppgave ? 1 : 0;
 }
 
 function getNumberOfFriskmeldingTilArbeidsformidlingOppgaver(

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -54,6 +54,13 @@ import {
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: QueryClient;
 
+const mockUnleashWithFeatureToggles = () => {
+  queryClient.setQueryData(
+    unleashQueryKeys.toggles(navEnhet.id, ""),
+    () => mockUnleashResponse
+  );
+};
+
 const renderGlobalNavigasjon = () =>
   render(
     <QueryClientProvider client={queryClient}>
@@ -275,14 +282,11 @@ describe("GlobalNavigasjon", () => {
     expect(screen.getByRole("link", { name: "Arbeidsuførhet" })).to.exist;
   });
 
-  it('viser en rød prikk for menypunkt "Snart slutt på sykepengene" når aktiv kandidat', () => {
+  it('viser en rød prikk for menypunkt "Snart slutt på sykepengene" når kandidat med svar', () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(
       senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
       () => [senOppfolgingKandidatMock]
-    );
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
     );
     renderGlobalNavigasjon();
 
@@ -291,13 +295,27 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser ikke en rød prikk for menypunkt "Snart slutt på sykepengene" når kandidat er ferdigbehandlet', () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(
       senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
       () => [ferdigbehandletKandidatMock]
     );
+    renderGlobalNavigasjon();
+
+    expect(screen.getByRole("link", { name: "Snart slutt på sykepengene" })).to
+      .exist;
+  });
+
+  it("viser ikke en rød prikk for menypunkt Snart slutt på sykepengene når kandidat uten svar", () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
+      senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
+      () => [
+        {
+          ...senOppfolgingKandidatMock,
+          svar: undefined,
+        },
+      ]
     );
     renderGlobalNavigasjon();
 
@@ -306,13 +324,10 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ikke ferdigbehandlet', () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => [
       defaultVedtak,
     ]);
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
-    );
     renderGlobalNavigasjon();
 
     expect(
@@ -321,6 +336,7 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ferdigbehandlet', () => {
+    mockUnleashWithFeatureToggles();
     const ferdigbehandletVedtak: VedtakResponseDTO = {
       ...defaultVedtak,
       ferdigbehandletAt: new Date(),
@@ -329,10 +345,6 @@ describe("GlobalNavigasjon", () => {
     queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => [
       ferdigbehandletVedtak,
     ]);
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
-    );
     renderGlobalNavigasjon();
 
     expect(
@@ -341,6 +353,7 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når bare ett av ferdigbehandletfeltene finnes', () => {
+    mockUnleashWithFeatureToggles();
     const ferdigbehandletVedtak: VedtakResponseDTO = {
       ...defaultVedtak,
       ferdigbehandletAt: new Date(),
@@ -348,10 +361,6 @@ describe("GlobalNavigasjon", () => {
     queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => [
       ferdigbehandletVedtak,
     ]);
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
-    );
     renderGlobalNavigasjon();
 
     expect(
@@ -360,11 +369,8 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser ikke en rød prikk for menypunkt "Friskmelding til arbeidsformidling" når ingen vedtak', () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(vedtakQueryKeys.vedtak(fnr), () => []);
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
-    );
     renderGlobalNavigasjon();
 
     expect(
@@ -373,13 +379,10 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser en rød prikk for menypunkt "Manglende Medvirkning" når forhåndsvarselet er utgått', () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(
       manglendeMedvirkningQueryKeys.manglendeMedvirkning(fnr),
       () => [defaultForhandsvarselVurderingAfterDeadline]
-    );
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
     );
     renderGlobalNavigasjon();
 
@@ -388,13 +391,10 @@ describe("GlobalNavigasjon", () => {
   });
 
   it('viser ikke en rød prikk for menypunkt "Manglende Medvirkning" når forhåndsvarselet ikke er utgått', () => {
+    mockUnleashWithFeatureToggles();
     queryClient.setQueryData(
       manglendeMedvirkningQueryKeys.manglendeMedvirkning(fnr),
       () => [defaultForhandsvarselVurdering]
-    );
-    queryClient.setQueryData(
-      unleashQueryKeys.toggles(navEnhet.id, ""),
-      () => mockUnleashResponse
     );
     renderGlobalNavigasjon();
 

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -88,6 +88,18 @@ describe("Sen oppfolging", () => {
     });
   });
 
+  it("Viser ingen knapp eller tekst for vurdering når bruker er kandidat til sen oppfølging uten å ha svart", () => {
+    mockSenOppfolgingKandidat({
+      ...senOppfolgingKandidatMock,
+      svar: undefined,
+    });
+    renderSenOppfolging();
+
+    expect(screen.queryByRole("button", { name: vurderingButtonText })).to.not
+      .exist;
+    expect(screen.queryByText(/Vurdert av/)).to.not.exist;
+  });
+
   it("Viser ingen knapp eller tekst for vurdering når bruker ikke er kandidat til sen oppfølging", () => {
     mockSenOppfolgingSvar();
     renderSenOppfolging();


### PR DESCRIPTION
Dette er for å bevare slik det er i prod i dag når vi begynner å konsumere varsler fra eSyfo. Da vil kandidater opprettes når vi får inn varsel, og vi vil lage oppgave når kandidaten har svart (eller det har gått 10 dager siden varsel). I apiet vi kaller her må vi derfor sjekke at kandidaten har svart i logikken som styrer rød prikk.

Siden vi nå får informasjon om kandidaten har svart via vårt api trenger vi ikke lenger laste spørsmål og svar fra esyfo sitt api ute i `SenOppfolgingSide`. Flyttet derfor denne lastingen inn i egen komponent med egen spinner og feilmelding dersom kallet feilet (slik at vi fortsatt kan vise resten av siden mens esyfo sitt api kalles).

Jobber videre med å vise rød prikk på at det har gått 10 dager siden varsel og vise når varsel ble sendt i komponenten

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/234a23b0-393e-48a6-b38b-2823ce943a2f)
![image](https://github.com/user-attachments/assets/84b44129-e548-4901-8d66-6025b6c2988d)
![image](https://github.com/user-attachments/assets/b16fa5ab-7c97-4de8-be9c-d8ef0c87a8f9)

