### PR TITLE
IS-2834: Remove ny tag from historikk in side menu

### DIFF
--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -12,7 +12,7 @@ import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 import { toOppfolgingsplanLPSMedPersonoppgave } from "@/utils/oppfolgingsplanerUtils";
 import { VedtakMenypunkt } from "@/components/globalnavigasjon/VedtakMenypunkt";
 import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
-import { BodyShort, Tag } from "@navikt/ds-react";
+import { BodyShort } from "@navikt/ds-react";
 import { EventType, logEvent } from "@/utils/amplitude";
 import { useGetArbeidsuforhetVurderingerQuery } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { useSenOppfolgingKandidatQuery } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
@@ -212,11 +212,6 @@ export const GlobalNavigasjon = ({
                   }}
                 >
                   <BodyShort size="small">{navn}</BodyShort>
-                  {menypunkt === Menypunkter.HISTORIKK && (
-                    <Tag variant="info" size="xsmall">
-                      Ny
-                    </Tag>
-                  )}
                   {tasks > 0 && (
                     <UnfinishedTasks tasks={tasks} menypunkt={menypunkt} />
                   )}

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -104,7 +104,7 @@ describe("GlobalNavigasjon", () => {
       "Arbeidsuførhet",
       "Friskmelding til arbeidsformidling",
       "Snart slutt på sykepengene",
-      "HistorikkNy",
+      "Historikk",
       "Vedtak",
     ];
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Fjerner "Ny" tag fra historikk menypunkt

### Screenshots 📸✨
Før
![Screenshot 2024-11-25 at 14 59 51](https://github.com/user-attachments/assets/d15a32b8-7e7e-4357-b1b3-75f4c1341f2a)
Nå
![Screenshot 2024-11-25 at 14 59 41](https://github.com/user-attachments/assets/19d80646-cf3b-45d7-9f69-9887bb88d148)
