### PR TITLE
IS-2460 Lagt til oppfølgingsoppgave i historikken

### DIFF
--- a/src/data/historikk/types/historikkTypes.ts
+++ b/src/data/historikk/types/historikkTypes.ts
@@ -19,10 +19,5 @@ export interface HistorikkEvent {
   tekst: string;
   tidspunkt: Date;
   kilde: HistorikkEventType;
-  expandable?: Expandable;
-}
-
-interface Expandable {
-  isExpandable: boolean;
-  content: string;
+  expandableContent?: string;
 }

--- a/src/data/historikk/types/historikkTypes.ts
+++ b/src/data/historikk/types/historikkTypes.ts
@@ -11,6 +11,7 @@ export type HistorikkEventType =
   | "DIALOG_MED_BEHANDLER"
   | "SEN_OPPFOLGING"
   | "DIALOGMOTEKANDIDAT"
+  | "OPPFOLGINGSOPPGAVE"
   | "OPPFOLGINGSPLAN_LPS";
 
 export interface HistorikkEvent {
@@ -18,4 +19,10 @@ export interface HistorikkEvent {
   tekst: string;
   tidspunkt: Date;
   kilde: HistorikkEventType;
+  expandable?: Expandable;
+}
+
+interface Expandable {
+  isExpandable: boolean;
+  content: string;
 }

--- a/src/data/oppfolgingsoppgave/types.ts
+++ b/src/data/oppfolgingsoppgave/types.ts
@@ -36,6 +36,25 @@ export interface OppfolgingsoppgaveResponseDTO {
   frist: string | null;
 }
 
+export interface OppfolgingsoppgaveNewResponseDTO {
+  uuid: string;
+  createdBy: string;
+  updatedAt: Date;
+  isActive: boolean;
+  createdAt: Date;
+  removedBy: string | null;
+  versjoner: OppfolgingsoppgaveVersjonResponseDTO[];
+}
+
+export interface OppfolgingsoppgaveVersjonResponseDTO {
+  uuid: string;
+  createdAt: Date;
+  createdBy: string;
+  tekst: string | null;
+  oppfolgingsgrunn: Oppfolgingsgrunn;
+  frist: string | null;
+}
+
 export enum Oppfolgingsgrunn {
   TA_KONTAKT_SYKEMELDT = "TA_KONTAKT_SYKEMELDT",
   TA_KONTAKT_ARBEIDSGIVER = "TA_KONTAKT_ARBEIDSGIVER",

--- a/src/data/oppfolgingsoppgave/useGetOppfolgingsoppgaver.tsx
+++ b/src/data/oppfolgingsoppgave/useGetOppfolgingsoppgaver.tsx
@@ -1,0 +1,37 @@
+import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { ISHUSKELAPP_ROOT } from "@/apiConstants";
+import { get } from "@/api/axios";
+import { useQuery } from "@tanstack/react-query";
+import { OppfolgingsoppgaveNewResponseDTO } from "@/data/oppfolgingsoppgave/types";
+
+export const oppfolgingsoppgaverQueryKeys = {
+  oppfolgingsoppgaver: (personident: string) => [
+    "oppfolgingsoppgaver",
+    personident,
+  ],
+};
+
+export const useGetOppfolgingsoppgaver = () => {
+  const personident = useValgtPersonident();
+  const path = `${ISHUSKELAPP_ROOT}/huskelapp?filter=all`;
+  const getOppfolgingsoppgaver = () =>
+    get<OppfolgingsoppgaveNewResponseDTO[]>(path, personident);
+
+  const {
+    data: oppfolgingsoppgaver,
+    isLoading,
+    isError,
+    isSuccess,
+  } = useQuery({
+    queryKey: oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+    queryFn: getOppfolgingsoppgaver,
+    enabled: !!personident,
+  });
+
+  return {
+    oppfolgingsoppgaver: oppfolgingsoppgaver,
+    isSuccess,
+    isLoading,
+    isError,
+  };
+};

--- a/src/hooks/historikk/useHistorikk.ts
+++ b/src/hooks/historikk/useHistorikk.ts
@@ -11,6 +11,7 @@ import { useDialogMedBehandlerHistorikk } from "@/hooks/historikk/useDialogMedBe
 import { useSenOppfolgingHistorikk } from "@/hooks/historikk/useSenOppfolgingHistorikk";
 import { useDialogmoteStatusEndringHistorikk } from "@/hooks/historikk/useDialogmoteStatusEndringHistorikk";
 import { useOppfolgingsplanHistorikk } from "@/hooks/historikk/useOppfolgingsplanHistorikk";
+import { useOppfolgingsoppgaveHistorikk } from "@/hooks/historikk/useOppfolgingsoppgaveHistorikk";
 
 interface HistorikkHook {
   isHistorikkLoading: boolean;
@@ -66,6 +67,8 @@ export function useHistorikk(): HistorikkHook {
   const dialogmoteStatusEndringHistorikk =
     useDialogmoteStatusEndringHistorikk();
 
+  const oppfolgingsoppgaveHistorikk = useOppfolgingsoppgaveHistorikk();
+
   const historikkEvents = motebehovHistorikk
     .concat(oppfolgingsplanHistorikk.events)
     .concat(lederHistorikk)
@@ -77,6 +80,7 @@ export function useHistorikk(): HistorikkHook {
     .concat(dialogMedBehandlerHistorikk.events)
     .concat(senOppfolgingHistorikk.events)
     .concat(dialogmotekandidatHistorikk)
+    .concat(oppfolgingsoppgaveHistorikk.events)
     .concat(dialogmoteStatusEndringHistorikk.events);
 
   const isHistorikkLoading =
@@ -91,6 +95,7 @@ export function useHistorikk(): HistorikkHook {
     dialogMedBehandlerHistorikk.isLoading ||
     senOppfolgingHistorikk.isLoading ||
     isDialogmotekandidatHistorikkLoading ||
+    oppfolgingsoppgaveHistorikk.isLoading ||
     dialogmoteStatusEndringHistorikk.isLoading;
 
   const isHistorikkError =
@@ -105,6 +110,7 @@ export function useHistorikk(): HistorikkHook {
     dialogMedBehandlerHistorikk.isError ||
     senOppfolgingHistorikk.isError ||
     isDialogmotekandidatHistorikkError ||
+    oppfolgingsoppgaveHistorikk.isError ||
     dialogmoteStatusEndringHistorikk.isError;
 
   return {

--- a/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
@@ -1,0 +1,80 @@
+import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
+import {
+  oppfolgingsgrunnToText,
+  OppfolgingsoppgaveNewResponseDTO,
+} from "@/data/oppfolgingsoppgave/types";
+import { useGetOppfolgingsoppgaver } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgaver";
+
+interface OppfolgingsoppgaveHistorikk {
+  isLoading: boolean;
+  isError: boolean;
+  events: HistorikkEvent[];
+}
+
+function createHistorikkEvents(
+  oppfolgingsoppgaver: OppfolgingsoppgaveNewResponseDTO[]
+): HistorikkEvent[] {
+  const historikkEvents: HistorikkEvent[] = [];
+
+  oppfolgingsoppgaver.map(({ isActive, removedBy, updatedAt, versjoner }) => {
+    const oppfolgingsgrunn = versjoner[0]?.oppfolgingsgrunn;
+    const oppfolgingsgrunnText =
+      oppfolgingsgrunn && oppfolgingsgrunnToText[oppfolgingsgrunn];
+
+    versjoner.forEach(({ createdAt, createdBy, tekst }, index) => {
+      if (index == 0) {
+        const opprettetOppfolgingsoppgave: HistorikkEvent = {
+          opprettetAv: createdBy,
+          tekst: `${createdBy} opprettet oppfølgingsoppgave (${oppfolgingsgrunnText})`,
+          tidspunkt: createdAt,
+          kilde: "OPPFOLGINGSOPPGAVE",
+          expandable: {
+            isExpandable: true,
+            content: tekst ?? "",
+          },
+        };
+        historikkEvents.push(opprettetOppfolgingsoppgave);
+      } else {
+        const endretOppfolgingsoppgave: HistorikkEvent = {
+          opprettetAv: createdBy,
+          tekst: `${createdBy} endret oppfølgingsoppgave (${oppfolgingsgrunnText})`,
+          tidspunkt: createdAt,
+          kilde: "OPPFOLGINGSOPPGAVE",
+          expandable: {
+            isExpandable: true,
+            content: tekst ?? "",
+          },
+        };
+        historikkEvents.push(endretOppfolgingsoppgave);
+      }
+    });
+
+    if (!isActive) {
+      const fjernetOppfolgingsoppgave: HistorikkEvent = {
+        opprettetAv: removedBy ?? "",
+        tekst: `${removedBy} fjernet oppfølgingsoppgaven (${oppfolgingsgrunnText})`,
+        tidspunkt: updatedAt,
+        kilde: "OPPFOLGINGSOPPGAVE",
+      };
+      historikkEvents.push(fjernetOppfolgingsoppgave);
+    }
+  });
+
+  return historikkEvents;
+}
+
+export function useOppfolgingsoppgaveHistorikk(): OppfolgingsoppgaveHistorikk {
+  const {
+    oppfolgingsoppgaver: oppfolgingsoppgaver,
+    isLoading: isOppfolgingsoppgaverLoading,
+    isError: isOppfolgingsoppgaverError,
+  } = useGetOppfolgingsoppgaver();
+
+  const historikkEvents = createHistorikkEvents(oppfolgingsoppgaver || []);
+
+  return {
+    isLoading: isOppfolgingsoppgaverLoading,
+    isError: isOppfolgingsoppgaverError,
+    events: historikkEvents,
+  };
+}

--- a/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
@@ -22,7 +22,7 @@ function createHistorikkEvents(
       oppfolgingsgrunn && oppfolgingsgrunnToText[oppfolgingsgrunn];
 
     versjoner.forEach(({ createdAt, createdBy, tekst }, index) => {
-      if (index == 0) {
+      if (index == versjoner.length - 1) {
         const opprettetOppfolgingsoppgave: HistorikkEvent = {
           opprettetAv: createdBy,
           tekst: `${createdBy} opprettet oppfølgingsoppgave (${oppfolgingsgrunnText})`,

--- a/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
@@ -28,10 +28,7 @@ function createHistorikkEvents(
           tekst: `${createdBy} opprettet oppfølgingsoppgave (${oppfolgingsgrunnText})`,
           tidspunkt: createdAt,
           kilde: "OPPFOLGINGSOPPGAVE",
-          expandable: {
-            isExpandable: true,
-            content: tekst ?? "",
-          },
+          expandableContent: tekst ?? "",
         };
         historikkEvents.push(opprettetOppfolgingsoppgave);
       } else {
@@ -40,10 +37,7 @@ function createHistorikkEvents(
           tekst: `${createdBy} endret oppfølgingsoppgave (${oppfolgingsgrunnText})`,
           tidspunkt: createdAt,
           kilde: "OPPFOLGINGSOPPGAVE",
-          expandable: {
-            isExpandable: true,
-            content: tekst ?? "",
-          },
+          expandableContent: tekst ?? "",
         };
         historikkEvents.push(endretOppfolgingsoppgave);
       }

--- a/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
+++ b/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
@@ -1,0 +1,76 @@
+import { generateUUID } from "@/utils/uuidUtils";
+import { VEILEDER_IDENT_DEFAULT } from "@/mocks/common/mockConstants";
+import { Oppfolgingsgrunn } from "@/data/oppfolgingsoppgave/types";
+import { addDays } from "@/utils/datoUtils";
+
+const DATO_INNENFOR_OPPFOLGINGSTILFELLE = new Date("2024-06-20");
+
+export const historikkOppfolgingsoppgaveAktivMock = {
+  uuid: generateUUID(),
+  createdBy: VEILEDER_IDENT_DEFAULT,
+  updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
+  isActive: true,
+  createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+  removedBy: null,
+  versjoner: [
+    {
+      uuid: generateUUID(),
+      createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst",
+      oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
+      frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 2),
+    },
+    {
+      uuid: generateUUID(),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst ver 2",
+      oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
+      frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 5),
+    },
+  ],
+};
+
+export const historikkOppfolgingsoppgaveFjernetMock = {
+  uuid: generateUUID(),
+  createdBy: VEILEDER_IDENT_DEFAULT,
+  updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -1),
+  isActive: false,
+  createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
+  removedBy: VEILEDER_IDENT_DEFAULT,
+  versjoner: [
+    {
+      uuid: generateUUID(),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst",
+      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+    },
+    {
+      uuid: generateUUID(),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -4),
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst ver 2",
+      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+    },
+    {
+      uuid: generateUUID(),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -3),
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst ver 3",
+      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+    },
+    {
+      uuid: generateUUID(),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -2),
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst ver 4",
+      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+    },
+  ],
+};

--- a/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
+++ b/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
@@ -15,19 +15,19 @@ export const historikkOppfolgingsoppgaveAktivMock = {
   versjoner: [
     {
       uuid: generateUUID(),
-      createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst",
-      oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
-      frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 2),
-    },
-    {
-      uuid: generateUUID(),
       createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
       createdBy: VEILEDER_IDENT_DEFAULT,
       tekst: "Oppfølgingsoppgavetekst ver 2",
       oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
       frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 5),
+    },
+    {
+      uuid: generateUUID(),
+      createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst",
+      oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
+      frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 2),
     },
   ],
 };
@@ -42,17 +42,9 @@ export const historikkOppfolgingsoppgaveFjernetMock = {
   versjoner: [
     {
       uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -2),
       createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst",
-      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
-      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-    },
-    {
-      uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -4),
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst ver 2",
+      tekst: "Oppfølgingsoppgavetekst ver 4",
       oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
       frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
     },
@@ -66,9 +58,17 @@ export const historikkOppfolgingsoppgaveFjernetMock = {
     },
     {
       uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -2),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -4),
       createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst ver 4",
+      tekst: "Oppfølgingsoppgavetekst ver 2",
+      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+    },
+    {
+      uuid: generateUUID(),
+      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
+      createdBy: VEILEDER_IDENT_DEFAULT,
+      tekst: "Oppfølgingsoppgavetekst",
       oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
       frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
     },

--- a/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
+++ b/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
@@ -19,8 +19,8 @@ const oppfolgingsoppgaveUuid = generateUUID();
 export const mockIshuskelapp = [
   http.get(`${ISHUSKELAPP_ROOT}/huskelapp?filter=all`, () => {
     return HttpResponse.json([
-      historikkOppfolgingsoppgaveFjernetMock,
       historikkOppfolgingsoppgaveAktivMock,
+      historikkOppfolgingsoppgaveFjernetMock,
     ]);
   }),
   http.get(`${ISHUSKELAPP_ROOT}/huskelapp`, () => {

--- a/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
+++ b/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
@@ -7,12 +7,22 @@ import {
 import { generateUUID } from "@/utils/uuidUtils";
 import { VEILEDER_IDENT_DEFAULT } from "../common/mockConstants";
 import { http, HttpResponse } from "msw";
+import {
+  historikkOppfolgingsoppgaveAktivMock,
+  historikkOppfolgingsoppgaveFjernetMock,
+} from "@/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock";
 
 let oppfolgingsoppgaveMock: OppfolgingsoppgaveResponseDTO | undefined =
   undefined;
 const oppfolgingsoppgaveUuid = generateUUID();
 
 export const mockIshuskelapp = [
+  http.get(`${ISHUSKELAPP_ROOT}/huskelapp?filter=all`, () => {
+    return HttpResponse.json([
+      historikkOppfolgingsoppgaveFjernetMock,
+      historikkOppfolgingsoppgaveAktivMock,
+    ]);
+  }),
   http.get(`${ISHUSKELAPP_ROOT}/huskelapp`, () => {
     return !!oppfolgingsoppgaveMock
       ? HttpResponse.json(oppfolgingsoppgaveMock)

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -63,6 +63,8 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
       return <Tag variant="neutral">Dialog med behandler</Tag>;
     case "SEN_OPPFOLGING":
       return <Tag variant="alt2">Snart slutt på sykepengene</Tag>;
+    case "OPPFOLGINGSOPPGAVE":
+      return <Tag variant="info">Oppfølgingsoppgave</Tag>;
     case "MOTEBEHOV":
     case "MOTER":
     case "DIALOGMOTEKANDIDAT":
@@ -133,6 +135,7 @@ export function Historikk({ historikkEvents, tilfeller }: Props): ReactElement {
         <Table>
           <Table.Header>
             <Table.Row>
+              <Table.ColumnHeader scope="col"></Table.ColumnHeader>
               <Table.ColumnHeader scope="col">Dato</Table.ColumnHeader>
               <Table.ColumnHeader scope="col">Beskrivelse</Table.ColumnHeader>
               <Table.ColumnHeader scope="col">Type</Table.ColumnHeader>
@@ -141,14 +144,23 @@ export function Historikk({ historikkEvents, tilfeller }: Props): ReactElement {
           <Table.Body>
             {filteredEvents()
               .sort(byTidspunkt())
-              .map((event, i) => {
-                return (
-                  <Table.Row key={i}>
+              .map(({ expandable, kilde, tekst, tidspunkt }, i) => {
+                return expandable?.isExpandable ? (
+                  <Table.ExpandableRow key={i} content={expandable.content}>
                     <Table.DataCell>
-                      {tilLesbarDatoMedArstall(event.tidspunkt)}
+                      {tilLesbarDatoMedArstall(tidspunkt)}
                     </Table.DataCell>
-                    <Table.DataCell>{event.tekst}</Table.DataCell>
-                    <Table.DataCell>{tagFromKilde(event.kilde)}</Table.DataCell>
+                    <Table.DataCell>{tekst}</Table.DataCell>
+                    <Table.DataCell>{tagFromKilde(kilde)}</Table.DataCell>
+                  </Table.ExpandableRow>
+                ) : (
+                  <Table.Row key={i}>
+                    <Table.DataCell></Table.DataCell>
+                    <Table.DataCell>
+                      {tilLesbarDatoMedArstall(tidspunkt)}
+                    </Table.DataCell>
+                    <Table.DataCell>{tekst}</Table.DataCell>
+                    <Table.DataCell>{tagFromKilde(kilde)}</Table.DataCell>
                   </Table.Row>
                 );
               })}

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -144,9 +144,9 @@ export function Historikk({ historikkEvents, tilfeller }: Props): ReactElement {
           <Table.Body>
             {filteredEvents()
               .sort(byTidspunkt())
-              .map(({ expandable, kilde, tekst, tidspunkt }, i) => {
-                return expandable?.isExpandable ? (
-                  <Table.ExpandableRow key={i} content={expandable.content}>
+              .map(({ expandableContent, kilde, tekst, tidspunkt }, i) => {
+                return expandableContent ? (
+                  <Table.ExpandableRow key={i} content={expandableContent}>
                     <Table.DataCell>
                       {tilLesbarDatoMedArstall(tidspunkt)}
                     </Table.DataCell>

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -676,6 +676,8 @@ describe("Historikk", () => {
   });
 
   describe("Oppfølgingsoppgave", () => {
+    const expandableToggleText = "Vis mer";
+
     it("Ingen oppfølgingsoppgaver", async () => {
       queryClient.setQueryData(
         oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(
@@ -688,7 +690,7 @@ describe("Historikk", () => {
 
       expect(await screen.findAllByText("Historikk")).to.exist;
       expect(
-        screen.queryAllByText("opprettet oppfølgingsoppgave", { exact: false })
+        screen.queryAllByRole("row", { name: RegExp("Oppfølgingsoppgave") })
       ).to.be.empty;
     });
 
@@ -704,18 +706,24 @@ describe("Historikk", () => {
 
       expect(await screen.findAllByText("Historikk")).to.exist;
       expect(
-        screen.getByText(
-          "Z990000 opprettet oppfølgingsoppgave (Vurder annen ytelse)"
-        )
+        screen.getByRole("row", {
+          name: new RegExp(
+            expandableToggleText +
+              " 21. juni 2024 Z990000 endret oppfølgingsoppgave \\(Vurder annen ytelse\\)"
+          ),
+        })
       ).to.exist;
       expect(
-        screen.getByText(
-          "Z990000 endret oppfølgingsoppgave (Vurder annen ytelse)"
-        )
+        screen.getByRole("row", {
+          name: new RegExp(
+            expandableToggleText +
+              " 20. juni 2024 Z990000 opprettet oppfølgingsoppgave \\(Vurder annen ytelse\\)"
+          ),
+        })
       ).to.exist;
     });
 
-    it("Fjernet oppfølginsoppgave inkluder endring", async () => {
+    it("Fjernet oppfølginsoppgave inkludert endring", async () => {
       queryClient.setQueryData(
         oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(
           ARBEIDSTAKER_DEFAULT.personIdent
@@ -727,19 +735,43 @@ describe("Historikk", () => {
 
       expect(await screen.findAllByText("Historikk")).to.exist;
       expect(
-        screen.getByText(
-          "Z990000 opprettet oppfølgingsoppgave (Ta kontakt med arbeidsgiver)"
-        )
+        screen.getByRole("row", {
+          name: new RegExp(
+            "19. juni 2024 Z990000 fjernet oppfølgingsoppgaven \\(Ta kontakt med arbeidsgiver\\)"
+          ),
+        })
       ).to.exist;
       expect(
-        screen.queryAllByText(
-          "Z990000 endret oppfølgingsoppgave (Ta kontakt med arbeidsgiver)"
-        ).length
-      ).toBe(3);
+        screen.getByRole("row", {
+          name: new RegExp(
+            expandableToggleText +
+              " 18. juni 2024 Z990000 endret oppfølgingsoppgave \\(Ta kontakt med arbeidsgiver\\)"
+          ),
+        })
+      ).to.exist;
       expect(
-        screen.getByText(
-          "Z990000 fjernet oppfølgingsoppgaven (Ta kontakt med arbeidsgiver)"
-        )
+        screen.getByRole("row", {
+          name: new RegExp(
+            expandableToggleText +
+              " 17. juni 2024 Z990000 endret oppfølgingsoppgave \\(Ta kontakt med arbeidsgiver\\)"
+          ),
+        })
+      ).to.exist;
+      expect(
+        screen.getByRole("row", {
+          name: new RegExp(
+            expandableToggleText +
+              " 16. juni 2024 Z990000 endret oppfølgingsoppgave \\(Ta kontakt med arbeidsgiver\\)"
+          ),
+        })
+      ).to.exist;
+      expect(
+        screen.getByRole("row", {
+          name: new RegExp(
+            expandableToggleText +
+              " 15. juni 2024 Z990000 opprettet oppfølgingsoppgave \\(Ta kontakt med arbeidsgiver\\)"
+          ),
+        })
       ).to.exist;
     });
   });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Har lagt til oppfølgingsoppgaver i historikken. Det er tatt i bruk nytt endepunkt med ny struktur.

Litt usikker på om testene burde teste noe som har med expandable om det i det hele tatt er mulig. Litt usikker på hvilke muligheter vi har med det vi bruker og så er det litt hva som gir mening/verdi.

Jeg tenker det gir mening å ta refaktorering av aktiv oppfølgingsoppgave som en egen PR.

Denne er avhengig av: https://github.com/navikt/ishuskelapp/pull/83

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/66ed24aa-595c-407e-8b31-13751bc3d358)

