### PR TITLE
IS-2019: Add motebehov historikk with svar

### DIFF
--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -22,3 +22,38 @@ export enum MotebehovSkjemaType {
   MELD_BEHOV = "MELD_BEHOV",
   SVAR_BEHOV = "SVAR_BEHOV",
 }
+
+export interface MeldtMotebehov {
+  id: string;
+  opprettetDato: Date;
+  opprettetAv: string;
+  opprettetAvNavn: string | null;
+  innmelder: MotebehovInnmelder;
+  arbeidstakerFnr: string;
+  virksomhetsnummer: string;
+  begrunnelse: string | null;
+  tildeltEnhet: string | null;
+  behandletTidspunkt: Date | null;
+  behandletVeilederIdent: string | null;
+  skjemaType: MotebehovSkjemaType.MELD_BEHOV;
+}
+
+export interface SvarMotebehov {
+  id: string;
+  opprettetDato: Date;
+  opprettetAv: string;
+  opprettetAvNavn: string | null;
+  innmelder: MotebehovInnmelder;
+  arbeidstakerFnr: string;
+  virksomhetsnummer: string;
+  motebehovSvar: MotebehovSvarVeilederDTO;
+  tildeltEnhet: string | null;
+  behandletTidspunkt: Date | null;
+  behandletVeilederIdent: string | null;
+  skjemaType: MotebehovSkjemaType.SVAR_BEHOV;
+}
+
+export enum MotebehovInnmelder {
+  ARBEIDSTAKER = "ARBEIDSTAKER",
+  ARBEIDSGIVER = "ARBEIDSGIVER",
+}

--- a/src/hooks/historikk/useHistorikk.ts
+++ b/src/hooks/historikk/useHistorikk.ts
@@ -12,6 +12,7 @@ import { useSenOppfolgingHistorikk } from "@/hooks/historikk/useSenOppfolgingHis
 import { useDialogmoteStatusEndringHistorikk } from "@/hooks/historikk/useDialogmoteStatusEndringHistorikk";
 import { useOppfolgingsplanHistorikk } from "@/hooks/historikk/useOppfolgingsplanHistorikk";
 import { useOppfolgingsoppgaveHistorikk } from "@/hooks/historikk/useOppfolgingsoppgaveHistorikk";
