### PR TITLE
IS-2796: Skal ikke vise OppsummeringBekreftelsespunkter for svarType OPPSUMMERING

### DIFF
--- a/src/sider/sykepengsoknader/soknad-felles-oppsummering/OppsummeringSporsmal.tsx
+++ b/src/sider/sykepengsoknader/soknad-felles-oppsummering/OppsummeringSporsmal.tsx
@@ -69,10 +69,11 @@ const OppsummeringSporsmal = (
     case SvarTypeDTO.KVITTERING: {
       return <OppsummeringKvittering {...props} />;
     }
-    case SvarTypeDTO.OPPSUMMERING:
     case SvarTypeDTO.BEKREFTELSESPUNKTER: {
       return <OppsummeringBekreftelsespunkter {...props} />;
     }
+    case SvarTypeDTO.OPPSUMMERING:
+      return null;
     default: {
       return null;
     }


### PR DESCRIPTION
Relatert til https://github.com/navikt/syfomodiaperson/pull/1420. Har avklart med @olebaba at det ikke gir mening å vise 
`OppsummeringBekreftelsespunkter` for denne svartypen da den ikke vil ha noen spørsmålstekst eller svar med verdier som kan vises. (for denne typen vil man bare ett svar som har verdien "true" dersom  brukeren har åpnet oppsummeringen) i søknaden.

Før:
![image](https://github.com/user-attachments/assets/4a6e7d2a-0eeb-43ba-87e4-ebe172dc0ab8)
Nå:
![image](https://github.com/user-attachments/assets/b0866e92-5508-480b-9c9f-6d5532f44dcb)
