### PR TITLE
IS-2898: Use correct field for createdBy in oppfolgingsoppgave

### DIFF
--- a/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
+++ b/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
@@ -31,7 +31,7 @@ export const Oppfolgingsoppgave = () => {
     aktivOppfolgingsoppgave?.versjoner?.[0];
 
   const { data: veilederinfo } = useVeilederInfoQuery(
-    aktivOppfolgingsoppgave?.createdBy ?? ""
+    aktivOppfolgingsoppgaveVersjon?.createdBy ?? ""
   );
   const isExistingOppfolgingsoppgave = !!aktivOppfolgingsoppgave;
   const handleRemoveOppfolgingsoppgave = (uuid: string) => {

--- a/src/data/oppfolgingsoppgave/types.ts
+++ b/src/data/oppfolgingsoppgave/types.ts
@@ -28,7 +28,6 @@ export interface EditOppfolgingsoppgaveRequestDTO {
 
 export interface OppfolgingsoppgaveResponseDTO {
   uuid: string;
-  createdBy: string;
   updatedAt: Date;
   isActive: boolean;
   createdAt: Date;

--- a/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
+++ b/src/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock.ts
@@ -11,7 +11,6 @@ const DATO_INNENFOR_OPPFOLGINGSTILFELLE = new Date("2024-06-20");
 export const historikkOppfolgingsoppgaveAktivMock: OppfolgingsoppgaveResponseDTO =
   {
     uuid: generateUUID(),
-    createdBy: VEILEDER_IDENT_DEFAULT,
     updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, 1),
     isActive: true,
     createdAt: DATO_INNENFOR_OPPFOLGINGSTILFELLE,
@@ -39,7 +38,6 @@ export const historikkOppfolgingsoppgaveAktivMock: OppfolgingsoppgaveResponseDTO
 export const historikkOppfolgingsoppgaveFjernetMock: OppfolgingsoppgaveResponseDTO =
   {
     uuid: generateUUID(),
-    createdBy: VEILEDER_IDENT_DEFAULT,
     updatedAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -1),
     isActive: false,
     createdAt: addDays(DATO_INNENFOR_OPPFOLGINGSTILFELLE, -5),

--- a/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
+++ b/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
@@ -68,7 +68,6 @@ export const mockIshuskelapp = [
       oppfolgingsoppgaverMock = oppfolgingsoppgaverMock = [
         {
           uuid: oppfolgingsoppgaveUuid,
-          createdBy: VEILEDER_IDENT_DEFAULT,
           updatedAt: new Date(),
           createdAt: new Date(),
           isActive: true,

--- a/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
+++ b/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
@@ -8,10 +8,7 @@ import {
   within,
 } from "@testing-library/react";
 import React from "react";
-import {
-  VEILEDER_DEFAULT,
-  VEILEDER_IDENT_DEFAULT,
-} from "@/mocks/common/mockConstants";
+import { VEILEDER_DEFAULT } from "@/mocks/common/mockConstants";
 import {
   EditOppfolgingsoppgaveRequestDTO,
   Oppfolgingsgrunn,
@@ -34,7 +31,6 @@ const oppfolgingsoppgaveOppfolgingsgrunn =
   Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE;
 const oppfolgingsoppgaveOppfogingsgrunnText = "Vurder behov for dialogmøte";
 const oppfolgingsoppgave: OppfolgingsoppgaveResponseDTO = {
-  createdBy: VEILEDER_IDENT_DEFAULT,
   uuid: generateUUID(),
   updatedAt: new Date(),
   createdAt: new Date(),
@@ -45,6 +41,7 @@ const oppfolgingsoppgave: OppfolgingsoppgaveResponseDTO = {
       oppfolgingsgrunn: oppfolgingsoppgaveOppfolgingsgrunn,
       tekst: "Dette var en veldig god grunn for å lage oppfolgingsoppgave.",
       frist: "2030-01-01",
+      createdBy: VEILEDER_DEFAULT.ident,
     } as OppfolgingsoppgaveVersjonResponseDTO,
   ],
 };


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Kom inn tilbakemelding på Viva Engage om at veilederen som lagde oppgaven ikke vises lenger.
Etter endringer i DTOen her, så får vi ikke `createdBy` på hovedobjektet, men inne i versjonen. 

### Screenshots 📸✨
I dev så det bare sånn ut:
<img width="269" alt="image" src="https://github.com/user-attachments/assets/95b15444-eb8f-42e8-ba7c-603f1e8f51c6" />

Nå:
<img width="243" alt="image" src="https://github.com/user-attachments/assets/733e9974-55ee-4ab3-bff0-38a1ff360ad1" />