+import { useMotebehovHistorikk } from "@/hooks/historikk/useMotebehovHistorikk";
 
 interface HistorikkHook {
   isHistorikkLoading: boolean;
@@ -25,6 +26,8 @@ export function useHistorikk(): HistorikkHook {
     isLoading: isMotebehovLoading,
     isError: isMotebehovError,
   } = useHistorikkMotebehovQuery();
+
+  const motebehovNyHistorikk = useMotebehovHistorikk();
 
   const oppfolgingsplanHistorikk = useOppfolgingsplanHistorikk();
 
@@ -70,6 +73,7 @@ export function useHistorikk(): HistorikkHook {
   const oppfolgingsoppgaveHistorikk = useOppfolgingsoppgaveHistorikk();
 
   const historikkEvents = motebehovHistorikk
+    .concat(motebehovNyHistorikk.events)
     .concat(oppfolgingsplanHistorikk.events)
     .concat(lederHistorikk)
     .concat(aktivitetskravHistorikk)
@@ -86,6 +90,7 @@ export function useHistorikk(): HistorikkHook {
   const isHistorikkLoading =
     oppfolgingsplanHistorikk.isLoading ||
     isMotebehovLoading ||
+    motebehovNyHistorikk.isLoading ||
     isLedereHistorikkLoading ||
     isAktivitetskravHistorikkLoading ||
     isArbeidsuforhetHistorikkLoading ||
@@ -100,6 +105,7 @@ export function useHistorikk(): HistorikkHook {
 
   const isHistorikkError =
     isMotebehovError ||
+    motebehovNyHistorikk.isError ||
     oppfolgingsplanHistorikk.isError ||
     isLedereHistorikkError ||
     isAktivitetskravHistorikkError ||

--- a/src/hooks/historikk/useHistorikk.ts
+++ b/src/hooks/historikk/useHistorikk.ts
@@ -1,5 +1,4 @@
 import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
-import { useHistorikkMotebehovQuery } from "@/data/historikk/historikkQueryHooks";
 import { useLedereHistorikk } from "@/hooks/historikk/useLedereHistorikk";
 import { useAktivitetskravHistorikk } from "@/hooks/historikk/useAktivitetskravHistorikk";
 import { useArbeidsuforhetHistorikk } from "@/hooks/historikk/useArbeidsuforhetHistorikk";
@@ -21,13 +20,7 @@ interface HistorikkHook {
 }
 
 export function useHistorikk(): HistorikkHook {
-  const {
-    data: motebehovHistorikk,
-    isLoading: isMotebehovLoading,
-    isError: isMotebehovError,
-  } = useHistorikkMotebehovQuery();
-
-  const motebehovNyHistorikk = useMotebehovHistorikk();
+  const motebehovHistorikk = useMotebehovHistorikk();
 
   const oppfolgingsplanHistorikk = useOppfolgingsplanHistorikk();
 
@@ -72,8 +65,7 @@ export function useHistorikk(): HistorikkHook {
 
   const oppfolgingsoppgaveHistorikk = useOppfolgingsoppgaveHistorikk();
 
-  const historikkEvents = motebehovHistorikk
-    .concat(motebehovNyHistorikk.events)
+  const historikkEvents = motebehovHistorikk.events
     .concat(oppfolgingsplanHistorikk.events)
     .concat(lederHistorikk)
     .concat(aktivitetskravHistorikk)
@@ -89,8 +81,7 @@ export function useHistorikk(): HistorikkHook {
 
   const isHistorikkLoading =
     oppfolgingsplanHistorikk.isLoading ||
-    isMotebehovLoading ||
-    motebehovNyHistorikk.isLoading ||
+    motebehovHistorikk.isLoading ||
     isLedereHistorikkLoading ||
     isAktivitetskravHistorikkLoading ||
     isArbeidsuforhetHistorikkLoading ||
@@ -104,8 +95,7 @@ export function useHistorikk(): HistorikkHook {
     dialogmoteStatusEndringHistorikk.isLoading;
 
   const isHistorikkError =
-    isMotebehovError ||
-    motebehovNyHistorikk.isError ||
+    motebehovHistorikk.isError ||
     oppfolgingsplanHistorikk.isError ||
     isLedereHistorikkError ||
     isAktivitetskravHistorikkError ||

--- a/src/hooks/historikk/useMotebehovHistorikk.ts
+++ b/src/hooks/historikk/useMotebehovHistorikk.ts
@@ -1,0 +1,123 @@
+import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
+import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
+import {
+  mapMotebehovToMeldtMotebehovFormat,
+  mapMotebehovToSvarMotebehovFormat,
+} from "@/utils/motebehovUtils";
+import {
+  MeldtMotebehov,
+  MotebehovInnmelder,
+  SvarMotebehov,
+} from "@/data/motebehov/types/motebehovTypes";
+
+function getTextForMeldtMotebehov(meldtMotebehov: MeldtMotebehov): string {
+  const meldtBehovBegrunnelse = meldtMotebehov.begrunnelse
+    ? `Begrunnelse: ${meldtMotebehov.begrunnelse}`
+    : "";
+
+  switch (meldtMotebehov.innmelder) {
+    case MotebehovInnmelder.ARBEIDSTAKER:
+      return `Den sykmeldte meldte behov for dialogmøte. ${meldtBehovBegrunnelse}`;
+    case MotebehovInnmelder.ARBEIDSGIVER:
+      return `${
+        meldtMotebehov.opprettetAvNavn
+          ? meldtMotebehov.opprettetAvNavn + " (Arbeidsgiver)"
+          : "Arbeidsgiver"
+      } meldte behov for dialogmøte. ${meldtBehovBegrunnelse}`;
+  }
+}
+
+function createHistorikkEventsFromMeldtMotebehov(
+  meldteMotebehov: MeldtMotebehov[]
+): HistorikkEvent[] {
+  const meldteMotebehovEvents: HistorikkEvent[] = [];
+  meldteMotebehov.map((motebehov: MeldtMotebehov) => {
+    meldteMotebehovEvents.push({
+      opprettetAv: motebehov.opprettetAvNavn ?? undefined,
+      tekst: getTextForMeldtMotebehov(motebehov),
+      tidspunkt: motebehov.opprettetDato,
+      kilde: "MOTEBEHOV",
+    });
+  });
+  meldteMotebehov.map((motebehov: MeldtMotebehov) => {
+    if (motebehov.behandletVeilederIdent && motebehov.behandletTidspunkt) {
+      meldteMotebehovEvents.push({
+        opprettetAv: motebehov.behandletVeilederIdent,
+        tekst: `Møtebehovet ble behandlet av ${motebehov.behandletVeilederIdent}`,
+        tidspunkt: motebehov.behandletTidspunkt,
+        kilde: "MOTEBEHOV",
+      });
+    }
+  });
+
+  return meldteMotebehovEvents;
+}
+
+function getTextForSvarMotebehov(svarMotebehov: SvarMotebehov): string {
+  const svarResultat = svarMotebehov.motebehovSvar.harMotebehov
+    ? "svarte ja på ønske om dialogmøte."
+    : "svarte nei på ønske om dialogmøte.";
+  const svarForklaring = svarMotebehov.motebehovSvar.forklaring
+    ? `Svaret var: ${svarMotebehov.motebehovSvar.forklaring}`
+    : "";
+
+  switch (svarMotebehov.innmelder) {
+    case MotebehovInnmelder.ARBEIDSTAKER:
+      return `Den sykmeldte ${svarResultat} ${svarForklaring}`;
+    case MotebehovInnmelder.ARBEIDSGIVER:
+      return `${
+        svarMotebehov.opprettetAvNavn
+          ? svarMotebehov.opprettetAvNavn + " (Arbeidsgiver) "
+          : "Arbeidsgiver "
+      }  ${svarResultat} ${svarForklaring}`;
+  }
+}
+
+function createHistorikkEventsFromSvarMotebehov(
+  svarMotebehov: SvarMotebehov[]
+): HistorikkEvent[] {
+  const svarMotebehovEvents: HistorikkEvent[] = [];
+  svarMotebehov.map((motebehov: SvarMotebehov) => {
+    svarMotebehovEvents.push({
+      opprettetAv: motebehov.opprettetAvNavn ?? undefined,
+      tekst: getTextForSvarMotebehov(motebehov),
+      tidspunkt: motebehov.opprettetDato,
+      kilde: "MOTEBEHOV",
+    });
+  });
+  svarMotebehov.map((motebehov: SvarMotebehov) => {
+    if (motebehov.behandletVeilederIdent && motebehov.behandletTidspunkt) {
+      svarMotebehovEvents.push({
+        opprettetAv: motebehov.behandletVeilederIdent,
+        tekst: `Møtebehovet ble behandlet av ${motebehov.behandletVeilederIdent}`,
+        tidspunkt: motebehov.behandletTidspunkt,
+        kilde: "MOTEBEHOV",
+      });
+    }
+  });
+
+  return svarMotebehovEvents;
+}
+
+interface MotebehovHistorikk {
+  isLoading: boolean;
+  isError: boolean;
+  events: HistorikkEvent[];
+}
+
+export function useMotebehovHistorikk(): MotebehovHistorikk {
+  const motebehov = useMotebehovQuery();
+  const meldtMotebehov = mapMotebehovToMeldtMotebehovFormat(motebehov.data);
+  const svarMotebehov = mapMotebehovToSvarMotebehovFormat(motebehov.data);
+
+  const meldtMotebehovEvents =
+    createHistorikkEventsFromMeldtMotebehov(meldtMotebehov);
+  const svarMotebehovEvents =
+    createHistorikkEventsFromSvarMotebehov(svarMotebehov);
+
+  return {
+    isLoading: motebehov.isLoading,
+    isError: motebehov.isError,
+    events: meldtMotebehovEvents.concat(svarMotebehovEvents),
+  };
+}

--- a/src/hooks/historikk/useMotebehovHistorikk.ts
+++ b/src/hooks/historikk/useMotebehovHistorikk.ts
@@ -43,7 +43,7 @@ function createHistorikkEventsFromMeldtMotebehov(
     if (motebehov.behandletVeilederIdent && motebehov.behandletTidspunkt) {
       meldteMotebehovEvents.push({
         opprettetAv: motebehov.behandletVeilederIdent,
-        tekst: `Møtebehovet ble behandlet av ${motebehov.behandletVeilederIdent}`,
+        tekst: `${motebehov.behandletVeilederIdent} vurderte behovet for dialogmøte`,
         tidspunkt: motebehov.behandletTidspunkt,
         kilde: "MOTEBEHOV",
       });
@@ -89,7 +89,7 @@ function createHistorikkEventsFromSvarMotebehov(
     if (motebehov.behandletVeilederIdent && motebehov.behandletTidspunkt) {
       svarMotebehovEvents.push({
         opprettetAv: motebehov.behandletVeilederIdent,
-        tekst: `Møtebehovet ble behandlet av ${motebehov.behandletVeilederIdent}`,
+        tekst: `${motebehov.behandletVeilederIdent} vurderte svaret på behovet for dialogmøte`,
         tidspunkt: motebehov.behandletTidspunkt,
         kilde: "MOTEBEHOV",
       });

--- a/src/mocks/syfomotebehov/historikkmotebehovMock.ts
+++ b/src/mocks/syfomotebehov/historikkmotebehovMock.ts
@@ -1,27 +1,27 @@
 export const historikkmotebehovMock = [
   {
     opprettetAv: null,
-    tekst: "Møtebehovet ble lest av Z990000",
-    tidspunkt: "2019-04-15T00:00:00",
+    tekst: "Møtebehovet ble behandlet av Z990000",
+    tidspunkt: "2024-04-15T00:00:00",
   },
   {
     opprettetAv: null,
-    tekst: "Møtebehovet ble lest av Z990000",
-    tidspunkt: "2019-03-11T00:00:00",
+    tekst: "Sam Samuel Jones har svart på møtebehov",
+    tidspunkt: "2024-03-11T00:00:00",
   },
   {
     opprettetAv: null,
-    tekst: "Møtebehovet ble lest av Z990000",
-    tidspunkt: "2019-02-29T00:00:00",
+    tekst: "Møtebehovet ble behandlet av Z990000",
+    tidspunkt: "2024-02-29T00:00:00",
   },
   {
     opprettetAv: null,
-    tekst: "Møtebehovet ble lest av Z990000",
-    tidspunkt: "2019-01-10T00:00:00",
+    tekst: "Møtebehovet ble behandlet av Z990000",
+    tidspunkt: "2024-01-10T00:00:00",
   },
   {
     opprettetAv: null,
-    tekst: "Møtebehovet ble lest av Z990000",
-    tidspunkt: "2019-01-09T00:00:00",
+    tekst: "Møtebehovet ble behandlet av Z990000",
+    tidspunkt: "2024-01-09T00:00:00",
   },
 ];

--- a/src/mocks/syfomotebehov/motebehovMock.ts
+++ b/src/mocks/syfomotebehov/motebehovMock.ts
@@ -9,10 +9,11 @@ import {
   MotebehovSkjemaType,
   MotebehovVeilederDTO,
 } from "@/data/motebehov/types/motebehovTypes";
+import { addDays } from "@/utils/datoUtils";
 
 const motebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
   id: "11111111-ee10-44b6-bddf-54d049ef25f9",
-  opprettetDato: new Date("2021-12-08"),
+  opprettetDato: addDays(new Date(), -25),
   aktorId: "1",
   opprettetAv: "1",
   opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
@@ -30,7 +31,7 @@ const motebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
 
 const motebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
   id: "33333333-ee10-44b6-bddf-54d049ef25f2",
-  opprettetDato: new Date("2019-01-08"),
+  opprettetDato: addDays(new Date(), -10),
   aktorId: "1",
   opprettetAv: "1",
   opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
@@ -41,14 +42,14 @@ const motebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
     forklaring: "Møter er bra!",
   },
   tildeltEnhet: ENHET_GRUNERLOKKA.nummer,
-  behandletTidspunkt: new Date("2019-01-10"),
+  behandletTidspunkt: addDays(new Date(), -1),
   behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
 };
 
 const motebehovArbeidsgiverMock: MotebehovVeilederDTO = {
   id: "22222222-9e9b-40b0-bd1c-d1c39dc5f481",
-  opprettetDato: new Date("2021-12-08"),
+  opprettetDato: addDays(new Date(), -5),
   aktorId: "1",
   opprettetAv: "1902690001009",
   opprettetAvNavn: "Are Arbeidsgiver",

--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -10,7 +10,6 @@ import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { DialogmoteFerdigstilteReferatPanel } from "@/sider/dialogmoter/components/DialogmoteFerdigstilteReferatPanel";
 import { DialogmoteStatus } from "@/data/dialogmote/types/dialogmoteTypes";
 import { useDialogmoteunntakQuery } from "@/data/dialogmotekandidat/dialogmoteunntakQueryHooks";
-import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 import * as Tredelt from "@/sider/TredeltSide";
 import Side from "@/sider/Side";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
@@ -44,7 +43,6 @@ export function Motelandingsside() {
     isLoading: henterLedere,
     isError: henterLedereFeilet,
   } = useLedereQuery();
-  const navbruker = useNavBrukerData();
 
   const henter =
     henterDialogmoter ||
@@ -67,7 +65,6 @@ export function Motelandingsside() {
             <DialogmoteOnskePanel
               motebehovData={motebehov}
               ledereData={currentLedere}
-              sykmeldt={navbruker}
             />
 
             <InnkallingDialogmotePanel aktivtDialogmote={aktivtDialogmote} />

--- a/src/sider/dialogmoter/motebehov/DialogmoteOnskePanel.tsx
+++ b/src/sider/dialogmoter/motebehov/DialogmoteOnskePanel.tsx
@@ -4,7 +4,6 @@ import BehandleMotebehovKnapp from "../../../components/motebehov/BehandleMotebe
 import { DialogmotePanel } from "@/sider/dialogmoter/components/DialogmotePanel";
 import React from "react";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
-import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { NarmesteLederRelasjonDTO } from "@/data/leder/ledereTypes";
 
 const texts = {
@@ -14,20 +13,14 @@ const texts = {
 interface Props {
   motebehovData: MotebehovVeilederDTO[];
   ledereData: NarmesteLederRelasjonDTO[];
-  sykmeldt?: BrukerinfoDTO;
 }
 
-export const DialogmoteOnskePanel = ({
-  motebehovData,
-  ledereData,
-  sykmeldt,
-}: Props) => {
+export const DialogmoteOnskePanel = ({ motebehovData, ledereData }: Props) => {
   return (
     <DialogmotePanel icon={UtropstegnImage} header={texts.onskerOmDialogmote}>
       <MotebehovKvittering
         motebehovData={motebehovData}
         ledereData={ledereData}
-        sykmeldt={sykmeldt}
       />
 
       <BehandleMotebehovKnapp motebehovData={motebehovData} />

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -6,12 +6,12 @@ import {
 } from "@/utils/motebehovUtils";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
-import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { ledereUtenMotebehovsvar } from "@/utils/ledereUtils";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { NarmesteLederRelasjonDTO } from "@/data/leder/ledereTypes";
 import { capitalizeAllWords } from "@/utils/stringUtils";
 import MotebehovKvitteringInnhold from "@/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold";
+import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 
 export const arbeidsgiverNavnEllerTomStreng = (lederNavn: string | null) => {
   return lederNavn ? `${lederNavn}` : "";
@@ -69,13 +69,12 @@ const composePersonSvarText = (
 
 interface MotebehovKvitteringInnholdArbeidstakerProps {
   arbeidstakersMotebehov?: MotebehovVeilederDTO;
-  sykmeldt?: BrukerinfoDTO;
 }
 
 export const MotebehovKvitteringInnholdArbeidstaker = ({
   arbeidstakersMotebehov,
-  sykmeldt,
 }: MotebehovKvitteringInnholdArbeidstakerProps) => {
+  const sykmeldt = useNavBrukerData();
   const arbeidstakerOnskerMote =
     arbeidstakersMotebehov?.motebehovSvar?.harMotebehov;
 
@@ -172,13 +171,11 @@ export const MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov = ({
 interface MotebehovKvitteringProps {
   motebehovData: MotebehovVeilederDTO[];
   ledereData: NarmesteLederRelasjonDTO[];
-  sykmeldt?: BrukerinfoDTO;
 }
 
 const MotebehovKvittering = ({
   motebehovData,
   ledereData,
-  sykmeldt,
 }: MotebehovKvitteringProps) => {
   const { tilfellerDescendingStart, latestOppfolgingstilfelle } =
     useOppfolgingstilfellePersonQuery();
@@ -200,7 +197,6 @@ const MotebehovKvittering = ({
         arbeidstakersMotebehov={finnArbeidstakerMotebehovSvar(
           aktiveMotebehovSvar
         )}
-        sykmeldt={sykmeldt}
       />
       <MotebehovKvitteringInnholdArbeidsgiver
         motebehovListeMedBareArbeidsgiversMotebehov={aktiveMotebehovSvar.filter(

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -1,6 +1,12 @@
 import dayjs from "dayjs";
 import { dagerMellomDatoer } from "./datoUtils";
-import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
+import {
+  MeldtMotebehov,
+  MotebehovInnmelder,
+  MotebehovSkjemaType,
+  MotebehovVeilederDTO,
+  SvarMotebehov,
+} from "@/data/motebehov/types/motebehovTypes";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { MotebehovTilbakemeldingDTO } from "@/data/motebehov/useBehandleMotebehovAndSendTilbakemelding";
 
@@ -179,6 +185,60 @@ export const toMotebehovTilbakemeldingDTO = (
   };
 };
 
-export function isSykmeldtSvar(motebehov) {
+export function isArbeidstakerMotebehov(motebehov: MotebehovVeilederDTO) {
   return motebehov.opprettetAv === motebehov.aktorId;
+}
+
+export function mapMotebehovToMeldtMotebehovFormat(
+  motebehov: MotebehovVeilederDTO[]
+): MeldtMotebehov[] {
+  return motebehov
+    .filter(
+      (motebehov) => motebehov.skjemaType === MotebehovSkjemaType.MELD_BEHOV
+    )
+    .map((motebehov) => {
+      return {
+        id: motebehov.id,
+        opprettetDato: motebehov.opprettetDato,
+        opprettetAv: motebehov.opprettetAv,
+        opprettetAvNavn: motebehov.opprettetAvNavn,
+        innmelder: isArbeidstakerMotebehov(motebehov)
+          ? MotebehovInnmelder.ARBEIDSTAKER
+          : MotebehovInnmelder.ARBEIDSGIVER,
+        arbeidstakerFnr: motebehov.arbeidstakerFnr,
+        virksomhetsnummer: motebehov.virksomhetsnummer,
+        begrunnelse: motebehov.motebehovSvar.forklaring,
+        tildeltEnhet: motebehov.tildeltEnhet,
+        behandletTidspunkt: motebehov.behandletTidspunkt,
+        behandletVeilederIdent: motebehov.behandletVeilederIdent,
+        skjemaType: MotebehovSkjemaType.MELD_BEHOV,
+      };
+    });
+}
+
+export function mapMotebehovToSvarMotebehovFormat(
+  motebehov: MotebehovVeilederDTO[]
+): SvarMotebehov[] {
+  return motebehov
+    .filter(
+      (motebehov) => motebehov.skjemaType === MotebehovSkjemaType.SVAR_BEHOV
+    )
+    .map((motebehov) => {
+      return {
+        id: motebehov.id,
+        opprettetDato: motebehov.opprettetDato,
+        opprettetAv: motebehov.opprettetAv,
+        opprettetAvNavn: motebehov.opprettetAvNavn,
+        innmelder: isArbeidstakerMotebehov(motebehov)
+          ? MotebehovInnmelder.ARBEIDSTAKER
+          : MotebehovInnmelder.ARBEIDSGIVER,
+        arbeidstakerFnr: motebehov.arbeidstakerFnr,
+        virksomhetsnummer: motebehov.virksomhetsnummer,
+        motebehovSvar: motebehov.motebehovSvar,
+        tildeltEnhet: motebehov.tildeltEnhet,
+        behandletTidspunkt: motebehov.behandletTidspunkt,
+        behandletVeilederIdent: motebehov.behandletVeilederIdent,
+        skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+      };
+    });
 }

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -52,6 +52,8 @@ import {
 } from "@/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock";
 import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
+import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
+import { motebehovMock } from "@/mocks/syfomotebehov/motebehovMock";
 
 let queryClient: QueryClient;
 
@@ -77,6 +79,10 @@ function setupTestdataHistorikk() {
   );
   queryClient.setQueryData(
     historikkQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => []
+  );
+  queryClient.setQueryData(
+    motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
     () => []
   );
   queryClient.setQueryData(
@@ -822,6 +828,36 @@ describe("Historikk", () => {
           `${VEILEDER_IDENT_DEFAULT} vurderte at aktivitetskravet var oppfylt`
         )
       ).to.exist;
+    });
+  });
+
+  describe("Møtebehov", () => {
+    it("viser meldte møtebehov", async () => {
+      queryClient.setQueryData(
+        motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+        () => motebehovMock
+      );
+
+      renderHistorikk();
+
+      expect(await screen.findAllByText("Historikk")).to.exist;
+      expect(screen.getAllByText("Dialogmøte")).to.have.length(4); // Tre behov, og én behandling
+      expect(
+        screen.getByText(
+          "Den sykmeldte svarte ja på ønske om dialogmøte. Svaret var: Jeg svarer på møtebehov ved 17 uker"
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          "Are Arbeidsgiver (Arbeidsgiver) svarte nei på ønske om dialogmøte. Svaret var: Jeg liker ikke møte!!"
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          "Den sykmeldte meldte behov for dialogmøte. Begrunnelse: Møter er bra!"
+        )
+      ).to.exist;
+      expect(screen.getByText("Møtebehovet ble behandlet av Z990000")).to.exist;
     });
   });
 });

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -16,7 +16,6 @@ import {
   VEILEDER_TILDELING_HISTORIKK_SYSTEM,
 } from "@/mocks/common/mockConstants";
 import { historikkQueryKeys } from "@/data/historikk/historikkQueryHooks";
-import { historikkmotebehovMock } from "@/mocks/syfomotebehov/historikkmotebehovMock";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
 import { arbeidsuforhetQueryKeys } from "@/data/arbeidsuforhet/arbeidsuforhetQueryHooks";
 import { manglendeMedvirkningQueryKeys } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
@@ -51,7 +50,7 @@ import {
   historikkOppfolgingsoppgaveFjernetMock,
 } from "@/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock";
 import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import { tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
+import { addWeeks, tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
 import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
 import { motebehovMock } from "@/mocks/syfomotebehov/motebehovMock";
 
@@ -195,8 +194,19 @@ describe("Historikk", () => {
 
   it("viser select/dropdown med valg om hendelser utenfor oppfolgingstilfelle", async () => {
     queryClient.setQueryData(
-      historikkQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [historikkmotebehovMock]
+      aktivitetskravQueryKeys.historikk(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          tidspunkt: new Date(),
+          status: AktivitetskravStatus.NY,
+          vurdertAv: null,
+        },
+        {
+          tidspunkt: addWeeks(new Date(), -100),
+          status: AktivitetskravStatus.OPPFYLT,
+          vurdertAv: VEILEDER_IDENT_DEFAULT,
+        },
+      ]
     );
     renderHistorikk();
 

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -867,7 +867,8 @@ describe("Historikk", () => {
           "Den sykmeldte meldte behov for dialogmøte. Begrunnelse: Møter er bra!"
         )
       ).to.exist;
-      expect(screen.getByText("Møtebehovet ble behandlet av Z990000")).to.exist;
+      expect(screen.getByText("Z990000 vurderte behovet for dialogmøte")).to
+        .exist;
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Har gjort følgende:
- Laget en ny intern modell for møtebehov som skiller på meldt møtebehov (de ønsker møte) og svar på møtebehov (de blir bedt om å svare på møtebehov ved uke 17 dialogmøtekandidat). Den mapper blant annet om en del verdier som bare finnes i ett av tilfellene, og deduserer noen felter basert på ting som kommer i DTOen.
- Fjerner bruk av /historikk-endepunktet hos esyfo, slik at vi bare kan forholde oss til en liste av møtebehov og heller mappe om denne til tekst slik vi ønsker det.
- Behandling av en møtebehov-oppgave skjer ved at feltene `behandletTidspunkt` og `behandletVeilederIdent` er fylt ut på samme entry i lista. Derfor går man gjennom lista to ganger og legger til behandlinger som en egen rad i historikken, der tidspunktet er tidspunktet for behandling og ikke for møtebehovet.

Kommer også til å fjerne kode tilhørende `/historikk`-endepuntket i egen PR etter dette.

### Screenshots 📸✨

Svar: 
Før: `Smiskende Dagbot har svart på møtebehov`
Etter:
<img width="1244" alt="image" src="https://github.com/user-attachments/assets/5cb40494-4b54-4d8d-9cc8-0a6a3e222273" />

Behandling: før
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/460433f0-71c5-41b4-98cb-bad2a099bb67">
etter
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/f8b76763-23e5-4939-b3b9-5f53521a4366" />


Meld behov: Før(første og tredje rad) og etter (andre og fjerde rad)
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/38be8e30-c0bb-43c2-9450-9523794bdf64">


