### PR TITLE
IS-2739: Add lps-planer to oppfolgingsplan-historikk

### DIFF
--- a/src/data/historikk/historikkQueryHooks.ts
+++ b/src/data/historikk/historikkQueryHooks.ts
@@ -5,7 +5,7 @@ import {
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import {
   HistorikkEvent,
-  HistorikkKilde,
+  HistorikkEventType,
 } from "@/data/historikk/types/historikkTypes";
 import { get } from "@/api/axios";
 import { useQuery } from "@tanstack/react-query";
@@ -52,7 +52,7 @@ export const useHistorikkOppfolgingsplan = () => {
 
 export const mapHistorikkEvents = (
   events: HistorikkEvent[],
-  kilde: HistorikkKilde
+  kilde: HistorikkEventType
 ): HistorikkEvent[] =>
   events.map((event) => ({
     ...event,

--- a/src/data/historikk/types/historikkTypes.ts
+++ b/src/data/historikk/types/historikkTypes.ts
@@ -9,7 +9,8 @@ export type HistorikkEventType =
   | "VEILEDER_TILDELING"
   | "DIALOG_MED_BEHANDLER"
   | "SEN_OPPFOLGING"
-  | "DIALOGMOTEKANDIDAT";
+  | "DIALOGMOTEKANDIDAT"
+  | "OPPFOLGINGSPLAN_LPS";
 
 export interface HistorikkEvent {
   opprettetAv?: string;

--- a/src/data/historikk/types/historikkTypes.ts
+++ b/src/data/historikk/types/historikkTypes.ts
@@ -1,6 +1,7 @@
-export type HistorikkKilde = "MOTER" | "MOTEBEHOV" | "OPPFOLGINGSPLAN";
 export type HistorikkEventType =
-  | HistorikkKilde
+  | "MOTER"
+  | "MOTEBEHOV"
+  | "OPPFOLGINGSPLAN"
   | "LEDER"
   | "AKTIVITETSKRAV"
   | "ARBEIDSUFORHET"

--- a/src/hooks/historikk/useHistorikk.ts
+++ b/src/hooks/historikk/useHistorikk.ts
@@ -1,8 +1,5 @@
-import { HistorikkEvent } from "../../data/historikk/types/historikkTypes";
-import {
-  useHistorikkMotebehovQuery,
-  useHistorikkOppfolgingsplan,
-} from "@/data/historikk/historikkQueryHooks";
+import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
+import { useHistorikkMotebehovQuery } from "@/data/historikk/historikkQueryHooks";
 import { useLedereHistorikk } from "@/hooks/historikk/useLedereHistorikk";
 import { useAktivitetskravHistorikk } from "@/hooks/historikk/useAktivitetskravHistorikk";
 import { useArbeidsuforhetHistorikk } from "@/hooks/historikk/useArbeidsuforhetHistorikk";
@@ -13,6 +10,7 @@ import { useDialogmotekandidatHistorikk } from "@/hooks/historikk/useDialogmotek
 import { useDialogMedBehandlerHistorikk } from "@/hooks/historikk/useDialogMedBehandlerHistorikk";
 import { useSenOppfolgingHistorikk } from "@/hooks/historikk/useSenOppfolgingHistorikk";
 import { useDialogmoteStatusEndringHistorikk } from "@/hooks/historikk/useDialogmoteStatusEndringHistorikk";
+import { useOppfolgingsplanHistorikk } from "@/hooks/historikk/useOppfolgingsplanHistorikk";
 
 interface HistorikkHook {
   isHistorikkLoading: boolean;
@@ -27,11 +25,7 @@ export function useHistorikk(): HistorikkHook {
     isError: isMotebehovError,
   } = useHistorikkMotebehovQuery();
 
-  const {
-    data: oppfolgingsplanHistorikk,
-    isLoading: isOppfolgingsplanLoading,
-    isError: isOppfolgingsplanError,
-  } = useHistorikkOppfolgingsplan();
+  const oppfolgingsplanHistorikk = useOppfolgingsplanHistorikk();
 
   const { lederHistorikk, isLedereHistorikkLoading, isLedereHistorikkError } =
     useLedereHistorikk();
@@ -73,7 +67,7 @@ export function useHistorikk(): HistorikkHook {
     useDialogmoteStatusEndringHistorikk();
 
   const historikkEvents = motebehovHistorikk
-    .concat(oppfolgingsplanHistorikk)
+    .concat(oppfolgingsplanHistorikk.events)
     .concat(lederHistorikk)
     .concat(aktivitetskravHistorikk)
     .concat(arbeidsuforhetHistorikk)
@@ -86,7 +80,7 @@ export function useHistorikk(): HistorikkHook {
     .concat(dialogmoteStatusEndringHistorikk.events);
 
   const isHistorikkLoading =
-    isOppfolgingsplanLoading ||
+    oppfolgingsplanHistorikk.isLoading ||
     isMotebehovLoading ||
     isLedereHistorikkLoading ||
     isAktivitetskravHistorikkLoading ||
@@ -101,7 +95,7 @@ export function useHistorikk(): HistorikkHook {
 
   const isHistorikkError =
     isMotebehovError ||
-    isOppfolgingsplanError ||
+    oppfolgingsplanHistorikk.isError ||
     isLedereHistorikkError ||
     isAktivitetskravHistorikkError ||
     isArbeidsuforhetHistorikkError ||

--- a/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
@@ -14,7 +14,7 @@ function toHistorikkEvents(
 ): HistorikkEvent[] {
   return oppfolgingsplanerLPS.map(({ opprettet, virksomhetsnummer }) => ({
     kilde: "OPPFOLGINGSPLAN_LPS",
-    tekst: `Oppfølgingsplanen ble delt med NAV av ${virksomhetsnummer}.`,
+    tekst: `Oppfølgingsplanen ble delt med Nav av ${virksomhetsnummer}.`,
     tidspunkt: new Date(opprettet),
   }));
 }

--- a/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
@@ -1,0 +1,43 @@
+import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
+import { useHistorikkOppfolgingsplan } from "@/data/historikk/historikkQueryHooks";
+import { useOppfolgingsplanerLPSQuery } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
+import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
+
+interface OppfolgingsplanHistorikk {
+  isLoading: boolean;
+  isError: boolean;
+  events: HistorikkEvent[];
+}
+
+function toHistorikkEvents(
+  oppfolgingsplanerLPS: OppfolgingsplanLPS[]
+): HistorikkEvent[] {
+  return oppfolgingsplanerLPS.map(({ opprettet, virksomhetsnummer }) => ({
+    kilde: "OPPFOLGINGSPLAN_LPS",
+    tekst: `Oppfølgingsplanen ble delt med NAV av ${virksomhetsnummer}.`,
+    tidspunkt: new Date(opprettet),
+  }));
+}
+
+export function useOppfolgingsplanHistorikk(): OppfolgingsplanHistorikk {
+  const {
+    data: oppfolgingsplanHistorikk,
+    isLoading: isOppfolgingsplanLoading,
+    isError: isOppfolgingsplanError,
+  } = useHistorikkOppfolgingsplan();
+  const {
+    data: oppfolgingsplanerLPS,
+    isLoading: isOppfolgingsplanerLPSLoading,
+    isError: isOppfolgingsplanerLPSError,
+  } = useOppfolgingsplanerLPSQuery();
+
+  const oppfolgingsplanHistorikkEvents = oppfolgingsplanHistorikk.concat(
+    toHistorikkEvents(oppfolgingsplanerLPS)
+  );
+
+  return {
+    isLoading: isOppfolgingsplanLoading || isOppfolgingsplanerLPSLoading,
+    isError: isOppfolgingsplanError || isOppfolgingsplanerLPSError,
+    events: oppfolgingsplanHistorikkEvents,
+  };
+}

--- a/src/mocks/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock.ts
+++ b/src/mocks/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock.ts
@@ -6,7 +6,9 @@ import {
 } from "../common/mockConstants";
 import { OppfolgingsplanLPS } from "@/data/oppfolgingsplan/types/OppfolgingsplanLPS";
 
-const getDefaultOppfolgingsplanLPS = (created: Date): OppfolgingsplanLPS => {
+export const getDefaultOppfolgingsplanLPS = (
+  created: Date
+): OppfolgingsplanLPS => {
   return {
     uuid: "5f1e2629-062b-442d-ae1f-3b08e9574cd2",
     fnr: ARBEIDSTAKER_DEFAULT.personIdent,

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -45,6 +45,8 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
   switch (kilde) {
     case "OPPFOLGINGSPLAN":
       return <Tag variant="alt3">Oppfølgingsplan</Tag>;
+    case "OPPFOLGINGSPLAN_LPS":
+      return <Tag variant="alt3">Oppfølgingsplan LPS</Tag>;
     case "LEDER":
       return <Tag variant="alt2">Leder</Tag>;
     case "VEILEDER_TILDELING":

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -43,6 +43,8 @@ import {
 import { generateUUID } from "@/utils/uuidUtils";
 import { dialogmoteStatusEndringMock } from "@/mocks/isdialogmote/dialogmoterMock";
 import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
+import { oppfolgingsplanQueryKeys } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
+import { getDefaultOppfolgingsplanLPS } from "@/mocks/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
 
 let queryClient: QueryClient;
 
@@ -72,6 +74,12 @@ function setupTestdataHistorikk() {
   );
   queryClient.setQueryData(
     historikkQueryKeys.oppfolgingsplan(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => []
+  );
+  queryClient.setQueryData(
+    oppfolgingsplanQueryKeys.oppfolgingsplanerLPS(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
     () => []
   );
   queryClient.setQueryData(
@@ -618,6 +626,39 @@ describe("Historikk", () => {
           "Dialogmøtet innkalt av Z970000 ble lukket av systemet"
         )
       ).to.exist;
+    });
+  });
+
+  describe("Oppfølgingsplaner", () => {
+    it("viser mottatte oppfølgingsplaner", () => {
+      const oppfolgingsplanHistorikkMock = {
+        tekst: "Oppfølgingsplanen ble delt med NAV av TEST.",
+        tidspunkt: new Date().toJSON(),
+      };
+      queryClient.setQueryData(
+        historikkQueryKeys.oppfolgingsplan(ARBEIDSTAKER_DEFAULT.personIdent),
+        () => [oppfolgingsplanHistorikkMock]
+      );
+      const defaultOppfolgingsplanLPS = getDefaultOppfolgingsplanLPS(
+        new Date()
+      );
+      queryClient.setQueryData(
+        oppfolgingsplanQueryKeys.oppfolgingsplanerLPS(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => [defaultOppfolgingsplanLPS]
+      );
+      renderHistorikk();
+
+      expect(screen.getByText("Oppfølgingsplanen ble delt med NAV av TEST.")).to
+        .exist;
+      expect(
+        screen.getByText(
+          `Oppfølgingsplanen ble delt med NAV av ${defaultOppfolgingsplanLPS.virksomhetsnummer}.`
+        )
+      ).to.exist;
+      expect(screen.getByText("Oppfølgingsplan")).to.exist;
+      expect(screen.getByText("Oppfølgingsplan LPS")).to.exist;
     });
   });
 });

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -632,7 +632,7 @@ describe("Historikk", () => {
   describe("Oppfølgingsplaner", () => {
     it("viser mottatte oppfølgingsplaner", () => {
       const oppfolgingsplanHistorikkMock = {
-        tekst: "Oppfølgingsplanen ble delt med NAV av TEST.",
+        tekst: "Oppfølgingsplanen ble delt med Nav av TEST.",
         tidspunkt: new Date().toJSON(),
       };
       queryClient.setQueryData(
@@ -650,11 +650,11 @@ describe("Historikk", () => {
       );
       renderHistorikk();
 
-      expect(screen.getByText("Oppfølgingsplanen ble delt med NAV av TEST.")).to
+      expect(screen.getByText("Oppfølgingsplanen ble delt med Nav av TEST.")).to
         .exist;
       expect(
         screen.getByText(
-          `Oppfølgingsplanen ble delt med NAV av ${defaultOppfolgingsplanLPS.virksomhetsnummer}.`
+          `Oppfølgingsplanen ble delt med Nav av ${defaultOppfolgingsplanLPS.virksomhetsnummer}.`
         )
       ).to.exist;
       expect(screen.getByText("Oppfølgingsplan")).to.exist;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Henter alle lps-oppfolgingsplaner og legger til i historikken ("interne" oppfolgingsplaner har vi allerede historikk på)
Ref denne tråden: https://nav-it.slack.com/archives/CGX6MF9S8/p1730811357036099

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/dabc827e-5900-48f3-96bb-8a0ad94df5a6)