### PR TITLE
IS-2427: Add svar på endringer (nytt tid/sted) to motesvarhistorikk

### DIFF
--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk.tsx
@@ -6,7 +6,7 @@ import MoteSvarHistorikkEvent from "@/sider/dialogmoter/components/motehistorikk
 
 const texts = {
   header: "Møtesvarhistorikk",
-  subtitle: "Oversikt over svar på tidligere innkallinger til dialogmøter",
+  subtitle: "Oversikt over svar på tidligere dialogmøter",
   ingenSvarHistorikk: "Ingen tidligere møtesvar",
 };
 

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEndringer.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEndringer.tsx
@@ -1,0 +1,71 @@
+import {
+  DialogmotedeltakerVarselDTO,
+  DialogmoteDTO,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+import { HStack, Label } from "@navikt/ds-react";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import { ArbeidsgiverSvar } from "@/sider/dialogmoter/components/svar/ArbeidsgiverSvar";
+import { ArbeidstakerSvar } from "@/sider/dialogmoter/components/svar/ArbeidstakerSvar";
+import { BehandlerSvar } from "@/sider/dialogmoter/components/svar/BehandlerSvar";
+import React from "react";
+
+interface Props {
+  dialogmote: DialogmoteDTO;
+}
+
+type SortableVarsel = Pick<
+  DialogmotedeltakerVarselDTO,
+  "varselType" | "createdAt"
+>;
+
+const getEndringVarslerSortedAsc = <T extends SortableVarsel>(varsler: T[]) =>
+  varsler
+    .filter(
+      ({ varselType }) => varselType == MotedeltakerVarselType.NYTT_TID_STED
+    )
+    .sort(byCreatedAtAsc);
+
+const byCreatedAtAsc = (v1: SortableVarsel, v2: SortableVarsel) =>
+  new Date(v1.createdAt).getTime() - new Date(v2.createdAt).getTime();
+
+export function MoteSvarHistorikkEndringer({ dialogmote }: Props) {
+  const endringVarslerArbeidsgiver = getEndringVarslerSortedAsc(
+    dialogmote.arbeidsgiver.varselList
+  );
+  const endringVarslerArbeidstaker = getEndringVarslerSortedAsc(
+    dialogmote.arbeidstaker.varselList
+  );
+  const endringVarslerBehandler = getEndringVarslerSortedAsc(
+    dialogmote.behandler?.varselList || []
+  );
+
+  return (
+    <div>
+      {endringVarslerArbeidsgiver.map((arbeidgiverVarsel, index) => (
+        <div key={index} className="mt-4">
+          <Label size="small">{`Endret tid/sted sendt ${tilDatoMedManedNavn(
+            arbeidgiverVarsel.createdAt
+          )} - svar:`}</Label>
+          <HStack gap="4">
+            <ArbeidsgiverSvar
+              varsel={arbeidgiverVarsel}
+              virksomhetsnummer={dialogmote.arbeidsgiver.virksomhetsnummer}
+              defaultClosed
+            />
+            <ArbeidstakerSvar
+              varsel={endringVarslerArbeidstaker[index]}
+              defaultClosed
+            />
+            {endringVarslerBehandler[index] && (
+              <BehandlerSvar
+                varsel={endringVarslerBehandler[index]}
+                behandlerNavn={dialogmote.behandler?.behandlerNavn || ""}
+              />
+            )}
+          </HStack>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEvent.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEvent.tsx
@@ -1,18 +1,16 @@
 import {
   DialogmoteDTO,
   DialogmoteStatus,
-  MotedeltakerVarselType,
 } from "@/data/dialogmote/types/dialogmoteTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import React, { useState } from "react";
 import * as Amplitude from "@/utils/amplitude";
 import { EventType } from "@/utils/amplitude";
-import { Accordion, Label } from "@navikt/ds-react";
+import { Accordion, HStack } from "@navikt/ds-react";
 import { DialogmoteStedInfo } from "@/sider/dialogmoter/components/DialogmoteStedInfo";
 import { DialogmoteVeilederInfo } from "@/sider/dialogmoter/components/DialogmoteVeilederInfo";
-import { ArbeidsgiverSvar } from "@/sider/dialogmoter/components/svar/ArbeidsgiverSvar";
-import { ArbeidstakerSvar } from "@/sider/dialogmoter/components/svar/ArbeidstakerSvar";
-import { BehandlerSvar } from "@/sider/dialogmoter/components/svar/BehandlerSvar";
+import { MoteSvarHistorikkInnkalling } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkInnkalling";
+import { MoteSvarHistorikkEndringer } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEndringer";
 
 const getHeaderText = (mote: DialogmoteDTO): string => {
   const moteDato = tilDatoMedManedNavn(mote.tid);
@@ -46,49 +44,20 @@ export default function MoteSvarHistorikkEvent({ dialogmote }: Props) {
     setIsOpen(!isOpen);
   };
 
-  const innkallingArbeidstaker = dialogmote.arbeidstaker.varselList.find(
-    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
-  );
-  const innkallingArbeidsgiver = dialogmote.arbeidsgiver.varselList.find(
-    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
-  );
-  const innkallingBehandler =
-    dialogmote.behandler &&
-    dialogmote.behandler.varselList.find(
-      ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
-    );
-
   return (
     <Accordion.Item open={isOpen}>
       <Accordion.Header onClick={handleAccordionClick}>
         {getHeaderText(dialogmote)}
       </Accordion.Header>
       <Accordion.Content>
-        <DialogmoteStedInfo dialogmote={dialogmote} />
-        <DialogmoteVeilederInfo dialogmote={dialogmote} />
-        <div className="mt-4">
-          <Label size="small">{`Innkalling sendt ${tilDatoMedManedNavn(
-            dialogmote.createdAt
-          )} - svar:`}</Label>
-          <div className="flex flex-col gap-4">
-            {innkallingArbeidsgiver && (
-              <ArbeidsgiverSvar
-                varsel={innkallingArbeidsgiver}
-                virksomhetsnummer={dialogmote.arbeidsgiver.virksomhetsnummer}
-                defaultClosed
-              />
-            )}
-            {innkallingArbeidstaker && (
-              <ArbeidstakerSvar varsel={innkallingArbeidstaker} defaultClosed />
-            )}
-            {innkallingBehandler && (
-              <BehandlerSvar
-                varsel={innkallingBehandler}
-                behandlerNavn={dialogmote.behandler.behandlerNavn}
-              />
-            )}
+        <HStack gap="4">
+          <div>
+            <DialogmoteStedInfo dialogmote={dialogmote} />
+            <DialogmoteVeilederInfo dialogmote={dialogmote} />
           </div>
-        </div>
+          <MoteSvarHistorikkInnkalling dialogmote={dialogmote} />
+          <MoteSvarHistorikkEndringer dialogmote={dialogmote} />
+        </HStack>
       </Accordion.Content>
     </Accordion.Item>
   );

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkInnkalling.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkInnkalling.tsx
@@ -1,0 +1,54 @@
+import { HStack, Label } from "@navikt/ds-react";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import { ArbeidsgiverSvar } from "@/sider/dialogmoter/components/svar/ArbeidsgiverSvar";
+import { ArbeidstakerSvar } from "@/sider/dialogmoter/components/svar/ArbeidstakerSvar";
+import { BehandlerSvar } from "@/sider/dialogmoter/components/svar/BehandlerSvar";
+import React from "react";
+import {
+  DialogmoteDTO,
+  MotedeltakerVarselType,
+} from "@/data/dialogmote/types/dialogmoteTypes";
+
+interface Props {
+  dialogmote: DialogmoteDTO;
+}
+
+export function MoteSvarHistorikkInnkalling({ dialogmote }: Props) {
+  const innkallingArbeidstaker = dialogmote.arbeidstaker.varselList.find(
+    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+  );
+  const innkallingArbeidsgiver = dialogmote.arbeidsgiver.varselList.find(
+    ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+  );
+  const innkallingBehandler =
+    dialogmote.behandler &&
+    dialogmote.behandler.varselList.find(
+      ({ varselType }) => varselType === MotedeltakerVarselType.INNKALT
+    );
+
+  return (
+    <div>
+      <Label size="small">{`Innkalling sendt ${tilDatoMedManedNavn(
+        dialogmote.createdAt
+      )} - svar:`}</Label>
+      <HStack gap="4">
+        {innkallingArbeidsgiver && (
+          <ArbeidsgiverSvar
+            varsel={innkallingArbeidsgiver}
+            virksomhetsnummer={dialogmote.arbeidsgiver.virksomhetsnummer}
+            defaultClosed
+          />
+        )}
+        {innkallingArbeidstaker && (
+          <ArbeidstakerSvar varsel={innkallingArbeidstaker} defaultClosed />
+        )}
+        {innkallingBehandler && (
+          <BehandlerSvar
+            varsel={innkallingBehandler}
+            behandlerNavn={dialogmote.behandler.behandlerNavn}
+          />
+        )}
+      </HStack>
+    </div>
+  );
+}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til arbeidstakers/arbeidsgivers/behandlers svar på utsendt endring av tid/sted for dialogmøte. I teorien kan endring av tid/sted skje flere ganger og kan svares på hver gang. Lagt alle disse kronologisk under svar på innkallingen vi har i møtesvar-historikken.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/d80451f8-aa20-46e3-a277-ad5cb8724922)


