### PR TITLE
IS-2850: Forhåndsvisning av stansbrevet (8-8) kræsjer ikke lenger uten avslagsdato

### DIFF
--- a/src/data/manglendemedvirkning/manglendeMedvirkningDocumentTexts.ts
+++ b/src/data/manglendemedvirkning/manglendeMedvirkningDocumentTexts.ts
@@ -71,12 +71,12 @@ export function getIkkeAktuellManglendeMedvirkningTexts() {
   };
 }
 
-export function getStansTexts(varselSvarfrist: Date) {
+export function getStansTexts(varselSvarfrist: Date | undefined) {
   return {
     header: "Nav har stanset sykepengene dine",
-    fom: `Nav har stanset sykepengene dine fra og med ${tilDatoMedManedNavn(
-      varselSvarfrist
-    )}.`,
+    fom: `Nav har stanset sykepengene dine fra og med ${
+      !!varselSvarfrist ? tilDatoMedManedNavn(varselSvarfrist) : ""
+    }.`,
     intro:
       "For å få sykepenger har du et selvstendig ansvar for å bidra til raskest mulig å komme tilbake i arbeid, kalt medvirkningsplikten.",
     hjemmel:

--- a/src/hooks/manglendemedvirkning/useManglendeMedvirkningVurderingDocument.ts
+++ b/src/hooks/manglendemedvirkning/useManglendeMedvirkningVurderingDocument.ts
@@ -34,7 +34,7 @@ type IkkeAktuellDocumentValues = {
 
 type StansDocumentValues = {
   begrunnelse: string;
-  stansdato: Date;
+  stansdato: Date | undefined;
 };
 
 interface Documents {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Lagt til en sjekk om stansdatoen finnes før man evt henter verdien for å kunne forhåndsvise brevet. Dette gjør at siden ikke kræsjer hvis man prøver å forhåndsvise uten å ha lagt inn avslagsdato. 
