### PR TITLE
IS-2753: Lagt til info om videmøte-link

### DIFF
--- a/src/data/dialogmote/dialogmoteTexts.ts
+++ b/src/data/dialogmote/dialogmoteTexts.ts
@@ -1,4 +1,4 @@
-import { Malform } from "../../context/malform/MalformContext";
+import { Malform } from "@/context/malform/MalformContext";
 
 const innkallingTextsBokmal = {
   arbeidstaker: {
@@ -213,11 +213,24 @@ export const getAvlysningTexts = (malform: Malform) => {
     : avlysningTextsBokmal;
 };
 
+type CommmonTexts = {
+  arbeidsgiverTitle: string;
+  moteTidTitle: string;
+  moteStedTitle: string;
+  videoLinkTitle: string;
+  videoMoteInfo: string;
+  arbeidsgiverTlfLabel: string;
+  arbeidsgiverTlf: string;
+  hilsen: string;
+  gjelder: string;
+};
+
 const commonTextsBokmal = {
   arbeidsgiverTitle: "Arbeidsgiver",
   moteTidTitle: "Møtetidspunkt",
   moteStedTitle: "Møtested",
   videoLinkTitle: "Lenke til videomøte",
+  videoMoteInfo: "Les mer om videomøte med Nav på nav.no/videomote-med-nav.",
   arbeidsgiverTlfLabel: "Arbeidsgivertelefonen",
   arbeidsgiverTlf: "55 55 33 36",
   hilsen: "Med vennlig hilsen",
@@ -229,13 +242,14 @@ const commonTextsNynorsk = {
   moteTidTitle: "Møtetidspunkt",
   moteStedTitle: "Møtestad",
   videoLinkTitle: "Lenke til videomøte",
+  videoMoteInfo: "Les mer om videomøte med Nav på nav.no/videomote-med-nav.",
   arbeidsgiverTlfLabel: "Arbeidsgivartelefonen",
   arbeidsgiverTlf: "55 55 33 36",
   hilsen: "Vennleg helsing",
   gjelder: "Gjeld",
 };
 
-export const getCommonTexts = (malform: Malform) => {
+export const getCommonTexts = (malform: Malform): CommmonTexts => {
   return malform === Malform.NYNORSK ? commonTextsNynorsk : commonTextsBokmal;
 };
 

--- a/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
+++ b/src/hooks/dialogmote/document/useDialogmoteDocumentComponents.ts
@@ -1,5 +1,6 @@
 import {
   createLink,
+  createParagraph,
   createParagraphWithTitle,
 } from "@/utils/documentComponentUtils";
 import { getCommonTexts } from "@/data/dialogmote/dialogmoteTexts";
@@ -50,6 +51,7 @@ export const useDialogmoteDocumentComponents = () => {
     );
     if (videoLink) {
       components.push(createLink(commonTexts.videoLinkTitle, videoLink));
+      components.push(createParagraph(commonTexts.videoMoteInfo));
     }
 
     const virksomhetsnavn = getVirksomhetsnavn(virksomhetsnummer);

--- a/test/dialogmote/testDataDocuments.ts
+++ b/test/dialogmote/testDataDocuments.ts
@@ -68,6 +68,10 @@ const expectedArbeidstakerInnkalling = (
     type: DocumentComponentType.LINK,
   },
   {
+    texts: [commonTextsBokmal.videoMoteInfo],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
     texts: [mote.arbeidsgivernavn],
     title: "Arbeidsgiver",
     type: DocumentComponentType.PARAGRAPH,
@@ -152,6 +156,10 @@ const expectedArbeidsgiverInnkalling = (
     texts: [mote.videolink],
     title: commonTextsBokmal.videoLinkTitle,
     type: DocumentComponentType.LINK,
+  },
+  {
+    texts: [commonTextsBokmal.videoMoteInfo],
+    type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.arbeidsgivernavn],
@@ -242,6 +250,10 @@ const expectedBehandlerInnkalling = (
     type: DocumentComponentType.LINK,
   },
   {
+    texts: [commonTextsBokmal.videoMoteInfo],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
     texts: [mote.arbeidsgivernavn],
     title: "Arbeidsgiver",
     type: DocumentComponentType.PARAGRAPH,
@@ -311,6 +323,10 @@ const expectedArbeidsgiverEndringsdokument = (
     texts: [endretMote.videolink],
     title: "Lenke til videomøte",
     type: DocumentComponentType.LINK,
+  },
+  {
+    texts: [commonTextsBokmal.videoMoteInfo],
+    type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.arbeidsgivernavn],
@@ -410,6 +426,10 @@ const expectedArbeidstakerEndringsdokument = (
     type: DocumentComponentType.LINK,
   },
   {
+    texts: [commonTextsBokmal.videoMoteInfo],
+    type: DocumentComponentType.PARAGRAPH,
+  },
+  {
     texts: [mote.arbeidsgivernavn],
     title: "Arbeidsgiver",
     type: DocumentComponentType.PARAGRAPH,
@@ -504,6 +524,10 @@ const expectedBehandlerEndringsdokument = (
     texts: [endretMote.videolink],
     title: "Lenke til videomøte",
     type: DocumentComponentType.LINK,
+  },
+  {
+    texts: [commonTextsBokmal.videoMoteInfo],
+    type: DocumentComponentType.PARAGRAPH,
   },
   {
     texts: [mote.arbeidsgivernavn],


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til setning med lenke til info om videomøte dersom lenke til videomøte er angitt. Bruker samme stil på denne som vi har i andre brev hvor vi lenker til relevant info på nav.no (dvs ingen lenke-styling - dels fordi vi ikke har støtte for det ut av boksen med DocumentComponent og dels fordi brevet kan gå fysisk)

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/ec746be8-38b9-43be-822c-5f998146f0eb)
