### PR TITLE
IS-2260: Filter enabled veileder

### DIFF
--- a/src/components/TildeltVeileder.tsx
+++ b/src/components/TildeltVeileder.tsx
@@ -87,7 +87,9 @@ const toVeilederOptions = (veiledere: Veileder[], aktivVeileder: Veileder) => {
     ...sortedVeiledere
       .filter(
         (veileder) =>
-          veileder.fornavn.length > 0 && veileder.etternavn.length > 0
+          veileder.enabled &&
+          veileder.fornavn.length > 0 &&
+          veileder.etternavn.length > 0
       )
       .filter((veileder) => veileder.ident !== aktivVeileder.ident)
       .map(toVeilederOption),

--- a/src/data/veilederinfo/types/Veileder.ts
+++ b/src/data/veilederinfo/types/Veileder.ts
@@ -4,6 +4,7 @@ export interface Veileder {
   etternavn: string;
   epost: string;
   telefonnummer?: string;
+  enabled: boolean | null;
 }
 
 export class Veileder {
@@ -12,12 +13,14 @@ export class Veileder {
   etternavn: string;
   epost: string;
   telefonnummer?: string;
+  enabled: boolean | null;
 
   constructor(
     ident: string,
     fornavn: string,
     etternavn: string,
     epost: string,
+    enabled: boolean | null,
     telefonnummer?: string
   ) {
     this.ident = ident;
@@ -25,6 +28,7 @@ export class Veileder {
     this.etternavn = etternavn;
     this.epost = epost;
     this.telefonnummer = telefonnummer;
+    this.enabled = enabled;
   }
 
   fulltNavn(): string {

--- a/src/data/veilederinfo/veilederinfoQueryHooks.ts
+++ b/src/data/veilederinfo/veilederinfoQueryHooks.ts
@@ -28,6 +28,7 @@ export const useAktivVeilederinfoQuery = () => {
         data.fornavn,
         data.etternavn,
         data.epost,
+        data.enabled,
         data.telefonnummer
       ),
   });
@@ -46,6 +47,7 @@ export const useVeilederInfoQuery = (ident: string) => {
         data.fornavn,
         data.etternavn,
         data.epost,
+        data.enabled,
         data.telefonnummer
       ),
   });

--- a/src/mocks/common/mockConstants.ts
+++ b/src/mocks/common/mockConstants.ts
@@ -51,6 +51,7 @@ export const VEILEDER_DEFAULT = new Veileder(
   "Vetle",
   "Veileder",
   "vetle.veileder@nav.no",
+  true,
   "12345678"
 );
 
@@ -61,6 +62,18 @@ export const ANNEN_VEILEDER = new Veileder(
   "Valdemar",
   "Vaileder",
   "valdemar.veileder@nav.no",
+  true,
+  "12345678"
+);
+
+export const INAKTIV_VEILEDER_IDENT = "Z980000";
+
+export const INAKTIV_VEILEDER = new Veileder(
+  INAKTIV_VEILEDER_IDENT,
+  "Viktor",
+  "Villeder",
+  "viktor.villeder@nav.no",
+  false,
   "12345678"
 );
 

--- a/test/components/TildeltVeilederTest.tsx
+++ b/test/components/TildeltVeilederTest.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   ANNEN_VEILEDER,
   ARBEIDSTAKER_DEFAULT,
+  INAKTIV_VEILEDER,
   VEILEDER_BRUKER_KNYTNING_DEFAULT,
   VEILEDER_DEFAULT,
   VEILEDER_IDENT_DEFAULT,
@@ -89,7 +90,7 @@ describe("TildeltVeileder", () => {
       );
       queryClient.setQueryData(
         veilederinfoQueryKeys.veiledereByEnhet(navEnhet.id),
-        () => [VEILEDER_DEFAULT, ANNEN_VEILEDER]
+        () => [VEILEDER_DEFAULT, ANNEN_VEILEDER, INAKTIV_VEILEDER]
       );
     });
     it("viser modal for endring av tildelt veileder", async () => {
@@ -109,6 +110,16 @@ describe("TildeltVeileder", () => {
           name: "Tildel veileder",
         })
       ).to.exist;
+    });
+    it("viser ikke inaktiv veileder i modal for endring av tildelt veileder", async () => {
+      renderTildelVeileder();
+      await clickButton("Endre");
+
+      expect(screen.getAllByRole("option")).to.have.length(2);
+      const inaktivVeilederOption = screen.queryByRole("option", {
+        name: `${INAKTIV_VEILEDER.etternavn}, ${INAKTIV_VEILEDER.fornavn}`,
+      });
+      expect(inaktivVeilederOption).to.not.exist;
     });
     it("validerer valgt veileder", async () => {
       renderTildelVeileder();


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser bare veiledere med `enabled=true` (dvs at de finnes og ikke er deaktivert i MS Graph) når man skal tildele person til veileder.
