### PR TITLE
IS-2790: Mulighet for å endre oppfølgingsgrunn på oppfølgingsoppgave

### DIFF
--- a/src/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave.tsx
@@ -6,17 +6,22 @@ import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfo
 import { aktivOppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
 import { OppfolgingsoppgaveRequestDTO } from "@/data/oppfolgingsoppgave/types";
 
+export const postOppfolgingsoppgave = (
+  personident: string,
+  nyOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO
+) =>
+  post<OppfolgingsoppgaveRequestDTO>(
+    `${ISHUSKELAPP_ROOT}/huskelapp`,
+    nyOppfolgingsoppgave,
+    personident
+  );
+
 export const useCreateOppfolgingsoppgave = () => {
   const personident = useValgtPersonident();
   const queryClient = useQueryClient();
-  const path = `${ISHUSKELAPP_ROOT}/huskelapp`;
-  const postOppfolgingsoppgave = (
-    nyOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO
-  ) =>
-    post<OppfolgingsoppgaveRequestDTO>(path, nyOppfolgingsoppgave, personident);
-
   return useMutation({
-    mutationFn: postOppfolgingsoppgave,
+    mutationFn: (nyOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO) =>
+      postOppfolgingsoppgave(personident, nyOppfolgingsoppgave),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey:

--- a/src/data/oppfolgingsoppgave/useDeleteAndCreateOppfolgingsoppgave.ts
+++ b/src/data/oppfolgingsoppgave/useDeleteAndCreateOppfolgingsoppgave.ts
@@ -1,0 +1,33 @@
+import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { deleteOppfolgingsoppgave } from "@/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave";
+import { postOppfolgingsoppgave } from "@/data/oppfolgingsoppgave/useCreateOppfolgingsoppgave";
+import { OppfolgingsoppgaveRequestDTO } from "@/data/oppfolgingsoppgave/types";
+import { aktivOppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
+import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
+
+export const useDeleteAndCreateOppfolgingsoppgave = () => {
+  const personident = useValgtPersonident();
+  const queryClient = useQueryClient();
+  const deleteAndCreateOppfolgingsoppgave = async (payload: {
+    existingOppfolgingsoppgaveUuid: string;
+    nyOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO;
+  }) => {
+    const { existingOppfolgingsoppgaveUuid, nyOppfolgingsoppgave } = payload;
+    await deleteOppfolgingsoppgave(personident, existingOppfolgingsoppgaveUuid);
+    await postOppfolgingsoppgave(personident, nyOppfolgingsoppgave);
+  };
+
+  return useMutation({
+    mutationFn: deleteAndCreateOppfolgingsoppgave,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey:
+          aktivOppfolgingsoppgaveQueryKeys.aktivOppfolgingsoppgave(personident),
+      });
+      queryClient.invalidateQueries({
+        queryKey: oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(personident),
+      });
+    },
+  });
+};

--- a/src/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave.tsx
+++ b/src/data/oppfolgingsoppgave/useRemoveOppfolgingsoppgave.tsx
@@ -5,16 +5,21 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
 import { aktivOppfolgingsoppgaveQueryKeys } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
 
+export const deleteOppfolgingsoppgave = (
+  personident: string,
+  oppfolgingsoppgaveUuid: string
+) =>
+  deleteRequest(
+    `${ISHUSKELAPP_ROOT}/huskelapp/${oppfolgingsoppgaveUuid}`,
+    personident
+  );
+
 export const useRemoveOppfolgingsoppgave = () => {
   const personident = useValgtPersonident();
   const queryClient = useQueryClient();
-  const deleteOppfolgingsoppgave = (oppfolgingsoppgaveUuid: string) => {
-    const path = `${ISHUSKELAPP_ROOT}/huskelapp/${oppfolgingsoppgaveUuid}`;
-    return deleteRequest(path, personident);
-  };
-
   return useMutation({
-    mutationFn: deleteOppfolgingsoppgave,
+    mutationFn: (oppfolgingsoppgaveUuid: string) =>
+      deleteOppfolgingsoppgave(personident, oppfolgingsoppgaveUuid),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey:

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -14,6 +14,7 @@ export enum EventType {
   AccordionOpen = "accordion åpnet",
   OppfolgingsgrunnSendt = "oppfolgingsgrunn sendt",
   OppfolgingsoppgaveEdited = "oppfolgingsoppgave endret",
+  OppfolgingsgrunnEdited = "oppfolgingsgrunn endret",
   IkkeAktuellVurderingArsak = "Ikke aktuell vurdering arsak",
   ViewPortAndScreenResolution = "viewport og skjermstørrelse",
   OptionSelected = "alternativ valgt",
@@ -68,6 +69,14 @@ type OppfolgingsoppgaveEdited = {
     url: string;
     oppfolgingsgrunn: Oppfolgingsgrunn;
     fieldsEdited: string[];
+  };
+};
+
+type OppfolgingsgrunnEdited = {
+  type: EventType.OppfolgingsgrunnEdited;
+  data: {
+    url: string;
+    oppfolgingsgrunn: Oppfolgingsgrunn;
   };
 };
 
@@ -136,6 +145,7 @@ type Event =
   | ViewPortAndScreenResolution
   | OppfolgingsgrunnSendt
   | OppfolgingsoppgaveEdited
+  | OppfolgingsgrunnEdited
   | IkkeAktuellVurderingArsak
   | OptionSelected
   | LinkClick

--- a/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
+++ b/test/oppfolgingsoppgave/OppfolgingsoppgaveModalTest.tsx
@@ -30,6 +30,8 @@ let queryClient: QueryClient;
 const oppfolgingsoppgaveOppfolgingsgrunn =
   Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE;
 const oppfolgingsoppgaveOppfogingsgrunnText = "Vurder behov for dialogmøte";
+const oppfolgingsoppgaveTekst =
+  "Dette var en veldig god grunn for å lage oppfolgingsoppgave.";
 const oppfolgingsoppgave: OppfolgingsoppgaveResponseDTO = {
   uuid: generateUUID(),
   updatedAt: new Date(),
@@ -39,7 +41,7 @@ const oppfolgingsoppgave: OppfolgingsoppgaveResponseDTO = {
   versjoner: [
     {
       oppfolgingsgrunn: oppfolgingsoppgaveOppfolgingsgrunn,
-      tekst: "Dette var en veldig god grunn for å lage oppfolgingsoppgave.",
+      tekst: oppfolgingsoppgaveTekst,
       frist: "2030-01-01",
       createdBy: VEILEDER_DEFAULT.ident,
     } as OppfolgingsoppgaveVersjonResponseDTO,
@@ -53,6 +55,14 @@ const renderOppfolgingsoppgave = () =>
       <Oppfolgingsoppgave />
     </QueryClientProvider>
   );
+
+async function clickEditButton() {
+  const editButton = await screen.findByRole("button", {
+    hidden: true,
+    name: "Endre",
+  });
+  await userEvent.click(editButton);
+}
 
 describe("Oppfolgingsoppgave", () => {
   beforeEach(() => {
@@ -115,11 +125,7 @@ describe("Oppfolgingsoppgave", () => {
     it("edit opens oppfolgingsoppgavemodal", async () => {
       renderOppfolgingsoppgave();
 
-      const editButton = await screen.findByRole("button", {
-        hidden: true,
-        name: "Endre",
-      });
-      await userEvent.click(editButton);
+      await clickEditButton();
 
       const dialogs = await screen.findAllByRole("dialog", {
         hidden: true,
@@ -129,14 +135,86 @@ describe("Oppfolgingsoppgave", () => {
       expect(within(oppfolgingsoppgaveModal).getByText("Lagre")).to.exist;
       expect(within(oppfolgingsoppgaveModal).getByText("Avbryt")).to.exist;
     });
-    it("edit date of existing oppfolgingsoppgavemodal", async () => {
+    it("edit oppfolgingsgrunn deletes oppfolgingsoppgave and creates new oppfolgingsoppgave", async () => {
       renderOppfolgingsoppgave();
 
-      const editButton = await screen.findByRole("button", {
-        hidden: true,
-        name: "Endre",
+      await clickEditButton();
+
+      const selectOppfolgingsgrunn = await screen.findByLabelText(
+        "Hvilken oppfølgingsgrunn har du? (obligatorisk)"
+      );
+      fireEvent.change(selectOppfolgingsgrunn, {
+        target: { value: Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT },
       });
-      await userEvent.click(editButton);
+
+      const lagreButton = screen.getByRole("button", {
+        hidden: true,
+        name: "Lagre",
+      });
+      await userEvent.click(lagreButton);
+
+      await waitFor(() => {
+        const deleteAndCreateOppfolgingsoppgaveMutation = queryClient
+          .getMutationCache()
+          .getAll();
+        const expectedOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO = {
+          tekst: oppfolgingsoppgaveTekst,
+          frist: "2030-01-01",
+          oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT,
+        };
+        expect(
+          deleteAndCreateOppfolgingsoppgaveMutation[0].state.variables
+        ).to.deep.equal({
+          existingOppfolgingsoppgaveUuid: oppfolgingsoppgave.uuid,
+          nyOppfolgingsoppgave: expectedOppfolgingsoppgave,
+        });
+      });
+    });
+    it("edit oppfolgingsgrunn and date deletes oppfolgingsoppgave and creates new oppfolgingsoppgave", async () => {
+      renderOppfolgingsoppgave();
+
+      await clickEditButton();
+
+      const selectOppfolgingsgrunn = await screen.findByLabelText(
+        "Hvilken oppfølgingsgrunn har du? (obligatorisk)"
+      );
+      fireEvent.change(selectOppfolgingsgrunn, {
+        target: { value: Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT },
+      });
+      const fristDateInput = screen.getByRole("textbox", {
+        hidden: true,
+        name: "Frist",
+      });
+      const fristDate = dayjs();
+      changeTextInput(fristDateInput, fristDate.format("DD-MM-YY"));
+
+      const lagreButton = screen.getByRole("button", {
+        hidden: true,
+        name: "Lagre",
+      });
+      await userEvent.click(lagreButton);
+
+      await waitFor(() => {
+        const deleteAndCreateOppfolgingsoppgaveMutation = queryClient
+          .getMutationCache()
+          .getAll();
+        const expectedOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO = {
+          tekst: oppfolgingsoppgaveTekst,
+          frist: fristDate.format("YYYY-MM-DD"),
+          oppfolgingsgrunn: Oppfolgingsgrunn.TA_KONTAKT_SYKEMELDT,
+        };
+        expect(
+          deleteAndCreateOppfolgingsoppgaveMutation[0].state.variables
+        ).to.deep.equal({
+          existingOppfolgingsoppgaveUuid: oppfolgingsoppgave.uuid,
+          nyOppfolgingsoppgave: expectedOppfolgingsoppgave,
+        });
+      });
+    });
+    it("edit date of existing oppfolgingsoppgavemodal edits existing oppfolgingsoppgave", async () => {
+      renderOppfolgingsoppgave();
+
+      await clickEditButton();
 
       const fristDateInput = screen.getByRole("textbox", {
         hidden: true,
@@ -156,7 +234,7 @@ describe("Oppfolgingsoppgave", () => {
           .getMutationCache()
           .getAll();
         const expectedOppfolgingsoppgave: EditOppfolgingsoppgaveRequestDTO = {
-          tekst: "Dette var en veldig god grunn for å lage oppfolgingsoppgave.",
+          tekst: oppfolgingsoppgaveTekst,
           frist: fristDate.format("YYYY-MM-DD"),
         };
         expect(
@@ -166,11 +244,8 @@ describe("Oppfolgingsoppgave", () => {
     });
     it("fails if date is not edited on existing oppfolgingsoppgavemodal", async () => {
       renderOppfolgingsoppgave();
-      const editButton = await screen.findByRole("button", {
-        hidden: true,
-        name: "Endre",
-      });
-      await userEvent.click(editButton);
+
+      await clickEditButton();
 
       expect(
         screen.getByRole("textbox", {
@@ -241,10 +316,7 @@ describe("Oppfolgingsoppgave", () => {
         target: { value: Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE },
       });
       const beskrivelseInput = screen.getByLabelText("Beskrivelse");
-      changeTextInput(
-        beskrivelseInput,
-        "Dette var en veldig god grunn for å lage oppfolgingsoppgave."
-      );
+      changeTextInput(beskrivelseInput, oppfolgingsoppgaveTekst);
 
       const fristDateInput = screen.getByRole("textbox", {
         hidden: true,
@@ -264,7 +336,7 @@ describe("Oppfolgingsoppgave", () => {
           .getAll();
         const expectedOppfolgingsoppgave: OppfolgingsoppgaveRequestDTO = {
           oppfolgingsgrunn: Oppfolgingsgrunn.VURDER_DIALOGMOTE_SENERE,
-          tekst: "Dette var en veldig god grunn for å lage oppfolgingsoppgave.",
+          tekst: oppfolgingsoppgaveTekst,
           frist: fristDate.format("YYYY-MM-DD"),
         };
         expect(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Gjør det mulig for veileder å endre oppfølgingsgrunn på oppfølgingsoppgave. 
Teknisk vil vi, dersom oppfølgingsgrunn er endret, fjerne den eksisterende oppfølgingsoppgaven og lage ny oppfølgingsoppgave med ny oppfølgingsgrunn og tekst og frist kopiert fra eksisterende oppfølgingsoppgave.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/a57368af-78e8-4c4d-a19c-69aae551b102)
![image](https://github.com/user-attachments/assets/f1b4fa3b-d392-4d73-85f8-5420e77dfc1e)

