### PR TITLE
Robustify tests

### DIFF
--- a/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/AvlysDialogmoteSkjemaTest.tsx
@@ -161,17 +161,18 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       moteTekster.fritekstTilArbeidsgiver
     );
 
+    const expectedSendtDato = new Date();
     await clickButton("Send");
 
     await waitFor(() => {
       const avlysMutation = queryClient.getMutationCache().getAll()[0];
       const expectedAvlysningDto = {
         arbeidsgiver: {
-          avlysning: expectedAvlysningDocuments.arbeidsgiver(),
+          avlysning: expectedAvlysningDocuments.arbeidsgiver(expectedSendtDato),
           begrunnelse: moteTekster.fritekstTilArbeidsgiver,
         },
         arbeidstaker: {
-          avlysning: expectedAvlysningDocuments.arbeidstaker(),
+          avlysning: expectedAvlysningDocuments.arbeidstaker(expectedSendtDato),
           begrunnelse: moteTekster.fritekstTilArbeidstaker,
         },
       };
@@ -202,21 +203,22 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       moteTekster.fritekstTilBehandler
     );
 
+    const expectedSendtDato = new Date();
     await clickButton("Send");
 
     await waitFor(() => {
       const avlysMutation = queryClient.getMutationCache().getAll()[0];
       const expectedAvlysningDto = {
         arbeidsgiver: {
-          avlysning: expectedAvlysningDocuments.arbeidsgiver(),
+          avlysning: expectedAvlysningDocuments.arbeidsgiver(expectedSendtDato),
           begrunnelse: moteTekster.fritekstTilArbeidsgiver,
         },
         arbeidstaker: {
-          avlysning: expectedAvlysningDocuments.arbeidstaker(),
+          avlysning: expectedAvlysningDocuments.arbeidstaker(expectedSendtDato),
           begrunnelse: moteTekster.fritekstTilArbeidstaker,
         },
         behandler: {
-          avlysning: expectedAvlysningDocuments.behandler(),
+          avlysning: expectedAvlysningDocuments.behandler(expectedSendtDato),
           begrunnelse: moteTekster.fritekstTilBehandler,
         },
       };
@@ -245,6 +247,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(2);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[0]);
 
     const forhandsvisningAvlysningArbeidstaker = screen.getAllByRole("dialog", {
@@ -264,7 +267,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       })
     ).to.exist;
     expectedAvlysningDocuments
-      .arbeidstaker()
+      .arbeidstaker(expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningAvlysningArbeidstaker).getByText(text)).to
@@ -293,6 +296,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(2);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[1]);
 
     const forhandsvisningAvlysningArbeidsgiver = screen.getAllByRole("dialog", {
@@ -311,7 +315,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       })
     ).to.exist;
     expectedAvlysningDocuments
-      .arbeidsgiver()
+      .arbeidsgiver(expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningAvlysningArbeidsgiver).getByText(text)).to
@@ -345,6 +349,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(3);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[2]);
 
     const forhandsvisningAvlysningBehandler = screen.getAllByRole("dialog", {
@@ -363,7 +368,7 @@ describe("AvlysDialogmoteSkjemaTest", () => {
       })
     ).to.exist;
     expectedAvlysningDocuments
-      .behandler()
+      .behandler(expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningAvlysningBehandler).getByText(text)).to

