### PR TITLE
IS: Make dates for oppfolgingstilfelle dynamic

### DIFF
--- a/src/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock.ts
+++ b/src/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock.ts
@@ -5,6 +5,7 @@ import {
   VIRKSOMHET_UTEN_NARMESTE_LEDER,
 } from "../common/mockConstants";
 import { OppfolgingstilfellePersonDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+import { addWeeks } from "@/utils/datoUtils";
 
 export const oppfolgingstilfellePersonMock: OppfolgingstilfellePersonDTO = {
   oppfolgingstilfelleList: [
@@ -26,8 +27,8 @@ export const oppfolgingstilfellePersonMock: OppfolgingstilfellePersonDTO = {
     },
     {
       arbeidstakerAtTilfelleEnd: true,
-      start: new Date("2024-02-21"),
-      end: new Date("2024-12-10"),
+      start: addWeeks(new Date(), -40),
+      end: addWeeks(new Date(), 20),
       virksomhetsnummerList: [
         VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
         VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -51,6 +51,7 @@ import {
   historikkOppfolgingsoppgaveFjernetMock,
 } from "@/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock";
 import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
+import { tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
 
 let queryClient: QueryClient;
 
@@ -168,12 +169,19 @@ describe("Historikk", () => {
     );
     renderHistorikk();
 
+    const lastOppfolgingstilfelle =
+      oppfolgingstilfellePersonMock.oppfolgingstilfelleList[
+        oppfolgingstilfellePersonMock.oppfolgingstilfelleList.length - 1
+      ];
+    const dropdownOptionText = tilLesbarPeriodeMedArstall(
+      lastOppfolgingstilfelle.start,
+      lastOppfolgingstilfelle.end
+    );
+
     expect(await screen.findAllByText("Historikk")).to.exist;
     expect(screen.getByLabelText("Sykefraværstilfelle")).to.exist;
     expect(screen.getByText("Sykefraværstilfelle")).to.exist;
-    expect(
-      screen.getByRole("option", { name: "21. februar – 10. desember 2024" })
-    ).to.exist;
+    expect(screen.getByRole("option", { name: dropdownOptionText })).to.exist;
     expect(
       screen.queryByRole("option", { name: "Utenfor sykefraværstilfelle" })
     ).to.not.exist;
@@ -186,10 +194,17 @@ describe("Historikk", () => {
     );
     renderHistorikk();
 
+    const lastOppfolgingstilfelle =
+      oppfolgingstilfellePersonMock.oppfolgingstilfelleList[
+        oppfolgingstilfellePersonMock.oppfolgingstilfelleList.length - 1
+      ];
+    const dropdownOptionText = tilLesbarPeriodeMedArstall(
+      lastOppfolgingstilfelle.start,
+      lastOppfolgingstilfelle.end
+    );
+
     expect(await screen.findAllByText("Historikk")).to.exist;
-    expect(
-      screen.getByRole("option", { name: "21. februar – 10. desember 2024" })
-    ).to.exist;
+    expect(screen.getByRole("option", { name: dropdownOptionText })).to.exist;
     expect(screen.getByRole("option", { name: "Utenfor sykefraværstilfelle" }))
       .to.exist;
   });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi hadde hardkodet oppfølgingstilfelle-datoer, som betyr at fra i morgen ville flere tester begynt å feile. Det var allerede en test som begynte i dag, så vi får håpe dette hjelper 👍🏼