### PR TITLE
IS-3011: Add preview of email for oppfølgingsplan forespørsel

### DIFF
--- a/src/components/LabelAndText.tsx
+++ b/src/components/LabelAndText.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { BodyShort } from "@navikt/ds-react";
+
+interface Props {
+  label: string;
+  text: string;
+}
+
+export default function LabelAndText({ label, text }: Props) {
+  return (
+    <div className="text-base font-normal flex gap-1 items-center">
+      <BodyShort weight="semibold">{label}</BodyShort>
+      <BodyShort>{text}</BodyShort>
+    </div>
+  );
+}

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
@@ -5,7 +5,9 @@ import {
   Box,
   Button,
   Heading,
+  ReadMore,
 } from "@navikt/ds-react";
+import { PaperplaneIcon } from "@navikt/aksel-icons";
 import React from "react";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { NarmesteLederRelasjonDTO } from "@/data/leder/ledereTypes";
@@ -23,18 +25,24 @@ import {
 } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { useOppfolgingsplanForesporselDocument } from "@/hooks/oppfolgingsplan/useOppfolgingsplanForesporselDocument";
 import { oppfolgingstilfelle } from "../../../../test/aktivitetskrav/vurdering/vurderingTestUtils";
+import LabelAndText from "@/components/LabelAndText";
 
 const texts = {
   aktivForesporsel:
     "Obs! Det ble bedt om oppfølgingsplan fra denne arbeidsgiveren",
-  header: "Be om oppfølgingsplan fra arbeidsgiver",
-  description:
-    "Her kan du be om oppfølgingsplan fra arbeidsgiver eller purre om det mangler.",
+  header: "Be om oppfølgingsplan",
+  description: {
+    info1: "Her kan du be om oppfølgingsplan fra arbeidsgiver.",
+    info2:
+      "Forespørselen blir journalført og vil være tilgjengelig for den sykmeldte på innloggede sider.",
+    info3: "Nærmeste leder vil motta et varsel på e-post.",
+  },
   virksomhet: "Virksomhet:",
   narmesteLeder: "Nærmeste leder:",
-  button: "Be om oppfølgingsplan",
+  button: "Send forespørsel",
   foresporselSendt: "Forespørsel om oppfølgingsplan sendt",
   foresporselFeilet: "Det skjedde en uventet feil. Vennligst prøv igjen senere",
+  readMoreText: "Dette får nærmeste leder tilsendt i e-posten fra Nav",
 };
 
 function logOppfolgingsplanForesporselEvent() {
@@ -45,6 +53,20 @@ function logOppfolgingsplanForesporselEvent() {
       tekst: "Be om oppfølgingsplan",
     },
   });