--- a/test/dialogmote/DialogmoteInnkallingSkjema/BehandlerInnkallingTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/BehandlerInnkallingTest.tsx
@@ -87,6 +87,7 @@ describe("Dialogmoteinnkallingskjema med behandler", () => {
     renderDialogmoteInnkallingSkjema();
     await passSkjemaInput();
 
+    const expectedSendtDato = new Date();
     await clickButton("Send innkallingene");
 
     await waitFor(() => {
@@ -95,12 +96,18 @@ describe("Dialogmoteinnkallingskjema med behandler", () => {
         arbeidsgiver: {
           virksomhetsnummer: arbeidsgiver.orgnr,
           fritekstInnkalling: moteTekster.fritekstTilArbeidsgiver,
-          innkalling: expectedInnkallingDocuments.arbeidsgiver(true),
+          innkalling: expectedInnkallingDocuments.arbeidsgiver(
+            true,
+            expectedSendtDato
+          ),
         },
         arbeidstaker: {
           personIdent: arbeidstaker.personident,
           fritekstInnkalling: moteTekster.fritekstTilArbeidstaker,
-          innkalling: expectedInnkallingDocuments.arbeidstaker(true),
+          innkalling: expectedInnkallingDocuments.arbeidstaker(
+            true,
+            expectedSendtDato
+          ),
         },
         behandler: {
           personIdent: behandler.fnr,
@@ -108,7 +115,7 @@ describe("Dialogmoteinnkallingskjema med behandler", () => {
           behandlerNavn: behandlerNavn(behandler),
           behandlerKontor: behandler.kontor,
           fritekstInnkalling: moteTekster.fritekstTilBehandler,
-          innkalling: expectedInnkallingDocuments.behandler(),
+          innkalling: expectedInnkallingDocuments.behandler(expectedSendtDato),
         },
         tidSted: {
           sted: mote.sted,

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingPreviewTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingPreviewTest.tsx
@@ -40,6 +40,7 @@ describe("Dialogmoteinnkallingskjema forhåndsvisning", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(2);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[0]);
     const forhandsvisningInnkallingArbeidstaker = screen.getAllByRole(
       "dialog",
@@ -61,7 +62,7 @@ describe("Dialogmoteinnkallingskjema forhåndsvisning", () => {
       })
     ).to.exist;
     expectedInnkallingDocuments
-      .arbeidstaker()
+      .arbeidstaker(false, expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningInnkallingArbeidstaker).getByText(text)).to
@@ -77,6 +78,7 @@ describe("Dialogmoteinnkallingskjema forhåndsvisning", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(2);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[1]);
     const forhandsvisningInnkallingArbeidsgiver = screen.getAllByRole(
       "dialog",
@@ -98,7 +100,7 @@ describe("Dialogmoteinnkallingskjema forhåndsvisning", () => {
       })
     ).to.exist;
     expectedInnkallingDocuments
-      .arbeidsgiver()
+      .arbeidsgiver(false, expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningInnkallingArbeidsgiver).getByText(text)).to
@@ -126,6 +128,7 @@ describe("Dialogmoteinnkallingskjema forhåndsvisning", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(3);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[2]);
     const forhandsvisningInnkallingBehandler = screen.getAllByRole("dialog", {
       hidden: true,
@@ -139,7 +142,7 @@ describe("Dialogmoteinnkallingskjema forhåndsvisning", () => {
     ).to.exist;
 
     expectedInnkallingDocuments
-      .behandler()
+      .behandler(expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningInnkallingBehandler).getByText(text)).to

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
@@ -184,6 +184,7 @@ describe("DialogmoteInnkallingSkjema", () => {
     renderDialogmoteInnkallingSkjema();
     passSkjemaInput();
 
+    const expectedSendtDato = new Date();
     await clickButton("Send innkallingene");
 
     await waitFor(() => {
@@ -192,12 +193,18 @@ describe("DialogmoteInnkallingSkjema", () => {
         arbeidsgiver: {
           virksomhetsnummer: arbeidsgiver.orgnr,
           fritekstInnkalling: moteTekster.fritekstTilArbeidsgiver,
-          innkalling: expectedInnkallingDocuments.arbeidsgiver(),
+          innkalling: expectedInnkallingDocuments.arbeidsgiver(
+            false,
+            expectedSendtDato
+          ),
         },
         arbeidstaker: {
           personIdent: arbeidstaker.personident,
           fritekstInnkalling: moteTekster.fritekstTilArbeidstaker,
-          innkalling: expectedInnkallingDocuments.arbeidstaker(),
+          innkalling: expectedInnkallingDocuments.arbeidstaker(
+            false,
+            expectedSendtDato
+          ),
         },
         tidSted: {
           sted: mote.sted,

--- a/test/dialogmote/EndreDialogmoteSkjemaTest.tsx
+++ b/test/dialogmote/EndreDialogmoteSkjemaTest.tsx
@@ -145,6 +145,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
     renderEndreDialogmoteSkjema(dialogmote);
     passSkjemaInput();
 
+    const expectedSendtDato = new Date();
     await clickButton("Send");
 
     await waitFor(() => {
@@ -152,11 +153,17 @@ describe("EndreDialogmoteSkjemaTest", () => {
       const expectedEndring = {
         arbeidsgiver: {
           begrunnelse: moteTekster.fritekstTilArbeidsgiver,
-          endringsdokument: expectedEndringDocuments.arbeidsgiver(),
+          endringsdokument: expectedEndringDocuments.arbeidsgiver(
+            false,
+            expectedSendtDato
+          ),
         },
         arbeidstaker: {
           begrunnelse: moteTekster.fritekstTilArbeidstaker,
-          endringsdokument: expectedEndringDocuments.arbeidstaker(),
+          endringsdokument: expectedEndringDocuments.arbeidstaker(
+            false,
+            expectedSendtDato
+          ),
         },
         videoLink: endretMote.videolink,
         sted: endretMote.sted,
@@ -210,6 +217,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
       moteTekster.fritekstTilBehandler
     );
 
+    const expectedSendtDato = new Date();
     await clickButton("Send");
 
     await waitFor(() => {
@@ -217,15 +225,22 @@ describe("EndreDialogmoteSkjemaTest", () => {
       const expectedEndring = {
         arbeidsgiver: {
           begrunnelse: moteTekster.fritekstTilArbeidsgiver,
-          endringsdokument: expectedEndringDocuments.arbeidsgiver(true),
+          endringsdokument: expectedEndringDocuments.arbeidsgiver(
+            true,
+            expectedSendtDato
+          ),
         },
         arbeidstaker: {
           begrunnelse: moteTekster.fritekstTilArbeidstaker,
-          endringsdokument: expectedEndringDocuments.arbeidstaker(true),
+          endringsdokument: expectedEndringDocuments.arbeidstaker(
+            true,
+            expectedSendtDato
+          ),
         },
         behandler: {
           begrunnelse: moteTekster.fritekstTilBehandler,
-          endringsdokument: expectedEndringDocuments.behandler(),
+          endringsdokument:
+            expectedEndringDocuments.behandler(expectedSendtDato),
         },
         videoLink: endretMote.videolink,
         sted: endretMote.sted,
@@ -242,6 +257,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(2);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[0]);
 
     const forhandsvisningEndringArbeidstaker = screen.getAllByRole("dialog", {
@@ -261,7 +277,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
       })
     ).to.exist;
     expectedEndringDocuments
-      .arbeidstaker()
+      .arbeidstaker(false, expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningEndringArbeidstaker).getByText(text)).to
@@ -276,6 +292,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(2);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[1]);
 
     const forhandsvisningEndringArbeidsgiver = screen.getAllByRole("dialog", {
@@ -295,7 +312,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
       })
     ).to.exist;
     expectedEndringDocuments
-      .arbeidsgiver()
+      .arbeidsgiver(false, expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningEndringArbeidsgiver).getByText(text)).to
@@ -316,6 +333,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
       name: "Forhåndsvisning",
     });
     expect(previewButtons).to.have.length(3);
+    const expectedSendtDato = new Date();
     await userEvent.click(previewButtons[2]);
 
     const forhandsvisningEndringBehandler = screen.getAllByRole("dialog", {
@@ -330,7 +348,7 @@ describe("EndreDialogmoteSkjemaTest", () => {
     ).to.exist;
 
     expectedEndringDocuments
-      .behandler()
+      .behandler(expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningEndringBehandler).getByText(text)).to

--- a/test/dialogmote/ReferatEndreTest.tsx
+++ b/test/dialogmote/ReferatEndreTest.tsx
@@ -100,6 +100,7 @@ describe("ReferatEndreTest", () => {
   it("endrer ferdigstilling av dialogmote ved submit av skjema", async () => {
     renderEndreReferat(dialogmoteMedFerdigstiltReferat);
     passSkjemaInput();
+    const expectedSendtDato = new Date();
     await clickButton("Lagre og send");
 
     const endringFerdigstillMutation = queryClient
@@ -114,7 +115,7 @@ describe("ReferatEndreTest", () => {
       arbeidstakerOppgave: moteTekster.arbeidstakersOppgave,
       begrunnelseEndring: moteTekster.begrunnelseEndring,
       veilederOppgave: moteTekster.veiledersOppgave,
-      document: expectedEndretReferatDocument(),
+      document: expectedEndretReferatDocument(expectedSendtDato),
       andreDeltakere: [],
     };
     expect(endringFerdigstillMutation?.state.variables).to.deep.equal(

--- a/test/dialogmote/ReferatMellomlagreTest.tsx
+++ b/test/dialogmote/ReferatMellomlagreTest.tsx
@@ -36,6 +36,7 @@ describe("ReferatMellomlagreTest", () => {
     stubMellomlagreApi(dialogmoteMedBehandler.uuid);
     renderReferat(dialogmoteMedBehandler);
     await passSkjemaTekstInput();
+    const expectedSendtDato = new Date();
     await clickButton("Lagre");
 
     const mellomlagreMutation = queryClient.getMutationCache().getAll().pop();
@@ -49,7 +50,7 @@ describe("ReferatMellomlagreTest", () => {
       behandlerMottarReferat: true,
       behandlerOppgave: moteTekster.behandlersOppgave,
       veilederOppgave: moteTekster.veiledersOppgave,
-      document: expectedReferatDocument(),
+      document: expectedReferatDocument(expectedSendtDato),
       andreDeltakere: [
         { funksjon: annenDeltakerFunksjon, navn: annenDeltakerNavn },
       ],

--- a/test/dialogmote/ReferatTest.tsx
+++ b/test/dialogmote/ReferatTest.tsx
@@ -244,6 +244,7 @@ describe("ReferatTest", () => {
     changeTextInput(annenDeltakerNavnInput, annenDeltakerNavn);
     changeTextInput(annenDeltakerFunksjonInput, annenDeltakerFunksjon);
 
+    const expectedSendtDato = new Date();
     await clickButton("Lagre og send");
 
     const ferdigstillMutation = queryClient.getMutationCache().getAll().pop();
@@ -257,7 +258,7 @@ describe("ReferatTest", () => {
       behandlerMottarReferat: true,
       behandlerOppgave: moteTekster.behandlersOppgave,
       veilederOppgave: moteTekster.veiledersOppgave,
-      document: expectedReferatDocument(),
+      document: expectedReferatDocument(expectedSendtDato),
       andreDeltakere: [
         { funksjon: annenDeltakerFunksjon, navn: annenDeltakerNavn },
       ],
@@ -277,12 +278,13 @@ describe("ReferatTest", () => {
     changeTextInput(annenDeltakerNavnInput, annenDeltakerNavn);
     changeTextInput(annenDeltakerFunksjonInput, annenDeltakerFunksjon);
 
+    const expectedSendtDato = new Date();
     await clickButton("Forhåndsvisning");
     const forhandsvisningReferat = screen.getByRole("dialog", {
       hidden: true,
     });
 
-    expectedReferatDocument()
+    expectedReferatDocument(expectedSendtDato)
       .flatMap((documentComponent) => documentComponent.texts)
       .forEach((text) => {
         expect(within(forhandsvisningReferat).getByText(text)).to.exist;

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -37,14 +37,15 @@ const endreTidStedTextsBokmal = getEndreTidStedTexts(Malform.BOKMAL);
 const avlysningTextsBokmal = getAvlysningTexts(Malform.BOKMAL);
 
 const expectedArbeidstakerInnkalling = (
-  medBehandler = false
+  medBehandler = false,
+  sendtDato: Date
 ): DocumentComponentDto[] => [
   {
     texts: ["Innkalling til dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -122,14 +123,15 @@ const expectedArbeidstakerInnkalling = (
 ];
 
 const expectedArbeidsgiverInnkalling = (
-  medBehandler = false
+  medBehandler = false,
+  sendtDato: Date
 ): DocumentComponentDto[] => [
   {
     texts: ["Innkalling til dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -205,13 +207,15 @@ const expectedArbeidsgiverInnkalling = (
   },
 ];
 
-const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
+const expectedBehandlerInnkalling = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: ["Innkalling til dialogmøte, svar ønskes"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -262,14 +266,15 @@ const expectedBehandlerInnkalling = (): DocumentComponentDto[] => [
 ];
 
 const expectedArbeidsgiverEndringsdokument = (
-  medBehandler = false
+  medBehandler = false,
+  sendtDato: Date
 ): DocumentComponentDto[] => [
   {
     texts: ["Endret dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -358,14 +363,15 @@ const expectedArbeidsgiverEndringsdokument = (
 ];
 
 const expectedArbeidstakerEndringsdokument = (
-  medBehandler = false
+  medBehandler = false,
+  sendtDato: Date
 ): DocumentComponentDto[] => [
   {
     texts: ["Endret dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -449,7 +455,9 @@ const expectedArbeidstakerEndringsdokument = (
   },
 ];
 
-const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
+const expectedBehandlerEndringsdokument = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: ["Endret dialogmøte, svar ønskes"],
     type: DocumentComponentType.HEADER_H1,
@@ -459,7 +467,7 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
     type: DocumentComponentType.PARAGRAPH,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -516,13 +524,15 @@ const expectedBehandlerEndringsdokument = (): DocumentComponentDto[] => [
   },
 ];
 
-const expectedAvlysningArbeidsgiver = (): DocumentComponentDto[] => [
+const expectedAvlysningArbeidsgiver = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: ["Avlysning av dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -554,13 +564,15 @@ const expectedAvlysningArbeidsgiver = (): DocumentComponentDto[] => [
   },
 ];
 
-const expectedAvlysningArbeidstaker = (): DocumentComponentDto[] => [
+const expectedAvlysningArbeidstaker = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: ["Avlysning av dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -592,13 +604,15 @@ const expectedAvlysningArbeidstaker = (): DocumentComponentDto[] => [
   },
 ];
 
-const expectedAvlysningBehandler = (): DocumentComponentDto[] => [
+const expectedAvlysningBehandler = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: ["Avlysning av dialogmøte"],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -630,13 +644,15 @@ const expectedAvlysningBehandler = (): DocumentComponentDto[] => [
   },
 ];
 
-export const expectedReferatDocument = (): DocumentComponentDto[] => [
+export const expectedReferatDocument = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: [referatTextsBokmal.nyttHeader],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -721,13 +737,15 @@ export const expectedReferatDocument = (): DocumentComponentDto[] => [
   },
 ];
 
-export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
+export const expectedEndretReferatDocument = (
+  sendtDato: Date
+): DocumentComponentDto[] => [
   {
     texts: [referatTextsBokmal.endretHeader],
     type: DocumentComponentType.HEADER_H1,
   },
   {
-    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(new Date())}`],
+    texts: [`Sendt ${tilDatoMedManedNavnOgKlokkeslettWithComma(sendtDato)}`],
     type: DocumentComponentType.PARAGRAPH,
   },
   {
@@ -815,18 +833,18 @@ export const expectedEndretReferatDocument = (): DocumentComponentDto[] => [
 ];
 
 export const expectedInnkallingDocuments = {
-  arbeidsgiver: (medBehandler = false) =>
-    expectedArbeidsgiverInnkalling(medBehandler),
-  arbeidstaker: (medBehandler = false) =>
-    expectedArbeidstakerInnkalling(medBehandler),
+  arbeidsgiver: (medBehandler = false, sendtDato: Date) =>
+    expectedArbeidsgiverInnkalling(medBehandler, sendtDato),
+  arbeidstaker: (medBehandler = false, sendtDato: Date) =>
+    expectedArbeidstakerInnkalling(medBehandler, sendtDato),
   behandler: expectedBehandlerInnkalling,
 };
 
 export const expectedEndringDocuments = {
-  arbeidsgiver: (medBehandler = false) =>
-    expectedArbeidsgiverEndringsdokument(medBehandler),
-  arbeidstaker: (medBehandler = false) =>
-    expectedArbeidstakerEndringsdokument(medBehandler),
+  arbeidsgiver: (medBehandler = false, sendtDato: Date) =>
+    expectedArbeidsgiverEndringsdokument(medBehandler, sendtDato),
+  arbeidstaker: (medBehandler = false, sendtDato: Date) =>
+    expectedArbeidstakerEndringsdokument(medBehandler, sendtDato),
   behandler: expectedBehandlerEndringsdokument,
 };
 


### PR DESCRIPTION
Prøver å minimere potensielle timing-problemer i testene ved å sende inn forventet sendt-tidspunkt til test-dokumentene i stedet for at dette genereres der man gjør assertion.
