### PR TITLE
IS-2848: Decrease stale time and refetch on window focus for some queries

### DIFF
--- a/src/data/aktivitetskrav/aktivitetskravQueryHooks.ts
+++ b/src/data/aktivitetskrav/aktivitetskravQueryHooks.ts
@@ -6,6 +6,7 @@ import {
   AktivitetskravHistorikkDTO,
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { useQuery } from "@tanstack/react-query";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 export const aktivitetskravQueryKeys = {
   aktivitetskrav: (personident: string) => ["aktivitetskrav", personident],
@@ -25,6 +26,8 @@ export const useAktivitetskravQuery = () => {
     queryKey: aktivitetskravQueryKeys.aktivitetskrav(personident),
     queryFn: fetchAktivitetskrav,
     enabled: !!personident,
+    refetchOnWindowFocus: true,
+    staleTime: minutesToMillis(5),
   });
 
   return {

--- a/src/data/aktivitetskrav/aktivitetskravQueryHooks.ts
+++ b/src/data/aktivitetskrav/aktivitetskravQueryHooks.ts
@@ -26,7 +26,6 @@ export const useAktivitetskravQuery = () => {
     queryKey: aktivitetskravQueryKeys.aktivitetskrav(personident),
     queryFn: fetchAktivitetskrav,
     enabled: !!personident,
-    refetchOnWindowFocus: true,
     staleTime: minutesToMillis(5),
   });
 

--- a/src/data/dialogmotekandidat/dialogmotekandidatQueryHooks.ts
+++ b/src/data/dialogmotekandidat/dialogmotekandidatQueryHooks.ts
@@ -7,6 +7,7 @@ import {
   DialogmotekandidatHistorikkDTO,
 } from "@/data/dialogmotekandidat/dialogmotekandidatTypes";
 import { useLatestFerdigstiltReferat } from "@/hooks/dialogmote/useDialogmoteReferat";
+import { minutesToMillis } from "@/utils/timeUtils";
 
 export const dialogmotekandidatQueryKeys = {
   kandidat: (personident: string) => ["dialogmotekandidat", personident],
@@ -43,6 +44,8 @@ export const useDialogmotekandidat = () => {
     queryKey: dialogmotekandidatQueryKeys.kandidat(personident),
     queryFn: fetchKandidat,
     enabled: !!personident,
+    refetchOnWindowFocus: true,
+    staleTime: minutesToMillis(5),
   });
 
   const isNoFerdigstiltDialogmoteReferatAfterKandidatAt =

--- a/src/data/dialogmotekandidat/dialogmotekandidatQueryHooks.ts
+++ b/src/data/dialogmotekandidat/dialogmotekandidatQueryHooks.ts
@@ -44,7 +44,6 @@ export const useDialogmotekandidat = () => {
     queryKey: dialogmotekandidatQueryKeys.kandidat(personident),
     queryFn: fetchKandidat,
     enabled: !!personident,
-    refetchOnWindowFocus: true,
     staleTime: minutesToMillis(5),
   });
 

--- a/src/data/senoppfolging/useSenOppfolgingKandidatQuery.ts
+++ b/src/data/senoppfolging/useSenOppfolgingKandidatQuery.ts
@@ -19,7 +19,6 @@ export const useSenOppfolgingKandidatQuery = () => {
     queryKey: senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
     queryFn: getSenOppfolgingKandidat,
     enabled: !!fnr,
-    refetchOnWindowFocus: true,
     staleTime: minutesToMillis(5),
   });
 

--- a/src/data/senoppfolging/useSenOppfolgingKandidatQuery.ts
+++ b/src/data/senoppfolging/useSenOppfolgingKandidatQuery.ts
@@ -19,7 +19,8 @@ export const useSenOppfolgingKandidatQuery = () => {
     queryKey: senOppfolgingKandidatQueryKeys.senOppfolgingKandidat(fnr),
     queryFn: getSenOppfolgingKandidat,
     enabled: !!fnr,
-    staleTime: minutesToMillis(60 * 12),
+    refetchOnWindowFocus: true,
+    staleTime: minutesToMillis(5),
   });
 
   return {


### PR DESCRIPTION
Vi har tilfeller av `ConflictException` ved vurdering av aktivitetskrav/sen oppfolging-kandidat/dialogmøte-unntak. Hypotesen er at dette skjer pga to veiledere som er inne på en bruker samtidig og gjør vurdering etter hverandre uten at data er oppdatert i frontend.
Reduserer `staleTime` på relevante queries slik at disse regnes som gamle etter 5min og blir refetchet når man går inn på siden for å gjøre vurdering. Setter i tillegg `refetchOnWindowFocus: true` slik at data refetches om man har vurdering-siden åpen og data er gamle.
Ref https://blogg.bekk.no/jeg-har-misforst%C3%A5tt-tanstack-querys-cachetime-og-det-har-nok-du-ogs%C3%A5-f6594bc1b5dd og https://tanstack.com/query/v4/docs/framework/react/guides/window-focus-refetching