### PR TITLE
Pengestopp improvements and refactor

### DIFF
--- a/src/components/pengestopp/PengestoppHistorikk.tsx
+++ b/src/components/pengestopp/PengestoppHistorikk.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
-import { StatusEndring } from "@/data/pengestopp/types/FlaggPerson";
 import {
-  displayArbeidsgiverNavn,
-  displayArsakText,
+  Arbeidsgiver,
+  StatusEndring,
+  sykepengestoppArsakTekster,
+} from "@/data/pengestopp/types/FlaggPerson";
+import {
   sykmeldingerToArbeidsgiver,
   uniqueArbeidsgivere,
 } from "@/utils/pengestoppUtils";
@@ -10,18 +12,27 @@ import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat
 import { texts } from "./Pengestopp";
 import { Box, Heading, Label } from "@navikt/ds-react";
 
-interface IPengestoppDropdown {
+interface Props {
   statusEndringList: StatusEndring[];
   sykmeldinger: SykmeldingOldFormat[];
 }
 
-const PengestoppHistorikk = ({
-  statusEndringList,
-  sykmeldinger,
-}: IPengestoppDropdown) => {
+const PengestoppHistorikk = ({ statusEndringList, sykmeldinger }: Props) => {
   const allArbeidsgivere = uniqueArbeidsgivere(
     sykmeldingerToArbeidsgiver(sykmeldinger)
   );
+
+  function getArbeidsgiverNavn(statusEndring: StatusEndring) {
+    return allArbeidsgivere.find(
+      (ag: Arbeidsgiver) => ag.orgnummer === statusEndring.virksomhetNr.value
+    )?.navn;
+  }
+
+  function getArsakText(statusEndring: StatusEndring) {
+    return `Årsak: ${statusEndring.arsakList
+      .map((arsak) => sykepengestoppArsakTekster[arsak.type])
+      .join(", ")}.`;
+  }
 
   return (
     <>
@@ -41,11 +52,11 @@ const PengestoppHistorikk = ({
               opprettet.getMonth() + 1
             }.${opprettet.getFullYear()} · Gjelder for:
             
-            ${displayArbeidsgiverNavn(allArbeidsgivere, statusEndring)}
+            ${getArbeidsgiverNavn(statusEndring)}
            `}</Label>
             <p>
               {statusEndring.arsakList?.length > 0 &&
-                displayArsakText(statusEndring.arsakList)}
+                getArsakText(statusEndring)}
             </p>
           </Box>
         );

--- a/src/data/pengestopp/types/FlaggPerson.ts
+++ b/src/data/pengestopp/types/FlaggPerson.ts
@@ -35,13 +35,43 @@ export interface EnhetNr {
   value: string;
 }
 
-export enum SykepengestoppArsakType {
+export enum DeprecatedSykepengestoppArsakType {
   BESTRIDELSE_SYKMELDING = "BESTRIDELSE_SYKMELDING",
+  TILBAKEDATERT_SYKMELDING = "TILBAKEDATERT_SYKMELDING",
+}
+
+export enum ValidSykepengestoppArsakType {
   MEDISINSK_VILKAR = "MEDISINSK_VILKAR",
   AKTIVITETSKRAV = "AKTIVITETSKRAV",
-  TILBAKEDATERT_SYKMELDING = "TILBAKEDATERT_SYKMELDING",
   MANGLENDE_MEDVIRKING = "MANGLENDE_MEDVIRKING",
 }
+
+export type SykepengestoppArsakType =
+  | DeprecatedSykepengestoppArsakType
+  | ValidSykepengestoppArsakType;
+
+export const validSykepengestoppArsakTekster: Record<
+  ValidSykepengestoppArsakType,
+  string
+> = {
+  [ValidSykepengestoppArsakType.MEDISINSK_VILKAR]:
+    "Medisinsk vilkår (§ 8-4 første ledd)",
+  [ValidSykepengestoppArsakType.MANGLENDE_MEDVIRKING]:
+    "Manglende medvirkning (§ 8-8 første ledd)",
+  [ValidSykepengestoppArsakType.AKTIVITETSKRAV]:
+    "Aktivitetskravet (§ 8-8 andre ledd)",
+};
+
+export const sykepengestoppArsakTekster: Record<
+  SykepengestoppArsakType,
+  string
+> = {
+  ...validSykepengestoppArsakTekster,
+  [DeprecatedSykepengestoppArsakType.BESTRIDELSE_SYKMELDING]:
+    "Bestridelse av sykmelding (§ 8-4 første ledd)",
+  [DeprecatedSykepengestoppArsakType.TILBAKEDATERT_SYKMELDING]:
+    "Tilbakedatert sykmelding (§ 8-7)",
+};
 
 export interface SykepengestoppArsak {
   type: SykepengestoppArsakType;

--- a/src/data/pengestopp/types/FlaggPerson.ts
+++ b/src/data/pengestopp/types/FlaggPerson.ts
@@ -35,6 +35,7 @@ export interface EnhetNr {
   value: string;
 }
 
+/* Skal ikke lenger kunne velges (fra april 24). Oppgavene er overført fra NAV-kontor til NAY. */
 export enum DeprecatedSykepengestoppArsakType {
   BESTRIDELSE_SYKMELDING = "BESTRIDELSE_SYKMELDING",
   TILBAKEDATERT_SYKMELDING = "TILBAKEDATERT_SYKMELDING",

--- a/src/mocks/ispengestopp/mockIspengestopp.ts
+++ b/src/mocks/ispengestopp/mockIspengestopp.ts
@@ -17,13 +17,6 @@ export const mockIspengestopp = [
       const body = await request.json();
       STATUSLIST = createStatusList(new Date(), body);
 
-      const stoppAutomatikk =
-        body.sykmeldtFnr && body.virksomhetNr && body.enhetNr;
-      console.error(stoppAutomatikk, {
-        stoppAutomatikk,
-        errorMsg: "invalid stoppAutomatikk object",
-      });
-      console.log("StoppAutomatikk: 201 CREATED");
       return new HttpResponse(null, { status: 201 });
     }
   ),

--- a/src/mocks/ispengestopp/pengestoppStatusMock.ts
+++ b/src/mocks/ispengestopp/pengestoppStatusMock.ts
@@ -4,16 +4,18 @@ import {
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
 import {
+  DeprecatedSykepengestoppArsakType,
   Status,
   StoppAutomatikk,
-  SykepengestoppArsakType,
 } from "@/data/pengestopp/types/FlaggPerson";
 
 const defaultStoppAutomatikk: StoppAutomatikk = {
   enhetNr: { value: ENHET_GAMLEOSLO.nummer },
   virksomhetNr: [{ value: VIRKSOMHET_PONTYPANDY.virksomhetsnummer }],
   sykmeldtFnr: { value: ARBEIDSTAKER_DEFAULT.personIdent },
-  arsakList: [{ type: SykepengestoppArsakType.BESTRIDELSE_SYKMELDING }],
+  arsakList: [
+    { type: DeprecatedSykepengestoppArsakType.BESTRIDELSE_SYKMELDING },
+  ],
 };
 
 export const createStatusList = (

--- a/src/utils/pengestoppUtils.ts
+++ b/src/utils/pengestoppUtils.ts
@@ -1,15 +1,9 @@
-import {
-  Arbeidsgiver,
-  Status,
-  StatusEndring,
-  SykepengestoppArsak,
-} from "@/data/pengestopp/types/FlaggPerson";
+import { Arbeidsgiver } from "@/data/pengestopp/types/FlaggPerson";
 import { senesteTom } from "./periodeUtils";
 import {
   SykmeldingOldFormat,
   SykmeldingStatus,
 } from "@/data/sykmelding/types/SykmeldingOldFormat";
-import { sykepengestoppArsakTekstListe } from "@/components/pengestopp/PengestoppModal";
 
 export const sykmeldingerToArbeidsgiver = (
   sykmeldinger: SykmeldingOldFormat[]
@@ -33,15 +27,6 @@ export const uniqueArbeidsgivere = (
     );
   });
 };
-
-export const allStoppAutomatikkStatusEndringer = (
-  statusEndringer: StatusEndring[]
-) => {
-  return statusEndringer.filter((statusEndring) => {
-    return statusEndring.status === Status.STOPP_AUTOMATIKK;
-  });
-};
-
 export const aktiveSykmeldingerFraSiste3Maneder = (
   sykmeldinger: SykmeldingOldFormat[]
 ) => {
@@ -65,23 +50,4 @@ export const unikeArbeidsgivereMedSykmeldingSiste3Maneder = (
   );
 
   return uniqueArbeidsgivere(arbeidsgiverFromSykmeldinger);
-};
-
-export const displayArsakText = (arsakList: SykepengestoppArsak[]) => {
-  return `Årsak: ${arsakList
-    .map((arsak) => {
-      return sykepengestoppArsakTekstListe.find((arsakTekst) => {
-        return arsakTekst.type === arsak.type;
-      })?.text;
-    })
-    .join(", ")}.`;
-};
-
-export const displayArbeidsgiverNavn = (
-  allArbeidsgivere: Arbeidsgiver[],
-  statusEndring: StatusEndring
-) => {
-  return allArbeidsgivere.find(
-    (ag: Arbeidsgiver) => ag.orgnummer === statusEndring.virksomhetNr.value
-  )?.navn;
 };

--- a/test/pengestopp/PengestoppTest.tsx
+++ b/test/pengestopp/PengestoppTest.tsx
@@ -13,9 +13,10 @@ import {
   VIRKSOMHET_PONTYPANDY,
 } from "@/mocks/common/mockConstants";
 import {
+  DeprecatedSykepengestoppArsakType,
   Status,
   StatusEndring,
-  SykepengestoppArsakType,
+  ValidSykepengestoppArsakType,
 } from "@/data/pengestopp/types/FlaggPerson";
 import { expect, describe, it, beforeEach } from "vitest";
 
@@ -29,18 +30,22 @@ const defaultStatusEndring = {
     value: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
   },
   sykmeldtFnr: { value: ARBEIDSTAKER_DEFAULT.personIdent },
-  arsakList: [{ type: SykepengestoppArsakType.BESTRIDELSE_SYKMELDING }],
+  arsakList: [
+    { type: DeprecatedSykepengestoppArsakType.BESTRIDELSE_SYKMELDING },
+  ],
   status: Status.STOPP_AUTOMATIKK,
 };
 const pengestoppHistorikk: StatusEndring[] = [
   defaultStatusEndring,
   {
     ...defaultStatusEndring,
-    arsakList: [{ type: SykepengestoppArsakType.TILBAKEDATERT_SYKMELDING }],
+    arsakList: [
+      { type: DeprecatedSykepengestoppArsakType.TILBAKEDATERT_SYKMELDING },
+    ],
   },
   {
     ...defaultStatusEndring,
-    arsakList: [{ type: SykepengestoppArsakType.MEDISINSK_VILKAR }],
+    arsakList: [{ type: ValidSykepengestoppArsakType.MEDISINSK_VILKAR }],
   },
 ];
 


### PR DESCRIPTION
Skrevet om `PengestoppModal` til å bruke `react-hook-form` for å forenkle skjemakoden og gjøre det mer likt andre skjemaer. 
I tillegg ryddet litt i årsaks-kodene slik at det er tydeligere hvilke som er i bruk og hvilke som finnes bare for historikk.
Funksjonaliteten skal være uendret :crossed_fingers: 