### PR TITLE
IS-2884: Move unntak-arsaker to ikke-aktuell

### DIFF
--- a/src/components/dialogmoteunntak/DialogmoteunntakSkjema.tsx
+++ b/src/components/dialogmoteunntak/DialogmoteunntakSkjema.tsx
@@ -3,9 +3,9 @@ import { Link, Navigate } from "react-router-dom";
 import { moteoversiktRoutePath } from "@/routers/AppRouter";
 import { useDialogmotekandidat } from "@/data/dialogmotekandidat/dialogmotekandidatQueryHooks";
 import {
-  CreateUnntakArsak,
   createUnntakArsakTexts,
   CreateUnntakDTO,
+  ValidUnntakArsak,
 } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { useSettDialogmoteunntak } from "@/data/dialogmotekandidat/useSettDialogmoteunntak";
@@ -33,7 +33,7 @@ export const texts = {
 export const dialogmoteunntakSkjemaBeskrivelseMaxLength = 2000;
 
 export interface DialogmoteunntakSkjemaValues {
-  arsak: CreateUnntakArsak;
+  arsak: ValidUnntakArsak;
   beskrivelse?: string;
 }
 

--- a/src/components/dialogmoteunntak/DialogmoteunntakSkjema.tsx
+++ b/src/components/dialogmoteunntak/DialogmoteunntakSkjema.tsx
@@ -3,8 +3,9 @@ import { Link, Navigate } from "react-router-dom";
 import { moteoversiktRoutePath } from "@/routers/AppRouter";
 import { useDialogmotekandidat } from "@/data/dialogmotekandidat/dialogmotekandidatQueryHooks";
 import {
+  CreateUnntakArsak,
+  createUnntakArsakTexts,
   CreateUnntakDTO,
-  UnntakArsak,
 } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { useSettDialogmoteunntak } from "@/data/dialogmotekandidat/useSettDialogmoteunntak";
@@ -29,41 +30,10 @@ export const texts = {
   avbryt: "Avbryt",
 };
 
-export interface UnntakArsakText {
-  arsak: UnntakArsak;
-  text: string;
-}
-export const unntakArsakTexts: UnntakArsakText[] = [
-  {
-    arsak: UnntakArsak.MEDISINSKE_GRUNNER,
-    text: "Medisinske grunner",
-  },
-  {
-    arsak: UnntakArsak.INNLEGGELSE_INSTITUSJON,
-    text: "Innleggelse i helseinstitusjon",
-  },
-  {
-    arsak: UnntakArsak.FRISKMELDT,
-    text: "Friskmeldt",
-  },
-  {
-    arsak: UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
-    text: "Forventet friskmelding innen 28 ukers sykmelding",
-  },
-  {
-    arsak: UnntakArsak.DOKUMENTERT_TILTAK_FRISKMELDING,
-    text: "Tiltak som sannsynligvis vil føre til en friskmelding",
-  },
-  {
-    arsak: UnntakArsak.ARBEIDSFORHOLD_OPPHORT,
-    text: "Arbeidsforholdet er opphørt",
-  },
-];
-
 export const dialogmoteunntakSkjemaBeskrivelseMaxLength = 2000;
 
 export interface DialogmoteunntakSkjemaValues {
-  arsak: UnntakArsak;
+  arsak: CreateUnntakArsak;
   beskrivelse?: string;
 }
 
@@ -108,13 +78,13 @@ const DialogmoteunntakSkjema = () => {
           size="small"
           error={errors.arsak && texts.arsakErrorMessage}
         >
-          {unntakArsakTexts.map((unntakArsakText, index) => (
+          {Object.entries(createUnntakArsakTexts).map(([key, tekst], index) => (
             <Radio
               key={index}
-              value={unntakArsakText.arsak}
+              value={key}
               {...register("arsak", { required: true })}
             >
-              {unntakArsakText.text}
+              {tekst}
             </Radio>
           ))}
         </RadioGroup>

--- a/src/data/dialogmotekandidat/types/dialogmoteikkeaktuellTypes.ts
+++ b/src/data/dialogmotekandidat/types/dialogmoteikkeaktuellTypes.ts
@@ -2,6 +2,8 @@ export enum IkkeAktuellArsak {
   ARBEIDSTAKER_AAP = "ARBEIDSTAKER_AAP",
   ARBEIDSTAKER_DOD = "ARBEIDSTAKER_DOD",
   DIALOGMOTE_AVHOLDT = "DIALOGMOTE_AVHOLDT",
+  FRISKMELDT = "FRISKMELDT",
+  ARBEIDSFORHOLD_OPPHORT = "ARBEIDSFORHOLD_OPPHORT",
 }
 
 export interface CreateIkkeAktuellDTO {
@@ -9,3 +11,11 @@ export interface CreateIkkeAktuellDTO {
   arsak: IkkeAktuellArsak;
   beskrivelse?: string;
 }
+
+export const ikkeAktuellArsakTexts: Record<IkkeAktuellArsak, string> = {
+  [IkkeAktuellArsak.ARBEIDSTAKER_AAP]: "Innbygger mottar AAP",
+  [IkkeAktuellArsak.ARBEIDSTAKER_DOD]: "Innbygger er død",
+  [IkkeAktuellArsak.DIALOGMOTE_AVHOLDT]: "Dialogmøte avholdt",
+  [IkkeAktuellArsak.FRISKMELDT]: "Friskmeldt",
+  [IkkeAktuellArsak.ARBEIDSFORHOLD_OPPHORT]: "Arbeidsforholdet er opphørt",
+};

--- a/src/data/dialogmotekandidat/types/dialogmoteunntakTypes.ts
+++ b/src/data/dialogmotekandidat/types/dialogmoteunntakTypes.ts
@@ -1,32 +1,30 @@
-export enum UnntakArsak {
+export enum ValidUnntakArsak {
   MEDISINSKE_GRUNNER = "MEDISINSKE_GRUNNER",
   INNLEGGELSE_INSTITUSJON = "INNLEGGELSE_INSTITUSJON",
-  FRISKMELDT = "FRISKMELDT",
   FORVENTET_FRISKMELDING_INNEN_28UKER = "FORVENTET_FRISKMELDING_INNEN_28UKER",
   DOKUMENTERT_TILTAK_FRISKMELDING = "DOKUMENTERT_TILTAK_FRISKMELDING",
+}
+
+export enum DeprecatedUnntakArsak {
+  FRISKMELDT = "FRISKMELDT",
   ARBEIDSFORHOLD_OPPHORT = "ARBEIDSFORHOLD_OPPHORT",
 }
 
-export enum CreateUnntakArsak {
-  MEDISINSKE_GRUNNER = "MEDISINSKE_GRUNNER",
-  INNLEGGELSE_INSTITUSJON = "INNLEGGELSE_INSTITUSJON",
-  FORVENTET_FRISKMELDING_INNEN_28UKER = "FORVENTET_FRISKMELDING_INNEN_28UKER",
-  DOKUMENTERT_TILTAK_FRISKMELDING = "DOKUMENTERT_TILTAK_FRISKMELDING",
-}
+export type UnntakArsak = ValidUnntakArsak | DeprecatedUnntakArsak;
 
-export const createUnntakArsakTexts: Record<CreateUnntakArsak, string> = {
-  [UnntakArsak.MEDISINSKE_GRUNNER]: "Medisinske grunner",
-  [UnntakArsak.INNLEGGELSE_INSTITUSJON]: "Innleggelse i helseinstitusjon",
-  [UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER]:
+export const createUnntakArsakTexts: Record<ValidUnntakArsak, string> = {
+  [ValidUnntakArsak.MEDISINSKE_GRUNNER]: "Medisinske grunner",
+  [ValidUnntakArsak.INNLEGGELSE_INSTITUSJON]: "Innleggelse i helseinstitusjon",
+  [ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER]:
     "Forventet friskmelding innen 28 ukers sykmelding",
-  [UnntakArsak.DOKUMENTERT_TILTAK_FRISKMELDING]:
+  [ValidUnntakArsak.DOKUMENTERT_TILTAK_FRISKMELDING]:
     "Tiltak som sannsynligvis vil føre til en friskmelding",
 };
 
 export const unntakArsakTexts: Record<UnntakArsak, string> = {
   ...createUnntakArsakTexts,
-  [UnntakArsak.FRISKMELDT]: "Friskmeldt",
-  [UnntakArsak.ARBEIDSFORHOLD_OPPHORT]: "Arbeidsforholdet er opphørt",
+  [DeprecatedUnntakArsak.FRISKMELDT]: "Friskmeldt",
+  [DeprecatedUnntakArsak.ARBEIDSFORHOLD_OPPHORT]: "Arbeidsforholdet er opphørt",
 };
 
 export interface UnntakDTO {
@@ -40,6 +38,6 @@ export interface UnntakDTO {
 
 export interface CreateUnntakDTO {
   personIdent: string;
-  arsak: CreateUnntakArsak;
+  arsak: ValidUnntakArsak;
   beskrivelse?: string;
 }

--- a/src/data/dialogmotekandidat/types/dialogmoteunntakTypes.ts
+++ b/src/data/dialogmotekandidat/types/dialogmoteunntakTypes.ts
@@ -7,6 +7,28 @@ export enum UnntakArsak {
   ARBEIDSFORHOLD_OPPHORT = "ARBEIDSFORHOLD_OPPHORT",
 }
 
+export enum CreateUnntakArsak {
+  MEDISINSKE_GRUNNER = "MEDISINSKE_GRUNNER",
+  INNLEGGELSE_INSTITUSJON = "INNLEGGELSE_INSTITUSJON",
+  FORVENTET_FRISKMELDING_INNEN_28UKER = "FORVENTET_FRISKMELDING_INNEN_28UKER",
+  DOKUMENTERT_TILTAK_FRISKMELDING = "DOKUMENTERT_TILTAK_FRISKMELDING",
+}
+
+export const createUnntakArsakTexts: Record<CreateUnntakArsak, string> = {
+  [UnntakArsak.MEDISINSKE_GRUNNER]: "Medisinske grunner",
+  [UnntakArsak.INNLEGGELSE_INSTITUSJON]: "Innleggelse i helseinstitusjon",
+  [UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER]:
+    "Forventet friskmelding innen 28 ukers sykmelding",
+  [UnntakArsak.DOKUMENTERT_TILTAK_FRISKMELDING]:
+    "Tiltak som sannsynligvis vil føre til en friskmelding",
+};
+
+export const unntakArsakTexts: Record<UnntakArsak, string> = {
+  ...createUnntakArsakTexts,
+  [UnntakArsak.FRISKMELDT]: "Friskmeldt",
+  [UnntakArsak.ARBEIDSFORHOLD_OPPHORT]: "Arbeidsforholdet er opphørt",
+};
+
 export interface UnntakDTO {
   uuid: string;
   createdAt: Date;
@@ -18,6 +40,6 @@ export interface UnntakDTO {
 
 export interface CreateUnntakDTO {
   personIdent: string;
-  arsak: UnntakArsak;
+  arsak: CreateUnntakArsak;
   beskrivelse?: string;
 }

--- a/src/mocks/isdialogmotekandidat/dialogmoteunntakMock.ts
+++ b/src/mocks/isdialogmotekandidat/dialogmoteunntakMock.ts
@@ -3,7 +3,11 @@ import {
   ARBEIDSTAKER_DEFAULT,
   VEILEDER_DEFAULT,
 } from "../common/mockConstants";
-import { UnntakArsak } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
+import {
+  DeprecatedUnntakArsak,
+  UnntakArsak,
+  ValidUnntakArsak,
+} from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 
 const createDialogmoteunntak = (arsak: UnntakArsak, beskrivelse?: string) => {
   return {
@@ -17,11 +21,11 @@ const createDialogmoteunntak = (arsak: UnntakArsak, beskrivelse?: string) => {
 };
 
 export const dialogmoteunntakMedBeskrivelse = createDialogmoteunntak(
-  UnntakArsak.ARBEIDSFORHOLD_OPPHORT,
+  DeprecatedUnntakArsak.ARBEIDSFORHOLD_OPPHORT,
   "Arbeidstaker jobber ikke lenger hos arbeidsgiver."
 );
 export const dialogmoteunntakUtenBeskrivelse = createDialogmoteunntak(
-  UnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+  ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
   undefined
 );
 

--- a/src/sider/dialogmoter/components/ikkeaktuell/DialogmoteIkkeAktuellSkjema.tsx
+++ b/src/sider/dialogmoter/components/ikkeaktuell/DialogmoteIkkeAktuellSkjema.tsx
@@ -5,6 +5,7 @@ import { useDialogmotekandidat } from "@/data/dialogmotekandidat/dialogmotekandi
 import {
   CreateIkkeAktuellDTO,
   IkkeAktuellArsak,
+  ikkeAktuellArsakTexts,
 } from "@/data/dialogmotekandidat/types/dialogmoteikkeaktuellTypes";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { useSettDialogmoteIkkeAktuell } from "@/data/dialogmotekandidat/useSettDialogmoteIkkeAktuell";
@@ -28,25 +29,6 @@ export const texts = {
   send: "Sett ikke aktuell",
   avbryt: "Avbryt",
 };
-
-export interface IkkeAktuellArsakText {
-  arsak: IkkeAktuellArsak;
-  text: string;
-}
-export const ikkeaktuellArsakTexts: IkkeAktuellArsakText[] = [
-  {
-    arsak: IkkeAktuellArsak.ARBEIDSTAKER_AAP,
-    text: "Innbygger mottar AAP",
-  },
-  {
-    arsak: IkkeAktuellArsak.ARBEIDSTAKER_DOD,
-    text: "Innbygger er død",
-  },
-  {
-    arsak: IkkeAktuellArsak.DIALOGMOTE_AVHOLDT,
-    text: "Dialogmøte avholdt",
-  },
-];
 
 export const skjemaBeskrivelseMaxLength = 2000;
 
@@ -96,13 +78,13 @@ const DialogmoteIkkeAktuellSkjema = () => {
           size="small"
           error={errors.arsak && texts.arsakErrorMessage}
         >
-          {ikkeaktuellArsakTexts.map((ikkeaktuellArsakText, index) => (
+          {Object.entries(ikkeAktuellArsakTexts).map(([key, tekst], index) => (
             <Radio
               key={index}
-              value={ikkeaktuellArsakText.arsak}
+              value={key}
               {...register("arsak", { required: true })}
             >
-              {ikkeaktuellArsakText.text}
+              {tekst}
             </Radio>
           ))}
         </RadioGroup>

--- a/src/sider/dialogmoter/components/motehistorikk/MoteHistorikkUnntak.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteHistorikkUnntak.tsx
@@ -1,12 +1,14 @@
 import React, { ReactElement } from "react";
-import { UnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
+import {
+  unntakArsakTexts,
+  UnntakDTO,
+} from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 
 import {
   DocumentComponentDto,
   DocumentComponentType,
 } from "@/data/documentcomponent/documentComponentTypes";
-import { unntakArsakTexts } from "@/components/dialogmoteunntak/DialogmoteunntakSkjema";
 import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { ForhandsvisDocumentAccordionItem } from "@/sider/dialogmoter/components/motehistorikk/ForhandsvisDocumentAccordionItem";
 
@@ -26,10 +28,7 @@ function createUnntakDocument(
   unntak: UnntakDTO,
   veilederNavn: string | undefined
 ): DocumentComponentDto[] {
-  const arsakText: string =
-    unntakArsakTexts.find(
-      (unntakArsakText) => unntakArsakText.arsak == unntak.arsak
-    )?.text || unntak.arsak;
+  const arsakText: string = unntakArsakTexts[unntak.arsak] || unntak.arsak;
   const componentList: DocumentComponentDto[] = [
     {
       type: DocumentComponentType.PARAGRAPH,

--- a/test/dialogmoteunntak/DialogmoteunntakSkjemaTest.tsx
+++ b/test/dialogmoteunntak/DialogmoteunntakSkjemaTest.tsx
@@ -21,9 +21,9 @@ import { dialogmotekandidatQueryKeys } from "@/data/dialogmotekandidat/dialogmot
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
 import { dialogmotekandidatMock } from "@/mocks/isdialogmotekandidat/dialogmotekandidatMock";
 import {
-  CreateUnntakArsak,
   createUnntakArsakTexts,
   CreateUnntakDTO,
+  ValidUnntakArsak,
 } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { renderWithRouter } from "../testRouterUtils";
 import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
@@ -70,7 +70,7 @@ describe("DialogmoteunntakSkjema", () => {
     expect(screen.getAllByText(maxLengthErrorMsg)).to.not.be.empty;
 
     passSkjemaInput(
-      CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+      ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
       "beskrivelse"
     );
 
@@ -91,14 +91,14 @@ describe("DialogmoteunntakSkjema", () => {
 
     expect(screen.getAllByRole("radio")).to.have.length(4);
 
-    passSkjemaInput(CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER);
+    passSkjemaInput(ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER);
 
     await clickButton(submitButtonText);
     await waitFor(() => {
       const unntakMutation = queryClient.getMutationCache().getAll()[0];
       const expectedCreateUnntakDTO: CreateUnntakDTO = {
         personIdent: arbeidstaker.personident,
-        arsak: CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+        arsak: ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
         beskrivelse: "",
       };
 
@@ -116,7 +116,7 @@ describe("DialogmoteunntakSkjema", () => {
     const beskrivelse = "Dette er en begrunnelse";
 
     passSkjemaInput(
-      CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+      ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
       beskrivelse
     );
 
@@ -126,7 +126,7 @@ describe("DialogmoteunntakSkjema", () => {
       const unntakMutation = queryClient.getMutationCache().getAll()[0];
       const expectedCreateUnntakDTO: CreateUnntakDTO = {
         personIdent: arbeidstaker.personident,
-        arsak: CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+        arsak: ValidUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
         beskrivelse,
       };
 
@@ -151,7 +151,7 @@ const renderDialogmoteunntakSkjema = () => {
   );
 };
 
-const passSkjemaInput = (arsak: CreateUnntakArsak, beskrivelse?: string) => {
+const passSkjemaInput = (arsak: ValidUnntakArsak, beskrivelse?: string) => {
   const arsakRadioButton = screen.getByText(createUnntakArsakTexts[arsak]);
   fireEvent.click(arsakRadioButton);
 

--- a/test/dialogmoteunntak/DialogmoteunntakSkjemaTest.tsx
+++ b/test/dialogmoteunntak/DialogmoteunntakSkjemaTest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { dialogmoteUnntakRoutePath } from "@/routers/AppRouter";
@@ -16,13 +16,15 @@ import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import DialogmoteunntakSkjema, {
   dialogmoteunntakSkjemaBeskrivelseMaxLength,
   texts as unntakSkjemaTexts,
-  UnntakArsakText,
-  unntakArsakTexts,
 } from "../../src/components/dialogmoteunntak/DialogmoteunntakSkjema";
 import { dialogmotekandidatQueryKeys } from "@/data/dialogmotekandidat/dialogmotekandidatQueryHooks";
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
 import { dialogmotekandidatMock } from "@/mocks/isdialogmotekandidat/dialogmotekandidatMock";
-import { CreateUnntakDTO } from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
+import {
+  CreateUnntakArsak,
+  createUnntakArsakTexts,
+  CreateUnntakDTO,
+} from "@/data/dialogmotekandidat/types/dialogmoteunntakTypes";
 import { renderWithRouter } from "../testRouterUtils";
 import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
 
@@ -67,7 +69,10 @@ describe("DialogmoteunntakSkjema", () => {
     const maxLengthErrorMsg = "1 tegn for mye";
     expect(screen.getAllByText(maxLengthErrorMsg)).to.not.be.empty;
 
-    passSkjemaInput(unntakArsakTexts[0], "beskrivelse");
+    passSkjemaInput(
+      CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+      "beskrivelse"
+    );
 
     // Feilmeldinger forsvinner
     await waitFor(() => {
@@ -84,17 +89,16 @@ describe("DialogmoteunntakSkjema", () => {
   it("sett unntak med kun med obligatorisk verdier fra skjema", async () => {
     renderDialogmoteunntakSkjema();
 
-    expect(screen.getAllByRole("radio")).to.have.length(6);
+    expect(screen.getAllByRole("radio")).to.have.length(4);
 
-    const unntakArsakText = unntakArsakTexts[0];
-    passSkjemaInput(unntakArsakText);
+    passSkjemaInput(CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER);
 
     await clickButton(submitButtonText);
     await waitFor(() => {
       const unntakMutation = queryClient.getMutationCache().getAll()[0];
       const expectedCreateUnntakDTO: CreateUnntakDTO = {
         personIdent: arbeidstaker.personident,
-        arsak: unntakArsakText.arsak,
+        arsak: CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
         beskrivelse: "",
       };
 
@@ -107,12 +111,14 @@ describe("DialogmoteunntakSkjema", () => {
   it("sett unntak med alle verdier fra skjema", async () => {
     renderDialogmoteunntakSkjema();
 
-    expect(screen.getAllByRole("radio")).to.have.length(6);
+    expect(screen.getAllByRole("radio")).to.have.length(4);
 
     const beskrivelse = "Dette er en begrunnelse";
-    const unntakArsakText = unntakArsakTexts[0];
 
-    passSkjemaInput(unntakArsakText, beskrivelse);
+    passSkjemaInput(
+      CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
+      beskrivelse
+    );
 
     await clickButton(submitButtonText);
 
@@ -120,7 +126,7 @@ describe("DialogmoteunntakSkjema", () => {
       const unntakMutation = queryClient.getMutationCache().getAll()[0];
       const expectedCreateUnntakDTO: CreateUnntakDTO = {
         personIdent: arbeidstaker.personident,
-        arsak: unntakArsakText.arsak,
+        arsak: CreateUnntakArsak.FORVENTET_FRISKMELDING_INNEN_28UKER,
         beskrivelse,
       };
 
@@ -145,11 +151,8 @@ const renderDialogmoteunntakSkjema = () => {
   );
 };
 
-const passSkjemaInput = (
-  unntakArsakText: UnntakArsakText,
-  beskrivelse?: string
-) => {
-  const arsakRadioButton = screen.getByText(unntakArsakText.text);
+const passSkjemaInput = (arsak: CreateUnntakArsak, beskrivelse?: string) => {
+  const arsakRadioButton = screen.getByText(createUnntakArsakTexts[arsak]);
   fireEvent.click(arsakRadioButton);
 
   if (beskrivelse) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Flytter årsakene "friskmeldt" og "arbeidsforhold opphørt" fra unntak til ikke aktuell. Årsakene må fortsatt ligge der for å kunne vise historiske unntak.

### Screenshots 📸✨

Unntak nå:
![image](https://github.com/user-attachments/assets/b2310d33-7fb4-4880-94e9-9905455952bd)
Ikke aktuell nå:
![image](https://github.com/user-attachments/assets/fb2fb274-03d8-42db-9265-cc68bf60b11d)
