### PR TITLE
IS-2536: Add indication when utbetalingsinfo is from before oppfolgin…

### DIFF
--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -4,7 +4,7 @@ import { formaterFnr } from "@/utils/fnrUtils";
 import CopyButton from "../../kopierknapp/CopyButton";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
-import { HStack, Tag } from "@navikt/ds-react";
+import { HStack } from "@navikt/ds-react";
 import { PersonkortHeaderTags } from "@/components/personkort/PersonkortHeader/PersonkortHeaderTags";
 import { KjonnIkon } from "@/components/personkort/PersonkortHeader/KjonnIkon";
 import { TilfellePeriod } from "@/components/personkort/PersonkortHeader/TilfellePeriod";
@@ -12,10 +12,9 @@ import { Varighet } from "@/components/personkort/PersonkortHeader/Varighet";
 import { Diagnosekode } from "@/components/personkort/PersonkortHeader/Diagnosekode";
 import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 import { NavnHeader } from "@/components/personkort/PersonkortHeader/NavnHeader";
-import { MaksdatoSummary } from "@/components/personkort/PersonkortHeader/MaksdatoSummary";
+import Utbetalingsinfo from "@/components/personkort/PersonkortHeader/Utbetalingsinfo";
 
 const texts = {
-  ikkeUtbetalt: "Sykepenger ikke utbetalt",
   copied: "Kopiert!",
 };
 
