### PR TITLE
IS-2912: remove tooltip on sykmelding

### DIFF
--- a/src/components/ImportantInformationIcon.tsx
+++ b/src/components/ImportantInformationIcon.tsx
@@ -1,17 +1,14 @@
 import { MerInformasjonImage } from "../../img/ImageComponents";
 import React from "react";
-import { Tooltip } from "@navikt/ds-react";
 
 export default function ImportantInformationIcon() {
   return (
-    <Tooltip content="Utdypende informasjon" className="z-20">
-      <img
-        height={18}
-        width={18}
-        alt="Viktig informasjon"
-        src={MerInformasjonImage}
-        className="max-w-[18px]"
-      />
-    </Tooltip>
+    <img
+      height={18}
+      width={18}
+      alt="Viktig informasjon"
+      src={MerInformasjonImage}
+      className="max-w-[18px]"
+    />
   );
 }

--- a/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
+++ b/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
@@ -35,10 +35,6 @@ const StyledExpantionCardHeader = styled(ExpansionCard.Header)`
   .navds-expansioncard__header-content {
     width: 100%;
   }
-
-  .navds-expansioncard__header-button::after {
-    pointer-events: none;
-  }
 `;
 
 function logAccordionOpened(isOpen: boolean) {
@@ -74,7 +70,7 @@ const UtvidbarSykmelding = ({ sykmelding }: UtvidbarSykmeldingProps) => {
     : "Sykmelding uten arbeidsgiver";
   return (
     <ExpansionCard aria-label={title} onToggle={logAccordionOpened}>
-      <StyledExpantionCardHeader>
+      <StyledExpantionCardHeader className="w-full">
         <ExpansionCard.Title
           as="div"
           className="flex justify-between m-0 text-base"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Reverserer [denne PRen](https://github.com/navikt/syfomodiaperson/pull/1572) fordi tooltipen om viktig info i sykmeldingen innskrenket muligheten til å trykke seg inn på kortet. Uten tooltipen kan man trykke hvor som helst på sykmeldingskortet, som gjør det lett å navigere seg mellom mange sykmeldinger spesielt på store skjermer. 

### Screenshots 📸✨
<details> 
<summary>Dette er sykmeldingskortet med de tre prikkene: </summary>

![image](https://github.com/user-attachments/assets/57768b39-601f-4164-8aa1-049c2a5b25ff)

</details>