+}
+
+function ReadMoreContent() {
+  return (
+    <BodyShort className="whitespace-pre-line">
+      {`Hei, \n
+      Nav ber om at du sender inn oppfølgingsplan for en av dine ansatte som er sykmeldt.
+      Logg inn på "Min side - arbeidsgiver". Klikk på varselet i "bjella" for å se hvem det gjelder. \n
+      Har du spørsmål, kan du kontakte oss på 55 55 33 36. \n
+      Vennlig hilsen Nav. \n
+      Du kan ikke svare på denne meldingen.
+      `}
+    </BodyShort>
+  );
 }
 
 interface Props {
@@ -99,27 +121,43 @@ export default function BeOmOppfolgingsplan({
           {aktivForesporselTekst}
         </Alert>
       )}
-      <Box background="surface-default" className="mb-4 flex flex-col p-4">
+      <Box
+        background="surface-default"
+        className="mb-4 flex flex-col p-4 gap-4"
+      >
         <Heading size="small" level="3">
           {texts.header}
         </Heading>
-        <BodyLong className="mb-2">{texts.description}</BodyLong>
-        <BodyShort>
-          {texts.virksomhet} {aktivNarmesteLeder.virksomhetsnavn}
-        </BodyShort>
-        <BodyShort className="mb-2">
-          {texts.narmesteLeder} {aktivNarmesteLeder.narmesteLederNavn}
-        </BodyShort>
+        <div>
+          <BodyLong>{texts.description.info1}</BodyLong>
+          <BodyLong>{texts.description.info2}</BodyLong>
+        </div>
+        <div>
+          <LabelAndText
+            label={texts.virksomhet}
+            text={aktivNarmesteLeder.virksomhetsnavn}
+          />
+          <LabelAndText
+            label={texts.narmesteLeder}
+            text={aktivNarmesteLeder.narmesteLederNavn}
+          />
+        </div>
+        <div>
+          <BodyLong>{texts.description.info3}</BodyLong>
+          <ReadMore header={texts.readMoreText}>
+            <ReadMoreContent />
+          </ReadMore>
+        </div>
         {postOppfolgingsplanForesporsel.isSuccess ? (
           <Alert inline variant="success">
             {texts.foresporselSendt}
           </Alert>
         ) : (
           <Button
-            className="w-fit mb-2"
-            size="small"
+            className="w-fit"
             onClick={onClick}
             loading={postOppfolgingsplanForesporsel.isPending}
+            icon={<PaperplaneIcon />}
           >
             {texts.button}
           </Button>

--- a/test/sider/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
+++ b/test/sider/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
@@ -148,10 +148,9 @@ describe("Oppfølgingsplaner visning", () => {
       );
       renderOppfolgingsplanerOversikt([]);
 
-      expect(screen.queryByText("Be om oppfølgingsplan fra arbeidsgiver")).to
-        .not.exist;
-      expect(screen.queryByRole("button", { name: "Be om oppfølgingsplan" })).to
-        .not.exist;
+      expect(screen.queryByText("Be om oppfølgingsplan")).to.not.exist;
+      expect(screen.queryByRole("button", { name: "Send forespørsel" })).to.not
+        .exist;
     });
     it("Viser ikke be om oppfølgingsplan funksjonalitet om sykmeldt har flere arbeidsgivere", () => {
       queryClient.setQueryData(
@@ -162,20 +161,24 @@ describe("Oppfølgingsplaner visning", () => {
 
       expect(screen.getByText("Det er ingen aktive oppfølgingsplaner")).to
         .exist;
-      expect(screen.queryByText("Be om oppfølgingsplan fra arbeidsgiver")).to
-        .not.exist;
-      expect(screen.queryByRole("button", { name: "Be om oppfølgingsplan" })).to
-        .not.exist;
+      expect(screen.queryByText("Be om oppfølgingsplan")).to.not.exist;
+      expect(screen.queryByRole("button", { name: "Send forespørsel" })).to.not
+        .exist;
     });
     it("Viser be om oppfølgingsplan funksjonalitet om det ikke finnes en aktiv oppfølgingsplan", () => {
       renderOppfolgingsplanerOversikt([]);
 
       expect(screen.getByText("Det er ingen aktive oppfølgingsplaner")).to
         .exist;
-      expect(screen.getByText("Be om oppfølgingsplan fra arbeidsgiver")).to
-        .exist;
-      expect(screen.getByRole("button", { name: "Be om oppfølgingsplan" })).to
-        .exist;
+      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
+      expect(screen.getByText("Nærmeste leder vil motta et varsel på e-post."))
+        .to.exist;
+      expect(
+        screen.queryByRole("button", {
+          name: "Dette får nærmeste leder tilsendt i e-posten fra Nav",
+        })
+      ).to.exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
     });
     it("Viser bekreftelse når bruker sender forespørsel om oppfølgingsplan", async () => {
       queryClient.setQueryData(
@@ -192,7 +195,7 @@ describe("Oppfølgingsplaner visning", () => {
         )
       );
 
-      await clickButton("Be om oppfølgingsplan");
+      await clickButton("Send forespørsel");
 
       await waitFor(() => {
         const oppfolgingspolanForesporselMutation = queryClient
@@ -208,7 +211,7 @@ describe("Oppfølgingsplaner visning", () => {
         });
       });
       expect(screen.getByText("Forespørsel om oppfølgingsplan sendt")).to.exist;
-      expect(screen.queryByText("Be om oppfølgingsplan")).to.not.exist;
+      expect(screen.queryByText("Send forespørsel")).to.not.exist;
     });
     it("Viser feilmelding når forespørsel om oppfølgingsplan feiler", async () => {
       mockServer.use(
@@ -223,10 +226,9 @@ describe("Oppfølgingsplaner visning", () => {
         )
       );
       renderOppfolgingsplanerOversikt([]);
-      expect(screen.getByRole("button", { name: "Be om oppfølgingsplan" })).to
-        .exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
       const beOmOppfolgingsplanButton = screen.getByRole("button", {
-        name: "Be om oppfølgingsplan",
+        name: "Send forespørsel",
       });
 
       await userEvent.click(beOmOppfolgingsplanButton);
@@ -257,16 +259,14 @@ describe("Oppfølgingsplaner visning", () => {
           )}`
         )
       ).to.exist;
-      expect(screen.getByText("Be om oppfølgingsplan fra arbeidsgiver")).to
-        .exist;
+      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
 
-      expect(screen.getByRole("button", { name: "Be om oppfølgingsplan" })).to
-        .exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
     });
     it("Sender forespørsel om oppfølgingsplan med document", async () => {
       renderOppfolgingsplanerOversikt([]);
 
-      await clickButton("Be om oppfølgingsplan");
+      await clickButton("Send forespørsel");
 
       const expectedForesporselRequest: NewOppfolgingsplanForesporselDTO = {
         arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til forhåndsvisning via `ReadMore` og lagt til nye tekster. Noen stylingendringer også.

Lagde en `LabelAndText` på utils-nivå, fordi vi har flere steder der vi har lignende logikk (`Info` i personkortet og `SyketilfelleSummaryElement` i utdraget fra sykefraværet). Implementerte ikke bruken av denne komponenten flere steder, fordi det er noen ting som er litt annerledes. Feks at det er **label:** text og label: **text** ulike steder, og at fontstørrelser er satt av en global less-styling 😢

### Screenshots 📸✨

<img width="1101" alt="image" src="https://github.com/user-attachments/assets/43672610-a831-4a56-8c05-43b5d8fe5cb4" />
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/21e5f9e9-5263-4955-80ee-018337bad179" />


