### PR TITLE
IS-2460: Refaktorert slik at oppfølgingsoppgave bruker ny datamodell

### DIFF
--- a/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
+++ b/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
@@ -10,7 +10,7 @@ import {
 } from "@navikt/ds-react";
 import React, { useState } from "react";
 import { OpenOppfolgingsoppgaveModalButton } from "@/components/oppfolgingsoppgave/OpenOppfolgingsoppgaveModalButton";
-import { useGetOppfolgingsoppgave } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgave";
+import { useAktivOppfolgingsoppgave } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { oppfolgingsgrunnToText } from "@/data/oppfolgingsoppgave/types";
@@ -26,25 +26,26 @@ const texts = {
 export const Oppfolgingsoppgave = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const removeOppfolgingsoppgave = useRemoveOppfolgingsoppgave();
-  const { oppfolgingsoppgave } = useGetOppfolgingsoppgave();
+  const { aktivOppfolgingsoppgave } = useAktivOppfolgingsoppgave();
+  const aktivOppfolgingsoppgaveVersjon =
+    aktivOppfolgingsoppgave?.versjoner?.[0];
+
   const { data: veilederinfo } = useVeilederInfoQuery(
-    oppfolgingsoppgave?.createdBy ?? ""
+    aktivOppfolgingsoppgave?.createdBy ?? ""
   );
-  const isExistingOppfolgingsoppgave = !!oppfolgingsoppgave;
+  const isExistingOppfolgingsoppgave = !!aktivOppfolgingsoppgave;
   const handleRemoveOppfolgingsoppgave = (uuid: string) => {
     removeOppfolgingsoppgave.mutate(uuid);
   };
 
-  const oppfolgingsgrunn = oppfolgingsoppgave?.oppfolgingsgrunn
-    ? oppfolgingsgrunnToText[oppfolgingsoppgave.oppfolgingsgrunn]
+  const oppfolgingsgrunn = aktivOppfolgingsoppgaveVersjon?.oppfolgingsgrunn
+    ? oppfolgingsgrunnToText[aktivOppfolgingsoppgaveVersjon.oppfolgingsgrunn]
     : null;
 
-  const beskrivelse = oppfolgingsoppgave?.tekst
-    ? oppfolgingsoppgave.tekst
-    : null;
+  const beskrivelse = aktivOppfolgingsoppgaveVersjon?.tekst ?? null;
 
-  const frist = oppfolgingsoppgave?.frist
-    ? tilLesbarDatoMedArUtenManedNavn(oppfolgingsoppgave?.frist)
+  const frist = aktivOppfolgingsoppgaveVersjon?.frist
+    ? tilLesbarDatoMedArUtenManedNavn(aktivOppfolgingsoppgaveVersjon?.frist)
     : undefined;
 
   return isExistingOppfolgingsoppgave ? (
@@ -84,7 +85,7 @@ export const Oppfolgingsoppgave = () => {
           type="button"
           variant={"secondary-neutral"}
           onClick={() =>
-            handleRemoveOppfolgingsoppgave(oppfolgingsoppgave.uuid)
+            handleRemoveOppfolgingsoppgave(aktivOppfolgingsoppgave.uuid)
           }
           loading={removeOppfolgingsoppgave.isPending}
           className={"ml-auto"}
@@ -96,12 +97,12 @@ export const Oppfolgingsoppgave = () => {
       <div className="mt-2">
         <Detail textColor="subtle" className="text-xs">
           {`Opprettet: ${tilLesbarDatoMedArUtenManedNavn(
-            oppfolgingsoppgave.createdAt
+            aktivOppfolgingsoppgave.createdAt
           )}`}
         </Detail>
         <Detail textColor="subtle" className="text-xs">
           {`Sist oppdatert: ${tilLesbarDatoMedArUtenManedNavn(
-            oppfolgingsoppgave.updatedAt
+            aktivOppfolgingsoppgave.updatedAt
           )}`}
         </Detail>
         {veilederinfo && (
@@ -117,7 +118,7 @@ export const Oppfolgingsoppgave = () => {
         <OppfolgingsoppgaveModal
           isOpen={isModalOpen}
           toggleOpen={setIsModalOpen}
-          existingOppfolgingsoppgave={oppfolgingsoppgave}
+          existingOppfolgingsoppgave={aktivOppfolgingsoppgave}
         />
       )}
     </Box>

--- a/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
+++ b/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
@@ -76,10 +76,16 @@ function logOppfolgingsoppgaveEdited(
   editedOppfolgingsoppgave: EditOppfolgingsoppgaveRequestDTO
 ) {
   const editedFields: string[] = [];
-  if (editedOppfolgingsoppgave.frist !== existingOppfolgingsoppgave.frist) {
+  const existingOppfolgingsoppgaveVersjon =
+    existingOppfolgingsoppgave.versjoner[0];
+  if (
+    editedOppfolgingsoppgave.frist !== existingOppfolgingsoppgaveVersjon?.frist
+  ) {
     editedFields.push("frist");
   }
-  if (editedOppfolgingsoppgave.tekst !== existingOppfolgingsoppgave.tekst) {
+  if (
+    editedOppfolgingsoppgave.tekst !== existingOppfolgingsoppgaveVersjon?.tekst
+  ) {
     editedFields.push("tekst");
   }
   Amplitude.logEvent({
@@ -103,6 +109,8 @@ export const OppfolgingsoppgaveModal = ({
   const editOppfolgingsoppgave = useEditOppfolgingsoppgave(
     existingOppfolgingsoppgave?.uuid
   );
+  const existingOppfolgingsoppgaveVersjon =
+    existingOppfolgingsoppgave?.versjoner?.[0];
   const {
     register,
     formState: { errors, isDirty },
@@ -111,19 +119,21 @@ export const OppfolgingsoppgaveModal = ({
     watch,
   } = useForm<FormValues>({
     defaultValues: {
-      beskrivelse: existingOppfolgingsoppgave?.tekst ?? "",
-      frist: existingOppfolgingsoppgave?.frist ?? null,
+      beskrivelse: existingOppfolgingsoppgaveVersjon?.tekst ?? "",
+      frist: existingOppfolgingsoppgaveVersjon?.frist ?? null,
     },
   });
   const watchedValues = watch();
   const isEditMode = !!existingOppfolgingsoppgave;
 
   const isFormEdited = useCallback(
-    (existingOppfolgingsoppgave) => {
+    (existingOppfolgingsoppgave: OppfolgingsoppgaveResponseDTO | undefined) => {
+      const existingOppfolgingsoppgaveVersjon =
+        existingOppfolgingsoppgave?.versjoner[0];
       const isFristEdited =
-        watchedValues.frist !== existingOppfolgingsoppgave?.frist;
+        watchedValues.frist !== existingOppfolgingsoppgaveVersjon?.frist;
       const isBeskrivelseEdited =
-        watchedValues.beskrivelse !== existingOppfolgingsoppgave?.tekst;
+        watchedValues.beskrivelse !== existingOppfolgingsoppgaveVersjon?.tekst;
       return isFristEdited || isBeskrivelseEdited;
     },
     [watchedValues]
@@ -187,8 +197,8 @@ export const OppfolgingsoppgaveModal = ({
     });
   }
 
-  const defaultSelectedDate = !!existingOppfolgingsoppgave?.frist
-    ? dayjs(existingOppfolgingsoppgave.frist).toDate()
+  const defaultSelectedDate = existingOppfolgingsoppgaveVersjon?.frist
+    ? dayjs(existingOppfolgingsoppgaveVersjon.frist).toDate()
     : undefined;
   const { datepickerProps, inputProps } = useDatepicker({
     onDateChange: (date: Date | undefined) => {
@@ -239,7 +249,7 @@ export const OppfolgingsoppgaveModal = ({
             {...register("oppfolgingsgrunn", { required: true })}
             error={errors.oppfolgingsgrunn && texts.missingOppfolgingsgrunn}
             readOnly={isEditMode}
-            value={existingOppfolgingsoppgave?.oppfolgingsgrunn}
+            value={existingOppfolgingsoppgaveVersjon?.oppfolgingsgrunn}
           >
             <option value="">{texts.oppfolgingsgrunnDefaultOption}</option>
             {Object.values(Oppfolgingsgrunn).map((oppfolgingsgrunn, index) => (

--- a/src/data/oppfolgingsoppgave/types.ts
+++ b/src/data/oppfolgingsoppgave/types.ts
@@ -30,16 +30,6 @@ export interface OppfolgingsoppgaveResponseDTO {
   uuid: string;
   createdBy: string;
   updatedAt: Date;
-  createdAt: Date;
-  tekst?: string;
-  oppfolgingsgrunn?: Oppfolgingsgrunn;
-  frist: string | null;
-}
-
-export interface OppfolgingsoppgaveNewResponseDTO {
-  uuid: string;
-  createdBy: string;
-  updatedAt: Date;
   isActive: boolean;
   createdAt: Date;
   removedBy: string | null;

--- a/src/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave.tsx
@@ -4,32 +4,33 @@ import { get } from "@/api/axios";
 import { useQuery } from "@tanstack/react-query";
 import { OppfolgingsoppgaveResponseDTO } from "@/data/oppfolgingsoppgave/types";
 
-export const oppfolgingsoppgaveQueryKeys = {
-  oppfolgingsoppgave: (personident: string) => [
-    "oppfolgingsoppgave",
+export const aktivOppfolgingsoppgaveQueryKeys = {
+  aktivOppfolgingsoppgave: (personident: string) => [
+    "aktivOppfolgingsoppgave",
     personident,
   ],
 };
 
-export const useGetOppfolgingsoppgave = () => {
+export const useAktivOppfolgingsoppgave = () => {
   const personident = useValgtPersonident();
-  const path = `${ISHUSKELAPP_ROOT}/huskelapp`;
+  const path = `${ISHUSKELAPP_ROOT}/huskelapp?isActive=true`;
   const getOppfolgingsoppgave = () =>
     get<OppfolgingsoppgaveResponseDTO>(path, personident);
 
   const {
-    data: oppfolgingsoppgave,
+    data: aktivOppfolgingsoppgave,
     isLoading,
     isError,
     isSuccess,
   } = useQuery({
-    queryKey: oppfolgingsoppgaveQueryKeys.oppfolgingsoppgave(personident),
+    queryKey:
+      aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(personident),
     queryFn: getOppfolgingsoppgave,
     enabled: !!personident,
   });
 
   return {
-    oppfolgingsoppgave: oppfolgingsoppgave,
+    aktivOppfolgingsoppgave: aktivOppfolgingsoppgave,
     isSuccess,
     isLoading,
     isError,

--- a/src/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave.tsx
@@ -17,18 +17,14 @@ export const useCreateOppfolgingsoppgave = () => {
 
   return useMutation({
     mutationFn: postOppfolgingsoppgave,
-    onSuccess: () =>
-      Promise.all([
-        queryClient.invalidateQueries({
-          queryKey:
-            aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(
-              personident
-            ),
-        }),
-        queryClient.invalidateQueries({
-          queryKey:
-            oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
-        }),
-      ]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey:
+          aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(personident),
+      });
+      queryClient.invalidateQueries({
+        queryKey: oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+      });
+    },
   });
 };

--- a/src/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave.tsx
@@ -2,7 +2,8 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISHUSKELAPP_ROOT } from "@/apiConstants";
 import { post } from "@/api/axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { oppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgave";
+import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
+import { aktivOppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
 import { OppfolgingsoppgaveRequestDTO } from "@/data/oppfolgingsoppgave/types";
 
 export const useCreateOppfolgingsoppgave = () => {
@@ -16,10 +17,18 @@ export const useCreateOppfolgingsoppgave = () => {
 
   return useMutation({
     mutationFn: postOppfolgingsoppgave,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: oppfolgingsoppgaveQueryKeys.oppfolgingsoppgave(personident),
-      });
-    },
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey:
+            aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(
+              personident
+            ),
+        }),
+        queryClient.invalidateQueries({
+          queryKey:
+            oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+        }),
+      ]),
   });
 };

--- a/src/data/oppfolgingsoppgave/useEditOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useEditOppfolgingsoppgave.tsx
@@ -23,18 +23,14 @@ export function useEditOppfolgingsoppgave(
 
   return useMutation({
     mutationFn: editOppfolgingsoppgave,
-    onSuccess: () =>
-      Promise.all([
-        queryClient.invalidateQueries({
-          queryKey:
-            aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(
-              personident
-            ),
-        }),
-        queryClient.invalidateQueries({
-          queryKey:
-            oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
-        }),
-      ]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey:
+          aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(personident),
+      });
+      queryClient.invalidateQueries({
+        queryKey: oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+      });
+    },
   });
 }

--- a/src/data/oppfolgingsoppgave/useEditOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useEditOppfolgingsoppgave.tsx
@@ -2,7 +2,8 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISHUSKELAPP_ROOT } from "@/apiConstants";
 import { EditOppfolgingsoppgaveRequestDTO } from "@/data/oppfolgingsoppgave/types";
 import { post } from "@/api/axios";
-import { oppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgave";
+import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
+import { aktivOppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export function useEditOppfolgingsoppgave(
@@ -22,10 +23,18 @@ export function useEditOppfolgingsoppgave(
 
   return useMutation({
     mutationFn: editOppfolgingsoppgave,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: oppfolgingsoppgaveQueryKeys.oppfolgingsoppgave(personident),
-      });
-    },
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey:
+            aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(
+              personident
+            ),
+        }),
+        queryClient.invalidateQueries({
+          queryKey:
+            oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+        }),
+      ]),
   });
 }

--- a/src/data/oppfolgingsoppgave/useOppfolgingsoppgaver.tsx
+++ b/src/data/oppfolgingsoppgave/useOppfolgingsoppgaver.tsx
@@ -2,7 +2,7 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISHUSKELAPP_ROOT } from "@/apiConstants";
 import { get } from "@/api/axios";
 import { useQuery } from "@tanstack/react-query";
-import { OppfolgingsoppgaveNewResponseDTO } from "@/data/oppfolgingsoppgave/types";
+import { OppfolgingsoppgaveResponseDTO } from "@/data/oppfolgingsoppgave/types";
 
 export const oppfolgingsoppgaverQueryKeys = {
   oppfolgingsoppgaver: (personident: string) => [
@@ -11,11 +11,11 @@ export const oppfolgingsoppgaverQueryKeys = {
   ],
 };
 
-export const useGetOppfolgingsoppgaver = () => {
+export const useOppfolgingsoppgaver = () => {
   const personident = useValgtPersonident();
   const path = `${ISHUSKELAPP_ROOT}/huskelapp?filter=all`;
   const getOppfolgingsoppgaver = () =>
-    get<OppfolgingsoppgaveNewResponseDTO[]>(path, personident);
+    get<OppfolgingsoppgaveResponseDTO[]>(path, personident);
 
   const {
     data: oppfolgingsoppgaver,

--- a/src/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave.tsx
@@ -15,18 +15,14 @@ export const useRemoveOppfolgingsoppgave = () => {
 
   return useMutation({
     mutationFn: deleteOppfolgingsoppgave,
-    onSuccess: () =>
-      Promise.all([
-        queryClient.invalidateQueries({
-          queryKey:
-            aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(
-              personident
-            ),
-        }),
-        queryClient.invalidateQueries({
-          queryKey:
-            oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
-        }),
-      ]),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey:
+          aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(personident),
+      });
+      queryClient.invalidateQueries({
+        queryKey: oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+      });
+    },
   });
 };

--- a/src/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave.tsx
@@ -2,7 +2,8 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISHUSKELAPP_ROOT } from "@/apiConstants";
 import { deleteRequest } from "@/api/axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { oppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgave";
+import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
+import { aktivOppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
 
 export const useRemoveOppfolgingsoppgave = () => {
   const personident = useValgtPersonident();
@@ -14,10 +15,18 @@ export const useRemoveOppfolgingsoppgave = () => {
 
   return useMutation({
     mutationFn: deleteOppfolgingsoppgave,
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: oppfolgingsoppgaveQueryKeys.oppfolgingsoppgave(personident),
-      });
-    },
+    onSuccess: () =>
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey:
+            aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(
+              personident
+            ),
+        }),
+        queryClient.invalidateQueries({
+          queryKey:
+            oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+        }),
+      ]),
   });
 };

--- a/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
@@ -1,9 +1,9 @@
 import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
 import {
   oppfolgingsgrunnToText,
-  OppfolgingsoppgaveNewResponseDTO,
+  OppfolgingsoppgaveResponseDTO,
 } from "@/data/oppfolgingsoppgave/types";
-import { useGetOppfolgingsoppgaver } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgaver";
+import { useOppfolgingsoppgaver } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
 
 interface OppfolgingsoppgaveHistorikk {
   isLoading: boolean;
@@ -12,7 +12,7 @@ interface OppfolgingsoppgaveHistorikk {
 }
 
 function createHistorikkEvents(
-  oppfolgingsoppgaver: OppfolgingsoppgaveNewResponseDTO[]
+  oppfolgingsoppgaver: OppfolgingsoppgaveResponseDTO[]
 ): HistorikkEvent[] {
   const historikkEvents: HistorikkEvent[] = [];
 
@@ -62,7 +62,7 @@ export function useOppfolgingsoppgaveHistorikk(): OppfolgingsoppgaveHistorikk {
     oppfolgingsoppgaver: oppfolgingsoppgaver,
     isLoading: isOppfolgingsoppgaverLoading,
     isError: isOppfolgingsoppgaverError,
-  } = useGetOppfolgingsoppgaver();
+  } = useOppfolgingsoppgaver();
 
   const historikkEvents = createHistorikkEvents(oppfolgingsoppgaver || []);
 

--- a/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
+++ b/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
@@ -1,76 +1,81 @@
 import { generateUUID } from "@/utils/uuidUtils";
 import { VEILEDER_IDENT_DEFAULT } from "@/mocks/common/mockConstants";
-import { Oppfolgingsgrunn } from "@/data/oppfolgingsoppgave/types";
+import {
+  Oppfolgingsgrunn,
+  OppfolgingsoppgaveResponseDTO,
+} from "@/data/oppfolgingsoppgave/types";
 import { addDays } from "@/utils/datoUtils";
 
 const DATO_INNENFOR_OPPFOLGINGSTILFELLE = new Date("2024-06-20");
 
-export const historikkOppfolgingsoppgaveAktivMock = {
-  uuid: generateUUID(),
-  createdBy: VEILEDER_IDENT_DEFAULT,
-  updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
-  isActive: true,
-  createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-  removedBy: null,
-  versjoner: [
-    {
-      uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst ver 2",
-      oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
-      frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 5),
-    },
-    {
-      uuid: generateUUID(),
-      createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst",
-      oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
-      frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 2),
-    },
-  ],
-};
+export const historikkOppfolgingsoppgaveAktivMock: OppfolgingsoppgaveResponseDTO =
+  {
+    uuid: generateUUID(),
+    createdBy: VEILEDER_IDENT_DEFAULT,
+    updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
+    isActive: true,
+    createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+    removedBy: null,
+    versjoner: [
+      {
+        uuid: generateUUID(),
+        createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
+        createdBy: VEILEDER_IDENT_DEFAULT,
+        tekst: "Oppfølgingsoppgavetekst ver 2",
+        oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
+        frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 5).toString(),
+      },
+      {
+        uuid: generateUUID(),
+        createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
+        createdBy: VEILEDER_IDENT_DEFAULT,
+        tekst: "Oppfølgingsoppgavetekst",
+        oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_ANNEN_YTELSE,
+        frist: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 2).toString(),
+      },
+    ],
+  };
 
-export const historikkOppfolgingsoppgaveFjernetMock = {
-  uuid: generateUUID(),
-  createdBy: VEILEDER_IDENT_DEFAULT,
-  updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -1),
-  isActive: false,
-  createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
-  removedBy: VEILEDER_IDENT_DEFAULT,
-  versjoner: [
-    {
-      uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -2),
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst ver 4",
-      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
-      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-    },
-    {
-      uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -3),
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst ver 3",
-      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
-      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-    },
-    {
-      uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -4),
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst ver 2",
-      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
-      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-    },
-    {
-      uuid: generateUUID(),
-      createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
-      createdBy: VEILEDER_IDENT_DEFAULT,
-      tekst: "Oppfølgingsoppgavetekst",
-      oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
-      frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
-    },
-  ],
-};
+export const historikkOppfolgingsoppgaveFjernetMock: OppfolgingsoppgaveResponseDTO =
+  {
+    uuid: generateUUID(),
+    createdBy: VEILEDER_IDENT_DEFAULT,
+    updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -1),
+    isActive: false,
+    createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
+    removedBy: VEILEDER_IDENT_DEFAULT,
+    versjoner: [
+      {
+        uuid: generateUUID(),
+        createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -2),
+        createdBy: VEILEDER_IDENT_DEFAULT,
+        tekst: "Oppfølgingsoppgavetekst ver 4",
+        oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+        frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE.toString(),
+      },
+      {
+        uuid: generateUUID(),
+        createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -3),
+        createdBy: VEILEDER_IDENT_DEFAULT,
+        tekst: "Oppfølgingsoppgavetekst ver 3",
+        oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+        frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE.toString(),
+      },
+      {
+        uuid: generateUUID(),
+        createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -4),
+        createdBy: VEILEDER_IDENT_DEFAULT,
+        tekst: "Oppfølgingsoppgavetekst ver 2",
+        oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+        frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE.toString(),
+      },
+      {
+        uuid: generateUUID(),
+        createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),
+        createdBy: VEILEDER_IDENT_DEFAULT,
+        tekst: "Oppfølgingsoppgavetekst",
+        oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_ARBEIDSGIVER,
+        frist: DATO_INNENFOR_OPPFOLGINGSTILFELLE.toString(),
+      },
+    ],
+  };

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -45,7 +45,7 @@ import { dialogmoteStatusEndringMock } from "@/mocks/isdialogmote/dialogmoterMoc
 import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
 import { oppfolgingsplanQueryKeys } from "@/data/oppfolgingsplan/oppfolgingsplanQueryHooks";
 import { getDefaultOppfolgingsplanLPS } from "@/mocks/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
