### PR TITLE
IS-2907: Display phone numbers on readable format

### DIFF
--- a/src/components/personkort/Personkort.tsx
+++ b/src/components/personkort/Personkort.tsx
@@ -15,7 +15,7 @@ const texts = {
   },
 };
 
-const Personkort = () => {
+export default function Personkort() {
   const [visning, setVisning] = useState(PERSONKORTVISNING_TYPE.SYKMELDT);
   const { hasSikkerhetstiltak } = useNavBrukerData();
 
@@ -106,6 +106,4 @@ const Personkort = () => {
       </Ekspanderbartpanel>
     </div>
   );
-};
-
-export default Personkort;
+}

--- a/src/components/personkort/PersonkortInformasjon.tsx
+++ b/src/components/personkort/PersonkortInformasjon.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 
-interface PersonkortInformasjonProps {
+interface Props {
   informasjonNokkelTekster: Map<string, string>;
   informasjon: any;
 }
 
-const PersonkortInformasjon = (
-  personkortInformasjonProps: PersonkortInformasjonProps
-) => {
-  const { informasjonNokkelTekster, informasjon } = personkortInformasjonProps;
+export default function PersonkortInformasjon({
+  informasjonNokkelTekster,
+  informasjon,
+}: Props) {
   return (
     <>
       {Object.keys(informasjon).map((nokkel, idx) => {
@@ -24,6 +24,4 @@ const PersonkortInformasjon = (
       })}
     </>
   );
-};
-
-export default PersonkortInformasjon;
+}

--- a/src/components/personkort/PersonkortLege.tsx
+++ b/src/components/personkort/PersonkortLege.tsx
@@ -8,6 +8,7 @@ import styled from "styled-components";
 import PersonkortInformasjon from "@/components/personkort/PersonkortInformasjon";
 import { FlexColumn, FlexRow } from "@/components/Layout";
 import { Detail, Heading } from "@navikt/ds-react";
+import { formatPhonenumber } from "@/utils/stringUtils";
 
 const texts = {
   name: "Legekontor",
@@ -86,9 +87,11 @@ export const FastlegeVikar = ({
 const PersonKortLegeRow = styled(Row)`
   margin-left: 0;
   margin-right: 0;
+
   &:not(:last-child) {
     margin-bottom: 1em;
   }
+
   ul li {
     display: block;
   }
@@ -140,7 +143,8 @@ const PersonkortLege = () => {
   const valgteElementerKontor =
     fastlege?.fastlegekontor &&
     (({ navn, telefon }) => {
-      return { navn, telefon };
+      const tlf = telefon ? formatPhonenumber(telefon) : telefon;
+      return { navn, tlf };
     })(fastlege.fastlegekontor);
 
   const valgteElementer = {

--- a/src/components/personkort/PersonkortSykmeldt.tsx
+++ b/src/components/personkort/PersonkortSykmeldt.tsx
@@ -11,6 +11,7 @@ import { PersonImage } from "../../../img/ImageComponents";
 import { usePersonAdresseQuery } from "@/data/personinfo/personAdresseQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
+import { formatPhonenumber } from "@/utils/stringUtils";
 
 const texts = {
   fnr: "F.nummer",
@@ -44,8 +45,11 @@ const PersonkortSykmeldt = () => {
     oppholdsadresse: formaterOppholdsadresse(personadresse?.oppholdsadresse),
   });
   const fnr = useValgtPersonident();
+  const formattedPhonenumber = navbruker.kontaktinfo?.tlf
+    ? formatPhonenumber(navbruker.kontaktinfo.tlf)
+    : navbruker.kontaktinfo?.tlf;
   const valgteElementerKontaktinfo = {
-    tlf: navbruker.kontaktinfo?.tlf,
+    tlf: formattedPhonenumber,
     epost: navbruker.kontaktinfo?.epost,
     fnr: formaterFnr(fnr),
   };

--- a/src/components/personkort/ledere/PersonKortVirksomhetLedere.tsx
+++ b/src/components/personkort/ledere/PersonKortVirksomhetLedere.tsx
@@ -10,7 +10,7 @@ import {
   NarmesteLederRelasjonStatus,
 } from "@/data/leder/ledereTypes";
 import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat";
-import { capitalizeAllWords } from "@/utils/stringUtils";
+import { capitalizeAllWords, formatPhonenumber } from "@/utils/stringUtils";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
 
 const texts = {
@@ -114,7 +114,7 @@ export const PersonKortVirksomhetLederRow = (
       <EpostButton epost={leder.narmesteLederEpost} />
       <PersonKortVirksomhetLederColumn
         colSize={2}
-        text={leder.narmesteLederTelefonnummer}
+        text={formatPhonenumber(leder.narmesteLederTelefonnummer)}
         isActive={isActive}
       />
       {leder.aktivFom && (

--- a/src/utils/stringUtils.ts
+++ b/src/utils/stringUtils.ts
@@ -21,3 +21,20 @@ export const capitalizeAllWords = (word: string): string =>
 export const containsWhiteSpace = (str: string) => {
   return /\s/g.test(str);
 };
+
+/**
+ * Splitter et telefonnummer som kommer inn på formatet 12345678 til 12 34 56 78 eller +4712345678 til +47 12 34 56 78.
+ * @param phonenumber Telefonnummeret som skal formateteres.
+ */
+export function formatPhonenumber(phonenumber: string): string {
+  if (phonenumber.length === 8) {
+    return phonenumber.replace(/(\d{2})(\d{2})(\d{2})(\d{2})/, "$1 $2 $3 $4");
+  } else if (phonenumber.length === 11) {
+    return phonenumber.replace(
+      /(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/,
+      "$1 $2 $3 $4 $5"
+    );
+  } else {
+    return phonenumber;
+  }
+}

--- a/test/utils/stringUtilsTest.ts
+++ b/test/utils/stringUtilsTest.ts
@@ -1,5 +1,5 @@
-import { expect, describe, it } from "vitest";
-import { capitalizeAllWords } from "@/utils/stringUtils";
+import { describe, expect, it } from "vitest";
+import { capitalizeAllWords, formatPhonenumber } from "@/utils/stringUtils";
 
 const expectedCapitalized = "Stevie Ray Vaughan";
 const expectedCapitalizedHyphen = "Jean-Luc Picard";
@@ -13,5 +13,22 @@ describe("stringUtils", () => {
   it("skal håndtere bindestrek", () => {
     const name = "Jean-luc Picard";
     expect(capitalizeAllWords(name)).to.equal(expectedCapitalizedHyphen);
+  });
+
+  describe("formatPhonenumber", () => {
+    it("skal formatere fra 12345678 til 12 34 56 78", () => {
+      const phonenumber = "12345678";
+      expect(formatPhonenumber(phonenumber)).to.equal("12 34 56 78");
+    });
+
+    it("skal formatere fra +4712345678 til +47 12 34 56 78", () => {
+      const phonenumber = "+4712345678";
+      expect(formatPhonenumber(phonenumber)).to.equal("+47 12 34 56 78");
+    });
+
+    it("returnerer samme nummer om format ikke passer", () => {
+      const phonenumber = "123 45 678";
+      expect(formatPhonenumber(phonenumber)).to.equal("123 45 678");
+    });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endrer visning av telefon nummere til et leselig format. 
- Håndterer både nummere som er på formatet 12345678 og +4712345678. Disse blir 12 34 56 78 og +47 12 3 56 78.
- Følger [språkrådets anbefalinger rundt visning av telefon nummere](https://arc.net/l/quote/aygjlewf)

### Screenshots 📸✨
Før

https://github.com/user-attachments/assets/a40804c9-4d28-4649-b9b7-8f9ed038e3c8




Etter

https://github.com/user-attachments/assets/16029146-9e84-401a-a388-3ee9e2c39b15


