### PR TITLE
IS-2769: Refactor historikk-page with design changes

### DIFF
--- a/src/hooks/historikk/useAktivitetskravHistorikk.ts
+++ b/src/hooks/historikk/useAktivitetskravHistorikk.ts
@@ -17,11 +17,14 @@ function getTextForHistorikk(
     case AktivitetskravStatus.NY_VURDERING:
       return `Det ble startet ny vurdering av aktivitetskravet`;
     case AktivitetskravStatus.UNNTAK:
+      return `${historikk.vurdertAv} vurderte unntak fra aktivitetskravet`;
     case AktivitetskravStatus.OPPFYLT:
+      return `${historikk.vurdertAv} vurderte at aktivitetskravet var oppfylt`;
     case AktivitetskravStatus.STANS:
-    case AktivitetskravStatus.IKKE_AKTUELL:
     case AktivitetskravStatus.IKKE_OPPFYLT:
-      return `${historikk.vurdertAv} vurderte ${historikk.status} for aktivitetskravet`;
+      return `${historikk.vurdertAv} vurderte at aktivitetskravet ikke var oppfylt`;
+    case AktivitetskravStatus.IKKE_AKTUELL:
+      return `${historikk.vurdertAv} vurderte at aktivitetskravet ikke var aktuelt`;
     case AktivitetskravStatus.FORHANDSVARSEL:
       return `Det ble sendt et forhåndsvarsel for aktivitetskravet av ${historikk.vurdertAv}`;
     case AktivitetskravStatus.LUKKET:

--- a/src/sider/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
+++ b/src/sider/aktivitetskrav/historikk/AktivitetskravHistorikk.tsx
@@ -29,7 +29,8 @@ const isRelevantForHistorikk = (vurdering: AktivitetskravVurderingDTO) =>
   vurdering.status === AktivitetskravStatus.STANS ||
   vurdering.status === AktivitetskravStatus.IKKE_OPPFYLT ||
   vurdering.status === AktivitetskravStatus.FORHANDSVARSEL ||
-  vurdering.status === AktivitetskravStatus.AVVENT;
+  vurdering.status === AktivitetskravStatus.AVVENT ||
+  vurdering.status === AktivitetskravStatus.IKKE_AKTUELL;
 
 const byCreatedAt = (
   v1: AktivitetskravVurderingDTO,
@@ -81,11 +82,13 @@ const headerPrefix = (status: AktivitetskravStatus): string => {
     case AktivitetskravStatus.AVVENT: {
       return "Avventer";
     }
+    case AktivitetskravStatus.IKKE_AKTUELL: {
+      return "Ikke aktuell";
+    }
     case AktivitetskravStatus.NY:
     case AktivitetskravStatus.NY_VURDERING:
     case AktivitetskravStatus.AUTOMATISK_OPPFYLT:
-    case AktivitetskravStatus.LUKKET:
-    case AktivitetskravStatus.IKKE_AKTUELL: {
+    case AktivitetskravStatus.LUKKET: {
       // Ikke relevant for historikk
       return "";
     }

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -58,11 +58,23 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
     case "MANGLENDE_MEDVIRKNING":
       return <Tag variant="warning">Manglende medvirkning</Tag>;
     case "FRISKMELDING_TIL_ARBEIDSFORMIDLING":
-      return <Tag variant="info">Friskmelding til arbeidsformidling</Tag>;
+      return (
+        <Tag className="w-max" variant="info">
+          Friskmelding til arbeidsformidling
+        </Tag>
+      );
     case "DIALOG_MED_BEHANDLER":
-      return <Tag variant="neutral">Dialog med behandler</Tag>;
+      return (
+        <Tag className="w-max" variant="neutral">
+          Dialog med behandler
+        </Tag>
+      );
     case "SEN_OPPFOLGING":
-      return <Tag variant="alt2">Snart slutt på sykepengene</Tag>;
+      return (
+        <Tag className="w-max" variant="alt2">
+          Snart slutt på sykepengene
+        </Tag>
+      );
     case "OPPFOLGINGSOPPGAVE":
       return <Tag variant="info">Oppfølgingsoppgave</Tag>;
     case "MOTEBEHOV":

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -50,6 +50,7 @@ import {
   historikkOppfolgingsoppgaveAktivMock,
   historikkOppfolgingsoppgaveFjernetMock,
 } from "@/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock";
+import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
 
 let queryClient: QueryClient;
 
@@ -772,6 +773,39 @@ describe("Historikk", () => {
               " 15. juni 2024 Z990000 opprettet oppfølgingsoppgave \\(Ta kontakt med arbeidsgiver\\)"
           ),
         })
+      ).to.exist;
+    });
+  });
+
+  describe("Aktivitetskrav", () => {
+    it("viser aktivitetskrav", async () => {
+      queryClient.setQueryData(
+        aktivitetskravQueryKeys.historikk(ARBEIDSTAKER_DEFAULT.personIdent),
+        () => [
+          {
+            tidspunkt: new Date(),
+            status: AktivitetskravStatus.NY,
+            vurdertAv: null,
+          },
+          {
+            tidspunkt: new Date(),
+            status: AktivitetskravStatus.OPPFYLT,
+            vurdertAv: VEILEDER_IDENT_DEFAULT,
+          },
+        ]
+      );
+
+      renderHistorikk();
+
+      expect(await screen.findAllByText("Historikk")).to.exist;
+      expect(screen.getAllByText("Aktivitetskrav")).to.have.length(3); // To tags og menypunktet
+      expect(
+        screen.getByText("Samuel Sam Jones ble kandidat til aktivitetskravet")
+      ).to.exist;
+      expect(
+        screen.getByText(
+          `${VEILEDER_IDENT_DEFAULT} vurderte at aktivitetskravet var oppfylt`
+        )
       ).to.exist;
     });
   });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi landet ikke på så mange endringer, men endret litt på tekstene slik at det ikke står "Det ble vurdert IKKE_AKTUELT" på aktivitetskrav, samt fikset noen av de lengste tagsene som fikk rar formatering på liten skjerm. Beholder ting i "vanlig størrelse" foreløpig, og så kan vi heller ta small når vi får konkrete tilbakemeldinger på ting. 

### Screenshots 📸✨
Se på "Snart slutt på sykepengene" tagsene.
Før:
<img width="589" alt="image" src="https://github.com/user-attachments/assets/401f451b-af1a-4dee-8961-9b13dc3b32ca">

Etter:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/a6cb001f-930d-4873-87a2-833c1cb218bb">

