### PR TITLE
IS-2712: Do not wait for oppfolgingsplaner to load

### DIFF
--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -5,7 +5,6 @@ import { InnkallingDialogmotePanel } from "./components/innkalling/InnkallingDia
 import SideLaster from "../../components/SideLaster";
 import { DialogmoteOnskePanel } from "./components/DialogmoteOnskePanel";
 import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
-import { useOppfolgingsplanerQuery } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
 import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { DialogmoteFerdigstilteReferatPanel } from "@/sider/dialogmoter/components/DialogmoteFerdigstilteReferatPanel";
@@ -24,7 +23,6 @@ const texts = {
 };
 
 export const Motelandingsside = () => {
-  const { isLoading: henterOppfolgingsplaner } = useOppfolgingsplanerQuery();
   const {
     isLoading: henterDialogmoter,
     isError: henterDialogmoterFeilet,
@@ -51,7 +49,6 @@ export const Motelandingsside = () => {
   const henter =
     henterDialogmoter ||
     henterDialogmoteunntak ||
-    henterOppfolgingsplaner ||
     henterMotebehov ||
     henterLedere;
   const hentingFeilet =

--- a/src/sider/nokkelinformasjon/Nokkelinformasjon.tsx
+++ b/src/sider/nokkelinformasjon/Nokkelinformasjon.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
 import UtdragFraSykefravaeret from "../../components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import { Sykmeldingsgrad } from "@/sider/nokkelinformasjon/sykmeldingsgrad/Sykmeldingsgrad";
-import { useOppfolgingsplanerQuery } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
 import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
-import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import Side from "@/sider/Side";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import SideLaster from "@/components/SideLaster";
@@ -16,25 +14,22 @@ const texts = {
 };
 
 export const Nokkelinformasjon = () => {
-  const { isLoading: henterOppfolgingsplaner } = useOppfolgingsplanerQuery();
-  const { isError: henterSykmeldingerFeilet } = useSykmeldingerQuery();
-  const { isLoading: henterLedere, isError: henterLedereFeilet } =
-    useLedereQuery();
-
+  const { isError: henterSykmeldingerFeilet, isLoading: henterSykmeldinger } =
+    useSykmeldingerQuery();
   const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
 
   const [selectedOppfolgingstilfelle, setSelectedOppfolgingstilfelle] =
     useState<OppfolgingstilfelleDTO | undefined>();
-
-  const henter = henterOppfolgingsplaner || henterLedere;
-  const hentingFeilet = henterSykmeldingerFeilet || henterLedereFeilet;
 
   return (
     <Side
       tittel={texts.pageTitle}
       aktivtMenypunkt={Menypunkter.NOKKELINFORMASJON}
     >
-      <SideLaster henter={henter} hentingFeilet={hentingFeilet}>
+      <SideLaster
+        henter={henterSykmeldinger}
+        hentingFeilet={henterSykmeldingerFeilet}
+      >
         <header>
           <Heading spacing size="large" className="hidden" level="1">
             {texts.pageTitle}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Siden mesteparten av innholdet i Utdrag fra sykefraværet kan vises uten at oppfølgingsplaner er lastet endrer vi slik at Utdrag fra sykefraværet rendres før oppfølgingsplaner er lastet ferdig. 
Viser spinner og evt feilmelding for lasting av oppfølgingsplaner i `UtdragOppfolgingsplaner`
