### PR TITLE
IS-2890: Add tooltip om viktig info i sykmeldingen

### DIFF
--- a/src/components/ImportantInformationIcon.tsx
+++ b/src/components/ImportantInformationIcon.tsx
@@ -1,14 +1,17 @@
 import { MerInformasjonImage } from "../../img/ImageComponents";
 import React from "react";
+import { Tooltip } from "@navikt/ds-react";
 
 export default function ImportantInformationIcon() {
   return (
-    <img
-      height={18}
-      width={18}
-      alt="Viktig informasjon"
-      src={MerInformasjonImage}
-      className="max-w-[18px]"
-    />
+    <Tooltip content="Utdypende informasjon" className="z-20">
+      <img
+        height={18}
+        width={18}
+        alt="Viktig informasjon"
+        src={MerInformasjonImage}
+        className="max-w-[18px]"
+      />
+    </Tooltip>
   );
 }

--- a/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
+++ b/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
@@ -35,6 +35,10 @@ const StyledExpantionCardHeader = styled(ExpansionCard.Header)`
   .navds-expansioncard__header-content {
     width: 100%;
   }
+
+  .navds-expansioncard__header-button::after {
+    pointer-events: none;
+  }
 `;
 
 function logAccordionOpened(isOpen: boolean) {
@@ -70,7 +74,7 @@ const UtvidbarSykmelding = ({ sykmelding }: UtvidbarSykmeldingProps) => {
     : "Sykmelding uten arbeidsgiver";
   return (
     <ExpansionCard aria-label={title} onToggle={logAccordionOpened}>
-      <StyledExpantionCardHeader className="w-full">
+      <StyledExpantionCardHeader>
         <ExpansionCard.Title
           as="div"
           className="flex justify-between m-0 text-base"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Lagt til tooltip på de tre prikkene som indikerer at det finnes viktig info i sykmeldingen. 
- [x] Tekstsjekk med Stine

### Screenshots 📸✨
Utdrag fra sykmeldingen
<img width="1184" alt="image" src="https://github.com/user-attachments/assets/bf0d3e06-21d8-4ffd-8e7c-1f7b3f916fb1">

Sykmeldingene på sykmeldingsiden
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/58531a94-35d5-4408-b188-7408706c0f35">