### PR TITLE
IS-2687: Viser info om varsel når kandidat er varslet og ikke svart

### DIFF
--- a/src/sider/senoppfolging/KandidatIkkeSvart.tsx
+++ b/src/sider/senoppfolging/KandidatIkkeSvart.tsx
@@ -10,7 +10,7 @@ interface Props {
   varselAt: Date;
 }
 
-export function KandidatVarsel({ varselAt }: Props) {
+export function KandidatIkkeSvart({ varselAt }: Props) {
   return (
     <Box
       background="surface-default"

--- a/src/sider/senoppfolging/KandidatVarsel.tsx
+++ b/src/sider/senoppfolging/KandidatVarsel.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { BodyShort, Box, Heading } from "@navikt/ds-react";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+
+const texts = {
+  ikkeSvartHeading: "Den sykmeldte har ikke svart",
+};
+
+interface Props {
+  varselAt: Date;
+}
+
+export function KandidatVarsel({ varselAt }: Props) {
+  return (
+    <Box
+      background="surface-default"
+      padding="6"
+      className="flex flex-col gap-4"
+    >
+      <Heading size="medium">{texts.ikkeSvartHeading}</Heading>
+      <BodyShort size="small">{`Den sykmeldte fikk varsel ${tilLesbarDatoMedArUtenManedNavn(
+        varselAt
+      )}`}</BodyShort>
+    </Box>
+  );
+}

--- a/src/sider/senoppfolging/SenOppfolging.tsx
+++ b/src/sider/senoppfolging/SenOppfolging.tsx
@@ -5,12 +5,14 @@ import { KandidatSvar } from "@/sider/senoppfolging/KandidatSvar";
 import { VurdertKandidat } from "@/sider/senoppfolging/VurdertKandidat";
 import * as Tredelt from "@/sider/TredeltSide";
 import {
+  SenOppfolgingKandidatResponseDTO,
   SenOppfolgingStatus,
   SenOppfolgingVurderingType,
 } from "@/data/senoppfolging/senOppfolgingTypes";
 import { VeiledningRutine } from "@/sider/senoppfolging/VeiledningRutine";
 import { NewVurderingForm } from "@/sider/senoppfolging/NewVurderingForm";
 import OvingssideLink from "@/sider/senoppfolging/OvingssideLink";
+import { KandidatVarsel } from "@/sider/senoppfolging/KandidatVarsel";
 
 const texts = {
   ikkeVarslet: {
@@ -25,22 +27,24 @@ const texts = {
 
 export default function SenOppfolging(): ReactElement {
   const { data: kandidater } = useSenOppfolgingKandidatQuery();
-  const kandidat = kandidater[0];
+  const kandidat: SenOppfolgingKandidatResponseDTO | undefined = kandidater[0];
   const svar = kandidat?.svar;
+  const varselAt = kandidat?.varselAt;
   const isFerdigbehandlet =
     kandidat?.status === SenOppfolgingStatus.FERDIGBEHANDLET;
   const ferdigbehandletVurdering = kandidat?.vurderinger.find(
     (vurdering) => vurdering.type === SenOppfolgingVurderingType.FERDIGBEHANDLET
   );
 
-  return svar ? (
+  return kandidat ? (
     <Tredelt.Container>
       <Tredelt.FirstColumn>
-        <KandidatSvar svar={svar} />
+        {svar && <KandidatSvar svar={svar} />}
+        {!svar && varselAt && <KandidatVarsel varselAt={varselAt} />}
         {isFerdigbehandlet && ferdigbehandletVurdering ? (
           <VurdertKandidat vurdering={ferdigbehandletVurdering} />
         ) : (
-          <NewVurderingForm kandidat={kandidat} />
+          svar && <NewVurderingForm kandidat={kandidat} />
         )}
       </Tredelt.FirstColumn>
       <Tredelt.SecondColumn>

--- a/src/sider/senoppfolging/SenOppfolging.tsx
+++ b/src/sider/senoppfolging/SenOppfolging.tsx
@@ -12,7 +12,7 @@ import {
 import { VeiledningRutine } from "@/sider/senoppfolging/VeiledningRutine";
 import { NewVurderingForm } from "@/sider/senoppfolging/NewVurderingForm";
 import OvingssideLink from "@/sider/senoppfolging/OvingssideLink";
-import { KandidatVarsel } from "@/sider/senoppfolging/KandidatVarsel";
+import { KandidatIkkeSvart } from "@/sider/senoppfolging/KandidatIkkeSvart";
 
 const texts = {
   ikkeVarslet: {
@@ -40,7 +40,7 @@ export default function SenOppfolging(): ReactElement {
     <Tredelt.Container>
       <Tredelt.FirstColumn>
         {svar && <KandidatSvar svar={svar} />}
-        {!svar && varselAt && <KandidatVarsel varselAt={varselAt} />}
+        {!svar && varselAt && <KandidatIkkeSvart varselAt={varselAt} />}
         {isFerdigbehandlet && ferdigbehandletVurdering ? (
           <VurdertKandidat vurdering={ferdigbehandletVurdering} />
         ) : (

--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -309,3 +309,7 @@ export const isExpiredForhandsvarsel = (
 
   return false;
 };
+
+export const isMinstTiDagerSiden = (dato: Date | undefined): boolean => {
+  return !!dato && dagerMellomDatoer(dato, new Date()) >= 10;
+};

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -27,7 +27,10 @@ import {
 } from "@/data/senoppfolging/senOppfolgingTypes";
 import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 import { VurderingResponseDTO as ManglendeMedvirkningVurderingResponseDTO } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
-import { isExpiredForhandsvarsel } from "@/utils/datoUtils";
+import {
+  isExpiredForhandsvarsel,
+  isMinstTiDagerSiden,
+} from "@/utils/datoUtils";
 
 const getNumberOfMoteOppgaver = (
   motebehov: MotebehovVeilederDTO[],
@@ -121,11 +124,13 @@ const getNumberOfArbeidsuforhetOppgaver = (
 function getNumberOfActiveSenOppfolgingOppgaver(
   senOppfolgingKandidatResponseDTO: SenOppfolgingKandidatResponseDTO[]
 ) {
-  const senOppfolgingKandidat: SenOppfolgingKandidatResponseDTO | undefined =
+  const kandidat: SenOppfolgingKandidatResponseDTO | undefined =
     senOppfolgingKandidatResponseDTO[0];
+  if (!kandidat || kandidat.status === SenOppfolgingStatus.FERDIGBEHANDLET) {
+    return 0;
+  }
   const isActiveSenOppfolgingOppgave =
-    senOppfolgingKandidat?.status === SenOppfolgingStatus.KANDIDAT &&
-    !!senOppfolgingKandidat.svar;
+    kandidat.svar || isMinstTiDagerSiden(kandidat.varselAt);
 
   return isActiveSenOppfolgingOppgave ? 1 : 0;
 }

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -319,6 +319,7 @@ describe("GlobalNavigasjon", () => {
       () => [
         {
           ...senOppfolgingKandidatMock,
+          varselAt: new Date(),
           svar: undefined,
         },
       ]

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -27,7 +27,7 @@ import {
   createForhandsvarsel,
   createVurdering,
 } from "../arbeidsuforhet/arbeidsuforhetTestData";
-import { addWeeks } from "@/utils/datoUtils";
+import { addDays, addWeeks } from "@/utils/datoUtils";
 import { VurderingType } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import { senOppfolgingKandidatQueryKeys } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
 import { unleashQueryKeys } from "@/data/unleash/unleashQueryHooks";
@@ -292,6 +292,41 @@ describe("GlobalNavigasjon", () => {
 
     expect(screen.getByRole("link", { name: "Snart slutt på sykepengene 1" }))
       .to.exist;
+  });
+
+  it('viser en rød prikk for menypunkt "Snart slutt på sykepengene" når kandidat varslet for minst ti dager siden uten svar', () => {
+    mockUnleashWithFeatureToggles();
+    queryClient.setQueryData(
+      senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
+      () => [
+        {
+          ...senOppfolgingKandidatMock,
+          varselAt: addDays(new Date(), -10),
+          svar: undefined,
+        },
+      ]
+    );
+    renderGlobalNavigasjon();
+
+    expect(screen.getByRole("link", { name: "Snart slutt på sykepengene 1" }))
+      .to.exist;
+  });
+
+  it('viser ikke en rød prikk for menypunkt "Snart slutt på sykepengene" når kandidat varslet i dag uten svar', () => {
+    mockUnleashWithFeatureToggles();
+    queryClient.setQueryData(
+      senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
+      () => [
+        {
+          ...senOppfolgingKandidatMock,
+          svar: undefined,
+        },
+      ]
+    );
+    renderGlobalNavigasjon();
+
+    expect(screen.getByRole("link", { name: "Snart slutt på sykepengene" })).to
+      .exist;
   });
 
   it('viser ikke en rød prikk for menypunkt "Snart slutt på sykepengene" når kandidat er ferdigbehandlet', () => {

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -77,6 +77,17 @@ describe("Sen oppfolging", () => {
     });
   });
 
+  it("Viser infotekst om varsel når bruker har fått varsel og ikke svart", () => {
+    mockSenOppfolgingKandidat({
+      ...senOppfolgingKandidatMock,
+      svar: undefined,
+    });
+    renderSenOppfolging();
+
+    expect(screen.getByText("Den sykmeldte har ikke svart")).to.exist;
+    expect(screen.getByText(/Den sykmeldte fikk varsel/)).to.exist;
+  });
+
   it("Viser side for oppfølging i sen fase med svar fra bruker", () => {
     mockSenOppfolgingSvar();
     mockSenOppfolgingKandidat(senOppfolgingKandidatMock);


### PR DESCRIPTION
Har også tilpasset logikk for rød prikk slik at denne vises når kandidat har svart eller det har gått minst ti dager siden varsel.

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/cc949240-cf98-4d23-89d9-a0b6b0fbd5c3)

Dette er som i skissene, men tenker at vi kanskje burde legge til noe mer tekst her etter hvert, f.eks. noe om at det kommer oppgave i oversikten når den sykmeldte svarer eller de ikke har svart på ti dager...
