### PR TITLE
IS-2460: Fjernet bruk av request parameter som ikke lenger finnes i apiet

### DIFF
--- a/src/data/oppfolgingsoppgave/useOppfolgingsoppgaver.tsx
+++ b/src/data/oppfolgingsoppgave/useOppfolgingsoppgaver.tsx
@@ -13,7 +13,7 @@ export const oppfolgingsoppgaverQueryKeys = {
 
 export const useOppfolgingsoppgaver = () => {
   const personident = useValgtPersonident();
-  const path = `${ISHUSKELAPP_ROOT}/huskelapp?filter=all`;
+  const path = `${ISHUSKELAPP_ROOT}/huskelapp`;
   const getOppfolgingsoppgaver = () =>
     get<OppfolgingsoppgaveResponseDTO[]>(path, personident);
 

--- a/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
+++ b/src/mocks/oppfolgingsoppgave/mockOppfolgingsoppgave.tsx
@@ -27,10 +27,8 @@ export const mockIshuskelapp = [
       } else {
         return new HttpResponse(null, { status: 204 });
       }
-    } else if (request.url.includes("?filter=all")) {
-      return HttpResponse.json(oppfolgingsoppgaverMock);
     } else {
-      return new HttpResponse(null, { status: 500 });
+      return HttpResponse.json(oppfolgingsoppgaverMock);
     }
   }),
   http.post<object, EditOppfolgingsoppgaveRequestDTO>(


### PR DESCRIPTION

### Hva har blitt lagt til✨🌈
Opprydding ifm. refaktorering av versjoner for oppfølgingsoppgaver. Fjernet bruk av request parameteren `filter` ettersom den ble fjernet i en tidligere [PR i ishuskelapp](https://github.com/navikt/ishuskelapp/pull/86/files#diff-48d50921c431f269f80d373e17706563e77f93e1771513e3f1c9ef431ad7394eL34)
