### PR TITLE
IS-2750: change text sen fase

### DIFF
--- a/src/sider/senoppfolging/NewVurderingForm.tsx
+++ b/src/sider/senoppfolging/NewVurderingForm.tsx
@@ -13,7 +13,7 @@ const texts = {
   button: "Fullfør vurdering",
   description: "Når du fullfører vurderingen fjernes hendelsen fra oversikten.",
   begrunnelseDescription:
-    "Det er valgfritt å skrive begrunnelse. Begrunnelsen vil være synlig i Modia, men vises ikke for den sykmeldte på innloggede sider. Innbyggeren kan kreve innsyn i det du skriver her. Begrunnelsen blir ikke journalført.",
+    "Begrunnelsen vil være synlig i Modia, men vises ikke for den sykmeldte på innloggede sider. Innbyggeren kan kreve innsyn i det du skriver her. Begrunnelsen blir ikke journalført.",
 };
 
 interface Props {

--- a/src/sider/senoppfolging/NewVurderingForm.tsx
+++ b/src/sider/senoppfolging/NewVurderingForm.tsx
@@ -13,7 +13,7 @@ const texts = {
   button: "Fullfør vurdering",
   description: "Når du fullfører vurderingen fjernes hendelsen fra oversikten.",
   begrunnelseDescription:
-    "Det er valgfritt å skrive begrunnelse. Begrunnelsen vil være synlig i Modia, men vises ikke for den sykmeldte. Begrunnelsen blir ikke journalført.",
+    "Det er valgfritt å skrive begrunnelse. Begrunnelsen vil være synlig i Modia, men vises ikke for den sykmeldte på innloggede sider. Innbyggeren kan kreve innsyn i det du skriver her. Begrunnelsen blir ikke journalført.",
 };
 
 interface Props {

--- a/src/sider/senoppfolging/NewVurderingForm.tsx
+++ b/src/sider/senoppfolging/NewVurderingForm.tsx
@@ -12,6 +12,7 @@ const texts = {
   missingBegrunnelse: "Du må skrive en begrunnelse",
   button: "Fullfør vurdering",
   description: "Når du fullfører vurderingen fjernes hendelsen fra oversikten.",
+  begrunnelseLabel: "Begrunnelse (valgfritt)",
   begrunnelseDescription:
     "Begrunnelsen vil være synlig i Modia, men vises ikke for den sykmeldte på innloggede sider. Innbyggeren kan kreve innsyn i det du skriver her. Begrunnelsen blir ikke journalført.",
 };
@@ -45,7 +46,7 @@ export function NewVurderingForm({ kandidat }: Props) {
     >
       <Heading size="medium">{texts.heading}</Heading>
       <Textarea
-        label="Begrunnelse"
+        label={texts.begrunnelseLabel}
         description={
           <BodyShort size="small" textColor="subtle">
             {texts.begrunnelseDescription}

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -197,7 +197,7 @@ describe("Sen oppfolging", () => {
     mockSenOppfolgingKandidat(senOppfolgingKandidatMock);
     renderSenOppfolging();
 
-    const begrunnelseInput = getTextInput("Begrunnelse");
+    const begrunnelseInput = getTextInput("Begrunnelse (valgfritt)");
     await changeTextInput(begrunnelseInput, "En flott begrunnelse");
     await clickButton(vurderingButtonText);
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret teksten i beskrivelsen av begrunnelsesfeltet i sen fase

### Screenshots 📸✨
**Før:**
![image](https://github.com/user-attachments/assets/7123f99f-6817-4d2f-a52f-0d956641dff1)

**Nå:**
![image](https://github.com/user-attachments/assets/ba73f919-74a4-4044-bb5c-22760796926d)
