### PR TITLE
IS-2876: Show 8-5 tag when active vedtak

### DIFF
--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -7,6 +7,7 @@ import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 import { useDiskresjonskodeQuery } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import { useUnderArbeidsrettetOppfolgingQuery } from "@/data/veilarboppfolging/useUnderArbeidsrettetOppfolgingQuery";
+import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
 
 const texts = {
   fetchDiskresjonskodeFailed: "Klarte ikke hente diskresjonskode for brukeren.",
@@ -18,6 +19,7 @@ const texts = {
   tegnsprakTolk: "Tegnspråktolk",
   sikkerhetstiltak: "Sikkerhetstiltak",
   ao: "Under arbeidsrettet oppfølging",
+  friskmeldingTilArbeidsformidling: "Har vedtak om § 8-5",
 };
 
 export const PersonkortHeaderTags = () => {
@@ -27,6 +29,7 @@ export const PersonkortHeaderTags = () => {
   const { error, data: diskresjonskode } = useDiskresjonskodeQuery();
   const { data: arbeidsrettetOppfolging } =
     useUnderArbeidsrettetOppfolgingQuery();
+  const { data: vedtakFriskTilArbeid } = useVedtakQuery();
 
   const isDead = !!dodsdato;
   const dateOfDeath = tilLesbarDatoMedArUtenManedNavn(dodsdato);
@@ -36,6 +39,9 @@ export const PersonkortHeaderTags = () => {
     tilrettelagtKommunikasjon?.talesprakTolk?.value;
   const tegnsprakTolkSprakkode =
     tilrettelagtKommunikasjon?.tegnsprakTolk?.value;
+  const hasActiveFriskmeldingVedtak =
+    vedtakFriskTilArbeid[0] &&
+    new Date(vedtakFriskTilArbeid[0].tom).getTime() >= new Date().getTime();
 
   return (
     <ErrorBoundary
@@ -61,6 +67,11 @@ export const PersonkortHeaderTags = () => {
         {arbeidsrettetOppfolging?.underOppfolging && (
           <Tag variant="warning" size="small">
             {texts.ao}
+          </Tag>
+        )}
+        {hasActiveFriskmeldingVedtak && (
+          <Tag variant="info" size="small">
+            {texts.friskmeldingTilArbeidsformidling}
           </Tag>
         )}
         {talesprakTolkSprakkode && (

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -25,6 +25,8 @@ import { maksdatoQueryKeys } from "@/data/maksdato/useMaksdatoQuery";
 import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { oppfolgingstilfellePersonMock } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock";
 import { addDays } from "@/utils/datoUtils";
+import { vedtakQueryKeys } from "@/data/frisktilarbeid/vedtakQuery";
+import { defaultVedtak } from "@/mocks/isfrisktilarbeid/mockIsfrisktilarbeid";
 
 let queryClient: any;
 
@@ -291,5 +293,15 @@ describe("PersonkortHeader", () => {
     renderPersonkortHeader();
 
     expect(screen.getByText("Under arbeidsrettet oppfølging")).to.exist;
+  });
+
+  it("viser 8-5 tag når under aktiv fom-tom periode", () => {
+    queryClient.setQueryData(
+      vedtakQueryKeys.vedtak(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [defaultVedtak]
+    );
+    renderPersonkortHeader();
+
+    expect(screen.getByText("Har vedtak om § 8-5")).to.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

~Trenger innspill på tekst her.~ Teksten vokste på Stine 🤌🏼
Viser altså en Tag når `tom`-dato er fremover i tid.

### Screenshots 📸✨
Blå tag ettersom det ikke er en warning. "Under arbeidsrettet oppfølging" burde nok også vært det, men gjør ikke endringer der i denne PRen. Tenker egt at kode 6/7 tagene burde vært røde også 🤷🏼‍♂️
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/143e6955-4e7d-47a7-a87f-f3ae0048bf83" />
