### PR TITLE
IS-2573: Add view when no historic meetings

### DIFF
--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -22,7 +22,7 @@ const texts = {
   dialogmoter: "Dialogmøter",
 };
 
-export const Motelandingsside = () => {
+export function Motelandingsside() {
   const {
     isLoading: henterDialogmoter,
     isError: henterDialogmoterFeilet,
@@ -57,9 +57,6 @@ export const Motelandingsside = () => {
     henterDialogmoterFeilet ||
     henterDialogmoteunntakFeilet;
 
-  const hasMotehistorikk =
-    historiskeDialogmoter.length > 0 || dialogmoteunntak.length > 0;
-
   return (
     <Side tittel={texts.pageTitle} aktivtMenypunkt={Menypunkter.DIALOGMOTE}>
       <SideLaster henter={henter} hentingFeilet={hentingFeilet}>
@@ -83,20 +80,18 @@ export const Motelandingsside = () => {
           </Tredelt.FirstColumn>
 
           <Tredelt.SecondColumn>
-            {hasMotehistorikk && (
-              <div className="flex flex-col gap-4">
-                <MotehistorikkPanel
-                  historiskeMoter={historiskeDialogmoter}
-                  dialogmoteunntak={dialogmoteunntak}
-                />
-                <MoteSvarHistorikk historiskeMoter={historiskeDialogmoter} />
-              </div>
-            )}
+            <div className="flex flex-col gap-4">
+              <MotehistorikkPanel
+                historiskeMoter={historiskeDialogmoter}
+                dialogmoteunntak={dialogmoteunntak}
+              />
+              <MoteSvarHistorikk historiskeMoter={historiskeDialogmoter} />
+            </div>
           </Tredelt.SecondColumn>
         </Tredelt.Container>
       </SideLaster>
     </Side>
   );
-};
+}
 
 export default Motelandingsside;

--- a/src/sider/dialogmoter/components/motehistorikk/ForhandsvisDocumentAccordionItem.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/ForhandsvisDocumentAccordionItem.tsx
@@ -1,0 +1,25 @@
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
+import React, { ReactElement } from "react";
+import { Accordion } from "@navikt/ds-react";
+import { DocumentComponentVisning } from "@/components/document/DocumentComponentVisning";
+
+interface Props {
+  document: DocumentComponentDto[];
+  children: string;
+}
+
+export function ForhandsvisDocumentAccordionItem({
+  document,
+  children,
+}: Props): ReactElement {
+  return (
+    <Accordion.Item>
+      <Accordion.Header>{children}</Accordion.Header>
+      <Accordion.Content>
+        {document.map((component, index) => (
+          <DocumentComponentVisning key={index} documentComponent={component} />
+        ))}
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}

--- a/src/sider/dialogmoter/components/motehistorikk/MoteHistorikkEvent.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteHistorikkEvent.tsx
@@ -1,0 +1,56 @@
+import React, { ReactElement } from "react";
+import {
+  DialogmoteDTO,
+  DialogmoteStatus,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import { useDialogmoteReferat } from "@/hooks/dialogmote/useDialogmoteReferat";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import { ForhandsvisDocumentAccordionItem } from "@/sider/dialogmoter/components/motehistorikk/ForhandsvisDocumentAccordionItem";
+
+const texts = {
+  avlystMote: "Avlysning av møte",
+  avholdtMote: "Referat fra møte",
+};
+
+interface Props {
+  mote: DialogmoteDTO;
+}
+
+export default function MoteHistorikkEvent({ mote }: Props): ReactElement {
+  const isMoteAvlyst = mote.status === DialogmoteStatus.AVLYST;
+  const { ferdigstilteReferat } = useDialogmoteReferat(mote);
+  const moteDatoTekst = tilDatoMedManedNavn(mote.tid);
+
+  if (isMoteAvlyst) {
+    const document =
+      mote.arbeidstaker.varselList.find(
+        (varsel) => varsel.varselType === MotedeltakerVarselType.AVLYST
+      )?.document || [];
+
+    return (
+      <ForhandsvisDocumentAccordionItem document={document}>
+        {`${texts.avlystMote} ${moteDatoTekst}`}
+      </ForhandsvisDocumentAccordionItem>
+    );
+  }
+
+  return (
+    <>
+      {ferdigstilteReferat.map((referat, index) => {
+        const suffix = referat.endring
+          ? ` - Endret ${tilDatoMedManedNavn(referat.updatedAt)}`
+          : "";
+
+        return (
+          <ForhandsvisDocumentAccordionItem
+            key={index}
+            document={referat.document}
+          >
+            {`${texts.avholdtMote} ${moteDatoTekst}${suffix}`}
+          </ForhandsvisDocumentAccordionItem>
+        );
+      })}
+    </>
+  );
+}

--- a/src/sider/dialogmoter/components/motehistorikk/MoteHistorikkUnntak.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteHistorikkUnntak.tsx
@@ -1,7 +1,6 @@
 import React, { ReactElement } from "react";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { ForhandsvisDocumentAccordionItem } from "@/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel";
 
 import {
   DocumentComponentDto,
@@ -9,24 +8,24 @@ import {
 } from "@/data/documentcomponent/documentComponentTypes";
 import { unntakArsakTexts } from "@/components/dialogmoteunntak/DialogmoteunntakSkjema";
 import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { ForhandsvisDocumentAccordionItem } from "@/sider/dialogmoter/components/motehistorikk/ForhandsvisDocumentAccordionItem";
 
 const texts = {
-  unntakTitle: "Unntak fra dialogmøte",
   unntakLenke: "Unntak fra dialogmøte",
   arsakLabel: "Årsak til unntak",
   beskrivelseLabel: "Beskrivelse",
   vurdertAvLabel: "Vurdert av",
 };
 
-export const unntakLenkeText = (unntakCreatedAt: Date) => {
+export function unntakLenkeText(unntakCreatedAt: Date) {
   const unntakDatoTekst = tilDatoMedManedNavn(unntakCreatedAt);
   return `${texts.unntakLenke} ${unntakDatoTekst}`;
-};
+}
 
-const createUnntakDocument = (
+function createUnntakDocument(
   unntak: UnntakDTO,
   veilederNavn: string | undefined
-): DocumentComponentDto[] => {
+): DocumentComponentDto[] {
   const arsakText: string =
     unntakArsakTexts.find(
       (unntakArsakText) => unntakArsakText.arsak == unntak.arsak
@@ -54,15 +53,13 @@ const createUnntakDocument = (
     });
   }
   return componentList;
-};
+}
 
-interface MoteHistorikkUnntakProps {
+interface Props {
   unntak: UnntakDTO;
 }
 
-export const MoteHistorikkUnntak = ({
-  unntak,
-}: MoteHistorikkUnntakProps): ReactElement => {
+export function MoteHistorikkUnntak({ unntak }: Props): ReactElement {
   const { data: veilederinfo } = useVeilederInfoQuery(unntak.createdBy);
   const unntakDocument = createUnntakDocument(
     unntak,
@@ -73,4 +70,4 @@ export const MoteHistorikkUnntak = ({
       {unntakLenkeText(unntak.createdAt)}
     </ForhandsvisDocumentAccordionItem>
   );
-};
+}

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk.tsx
@@ -1,126 +1,42 @@
-import {
-  DialogmoteDTO,
-  DialogmoteStatus,
-  MotedeltakerVarselType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { FortidenImage } from "../../../../../img/ImageComponents";
-import { Accordion, BodyLong, Box, Heading, Label } from "@navikt/ds-react";
-import React, { useState } from "react";
-import { tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { DialogmoteVeilederInfo } from "@/sider/dialogmoter/components/DialogmoteVeilederInfo";
-import { DialogmoteStedInfo } from "@/sider/dialogmoter/components/DialogmoteStedInfo";
-import * as Amplitude from "@/utils/amplitude";
-import { EventType } from "@/utils/amplitude";
-import { ArbeidsgiverSvar } from "@/sider/dialogmoter/components/svar/ArbeidsgiverSvar";
-import { ArbeidstakerSvar } from "@/sider/dialogmoter/components/svar/ArbeidstakerSvar";
-import { BehandlerSvar } from "@/sider/dialogmoter/components/svar/BehandlerSvar";
+import { Accordion, BodyLong, BodyShort, Box, Heading } from "@navikt/ds-react";
+import React from "react";
+import MoteSvarHistorikkEvent from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEvent";
 
 const texts = {
   header: "Møtesvarhistorikk",
   subtitle: "Oversikt over svar på tidligere innkallinger til dialogmøter",
+  ingenSvarHistorikk: "Ingen tidligere møtesvar",
 };
 
-const getHeaderText = (mote: DialogmoteDTO): string => {
-  const moteDato = tilDatoMedManedNavn(mote.tid);
-  switch (mote.status) {
-    case DialogmoteStatus.AVLYST:
-      return `Avlyst møte ${moteDato}`;
-    case DialogmoteStatus.FERDIGSTILT:
-      return `Møte ${moteDato}`;
-    default:
-      return "";
-  }
-};
-
-interface MoteSvarHistorikkItemProps {
-  dialogmote: DialogmoteDTO;
-}
-
-const MoteSvarHistorikkItem = ({ dialogmote }: MoteSvarHistorikkItemProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const handleAccordionClick = () => {
-    if (!isOpen) {
-      Amplitude.logEvent({
-        type: EventType.AccordionOpen,
-        data: {
-          tekst: `Åpne møtesvar-historikk accordion`,
-          url: window.location.href,
-        },
-      });
-    }
-    setIsOpen(!isOpen);
-  };
-
-  const innkallingArbeidstaker = dialogmote.arbeidstaker.varselList.find(
-    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
-  );
-  const innkallingArbeidsgiver = dialogmote.arbeidsgiver.varselList.find(
-    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
-  );
-  const innkallingBehandler =
-    dialogmote.behandler &&
-    dialogmote.behandler.varselList.find(
-      ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
-    );
-
-  return (
-    <Accordion.Item open={isOpen}>
-      <Accordion.Header onClick={handleAccordionClick}>
-        {getHeaderText(dialogmote)}
-      </Accordion.Header>
-      <Accordion.Content>
-        <DialogmoteStedInfo dialogmote={dialogmote} />
-        <DialogmoteVeilederInfo dialogmote={dialogmote} />
-        <div className="mt-4">
-          <Label size="small">{`Innkalling sendt ${tilDatoMedManedNavn(
-            dialogmote.createdAt
-          )} - svar:`}</Label>
-          <div className="flex flex-col gap-4">
-            {innkallingArbeidsgiver && (
-              <ArbeidsgiverSvar
-                varsel={innkallingArbeidsgiver}
-                virksomhetsnummer={dialogmote.arbeidsgiver.virksomhetsnummer}
-                defaultClosed
-              />
-            )}
-            {innkallingArbeidstaker && (
-              <ArbeidstakerSvar varsel={innkallingArbeidstaker} defaultClosed />
-            )}
-            {innkallingBehandler && (
-              <BehandlerSvar
-                varsel={innkallingBehandler}
-                behandlerNavn={dialogmote.behandler.behandlerNavn}
-              />
-            )}
-          </div>
-        </div>
-      </Accordion.Content>
-    </Accordion.Item>
-  );
-};
-
-interface MoteSvarHistorikkProps {
+interface Props {
   historiskeMoter: DialogmoteDTO[];
 }
 
-export const MoteSvarHistorikk = ({
-  historiskeMoter,
-}: MoteSvarHistorikkProps) => (
-  <Box background="surface-default" className="p-8">
-    <div className="flex flex-row mb-4">
-      <img src={FortidenImage} alt="moteikon" className="w-12 mr-4" />
-      <div className="flex flex-col">
-        <Heading level="2" size="medium" className="">
-          {texts.header}
-        </Heading>
-        <BodyLong size="small">{texts.subtitle}</BodyLong>
+export function MoteSvarHistorikk({ historiskeMoter }: Props) {
+  const hasMoteHistorikk = historiskeMoter.length > 0;
+
+  return (
+    <Box background="surface-default" className="p-8">
+      <div className="flex flex-row mb-4">
+        <img src={FortidenImage} alt="moteikon" className="w-12 mr-4" />
+        <div className="flex flex-col">
+          <Heading level="2" size="medium" className="">
+            {texts.header}
+          </Heading>
+          <BodyLong size="small">{texts.subtitle}</BodyLong>
+        </div>
       </div>
-    </div>
-    <Accordion>
-      {historiskeMoter.map((mote, index) => (
-        <MoteSvarHistorikkItem dialogmote={mote} key={index} />
-      ))}
-    </Accordion>
-  </Box>
-);
+      {hasMoteHistorikk ? (
+        <Accordion>
+          {historiskeMoter.map((mote, index) => (
+            <MoteSvarHistorikkEvent dialogmote={mote} key={index} />
+          ))}
+        </Accordion>
+      ) : (
+        <BodyShort>{texts.ingenSvarHistorikk}</BodyShort>
+      )}
+    </Box>
+  );
+}

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEvent.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEvent.tsx
@@ -1,0 +1,95 @@
+import {
+  DialogmoteDTO,
+  DialogmoteStatus,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import React, { useState } from "react";
+import * as Amplitude from "@/utils/amplitude";
+import { EventType } from "@/utils/amplitude";
+import { Accordion, Label } from "@navikt/ds-react";
+import { DialogmoteStedInfo } from "@/sider/dialogmoter/components/DialogmoteStedInfo";
+import { DialogmoteVeilederInfo } from "@/sider/dialogmoter/components/DialogmoteVeilederInfo";
+import { ArbeidsgiverSvar } from "@/sider/dialogmoter/components/svar/ArbeidsgiverSvar";
+import { ArbeidstakerSvar } from "@/sider/dialogmoter/components/svar/ArbeidstakerSvar";
+import { BehandlerSvar } from "@/sider/dialogmoter/components/svar/BehandlerSvar";
+
+const getHeaderText = (mote: DialogmoteDTO): string => {
+  const moteDato = tilDatoMedManedNavn(mote.tid);
+  switch (mote.status) {
+    case DialogmoteStatus.AVLYST:
+      return `Avlyst møte ${moteDato}`;
+    case DialogmoteStatus.FERDIGSTILT:
+      return `Møte ${moteDato}`;
+    default:
+      return "";
+  }
+};
+
+interface Props {
+  dialogmote: DialogmoteDTO;
+}
+
+export default function MoteSvarHistorikkEvent({ dialogmote }: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleAccordionClick = () => {
+    if (!isOpen) {
+      Amplitude.logEvent({
+        type: EventType.AccordionOpen,
+        data: {
+          tekst: `Åpne møtesvar-historikk accordion`,
+          url: window.location.href,
+        },
+      });
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const innkallingArbeidstaker = dialogmote.arbeidstaker.varselList.find(
+    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+  );
+  const innkallingArbeidsgiver = dialogmote.arbeidsgiver.varselList.find(
+    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+  );
+  const innkallingBehandler =
+    dialogmote.behandler &&
+    dialogmote.behandler.varselList.find(
+      ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+    );
+
+  return (
+    <Accordion.Item open={isOpen}>
+      <Accordion.Header onClick={handleAccordionClick}>
+        {getHeaderText(dialogmote)}
+      </Accordion.Header>
+      <Accordion.Content>
+        <DialogmoteStedInfo dialogmote={dialogmote} />
+        <DialogmoteVeilederInfo dialogmote={dialogmote} />
+        <div className="mt-4">
+          <Label size="small">{`Innkalling sendt ${tilDatoMedManedNavn(
+            dialogmote.createdAt
+          )} - svar:`}</Label>
+          <div className="flex flex-col gap-4">
+            {innkallingArbeidsgiver && (
+              <ArbeidsgiverSvar
+                varsel={innkallingArbeidsgiver}
+                virksomhetsnummer={dialogmote.arbeidsgiver.virksomhetsnummer}
+                defaultClosed
+              />
+            )}
+            {innkallingArbeidstaker && (
+              <ArbeidstakerSvar varsel={innkallingArbeidstaker} defaultClosed />
+            )}
+            {innkallingBehandler && (
+              <BehandlerSvar
+                varsel={innkallingBehandler}
+                behandlerNavn={dialogmote.behandler.behandlerNavn}
+              />
+            )}
+          </div>
+        </div>
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}

--- a/src/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel.tsx
@@ -1,100 +1,30 @@
 import { FortidenImage } from "../../../../../img/ImageComponents";
-import React, { ReactElement } from "react";
-import {
-  DialogmoteDTO,
-  DialogmoteStatus,
-  MotedeltakerVarselType,
-} from "@/data/dialogmote/types/dialogmoteTypes";
-import { tilDatoMedManedNavn } from "@/utils/datoUtils";
-import { useDialogmoteReferat } from "@/hooks/dialogmote/useDialogmoteReferat";
+import React from "react";
+import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { MoteHistorikkUnntak } from "@/sider/dialogmoter/components/motehistorikk/MoteHistorikkUnntak";
-import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
-import { Accordion, BodyLong, Box, Heading } from "@navikt/ds-react";
-import { DocumentComponentVisning } from "@/components/document/DocumentComponentVisning";
+import { Accordion, BodyLong, BodyShort, Box, Heading } from "@navikt/ds-react";
+import MoteHistorikkEvent from "@/sider/dialogmoter/components/motehistorikk/MoteHistorikkEvent";
 
 const texts = {
   header: "Møtehistorikk",
   subtitle:
     "Oversikt over tidligere dialogmøter som ble innkalt i Modia (inkluderer ikke historikk fra Arena).",
-  avlystMote: "Avlysning av møte",
-  avholdtMote: "Referat fra møte",
-  referat: "Referat",
-  avlysningsBrev: "Avlysningsbrev",
+  ingenHistoriskeMoter: "Ingen tidligere møtehistorikk",
 };
 
-interface ForhandsvisDocumentAccordionItemProps {
-  document: DocumentComponentDto[];
-  children: string;
-}
-
-export const ForhandsvisDocumentAccordionItem = ({
-  document,
-  children,
-}: ForhandsvisDocumentAccordionItemProps): ReactElement => {
-  return (
-    <Accordion.Item>
-      <Accordion.Header>{children}</Accordion.Header>
-      <Accordion.Content>
-        {document.map((component, index) => (
-          <DocumentComponentVisning key={index} documentComponent={component} />
-        ))}
-      </Accordion.Content>
-    </Accordion.Item>
-  );
-};
-
-interface MoteHistorikkProps {
-  mote: DialogmoteDTO;
-}
-
-const MoteHistorikk = ({ mote }: MoteHistorikkProps): ReactElement => {
-  const isMoteAvlyst = mote.status === DialogmoteStatus.AVLYST;
-  const { ferdigstilteReferat } = useDialogmoteReferat(mote);
-  const moteDatoTekst = tilDatoMedManedNavn(mote.tid);
-
-  if (isMoteAvlyst) {
-    const document =
-      mote.arbeidstaker.varselList.find(
-        (varsel) => varsel.varselType === MotedeltakerVarselType.AVLYST
-      )?.document || [];
-
-    return (
-      <ForhandsvisDocumentAccordionItem document={document}>
-        {`${texts.avlystMote} ${moteDatoTekst}`}
-      </ForhandsvisDocumentAccordionItem>
-    );
-  }
-
-  return (
-    <>
-      {ferdigstilteReferat.map((referat, index) => {
-        const suffix = referat.endring
-          ? ` - Endret ${tilDatoMedManedNavn(referat.updatedAt)}`
-          : "";
-
-        return (
-          <ForhandsvisDocumentAccordionItem
-            key={index}
-            document={referat.document}
-          >
-            {`${texts.avholdtMote} ${moteDatoTekst}${suffix}`}
-          </ForhandsvisDocumentAccordionItem>
-        );
-      })}
-    </>
-  );
-};
-
-interface MotehistorikkPanelProps {
+interface Props {
   dialogmoteunntak: UnntakDTO[];
   historiskeMoter: DialogmoteDTO[];
 }
 
-export const MotehistorikkPanel = ({
-  dialogmoteunntak,
+export function MotehistorikkPanel({
   historiskeMoter,
-}: MotehistorikkPanelProps) => {
+  dialogmoteunntak,
+}: Props) {
+  const hasMotehistorikk =
+    historiskeMoter.length > 0 || dialogmoteunntak.length > 0;
+
   return (
     <Box background="surface-default" className="p-8">
       <div className="flex flex-row mb-4">
@@ -106,14 +36,18 @@ export const MotehistorikkPanel = ({
           <BodyLong size="small">{texts.subtitle}</BodyLong>
         </div>
       </div>
-      <Accordion>
-        {historiskeMoter.map((mote, index) => (
-          <MoteHistorikk key={index} mote={mote} />
-        ))}
-        {dialogmoteunntak.map((unntak, index) => (
-          <MoteHistorikkUnntak key={index} unntak={unntak} />
-        ))}
-      </Accordion>
+      {hasMotehistorikk ? (
+        <Accordion>
+          {historiskeMoter.map((mote, index) => (
+            <MoteHistorikkEvent key={index} mote={mote} />
+          ))}
+          {dialogmoteunntak.map((unntak, index) => (
+            <MoteHistorikkUnntak key={index} unntak={unntak} />
+          ))}
+        </Accordion>
+      ) : (
+        <BodyShort>{texts.ingenHistoriskeMoter}</BodyShort>
+      )}
     </Box>
   );
-};
+}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til visning for når man ikke har noen historiske møter å vise
- Splittet også ut en del lengre filer i egne komponenter

### Screenshots 📸✨
Før
Se [vedlegg i PR](https://trello.com/c/6HFdx6nx/2573-viser-ikke-tredjekolonne-p%C3%A5-dialogm%C3%B8ter-side)

Etter
![Screenshot 2024-10-31 at 14 54 45](https://github.com/user-attachments/assets/2bc336eb-c662-4a3b-bde8-1fd86f0a6490)