-import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useGetOppfolgingsoppgaver";
+import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
 import {
   historikkOppfolgingsoppgaveAktivMock,
   historikkOppfolgingsoppgaveFjernetMock,

--- a/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
+++ b/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
@@ -13,13 +13,14 @@ import {
   VEILEDER_IDENT_DEFAULT,
 } from "@/mocks/common/mockConstants";
 import {
+  EditOppfolgingsoppgaveRequestDTO,
+  Oppfolgingsgrunn,
   OppfolgingsoppgaveRequestDTO,
   OppfolgingsoppgaveResponseDTO,
-  Oppfolgingsgrunn,
-  EditOppfolgingsoppgaveRequestDTO,
+  OppfolgingsoppgaveVersjonResponseDTO,
 } from "@/data/oppfolgingsoppgave/types";
 import { generateUUID } from "@/utils/uuidUtils";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { Oppfolgingsoppgave } from "@/components/oppfolgingsoppgave/Oppfolgingsoppgave";
 import { changeTextInput } from "../testUtils";
@@ -35,11 +36,17 @@ const oppfolgingsoppgaveOppfogingsgrunnText = "Vurder behov for dialogmøte";
 const oppfolgingsoppgave: OppfolgingsoppgaveResponseDTO = {
   createdBy: VEILEDER_IDENT_DEFAULT,
   uuid: generateUUID(),
-  oppfolgingsgrunn: oppfolgingsoppgaveOppfolgingsgrunn,
-  tekst: "Dette var en veldig god grunn for å lage oppfolgingsoppgave.",
   updatedAt: new Date(),
   createdAt: new Date(),
-  frist: "2030-01-01",
+  isActive: true,
+  removedBy: null,
+  versjoner: [
+    {
+      oppfolgingsgrunn: oppfolgingsoppgaveOppfolgingsgrunn,
+      tekst: "Dette var en veldig god grunn for å lage oppfolgingsoppgave.",
+      frist: "2030-01-01",
+    } as OppfolgingsoppgaveVersjonResponseDTO,
+  ],
 };
 const openOppfolgingsoppgaveButtonText = "Oppfølgingsoppgave";
 

--- a/test/stubs/stubIshuskelapp.ts
+++ b/test/stubs/stubIshuskelapp.ts
@@ -7,7 +7,9 @@ export const stubOppfolgingsoppgaveApi = (
   oppfolgingsoppgave: OppfolgingsoppgaveResponseDTO | undefined
 ) =>
   mockServer.use(
-    http.get(`*${ISHUSKELAPP_ROOT}/huskelapp`, () =>
-      HttpResponse.json(oppfolgingsoppgave)
+    http.get(`*${ISHUSKELAPP_ROOT}/huskelapp`, ({ request }) =>
+      request.url.includes("?isActive=true")
+        ? HttpResponse.json(oppfolgingsoppgave)
+        : HttpResponse.json(null)
     )
   );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Denne bygger videre på tidligere [PR](https://github.com/navikt/syfomodiaperson/pull/1545) og tar for seg avvikling av tidligere datamodell for aktiv oppfølgingsoppgave. APIet leverer nå oppfølgingsoppgave som har flere versjoner hvorav siste versjon ligger først i lista.

Har i tillegg fikset slik at mock for oppfølgingsoppgave fungerer, mao. er det nå mulig å opprette, endre og slette oppfølgingsoppgaven og det vil også resultere i at historikken får nye forekomster.

