### PR TITLE
IS-2886: Move /internal path to not be blocked by nais on ansatt-ingress

### DIFF
--- a/src/apiConstants.ts
+++ b/src/apiConstants.ts
@@ -33,7 +33,7 @@ export const LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT =
 export const MEROPPFOLGING_BACKEND_ROOT =
   "/meroppfolging-backend/api/v2/internad";
 export const SYFOPERSON_ROOT = "/syfoperson/api/v2";
-export const SYFOSMREGISTER_ROOT = "/syfosmregister/api/v2";
+export const SYFOSMREGISTER_ROOT = "/syfosmregister/api/v2/internal";
 export const SYFOOVERSIKTSRV_PERSONTILDELING_ROOT = "/api/v2/persontildeling";
 export const SYKEPENGESOKNAD_BACKEND_ROOT = "/sykepengesoknad-backend/api";
 export const ISTILGANGSKONTROLL_ROOT = "/istilgangskontroll/api";

--- a/src/data/sykmelding/sykmeldingQueryHooks.ts
+++ b/src/data/sykmelding/sykmeldingQueryHooks.ts
@@ -16,7 +16,7 @@ export const sykmeldingerQueryKeys = {
 
 export const useSykmeldingerQuery = () => {
   const fnr = useValgtPersonident();
-  const path = `${SYFOSMREGISTER_ROOT}/internal/sykmeldinger`;
+  const path = `${SYFOSMREGISTER_ROOT}/sykmeldinger`;
   const fetchSykmeldinger = () => get<SykmeldingNewFormatDTO[]>(path, fnr);
   const query = useQuery({
     queryKey: sykmeldingerQueryKeys.sykmeldinger(fnr),

--- a/src/mocks/syfosmregister/mockSyfosmregister.ts
+++ b/src/mocks/syfosmregister/mockSyfosmregister.ts
@@ -3,7 +3,7 @@ import { SYFOSMREGISTER_ROOT } from "@/apiConstants";
 import { http, HttpResponse } from "msw";
 
 export const mockSyfosmregister = http.get(
-  `${SYFOSMREGISTER_ROOT}/internal/sykmeldinger`,
+  `${SYFOSMREGISTER_ROOT}/sykmeldinger`,
   () => {
     return HttpResponse.json(sykmeldingerMock);
   }

--- a/test/stubs/stubSyfosmregister.ts
+++ b/test/stubs/stubSyfosmregister.ts
@@ -5,7 +5,7 @@ import { mockServer } from "../setup";
 
 export const stubSykmeldingApi = () =>
   mockServer.use(
-    http.get(`*${SYFOSMREGISTER_ROOT}/internal/sykmeldinger`, () =>
+    http.get(`*${SYFOSMREGISTER_ROOT}/sykmeldinger`, () =>
       HttpResponse.json(sykmeldingerMock)
     )
   );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Man får 404 fra `syfosmregister` via ansatt-ingressen, så Peter får ikke opp noen sykmeldinger i dev :/ Det skyldes visstnok at nais filtrerer ut `/internal` paths, så dette var et forslag fra Karl i team sykmelding. Vi prøver!

Se diskusjon på slack: https://nav-it.slack.com/archives/CMA3XV997/p1728290644151249
