### PR TITLE
IS-2536: Add indication when utbetalingsinfo is from before oppfolgin…

### DIFF
--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -13,6 +13,9 @@ import { Diagnosekode } from "@/components/personkort/PersonkortHeader/Diagnosek
 import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 import { NavnHeader } from "@/components/personkort/PersonkortHeader/NavnHeader";
 import { MaksdatoSummary } from "@/components/personkort/PersonkortHeader/MaksdatoSummary";
+import { useStartOfLatestOppfolgingstilfelle } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import UtdatertUtbetalingsinfoAlert from "@/components/personkort/PersonkortHeader/UtdatertUtbetalingsinfoAlert";
+import { isDateBefore } from "@/utils/datoUtils";
 
 const texts = {
   ikkeUtbetalt: "Sykepenger ikke utbetalt",
@@ -32,7 +35,12 @@ const StyledFnr = styled.div`
 export function PersonkortHeader() {
   const navbruker = useNavBrukerData();
   const personident = useValgtPersonident();
+  const startDate = useStartOfLatestOppfolgingstilfelle();
   const { data: maksDato, isSuccess } = useMaksdatoQuery();
+  const isUtbetalingsinfoFromBeforeOppfolgingstilfelleStart = isDateBefore(
+    maksDato?.maxDate?.opprettet,
+    startDate
+  );
 
   return (
     <>
@@ -54,7 +62,12 @@ export function PersonkortHeader() {
 
           {isSuccess ? (
             maksDato?.maxDate ? (
-              <MaksdatoSummary maxDate={maksDato.maxDate} />
+              <>
+                <MaksdatoSummary maxDate={maksDato.maxDate} />
+                {isUtbetalingsinfoFromBeforeOppfolgingstilfelleStart && (
+                  <UtdatertUtbetalingsinfoAlert />
+                )}
+              </>
             ) : (
               <Tag variant="warning" size="small" className="mt-1">
                 {texts.ikkeUtbetalt}

--- a/src/components/personkort/PersonkortHeader/UtdatertUtbetalingsinfoAlert.tsx
+++ b/src/components/personkort/PersonkortHeader/UtdatertUtbetalingsinfoAlert.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { Alert } from "@navikt/ds-react";
+
+export default function UtdatertUtbetalingsinfoAlert() {
+  return (
+    <Alert inline variant="warning" size="small">
+      Utbetalingsinfo kan gjelde tidligere oppfølgingstilfelle
+    </Alert>
+  );
+}

--- a/src/mocks/syfoperson/persondataMock.ts
+++ b/src/mocks/syfoperson/persondataMock.ts
@@ -31,6 +31,6 @@ export const maksdatoMock = {
     forelopig_beregnet_slutt: maksdato,
     utbetalt_tom: "2024-07-01",
     gjenstaende_sykedager: "70",
-    opprettet: "2023-01-01T12:00:00.000000",
+    opprettet: Date.now().toString(),
   },
 };

--- a/src/utils/datoUtils.ts
+++ b/src/utils/datoUtils.ts
@@ -309,3 +309,8 @@ export const isExpiredForhandsvarsel = (
 
   return false;
 };
+
+export function isDateBefore(date?: Date, targetDate?: Date): boolean {
+  const hasValues = !!date && !!targetDate;
+  return hasValues && targetDate < date;
+}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til indikasjon med informasjon (når bruker trykker) om at utbetalingsinfo er fra før oppfølgingstilfellet sin startdato. Dette for å hjelpe veileder å legge merke til at maksdato ikke nødvendigvis er reell.

- [ ] Designsjekk
- [ ] Tekstsjekk med Stine

### Screenshots 📸✨
Foreløpig utseende
![Screenshot 2024-12-02 at 13 20 51](https://github.com/user-attachments/assets/9819ba90-54a8-4bd4-a302-10313f1e7d9a)
![Screenshot 2024-12-02 at 13 17 05](https://github.com/user-attachments/assets/1e7d298c-8739-4229-bea1-33a125c6808b)

Videre iterasjon:
<img width="1457" alt="Skjermbilde 2024-12-04 kl  11 50 57" src="https://github.com/user-attachments/assets/00c9efdb-8f4c-4a9e-8c4a-4e6187c047f8">


