### PR TITLE
IS-2688: Vis vurdering-skjema hvis varsel ikke besvart på 10 dager

### DIFF
--- a/src/sider/senoppfolging/KandidatIkkeSvart.tsx
+++ b/src/sider/senoppfolging/KandidatIkkeSvart.tsx
@@ -1,32 +1,41 @@
 import React from "react";
 import { BodyShort, Box, Heading } from "@navikt/ds-react";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
-import { getVarselSvarfrist } from "@/utils/senOppfolgingUtils";
+import {
+  getVarselSvarfrist,
+  isVarselSvarfristUtlopt,
+} from "@/utils/senOppfolgingUtils";
 
 const texts = {
-  ikkeSvartHeading: "Den sykmeldte har ikke svart",
+  heading: "Den sykmeldte har ikke svart",
 };
 
 interface Props {
   varselAt: Date;
 }
 
-export function KandidatIkkeSvart({ varselAt }: Props) {
-  const svarFrist = getVarselSvarfrist(varselAt);
+function getOppgaveText(varselAt: Date): string {
+  if (isVarselSvarfristUtlopt(varselAt)) {
+    return "Den sykmeldte har fått en påminnelse om å svare og fortsatt ikke svart. Du kan nå gjøre en vurdering om den sykmeldte trenger oppfølging fra NAV i sen fase av sykefraværet. Hvis den sykmeldte svarer på et senere tidspunkt vil du få en ny oppgave.";
+  } else {
+    return `Når spørsmålene er besvart eller hvis den sykmeldte ikke svarer innen ${tilLesbarDatoMedArUtenManedNavn(
+      getVarselSvarfrist(varselAt)
+    )}, vil du få en oppgave i oversikten om å vurdere videre oppfølging.`;
+  }
+}
 
+export function KandidatIkkeSvart({ varselAt }: Props) {
   return (
     <Box
       background="surface-default"
       padding="6"
-      className="flex flex-col gap-4"
+      className="flex flex-col gap-4 mb-2"
     >
-      <Heading size="medium">{texts.ikkeSvartHeading}</Heading>
+      <Heading size="medium">{texts.heading}</Heading>
       <BodyShort size="small">{`Den sykmeldte fikk varsel ${tilLesbarDatoMedArUtenManedNavn(
         varselAt
       )} om at det er snart slutt på sykepengene og kan nå svare på spørsmål rundt sin situasjon på innloggede sider.`}</BodyShort>
-      <BodyShort size="small">{`Når spørsmålene er besvart eller hvis den sykmeldte ikke svarer innen ${tilLesbarDatoMedArUtenManedNavn(
-        svarFrist
-      )}, vil du få en oppgave i oversikten om å vurdere videre oppfølging.`}</BodyShort>
+      <BodyShort size="small">{getOppgaveText(varselAt)}</BodyShort>
     </Box>
   );
 }

--- a/src/sider/senoppfolging/SenOppfolging.tsx
+++ b/src/sider/senoppfolging/SenOppfolging.tsx
@@ -13,6 +13,7 @@ import { VeiledningRutine } from "@/sider/senoppfolging/VeiledningRutine";
 import { NewVurderingForm } from "@/sider/senoppfolging/NewVurderingForm";
 import OvingssideLink from "@/sider/senoppfolging/OvingssideLink";
 import { KandidatIkkeSvart } from "@/sider/senoppfolging/KandidatIkkeSvart";
+import { isVarselUbesvart } from "@/utils/senOppfolgingUtils";
 
 const texts = {
   ikkeVarslet: {
@@ -35,7 +36,6 @@ export default function SenOppfolging(): ReactElement {
   const ferdigbehandletVurdering = kandidat?.vurderinger.find(
     (vurdering) => vurdering.type === SenOppfolgingVurderingType.FERDIGBEHANDLET
   );
-
   return kandidat ? (
     <Tredelt.Container>
       <Tredelt.FirstColumn>
@@ -44,7 +44,9 @@ export default function SenOppfolging(): ReactElement {
         {isFerdigbehandlet && ferdigbehandletVurdering ? (
           <VurdertKandidat vurdering={ferdigbehandletVurdering} />
         ) : (
-          svar && <NewVurderingForm kandidat={kandidat} />
+          (svar || isVarselUbesvart(kandidat)) && (
+            <NewVurderingForm kandidat={kandidat} />
+          )
         )}
       </Tredelt.FirstColumn>
       <Tredelt.SecondColumn>

--- a/src/utils/senOppfolgingUtils.ts
+++ b/src/utils/senOppfolgingUtils.ts
@@ -5,15 +5,15 @@ export function isVarselUbesvart(
   kandidat: SenOppfolgingKandidatResponseDTO
 ): boolean {
   const { svar, varselAt } = kandidat;
-  if (!svar && !!varselAt) {
-    return (
-      dagerMellomDatoerUtenAbs(getVarselSvarfrist(varselAt), new Date()) >= 0
-    );
-  } else {
-    return false;
-  }
+  return !svar && !!varselAt ? isVarselSvarfristUtlopt(varselAt) : false;
 }
 
-export function getVarselSvarfrist(varselAt: Date) {
+export function isVarselSvarfristUtlopt(varselAt: Date): boolean {
+  return (
+    dagerMellomDatoerUtenAbs(getVarselSvarfrist(varselAt), new Date()) >= 0
+  );
+}
+
+export function getVarselSvarfrist(varselAt: Date): Date {
   return addDays(varselAt, 10);
 }

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -117,7 +117,7 @@ describe("Sen oppfolging", () => {
     });
   });
 
-  it("Viser ingen knapp eller tekst for vurdering når bruker er kandidat til sen oppfølging uten å ha svart", () => {
+  it("Viser ingen knapp eller tekst for vurdering når bruker er kandidat til sen oppfølging uten å ha svart og varsel ikke utløpt", () => {
     mockSenOppfolgingKandidat({
       ...senOppfolgingKandidatMock,
       svar: undefined,
@@ -138,7 +138,21 @@ describe("Sen oppfolging", () => {
     expect(screen.queryByText(/Vurdert av/)).to.not.exist;
   });
 
-  it("Viser knapp for å fullføre vurdering når bruker er kandidat til sen oppfølging", () => {
+  it("Viser knapp for å fullføre vurdering når bruker er kandidat til sen oppfølging uten å ha svart og varsel utløpt", () => {
+    const varselDato = addDays(new Date(), -10);
+    mockSenOppfolgingKandidat({
+      ...senOppfolgingKandidatMock,
+      svar: undefined,
+      varselAt: varselDato,
+    });
+    renderSenOppfolging();
+
+    expect(screen.getByText(/Den sykmeldte har fått en påminnelse/)).to.exist;
+    expect(screen.getByText(/Du kan nå gjøre en vurdering/)).to.exist;
+    expect(screen.getByRole("button", { name: vurderingButtonText })).to.exist;
+  });
+
+  it("Viser knapp for å fullføre vurdering når bruker er kandidat til sen oppfølging med svar", () => {
     mockSenOppfolgingSvar();
     mockSenOppfolgingKandidat(senOppfolgingKandidatMock);
     renderSenOppfolging();


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser samme vurdering-skjema som ved svar dersom den sykmeldte ikke har svart på 10 dager.
I tillegg laget ulike varianter av teksten i boksen over avhengig av om varsel-svarfristen er utløpt eller ikke.

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/1a56564f-9e19-4596-9e76-ffd3bcfb7e1e)
