### PR TITLE
IS-2897: Use kontaktinformasjon api for kontaktinfo

### DIFF
--- a/src/components/personkort/PersonkortSykmeldt.tsx
+++ b/src/components/personkort/PersonkortSykmeldt.tsx
@@ -9,9 +9,9 @@ import {
 import { PersonImage } from "../../../img/ImageComponents";
 import { usePersonAdresseQuery } from "@/data/personinfo/personAdresseQueryHooks";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
-import { useNavBrukerData } from "@/data/navbruker/navbruker_hooks";
 import { formaterFnr } from "@/utils/fnrUtils";
 import { formatPhonenumber } from "@/utils/stringUtils";
+import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 
 const texts = {
   fnr: "F.nummer",
@@ -24,7 +24,7 @@ const texts = {
 
 export default function PersonkortSykmeldt() {
   const { data: personadresse } = usePersonAdresseQuery();
-  const navbruker = useNavBrukerData();
+  const { data: kontaktinfo } = useKontaktinfoQuery();
   const informasjonNokkelTekster = new Map([
     ["fnr", texts.fnr],
     ["tlf", texts.phone],
@@ -45,12 +45,12 @@ export default function PersonkortSykmeldt() {
     oppholdsadresse: formaterOppholdsadresse(personadresse?.oppholdsadresse),
   });
   const fnr = useValgtPersonident();
-  const formattedPhonenumber = navbruker.kontaktinfo?.tlf
-    ? formatPhonenumber(navbruker.kontaktinfo.tlf)
-    : navbruker.kontaktinfo?.tlf;
+  const formattedPhonenumber = kontaktinfo?.tlf
+    ? formatPhonenumber(kontaktinfo.tlf)
+    : kontaktinfo?.tlf;
   const valgteElementerKontaktinfo = {
     tlf: formattedPhonenumber,
-    epost: navbruker.kontaktinfo?.epost,
+    epost: kontaktinfo?.epost,
     fnr: formaterFnr(fnr),
   };
   const valgteElementer = Object.assign(

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -2,12 +2,16 @@ import { useQuery } from "@tanstack/react-query";
 import { get } from "@/api/axios";
 import { SYFOPERSON_ROOT } from "@/apiConstants";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
-import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
+import {
+  BrukerinfoDTO,
+  KontaktinfoDTO,
+} from "@/data/navbruker/types/BrukerinfoDTO";
 import { erGyldigFodselsnummer } from "@/utils/frnValideringUtils";
 import { minutesToMillis } from "@/utils/utils";
 
-export const brukerinfoQueryKeys = {
+export const brukerQueryKeys = {
   brukerinfo: (personident: string) => ["brukerinfo", personident],
+  kontaktinfo: (personident: string) => ["kontaktinfo", personident],
 };
 
 export const useBrukerinfoQuery = () => {
@@ -15,7 +19,7 @@ export const useBrukerinfoQuery = () => {
   const path = `${SYFOPERSON_ROOT}/person/brukerinfo`;
   const fetchBrukerInfo = () => get<BrukerinfoDTO>(path, personident);
   const query = useQuery({
-    queryKey: brukerinfoQueryKeys.brukerinfo(personident),
+    queryKey: brukerQueryKeys.brukerinfo(personident),
     queryFn: fetchBrukerInfo,
     enabled: !!personident && erGyldigFodselsnummer(personident),
     staleTime: minutesToMillis(60 * 12),
@@ -23,7 +27,6 @@ export const useBrukerinfoQuery = () => {
 
   const defaultData: BrukerinfoDTO = {
     navn: "",
-    kontaktinfo: undefined,
     arbeidssituasjon: "ARBEIDSTAKER",
     dodsdato: null,
     tilrettelagtKommunikasjon: {
@@ -36,8 +39,23 @@ export const useBrukerinfoQuery = () => {
   return {
     ...query,
     brukerinfo: query.data || defaultData,
-    brukerKanIkkeVarslesDigitalt:
-      query.data?.kontaktinfo?.skalHaVarsel === false,
-    brukerKanVarslesDigitalt: query.data?.kontaktinfo?.skalHaVarsel === true,
+  };
+};
+
+export const useKontaktinfoQuery = () => {
+  const personident = useValgtPersonident();
+  const path = `${SYFOPERSON_ROOT}/person/kontaktinformasjon`;
+  const fetchKontaktinfo = () => get<KontaktinfoDTO>(path, personident);
+  const query = useQuery({
+    queryKey: brukerQueryKeys.kontaktinfo(personident),
+    queryFn: fetchKontaktinfo,
+    enabled: !!personident && erGyldigFodselsnummer(personident),
+    staleTime: minutesToMillis(60 * 12),
+  });
+
+  return {
+    ...query,
+    brukerKanIkkeVarslesDigitalt: query.data?.skalHaVarsel === false,
+    brukerKanVarslesDigitalt: query.data?.skalHaVarsel === true,
   };
 };

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -6,7 +6,6 @@ export interface KontaktinfoDTO {
 
 export interface BrukerinfoDTO {
   navn: string;
-  kontaktinfo?: KontaktinfoDTO;
   arbeidssituasjon: string;
   dodsdato: string | null;
   tilrettelagtKommunikasjon: TilrettelagtKommunikasjon | null;

--- a/src/mocks/syfoperson/mockSyfoperson.ts
+++ b/src/mocks/syfoperson/mockSyfoperson.ts
@@ -21,4 +21,8 @@ export const mockSyfoperson = [
   http.get(`${SYFOPERSON_ROOT}/person/brukerinfo`, () => {
     return HttpResponse.json(brukerinfoMock);
   }),
+
+  http.get(`${SYFOPERSON_ROOT}/person/kontaktinformasjon`, () => {
+    return HttpResponse.json(brukerinfoMock);
+  }),
 ];

--- a/src/mocks/syfoperson/persondataMock.ts
+++ b/src/mocks/syfoperson/persondataMock.ts
@@ -5,13 +5,14 @@ import {
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { weeksFromToday } from "../../../test/testUtils";
 
+export const kontaktinformasjonMock = {
+  epost: ARBEIDSTAKER_DEFAULT.epost,
+  tlf: "99887766",
+  skalHaVarsel: true,
+};
+
 export const brukerinfoMock: BrukerinfoDTO = {
   navn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
-  kontaktinfo: {
-    epost: ARBEIDSTAKER_DEFAULT.epost,
-    tlf: "99887766",
-    skalHaVarsel: true,
-  },
   arbeidssituasjon: "ARBEIDSTAKER",
   dodsdato: null,
   tilrettelagtKommunikasjon: null,

--- a/src/sider/dialogmoter/components/DialogmoteSideContainer.tsx
+++ b/src/sider/dialogmoter/components/DialogmoteSideContainer.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { BrukerKanIkkeVarslesPapirpostAdvarsel } from "@/sider/dialogmoter/components/BrukerKanIkkeVarslesPapirpostAdvarsel";
 import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
-import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import Side from "@/sider/Side";
 import SideLaster from "@/components/SideLaster";
@@ -29,7 +29,7 @@ export const DialogmoteSideContainer = ({
     dialogmoteUuid: string;
   }>();
   const { isLoading, isError, data: dialogmoter } = useDialogmoterQuery();
-  const { brukerKanIkkeVarslesDigitalt } = useBrukerinfoQuery();
+  const { brukerKanIkkeVarslesDigitalt } = useKontaktinfoQuery();
 
   const dialogmote = dialogmoter.find(
     (dialogmote) => dialogmote.uuid === dialogmoteUuid

--- a/src/sider/dialogmoter/components/endre/EndreDialogmoteContainer.tsx
+++ b/src/sider/dialogmoter/components/endre/EndreDialogmoteContainer.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import EndreDialogmoteSkjema from "./EndreDialogmoteSkjema";
 import { useParams } from "react-router-dom";
 import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
-import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import Side from "@/sider/Side";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import SideLaster from "@/components/SideLaster";
@@ -28,7 +28,7 @@ const EndreDialogmoteContainer = () => {
     dialogmoteUuid: string;
   }>();
   const { isLoading, isError, data: dialogmoter } = useDialogmoterQuery();
-  const { brukerKanIkkeVarslesDigitalt } = useBrukerinfoQuery();
+  const { brukerKanIkkeVarslesDigitalt } = useKontaktinfoQuery();
 
   const dialogmote = dialogmoter.find(
     (dialogmote) => dialogmote.uuid === dialogmoteUuid

--- a/src/sider/dialogmoter/components/innkalling/DialogmoteInnkallingContainer.tsx
+++ b/src/sider/dialogmoter/components/innkalling/DialogmoteInnkallingContainer.tsx
@@ -8,7 +8,7 @@ import { Navigate } from "react-router-dom";
 import { moteoversiktRoutePath } from "@/routers/AppRouter";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
-import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { ArbeidstakerHarIkkeAktivSykmeldingAdvarsel } from "@/sider/dialogmoter/components/ArbeidstakerHarIkkeAktivSykmelding";
 import * as Tredelt from "@/sider/TredeltSide";
 import { MotehistorikkPanel } from "@/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel";
@@ -23,7 +23,7 @@ const texts = {
 };
 
 export const DialogmoteInnkallingSide = (): ReactElement => {
-  const { brukerKanIkkeVarslesDigitalt } = useBrukerinfoQuery();
+  const { brukerKanIkkeVarslesDigitalt } = useKontaktinfoQuery();
   const { hasActiveOppfolgingstilfelle, hasOppfolgingstilfelle } =
     useOppfolgingstilfellePersonQuery();
 

--- a/src/sider/dialogmoter/components/innkalling/DialogmoteInnkallingSkjema.tsx
+++ b/src/sider/dialogmoter/components/innkalling/DialogmoteInnkallingSkjema.tsx
@@ -24,7 +24,7 @@ import { MalformRadioGroup } from "@/components/MalformRadioGroup";
 import * as Amplitude from "@/utils/amplitude";
 import { EventType } from "@/utils/amplitude";
 import { useMalform } from "@/context/malform/MalformContext";
-import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { DialogmoteDato } from "@/sider/dialogmoter/components/DialogmoteDato";
 import DialogmoteKlokkeslett from "@/sider/dialogmoter/components/DialogmoteKlokkeslett";
 import DialogmoteSted, {
@@ -111,7 +111,7 @@ const toInnkalling = (
 
 export const DialogmoteInnkallingSkjema = () => {
   const fnr = useValgtPersonident();
-  const { brukerKanIkkeVarslesDigitalt } = useBrukerinfoQuery();
+  const { brukerKanIkkeVarslesDigitalt } = useKontaktinfoQuery();
   const [selectedBehandler, setSelectedBehandler] = useState<BehandlerDTO>();
   const innkallingDocument = useInnkallingDocument();
   const { toTidStedDto } = useSkjemaValuesToDto();

--- a/src/sider/dialogmoter/components/innkalling/InnkallingDialogmotePanel.tsx
+++ b/src/sider/dialogmoter/components/innkalling/InnkallingDialogmotePanel.tsx
@@ -6,7 +6,7 @@ import { DialogmoteMoteStatusPanel } from "./DialogmoteMoteStatusPanel";
 import { BrukerKanIkkeVarslesPapirpostAdvarsel } from "@/sider/dialogmoter/components/BrukerKanIkkeVarslesPapirpostAdvarsel";
 import { DialogmoteDTO } from "@/data/dialogmote/types/dialogmoteTypes";
 import { useDialogmotekandidat } from "@/data/dialogmotekandidat/dialogmotekandidatQueryHooks";
-import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { ArbeidstakerHarIkkeAktivSykmeldingAdvarsel } from "@/sider/dialogmoter/components/ArbeidstakerHarIkkeAktivSykmelding";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { BodyShort, Button } from "@navikt/ds-react";
@@ -42,7 +42,7 @@ interface InnkallingDialogmotePanelProps {
 export const InnkallingDialogmotePanel = ({
   aktivtDialogmote,
 }: InnkallingDialogmotePanelProps): ReactElement => {
-  const { brukerKanIkkeVarslesDigitalt } = useBrukerinfoQuery();
+  const { brukerKanIkkeVarslesDigitalt } = useKontaktinfoQuery();
   const { hasActiveOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
   const { isKandidat } = useDialogmotekandidat();
 

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -15,7 +15,7 @@ import {
   maksdatoMock,
 } from "@/mocks/syfoperson/persondataMock";
 import { diskresjonskodeQueryKeys } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { daysFromToday } from "../../testUtils";
 import dayjs from "dayjs";
 import { underArbeidsrettetOppfolgingQueryKeys } from "@/data/veilarboppfolging/useUnderArbeidsrettetOppfolgingQuery";
@@ -106,7 +106,7 @@ describe("PersonkortHeader", () => {
       tegnsprakTolk: null,
     };
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => {
         return {
           ...brukerinfoMock,
@@ -131,7 +131,7 @@ describe("PersonkortHeader", () => {
       },
     };
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => {
         return {
           ...brukerinfoMock,
@@ -148,7 +148,7 @@ describe("PersonkortHeader", () => {
 
   it("viser dødsdato når dato finnes i brukerinfo", () => {
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => {
         return {
           ...brukerinfoMock,
@@ -248,7 +248,7 @@ describe("PersonkortHeader", () => {
 
   it("viser ikke sikkerhetstiltak-tag når bruker mangler sikkerhetstiltak", () => {
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => ({
         ...brukerinfoMock,
         sikkerhetstiltak: [],
@@ -261,7 +261,7 @@ describe("PersonkortHeader", () => {
 
   it("viser sikkerhetstiltak-tag når bruker har sikkerhetstiltak", () => {
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => ({
         ...brukerinfoMock,
         sikkerhetstiltak: [

--- a/test/components/personkort/PersonkortTest.tsx
+++ b/test/components/personkort/PersonkortTest.tsx
@@ -5,7 +5,7 @@ import { stubFastlegerApi } from "../../stubs/stubFastlegeRest";
 import { render, screen } from "@testing-library/react";
 import { queryClientWithAktivBruker } from "../../testQueryClient";
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
 import Personkort from "@/components/personkort/Personkort";
 import { daysFromToday, getButton } from "../../testUtils";
@@ -27,7 +27,7 @@ describe("Personkort", () => {
   beforeEach(() => {
     queryClient = queryClientWithAktivBruker();
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => brukerinfoMock
     );
     stubFastlegerApi();
@@ -35,7 +35,7 @@ describe("Personkort", () => {
 
   it("Skal vise Sikkerhetstiltak-button-tab hvis bruker har sikkerhetstiltak", async () => {
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => ({
         ...brukerinfoMock,
         sikkerhetstiltak: [
@@ -56,7 +56,7 @@ describe("Personkort", () => {
 
   it("Skal ikke vise Sikkerhetstiltak-button-tab hvis bruker mangler sikkerhetstiltak", async () => {
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => brukerinfoMock
     );
 

--- a/test/components/personkort/PersonkortVisningTest.tsx
+++ b/test/components/personkort/PersonkortVisningTest.tsx
@@ -9,7 +9,7 @@ import { render, screen } from "@testing-library/react";
 import { fastlegerMock } from "@/mocks/fastlegerest/fastlegerMock";
 import { queryClientWithAktivBruker } from "../../testQueryClient";
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
 import { daysFromToday } from "../../testUtils";
 import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
@@ -20,7 +20,7 @@ describe("PersonkortVisning", () => {
   beforeEach(() => {
     queryClient = queryClientWithAktivBruker();
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => brukerinfoMock
     );
     stubFastlegerApi();
@@ -78,7 +78,7 @@ describe("PersonkortVisning", () => {
     )}`;
 
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => ({
         ...brukerinfoMock,
         sikkerhetstiltak: [

--- a/test/containers/MotelandingssideContainerTest.tsx
+++ b/test/containers/MotelandingssideContainerTest.tsx
@@ -18,7 +18,7 @@ import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
 import { queryClientWithAktivBruker } from "../testQueryClient";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { MemoryRouter } from "react-router-dom";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { dialogmoteunntakQueryKeys } from "@/data/dialogmotekandidat/dialogmoteunntakQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
 
@@ -56,7 +56,7 @@ describe("MotelandingssideSide", () => {
   beforeEach(() => {
     queryClient = queryClientWithAktivBruker();
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => brukerinfoMock
     );
     queryClient.setQueryData(dialogmoterQueryKeys.dialogmoter(fnr), () => []);

--- a/test/containers/SykepengesoknadSideTest.tsx
+++ b/test/containers/SykepengesoknadSideTest.tsx
@@ -10,7 +10,7 @@ import { sykepengesoknaderQueryKeys } from "@/data/sykepengesoknad/sykepengesokn
 import { sykmeldingerQueryKeys } from "@/data/sykmelding/sykmeldingQueryHooks";
 import { queryClientWithAktivBruker } from "../testQueryClient";
 import { renderWithRouter } from "../testRouterUtils";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
 import { SykepengesoknadSideContent } from "@/sider/sykepengsoknader/container/SykepengesoknadSide";
 
@@ -24,7 +24,7 @@ describe("SykepengesoknadSide", () => {
   beforeEach(() => {
     queryClient = queryClientWithAktivBruker();
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => brukerinfoMock
     );
     queryClient.setQueryData(

--- a/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
+++ b/test/dialogmote/DialogmoteInnkallingSkjema/DialogmoteInnkallingSkjemaTest.tsx
@@ -30,8 +30,8 @@ import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
 import { Malform, MalformProvider } from "@/context/malform/MalformContext";
 import userEvent from "@testing-library/user-event";
 import { getInnkallingTexts } from "@/data/dialogmote/dialogmoteTexts";
-import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { kontaktinformasjonMock } from "@/mocks/syfoperson/persondataMock";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import {
   DialogmoteInnkallingSkjema,
   texts,
@@ -103,14 +103,11 @@ describe("DialogmoteInnkallingSkjema", () => {
 
   it("viser advarsel om papirpost når bruker ikke kan varsles digitalt", () => {
     const kanIkkeVarsles = {
-      ...brukerinfoMock,
-      kontaktinfo: {
-        ...brukerinfoMock.kontaktinfo,
-        skalHaVarsel: false,
-      },
+      ...kontaktinformasjonMock,
+      skalHaVarsel: false,
     };
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.kontaktinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => kanIkkeVarsles
     );
     renderDialogmoteInnkallingSkjema();
@@ -120,14 +117,11 @@ describe("DialogmoteInnkallingSkjema", () => {
   });
   it("viser ikke advarsel om papirpost når bruker kan varsles digitalt", () => {
     const kanVarsles = {
-      ...brukerinfoMock,
-      kontaktinfo: {
-        ...brukerinfoMock.kontaktinfo,
-        skalHaVarsel: true,
-      },
+      ...kontaktinformasjonMock,
+      skalHaVarsel: true,
     };
     queryClient.setQueryData(
-      brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+      brukerQueryKeys.kontaktinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => kanVarsles
     );
     renderDialogmoteInnkallingSkjema();

--- a/test/dialogmote/InnkallingDialogmotePanelTest.tsx
+++ b/test/dialogmote/InnkallingDialogmotePanelTest.tsx
@@ -20,30 +20,25 @@ import {
   createDialogmote,
   createReferat,
 } from "@/mocks/isdialogmote/dialogmoterMock";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
-import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { kontaktinformasjonMock } from "@/mocks/syfoperson/persondataMock";
+import { KontaktinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 
 let queryClient: QueryClient;
 
 const brukerKanVarsles = {
-  ...brukerinfoMock,
-  kontaktinfo: {
-    ...brukerinfoMock.kontaktinfo,
-    skalHaVarsel: true,
-  },
+  ...kontaktinformasjonMock,
+  skalHaVarsel: true,
 };
 const brukerKanIkkeVarsles = {
-  ...brukerinfoMock,
-  kontaktinfo: {
-    ...brukerinfoMock.kontaktinfo,
-    skalHaVarsel: false,
-  },
+  ...kontaktinformasjonMock,
+  skalHaVarsel: false,
 };
 
-const renderInnkallingDialogmotePanel = (navbruker: any) => {
+const renderInnkallingDialogmotePanel = (kontaktinfo: KontaktinfoDTO) => {
   queryClient.setQueryData(
-    brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
-    () => navbruker
+    brukerQueryKeys.kontaktinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => kontaktinfo
   );
   return render(
     <MemoryRouter>

--- a/test/testQueryClient.ts
+++ b/test/testQueryClient.ts
@@ -19,7 +19,7 @@ import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/p
 import { oppfolgingstilfellePersonMock } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock";
 import { unleashQueryKeys } from "@/data/unleash/unleashQueryHooks";
 import { mockUnleashResponse } from "@/mocks/unleashMocks";
-import { brukerinfoQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { behandlereQueryKeys } from "@/data/behandler/behandlereQueryHooks";
 import {
   behandlerByBehandlerRefMock,
@@ -62,7 +62,7 @@ export const setQueryDataWithPersonkortdata = (
   existingClient: QueryClient
 ): void => {
   existingClient.setQueryData(
-    brukerinfoQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+    brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
     () => brukerinfoMock
   );
   existingClient.setQueryData(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Bruker `/kontaktinformasjon`-endpunkt i syfoperson for å hente info fra KRR. 
Fjerner samtidig bruk av kontaktinfo fra responsen til brukerinfo-kallet. Etterpå kan vi fjerne henting av kontaktinfo fra KRR i `/brukerinfo`-endepunket i syfoperson.