@@ -32,7 +31,8 @@ const StyledFnr = styled.div`
 export function PersonkortHeader() {
   const navbruker = useNavBrukerData();
   const personident = useValgtPersonident();
-  const { data: maksDato, isSuccess } = useMaksdatoQuery();
+  const getMaksdato = useMaksdatoQuery();
+  const maksdato = getMaksdato.data?.maxDate;
 
   return (
     <>
@@ -52,15 +52,7 @@ export function PersonkortHeader() {
             <Diagnosekode />
           </HStack>
 
-          {isSuccess ? (
-            maksDato?.maxDate ? (
-              <MaksdatoSummary maxDate={maksDato.maxDate} />
-            ) : (
-              <Tag variant="warning" size="small" className="mt-1">
-                {texts.ikkeUtbetalt}
-              </Tag>
-            )
-          ) : null}
+          {getMaksdato.isSuccess && <Utbetalingsinfo maksdato={maksdato} />}
         </div>
       </div>
       <PersonkortHeaderTags />

--- a/src/components/personkort/PersonkortHeader/Utbetalingsinfo.tsx
+++ b/src/components/personkort/PersonkortHeader/Utbetalingsinfo.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { Alert, Tag } from "@navikt/ds-react";
+import { MaksdatoSummary } from "@/components/personkort/PersonkortHeader/MaksdatoSummary";
+import { useStartOfLatestOppfolgingstilfelle } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { Maksdato } from "@/data/maksdato/useMaksdatoQuery";
+
+const texts = {
+  ikkeUtbetalt: "Sykepenger ikke utbetalt",
+  utbetalingsinfoAlert:
+    "Maksdatoen kan gjelde et tidligere oppfølgingstilfelle.",
+};
+
+function isUtbetalingsinfoFromBeforeOppfolgingstilfelleStart(
+  maksdato: Maksdato,
+  startDate?: Date
+): boolean {
+  return !!startDate && maksdato.opprettet < startDate;
+}
+
+interface Props {
+  maksdato: Maksdato | null | undefined;
+}
+
+export default function Utbetalingsinfo({ maksdato }: Props) {
+  const startDate = useStartOfLatestOppfolgingstilfelle();
+
+  return maksdato ? (
+    <>
+      <MaksdatoSummary maxDate={maksdato} />
+      {isUtbetalingsinfoFromBeforeOppfolgingstilfelleStart(
+        maksdato,
+        startDate
+      ) && (
+        <Alert inline variant="warning" size="small">
+          {texts.utbetalingsinfoAlert}
+        </Alert>
+      )}
+    </>
+  ) : (
+    <Tag variant="warning" size="small" className="mt-1">
+      {texts.ikkeUtbetalt}
+    </Tag>
+  );
+}

--- a/src/mocks/syfoperson/persondataMock.ts
+++ b/src/mocks/syfoperson/persondataMock.ts
@@ -22,7 +22,7 @@ export const diskresjonskodeMock: "6" | "7" | "" = "";
 
 export const isEgenansattMock = false;
 
-export const maksdato = weeksFromToday(13).toString();
+export const maksdato = weeksFromToday(13);
 
 export const maksdatoMock = {
   maxDate: {
@@ -31,6 +31,6 @@ export const maksdatoMock = {
     forelopig_beregnet_slutt: maksdato,
     utbetalt_tom: "2024-07-01",
     gjenstaende_sykedager: "70",
-    opprettet: "2023-01-01T12:00:00.000000",
+    opprettet: Date.now().toString(),
   },
 };

--- a/test/data/maksdatoQueryTest.tsx
+++ b/test/data/maksdatoQueryTest.tsx
@@ -23,6 +23,25 @@ describe("maksdatoQuery", () => {
 
     await waitFor(() => expect(result.current.isSuccess).to.be.true);
 
-    expect(result.current.data).to.deep.equal(maksdatoMock);
+    expect(result.current.data?.maxDate?.id).to.deep.equal(
+      maksdatoMock.maxDate.id
+    );
+    expect(result.current.data?.maxDate?.fnr).to.deep.equal(
+      maksdatoMock.maxDate.fnr
+    );
+    expect(result.current.data?.maxDate?.opprettet).to.deep.equal(
+      maksdatoMock.maxDate.opprettet
+    );
+    expect(result.current.data?.maxDate?.utbetalt_tom).to.deep.equal(
+      maksdatoMock.maxDate.utbetalt_tom
+    );
+    expect(result.current.data?.maxDate?.gjenstaende_sykedager).to.deep.equal(
+      maksdatoMock.maxDate.gjenstaende_sykedager
+    );
+    expect(
+      result.current.data?.maxDate?.forelopig_beregnet_slutt
+    ).to.deep.equal(
+      maksdatoMock.maxDate.forelopig_beregnet_slutt.toISOString()
+    );
   });
 });

--- a/test/stubs/stubSykepengerdagerInformasjon.ts
+++ b/test/stubs/stubSykepengerdagerInformasjon.ts
@@ -1,9 +1,9 @@
 import { SYKEPENGEDAGER_INFORMASJON_ROOT } from "@/apiConstants";
-import { maksdatoMock } from "@/mocks/syfoperson/persondataMock";
 import { mockServer } from "../setup";
 import { http, HttpResponse } from "msw";
+import { maksdatoMock } from "@/mocks/syfoperson/persondataMock";
 
-export const stubMaxdateApi = (maxDate: string) =>
+export const stubMaxdateApi = (maxDate: Date) =>
   mockServer.use(
     http.get(`*${SYKEPENGEDAGER_INFORMASJON_ROOT}/sykepenger/maxdate`, () =>
       HttpResponse.json({


### PR DESCRIPTION
Var problemer med branch navnet så denne PRen erstatter [denne PRen](https://github.com/navikt/syfomodiaperson/pull/1555).

### Hva har blitt lagt til✨🌈
- Legger til indikasjon med informasjon (når bruker trykker) om at utbetalingsinfo er fra før oppfølgingstilfellet sin startdato. Dette for å hjelpe veileder å legge merke til at maksdato ikke nødvendigvis er reell.

- [x] Designsjekk
- [x] Tekstsjekk med Stine

### Screenshots 📸✨
<img width="784" alt="image" src="https://github.com/user-attachments/assets/5ba341cd-a59a-40cd-9bf8-4f4450603461">

<details>
<summary>Første iterasjon: </summary>

![Screenshot 2024-12-02 at 13 20 51](https://github.com/user-attachments/assets/9819ba90-54a8-4bd4-a302-10313f1e7d9a)
![Screenshot 2024-12-02 at 13 17 05](https://github.com/user-attachments/assets/1e7d298c-8739-4229-bea1-33a125c6808b)

</details>