### PR TITLE
IS-2995 Endret slik at visning av oppfølgingsoppgaveteksten tar hensyn til whitespace

### DIFF
--- a/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
+++ b/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
@@ -68,7 +68,7 @@ export const Oppfolgingsoppgave = () => {
           <Heading className="mb-2" size="xsmall">
             {"Beskrivelse"}
           </Heading>
-          <BodyShort className="mb-4 preserve-whitespace">
+          <BodyShort className="mb-4 whitespace-pre-wrap">
             {beskrivelse}
           </BodyShort>
         </>

--- a/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
+++ b/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
@@ -68,7 +68,9 @@ export const Oppfolgingsoppgave = () => {
           <Heading className="mb-2" size="xsmall">
             {"Beskrivelse"}
           </Heading>
-          <BodyShort className="mb-4">{beskrivelse}</BodyShort>
+          <BodyShort className="mb-4 preserve-whitespace">
+            {beskrivelse}
+          </BodyShort>
         </>
       )}
       <Button

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -172,7 +172,14 @@ export function Historikk({ historikkEvents, tilfeller }: Props): ReactElement {
               .sort(byTidspunkt())
               .map(({ expandableContent, kilde, tekst, tidspunkt }, i) => {
                 return expandableContent ? (
-                  <Table.ExpandableRow key={i} content={expandableContent}>
+                  <Table.ExpandableRow
+                    key={i}
+                    content={
+                      <span className={`preserve-whitespace`}>
+                        {expandableContent}
+                      </span>
+                    }
+                  >
                     <Table.DataCell>
                       {tilLesbarDatoMedArstall(tidspunkt)}
                     </Table.DataCell>

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -175,7 +175,7 @@ export function Historikk({ historikkEvents, tilfeller }: Props): ReactElement {
                   <Table.ExpandableRow
                     key={i}
                     content={
-                      <span className={`preserve-whitespace`}>
+                      <span className="whitespace-pre-wrap">
                         {expandableContent}
                       </span>
                     }

--- a/src/styles/_utils.less
+++ b/src/styles/_utils.less
@@ -12,3 +12,7 @@
   padding: 0;
   border: 0;
 }
+
+.preserve-whitespace {
+  white-space: pre-wrap;
+}

--- a/src/styles/_utils.less
+++ b/src/styles/_utils.less
@@ -12,7 +12,3 @@
   padding: 0;
   border: 0;
 }
-
-.preserve-whitespace {
-  white-space: pre-wrap;
-}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Tekst som inneholder linjeskift vil nå brekke riktig i både visningen til venstre under menyen og i historikk. Det er en god del forskjellige måter dette kan løses på, så er bare si ifra om det er en annen foretrukket måte å gjøre dette på.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/6a47dd18-37eb-4ece-b516-70ffa1ac8c62)

