### PR TITLE
IS-3073: Be om oppfølgingsplan ved flere arbeidsgivere

### DIFF
--- a/src/data/virksomhet/virksomhetQueryHooks.ts
+++ b/src/data/virksomhet/virksomhetQueryHooks.ts
@@ -7,7 +7,7 @@ import {
 import { useQuery } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/utils";
 
-const virksomhetQueryKeys = {
+export const virksomhetQueryKeys = {
   virksomhet: (virksomhetsnummer: string) => ["virksomhet", virksomhetsnummer],
 };
 

--- a/src/mocks/common/mockConstants.ts
+++ b/src/mocks/common/mockConstants.ts
@@ -107,6 +107,11 @@ export const NARMESTE_LEDER_DEFAULT = {
   personident: "02690001009",
 };
 
+const ANNEN_NARMESTE_LEDER = {
+  navn: "Sara Sjef",
+  personident: "02790001009",
+};
+
 export const LEDERE_DEFAULT = [
   {
     uuid: "3",
@@ -124,6 +129,15 @@ export const LEDERE_DEFAULT = [
     status: NarmesteLederRelasjonStatus.INNMELDT_AKTIV,
   },
 ];
+
+export const ANNEN_LEDER_AKTIV = {
+  ...LEDERE_DEFAULT[0],
+  uuid: "4",
+  virksomhetsnummer: VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
+  virksomhetsnavn: VIRKSOMHET_BRANNOGBIL.virksomhetsnavn,
+  narmesteLederPersonIdentNumber: ANNEN_NARMESTE_LEDER.personident,
+  narmesteLederNavn: ANNEN_NARMESTE_LEDER.navn,
+};
 
 export const VEILEDER_BRUKER_KNYTNING_DEFAULT: VeilederBrukerKnytningDTO = {
   personident: ARBEIDSTAKER_DEFAULT.personIdent,

--- a/src/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock.ts
+++ b/src/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock.ts
@@ -7,6 +7,18 @@ import {
 import { OppfolgingstilfellePersonDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { addWeeks } from "@/utils/datoUtils";
 
+export const currentOppfolgingstilfelle = {
+  arbeidstakerAtTilfelleEnd: true,
+  start: addWeeks(new Date(), -40),
+  end: addWeeks(new Date(), 20),
+  virksomhetsnummerList: [
+    VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
+    VIRKSOMHET_UTEN_NARMESTE_LEDER.virksomhetsnummer,
+  ],
+  antallSykedager: 294,
+  varighetUker: 48,
+};
 export const oppfolgingstilfellePersonMock: OppfolgingstilfellePersonDTO = {
   oppfolgingstilfelleList: [
     {
@@ -25,18 +37,7 @@ export const oppfolgingstilfellePersonMock: OppfolgingstilfellePersonDTO = {
       antallSykedager: 294,
       varighetUker: 48,
     },
-    {
-      arbeidstakerAtTilfelleEnd: true,
-      start: addWeeks(new Date(), -40),
-      end: addWeeks(new Date(), 20),
-      virksomhetsnummerList: [
-        VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-        VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
-        VIRKSOMHET_UTEN_NARMESTE_LEDER.virksomhetsnummer,
-      ],
-      antallSykedager: 294,
-      varighetUker: 48,
-    },
+    currentOppfolgingstilfelle,
   ],
   personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
 };

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner.tsx
@@ -78,10 +78,19 @@ export default function AktiveOppfolgingsplaner({
         currentOppfolgingstilfelle
       )
     : [];
+  const activeNarmesteLedereWithoutActivePlan = activeNarmesteLedere.filter(
+    (leder) =>
+      !aktivePlaner.some(
+        (plan) => plan.virksomhet.virksomhetsnummer === leder.virksomhetsnummer
+      ) &&
+      !oppfolgingsplanerLPSUnprocessed.some(
+        (plan) => plan.virksomhetsnummer === leder.virksomhetsnummer
+      )
+  );
   const isBeOmOppfolgingsplanVisible =
     toggles.isBeOmOppfolgingsplanEnabled &&
     !!currentOppfolgingstilfelle &&
-    activeNarmesteLedere.length > 0;
+    activeNarmesteLedereWithoutActivePlan.length > 0;
 
   return (
     <div className="mb-8">
@@ -103,17 +112,15 @@ export default function AktiveOppfolgingsplaner({
           })}
         </>
       ) : (
-        <>
-          <Box background="surface-default" className="p-4 mb-2">
-            <BodyShort>{texts.ingenAktiveOppfolgingsplaner}</BodyShort>
-          </Box>
-          {isBeOmOppfolgingsplanVisible && (
-            <BeOmOppfolgingsplan
-              activeNarmesteLedere={activeNarmesteLedere}
-              currentOppfolgingstilfelle={currentOppfolgingstilfelle}
-            />
-          )}
-        </>
+        <Box background="surface-default" className="p-4 mb-2">
+          <BodyShort>{texts.ingenAktiveOppfolgingsplaner}</BodyShort>
+        </Box>
+      )}
+      {isBeOmOppfolgingsplanVisible && (
+        <BeOmOppfolgingsplan
+          activeNarmesteLedere={activeNarmesteLedereWithoutActivePlan}
+          currentOppfolgingstilfelle={currentOppfolgingstilfelle}
+        />
       )}
     </div>
   );

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner.tsx
@@ -78,12 +78,10 @@ export default function AktiveOppfolgingsplaner({
         currentOppfolgingstilfelle
       )
     : [];
-  const activeNarmesteLederIfSingle =
-    activeNarmesteLedere.length === 1 ? activeNarmesteLedere[0] : undefined;
   const isBeOmOppfolgingsplanVisible =
     toggles.isBeOmOppfolgingsplanEnabled &&
     !!currentOppfolgingstilfelle &&
-    !!activeNarmesteLederIfSingle;
+    activeNarmesteLedere.length > 0;
 
   return (
     <div className="mb-8">
@@ -111,7 +109,7 @@ export default function AktiveOppfolgingsplaner({
           </Box>
           {isBeOmOppfolgingsplanVisible && (
             <BeOmOppfolgingsplan
-              aktivNarmesteLeder={activeNarmesteLederIfSingle}
+              activeNarmesteLedere={activeNarmesteLedere}
               currentOppfolgingstilfelle={currentOppfolgingstilfelle}
             />
           )}

--- a/test/sider/oppfolgingsplaner/BeOmOppfolgingsplanTest.tsx
+++ b/test/sider/oppfolgingsplaner/BeOmOppfolgingsplanTest.tsx
@@ -1,0 +1,240 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
+import { navEnhet } from "../../dialogmote/testData";
+import React from "react";
+import { beforeEach, describe, expect, it } from "vitest";
+import BeOmOppfolgingsplan from "@/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan";
+import { NarmesteLederRelasjonDTO } from "@/data/leder/ledereTypes";
+import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+import { queryClientWithMockData } from "../../testQueryClient";
+import {
+  NewOppfolgingsplanForesporselDTO,
+  oppfolgingsplanForesporselQueryKeys,
+  OppfolgingsplanForesporselResponse,
+} from "@/data/oppfolgingsplan/oppfolgingsplanForesporselHooks";
+import {
+  ANNEN_LEDER_AKTIV,
+  ARBEIDSTAKER_DEFAULT,
+  LEDERE_DEFAULT,
+  NARMESTE_LEDER_DEFAULT,
+  VEILEDER_DEFAULT,
+  VIRKSOMHET_BRANNOGBIL,
+  VIRKSOMHET_PONTYPANDY,
+} from "@/mocks/common/mockConstants";
+import { mockServer } from "../../setup";
+import { http, HttpResponse } from "msw";
+import { ISOPPFOLGINGSPLAN_ROOT } from "@/apiConstants";
+import { clickButton } from "../../testUtils";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { getExpectedForesporselDocument } from "./oppfolgingsplanTestdata";
+import { generateUUID } from "@/utils/utils";
+import { currentOppfolgingstilfelle } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock";
+import userEvent from "@testing-library/user-event";
+import { virksomhetQueryKeys } from "@/data/virksomhet/virksomhetQueryHooks";
+import { EregOrganisasjonResponseDTO } from "@/data/virksomhet/types/EregOrganisasjonResponseDTO";
+
+let queryClient: QueryClient;
+
+const singleNarmesteLeder =
+  LEDERE_DEFAULT as unknown as NarmesteLederRelasjonDTO[];
+const multipleNarmesteLeder = [
+  ...LEDERE_DEFAULT,
+  ANNEN_LEDER_AKTIV,
+] as unknown as NarmesteLederRelasjonDTO[];
+
+const renderBeOmOppfolgingsplan = (
+  narmesteledere: NarmesteLederRelasjonDTO[] = singleNarmesteLeder,
+  tilfelle: OppfolgingstilfelleDTO = currentOppfolgingstilfelle
+) => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{ valgtEnhet: navEnhet.id, setValgtEnhet: () => void 0 }}
+      >
+        <BeOmOppfolgingsplan
+          activeNarmesteLedere={narmesteledere}
+          currentOppfolgingstilfelle={tilfelle}
+        />
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+const foresporselDocument = getExpectedForesporselDocument({
+  narmesteLeder: LEDERE_DEFAULT[0].narmesteLederNavn,
+  virksomhetNavn: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
+});
+
+const existingForesporsel: OppfolgingsplanForesporselResponse = {
+  uuid: generateUUID(),
+  createdAt: new Date(),
+  arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
+  veilederident: VEILEDER_DEFAULT.ident,
+  virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+  narmestelederPersonident: NARMESTE_LEDER_DEFAULT.personident,
+  document: foresporselDocument,
+};
+
+describe("BeOmOppfolgingsplan", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+  it("Viser bekreftelse når bruker sender forespørsel om oppfølgingsplan", async () => {
+    queryClient.setQueryData(
+      oppfolgingsplanForesporselQueryKeys.foresporsel(
+        ARBEIDSTAKER_DEFAULT.personIdent
+      ),
+      () => []
+    );
+    renderBeOmOppfolgingsplan();
+    mockServer.use(
+      http.post(
+        `*${ISOPPFOLGINGSPLAN_ROOT}/oppfolgingsplan/foresporsler`,
+        () => new HttpResponse(null, { status: 200 })
+      )
+    );
+
+    await clickButton("Send forespørsel");
+
+    expect(await screen.findByText("Forespørsel om oppfølgingsplan sendt")).to
+      .exist;
+    expect(screen.queryByText("Send forespørsel")).to.not.exist;
+  });
+  it("Viser feilmelding når forespørsel om oppfølgingsplan feiler", async () => {
+    mockServer.use(
+      http.post(
+        `${ISOPPFOLGINGSPLAN_ROOT}/oppfolgingsplan/foresporsler`,
+        () => {
+          HttpResponse.json(
+            { error: "Internal server error" },
+            { status: 500 }
+          );
+        }
+      )
+    );
+    renderBeOmOppfolgingsplan();
+    expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
+    const beOmOppfolgingsplanButton = screen.getByRole("button", {
+      name: "Send forespørsel",
+    });
+
+    await userEvent.click(beOmOppfolgingsplanButton);
+    expect(
+      await screen.findByText(
+        "Det skjedde en uventet feil. Vennligst prøv igjen senere"
+      )
+    ).to.exist;
+  });
+  it("Viser bekreftelse på at det er forespurt om oppfølgingsplan tidligere i oppfølgingstilfellet", async () => {
+    queryClient.setQueryData(
+      oppfolgingsplanForesporselQueryKeys.foresporsel(
+        ARBEIDSTAKER_DEFAULT.personIdent
+      ),
+      () => [existingForesporsel]
+    );
+    const virksomhetResponse: EregOrganisasjonResponseDTO = {
+      navn: {
+        navnelinje1: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
+      },
+    };
+    queryClient.setQueryData(
+      virksomhetQueryKeys.virksomhet(VIRKSOMHET_PONTYPANDY.virksomhetsnummer),
+      () => virksomhetResponse
+    );
+    renderBeOmOppfolgingsplan();
+
+    expect(
+      screen.getByText(
+        `Obs! Det ble bedt om oppfølgingsplan fra ${
+          VIRKSOMHET_PONTYPANDY.virksomhetsnavn
+        } ${tilLesbarDatoMedArUtenManedNavn(existingForesporsel.createdAt)}`
+      )
+    ).to.exist;
+    expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
+    expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
+  });
+  it("Sender forespørsel om oppfølgingsplan med document", async () => {
+    renderBeOmOppfolgingsplan();
+
+    await clickButton("Send forespørsel");
+
+    const expectedForesporselRequest: NewOppfolgingsplanForesporselDTO = {
+      arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
+      virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+      narmestelederPersonident:
+        LEDERE_DEFAULT[0].narmesteLederPersonIdentNumber,
+      document: getExpectedForesporselDocument({
+        narmesteLeder: LEDERE_DEFAULT[0].narmesteLederNavn,
+        virksomhetNavn: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
+      }),
+    };
+
+    await waitFor(() => {
+      const foresporselMutation = queryClient.getMutationCache().getAll().pop();
+      expect(foresporselMutation?.state.variables).to.deep.equal(
+        expectedForesporselRequest
+      );
+    });
+  });
+  it("Viser navn på virksomhet og nærmeste leder når kun en nærmeste leder", () => {
+    renderBeOmOppfolgingsplan();
+
+    expect(screen.getByText("Virksomhet:")).to.exist;
+    expect(screen.getByText("Nærmeste leder:")).to.exist;
+    expect(screen.getByText(VIRKSOMHET_PONTYPANDY.virksomhetsnavn)).to.exist;
+    expect(screen.getByText(LEDERE_DEFAULT[0].narmesteLederNavn)).to.exist;
+  });
+
+  it("Validerer valgt arbeidsgiver når flere nærmeste ledere", async () => {
+    renderBeOmOppfolgingsplan(multipleNarmesteLeder);
+
+    await clickButton("Send forespørsel");
+
+    expect(await screen.findByText("Vennligst velg arbeidsgiver")).to.exist;
+  });
+
+  it("Viser navn på virksomhet og nærmeste leder når arbeidsgiver valgt", () => {
+    renderBeOmOppfolgingsplan(multipleNarmesteLeder);
+
+    expect(screen.queryByText("Virksomhet:")).to.not.exist;
+    expect(screen.queryByText("Nærmeste leder:")).to.not.exist;
+
+    const virksomhetRadiobutton = screen.getByText(
+      VIRKSOMHET_PONTYPANDY.virksomhetsnavn
+    );
+    fireEvent.click(virksomhetRadiobutton);
+
+    expect(screen.getByText("Virksomhet:")).to.exist;
+    expect(screen.getByText("Nærmeste leder:")).to.exist;
+  });
+
+  it("Sender forespørsel om oppfølgingsplan med valgt arbeidsgiver", async () => {
+    renderBeOmOppfolgingsplan(multipleNarmesteLeder);
+
+    const virksomhetRadiobutton = screen.getByText(
+      VIRKSOMHET_BRANNOGBIL.virksomhetsnavn
+    );
+    fireEvent.click(virksomhetRadiobutton);
+
+    await clickButton("Send forespørsel");
+
+    const expectedForesporselRequest: NewOppfolgingsplanForesporselDTO = {
+      arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
+      virksomhetsnummer: VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
+      narmestelederPersonident:
+        ANNEN_LEDER_AKTIV.narmesteLederPersonIdentNumber,
+      document: getExpectedForesporselDocument({
+        narmesteLeder: ANNEN_LEDER_AKTIV.narmesteLederNavn,
+        virksomhetNavn: VIRKSOMHET_BRANNOGBIL.virksomhetsnavn,
+      }),
+    };
+
+    await waitFor(() => {
+      const foresporselMutation = queryClient.getMutationCache().getAll().pop();
+      expect(foresporselMutation?.state.variables).to.deep.equal(
+        expectedForesporselRequest
+      );
+    });
+  });
+});

--- a/test/sider/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
+++ b/test/sider/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
@@ -1,18 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  queryClientWithAktivBruker,
-  queryClientWithMockData,
-} from "../../testQueryClient";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { queryClientWithMockData } from "../../testQueryClient";
+import { render, screen, within } from "@testing-library/react";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { navEnhet } from "../../dialogmote/testData";
 import React from "react";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  ANNEN_LEDER_AKTIV,
   ARBEIDSTAKER_DEFAULT,
   LEDERE_DEFAULT,
-  NARMESTE_LEDER_DEFAULT,
-  VEILEDER_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "@/mocks/common/mockConstants";
 import dayjs from "dayjs";
@@ -23,25 +19,12 @@ import {
   PersonOppgave,
   PersonOppgaveType,
 } from "@/data/personoppgave/types/PersonOppgave";
-import {
-  restdatoTilLesbarDato,
-  tilLesbarDatoMedArUtenManedNavn,
-} from "@/utils/datoUtils";
+import { restdatoTilLesbarDato } from "@/utils/datoUtils";
 import { generateUUID } from "@/utils/utils";
 import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { generateOppfolgingstilfelle } from "../../testDataUtils";
-import { clickButton, daysFromToday } from "../../testUtils";
+import { daysFromToday } from "../../testUtils";
 import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
-import {
-  NewOppfolgingsplanForesporselDTO,
-  oppfolgingsplanForesporselQueryKeys,
-  OppfolgingsplanForesporselResponse,
-} from "@/data/oppfolgingsplan/oppfolgingsplanForesporselHooks";
-import { getExpectedForesporselDocument } from "./oppfolgingsplanTestdata";
-import userEvent from "@testing-library/user-event";
-import { mockServer } from "../../setup";
-import { http, HttpResponse } from "msw";
-import { ISOPPFOLGINGSPLAN_ROOT } from "@/apiConstants";
 
 let queryClient: QueryClient;
 
@@ -63,77 +46,61 @@ const renderOppfolgingsplanerOversikt = (
   );
 };
 
-describe("Oppfølgingsplaner visning", () => {
+describe("OppfolgingsplanerOversikt", () => {
   beforeEach(() => {
-    queryClient = queryClientWithAktivBruker();
+    queryClient = queryClientWithMockData();
   });
+  describe("Oppfølgingsplaner visning", () => {
+    it("Sorterer ubehandlede oppfølgingsplan-LPSer etter opprettet dato", () => {
+      const olderOppfolgingsplan = createOppfolgingsplanLps(90, false);
+      const newerOppfolgingsplan = createOppfolgingsplanLps(10, false);
 
-  it("Sorterer ubehandlede oppfølgingsplan-LPSer etter opprettet dato", () => {
-    const olderOppfolgingsplan = createOppfolgingsplanLps(90, false);
-    const newerOppfolgingsplan = createOppfolgingsplanLps(10, false);
+      renderOppfolgingsplanerOversikt([
+        olderOppfolgingsplan,
+        newerOppfolgingsplan,
+      ]);
 
-    renderOppfolgingsplanerOversikt([
-      olderOppfolgingsplan,
-      newerOppfolgingsplan,
-    ]);
+      const olderDate = restdatoTilLesbarDato(olderOppfolgingsplan.opprettet);
+      const newerDate = restdatoTilLesbarDato(newerOppfolgingsplan.opprettet);
 
-    const olderDate = restdatoTilLesbarDato(olderOppfolgingsplan.opprettet);
-    const newerDate = restdatoTilLesbarDato(newerOppfolgingsplan.opprettet);
+      const oppfolgingsplanerLPS = screen.getAllByTestId("oppfolgingsplan-lps");
 
-    const oppfolgingsplanerLPS = screen.getAllByTestId("oppfolgingsplan-lps");
+      expect(oppfolgingsplanerLPS.length).to.equal(2);
+      expect(oppfolgingsplanerLPS[0].textContent).to.contain(newerDate);
+      expect(within(oppfolgingsplanerLPS[0]).getByText("Marker som behandlet"))
+        .to.exist;
+      expect(oppfolgingsplanerLPS[1].textContent).to.contain(olderDate);
+      expect(within(oppfolgingsplanerLPS[1]).getByText("Marker som behandlet"))
+        .to.exist;
+    });
 
-    expect(oppfolgingsplanerLPS.length).to.equal(2);
-    expect(oppfolgingsplanerLPS[0].textContent).to.contain(newerDate);
-    expect(within(oppfolgingsplanerLPS[0]).getByText("Marker som behandlet")).to
-      .exist;
-    expect(oppfolgingsplanerLPS[1].textContent).to.contain(olderDate);
-    expect(within(oppfolgingsplanerLPS[1]).getByText("Marker som behandlet")).to
-      .exist;
-  });
+    it("Sorterer behandlede oppfølgingsplan-LPSer etter opprettet dato", () => {
+      const olderOppfolgingsplan = createOppfolgingsplanLps(90, true);
+      const newerOppfolgingsplan = createOppfolgingsplanLps(10, true);
 
-  it("Sorterer behandlede oppfølgingsplan-LPSer etter opprettet dato", () => {
-    const olderOppfolgingsplan = createOppfolgingsplanLps(90, true);
-    const newerOppfolgingsplan = createOppfolgingsplanLps(10, true);
+      renderOppfolgingsplanerOversikt([
+        olderOppfolgingsplan,
+        newerOppfolgingsplan,
+      ]);
 
-    renderOppfolgingsplanerOversikt([
-      olderOppfolgingsplan,
-      newerOppfolgingsplan,
-    ]);
+      const olderDate = restdatoTilLesbarDato(olderOppfolgingsplan.opprettet);
+      const newerDate = restdatoTilLesbarDato(newerOppfolgingsplan.opprettet);
 
-    const olderDate = restdatoTilLesbarDato(olderOppfolgingsplan.opprettet);
-    const newerDate = restdatoTilLesbarDato(newerOppfolgingsplan.opprettet);
+      const oppfolgingsplanerLPS = screen.getAllByTestId("oppfolgingsplan-lps");
 
-    const oppfolgingsplanerLPS = screen.getAllByTestId("oppfolgingsplan-lps");
-
-    expect(oppfolgingsplanerLPS.length).to.equal(2);
-    expect(oppfolgingsplanerLPS[0].textContent).to.contain(newerDate);
-    expect(within(oppfolgingsplanerLPS[0]).queryByText("Marker som behandlet"))
-      .to.be.null;
-    expect(oppfolgingsplanerLPS[1].textContent).to.contain(olderDate);
-    expect(within(oppfolgingsplanerLPS[1]).queryByText("Marker som behandlet"))
-      .to.be.null;
+      expect(oppfolgingsplanerLPS.length).to.equal(2);
+      expect(oppfolgingsplanerLPS[0].textContent).to.contain(newerDate);
+      expect(
+        within(oppfolgingsplanerLPS[0]).queryByText("Marker som behandlet")
+      ).to.be.null;
+      expect(oppfolgingsplanerLPS[1].textContent).to.contain(olderDate);
+      expect(
+        within(oppfolgingsplanerLPS[1]).queryByText("Marker som behandlet")
+      ).to.be.null;
+    });
   });
 
   describe("Be om oppfølgingsplan", () => {
-    beforeEach(() => {
-      queryClient = queryClientWithMockData();
-    });
-
-    const foresporselDocument = getExpectedForesporselDocument({
-      narmesteLeder: LEDERE_DEFAULT[0].narmesteLederNavn,
-      virksomhetNavn: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
-    });
-
-    const existingForesporsel: OppfolgingsplanForesporselResponse = {
-      uuid: generateUUID(),
-      createdAt: new Date(),
-      arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
-      veilederident: VEILEDER_DEFAULT.ident,
-      virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-      narmestelederPersonident: NARMESTE_LEDER_DEFAULT.personident,
-      document: foresporselDocument,
-    };
-
     it("Viser ikke be om oppfølgingsplan funksjonalitet om sykmeldt ikke har aktivt oppfølgingstilfelle", () => {
       queryClient.setQueryData(
         oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(
@@ -152,18 +119,25 @@ describe("Oppfølgingsplaner visning", () => {
       expect(screen.queryByRole("button", { name: "Send forespørsel" })).to.not
         .exist;
     });
-    it("Viser ikke be om oppfølgingsplan funksjonalitet om sykmeldt har flere arbeidsgivere", () => {
+    it("Viser be om oppfølgingsplan funksjonalitet om sykmeldt har en arbeidsgiver", () => {
+      renderOppfolgingsplanerOversikt([]);
+
+      expect(screen.getByText("Det er ingen aktive oppfølgingsplaner")).to
+        .exist;
+      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
+    });
+    it("Viser be om oppfølgingsplan funksjonalitet om sykmeldt har flere arbeidsgivere", () => {
       queryClient.setQueryData(
         ledereQueryKeys.ledere(ARBEIDSTAKER_DEFAULT.personIdent),
-        () => LEDERE_DEFAULT.concat(LEDERE_DEFAULT)
+        () => [...LEDERE_DEFAULT, ANNEN_LEDER_AKTIV]
       );
       renderOppfolgingsplanerOversikt([]);
 
       expect(screen.getByText("Det er ingen aktive oppfølgingsplaner")).to
         .exist;
-      expect(screen.queryByText("Be om oppfølgingsplan")).to.not.exist;
-      expect(screen.queryByRole("button", { name: "Send forespørsel" })).to.not
-        .exist;
+      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
     });
     it("Viser be om oppfølgingsplan funksjonalitet om det ikke finnes en aktiv oppfølgingsplan", () => {
       renderOppfolgingsplanerOversikt([]);
@@ -179,115 +153,6 @@ describe("Oppfølgingsplaner visning", () => {
         })
       ).to.exist;
       expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
-    });
-    it("Viser bekreftelse når bruker sender forespørsel om oppfølgingsplan", async () => {
-      queryClient.setQueryData(
-        oppfolgingsplanForesporselQueryKeys.foresporsel(
-          ARBEIDSTAKER_DEFAULT.personIdent
-        ),
-        () => []
-      );
-      renderOppfolgingsplanerOversikt([]);
-      mockServer.use(
-        http.post(
-          `*${ISOPPFOLGINGSPLAN_ROOT}/oppfolgingsplan/foresporsler`,
-          () => new HttpResponse(null, { status: 200 })
-        )
-      );
-
-      await clickButton("Send forespørsel");
-
-      await waitFor(() => {
-        const oppfolgingspolanForesporselMutation = queryClient
-          .getMutationCache()
-          .getAll()[0];
-        expect(
-          oppfolgingspolanForesporselMutation.state.variables
-        ).to.deep.equal({
-          arbeidstakerPersonident: "19026900010",
-          virksomhetsnummer: "110110110",
-          narmestelederPersonident: "02690001009",
-          document: foresporselDocument,
-        });
-      });
-      expect(screen.getByText("Forespørsel om oppfølgingsplan sendt")).to.exist;
-      expect(screen.queryByText("Send forespørsel")).to.not.exist;
-    });
-    it("Viser feilmelding når forespørsel om oppfølgingsplan feiler", async () => {
-      mockServer.use(
-        http.post(
-          `${ISOPPFOLGINGSPLAN_ROOT}/oppfolgingsplan/foresporsler`,
-          () => {
-            HttpResponse.json(
-              { error: "Internal server error" },
-              { status: 500 }
-            );
-          }
-        )
-      );
-      renderOppfolgingsplanerOversikt([]);
-      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
-      const beOmOppfolgingsplanButton = screen.getByRole("button", {
-        name: "Send forespørsel",
-      });
-
-      await userEvent.click(beOmOppfolgingsplanButton);
-
-      await waitFor(() => {
-        expect(
-          screen.getByText(
-            "Det skjedde en uventet feil. Vennligst prøv igjen senere"
-          )
-        ).to.exist;
-      });
-    });
-    it("Viser bekreftelse på at det er forespurt om oppfølgingsplan tidligere i oppfølgingstilfellet", async () => {
-      queryClient.setQueryData(
-        oppfolgingsplanForesporselQueryKeys.foresporsel(
-          ARBEIDSTAKER_DEFAULT.personIdent
-        ),
-        () => [existingForesporsel]
-      );
-      renderOppfolgingsplanerOversikt([]);
-
-      expect(screen.getByText("Det er ingen aktive oppfølgingsplaner")).to
-        .exist;
-      expect(
-        screen.getByText(
-          `Obs! Det ble bedt om oppfølgingsplan fra denne arbeidsgiveren ${tilLesbarDatoMedArUtenManedNavn(
-            existingForesporsel.createdAt
-          )}`
-        )
-      ).to.exist;
-      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
-
-      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
-    });
-    it("Sender forespørsel om oppfølgingsplan med document", async () => {
-      renderOppfolgingsplanerOversikt([]);
-
-      await clickButton("Send forespørsel");
-
-      const expectedForesporselRequest: NewOppfolgingsplanForesporselDTO = {
-        arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
-        virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-        narmestelederPersonident:
-          LEDERE_DEFAULT[0].narmesteLederPersonIdentNumber,
-        document: getExpectedForesporselDocument({
-          narmesteLeder: LEDERE_DEFAULT[0].narmesteLederNavn,
-          virksomhetNavn: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
-        }),
-      };
-
-      await waitFor(() => {
-        const foresporselMutation = queryClient
-          .getMutationCache()
-          .getAll()
-          .pop();
-        expect(foresporselMutation?.state.variables).to.deep.equal(
-          expectedForesporselRequest
-        );
-      });
     });
   });
 });

--- a/test/sider/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
+++ b/test/sider/oppfolgingsplaner/OppfolgingsplanerOversiktTest.tsx
@@ -9,6 +9,7 @@ import {
   ANNEN_LEDER_AKTIV,
   ARBEIDSTAKER_DEFAULT,
   LEDERE_DEFAULT,
+  VIRKSOMHET_BRANNOGBIL,
   VIRKSOMHET_PONTYPANDY,
 } from "@/mocks/common/mockConstants";
 import dayjs from "dayjs";
@@ -153,6 +154,69 @@ describe("OppfolgingsplanerOversikt", () => {
         })
       ).to.exist;
       expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
+    });
+    it("Viser be om oppfølgingsplan funksjonalitet om det ikke finnes aktiv oppfølgingsplan fra alle arbeidsgivere", () => {
+      queryClient.setQueryData(
+        ledereQueryKeys.ledere(ARBEIDSTAKER_DEFAULT.personIdent),
+        () => [...LEDERE_DEFAULT, ANNEN_LEDER_AKTIV]
+      );
+      renderOppfolgingsplanerOversikt([createOppfolgingsplanLps(10, false)]);
+
+      expect(screen.queryByText("Det er ingen aktive oppfølgingsplaner")).to.not
+        .exist;
+      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
+    });
+    it("Kan ikke be om oppfølgingsplan fra arbeidsgiver med aktiv oppfølgingsplan", () => {
+      queryClient.setQueryData(
+        ledereQueryKeys.ledere(ARBEIDSTAKER_DEFAULT.personIdent),
+        () => [...LEDERE_DEFAULT, ANNEN_LEDER_AKTIV]
+      );
+      renderOppfolgingsplanerOversikt([createOppfolgingsplanLps(10, false)]);
+
+      expect(screen.queryByText("Det er ingen aktive oppfølgingsplaner")).to.not
+        .exist;
+      expect(screen.getByText("Be om oppfølgingsplan")).to.exist;
+      expect(screen.getByRole("button", { name: "Send forespørsel" })).to.exist;
+
+      expect(screen.queryAllByRole("radio")).to.be.empty;
+      expect(screen.getByText("Virksomhet:")).to.exist;
+      expect(screen.getByText("Nærmeste leder:")).to.exist;
+      expect(screen.getByText(VIRKSOMHET_BRANNOGBIL.virksomhetsnavn)).to.exist;
+      expect(screen.getByText(ANNEN_LEDER_AKTIV.narmesteLederNavn)).to.exist;
+    });
+    it("Viser ikke be om oppfølgingsplan funksjonalitet om det finnes aktiv oppfølgingsplan fra alle arbeidsgiver", () => {
+      queryClient.setQueryData(
+        ledereQueryKeys.ledere(ARBEIDSTAKER_DEFAULT.personIdent),
+        () => [...LEDERE_DEFAULT, ANNEN_LEDER_AKTIV]
+      );
+      const oppfolgingsplanLPSDefaultVirksomhet = createOppfolgingsplanLps(
+        10,
+        false
+      );
+      const oppfolgingsplanLPSAnnenVirksomhet: OppfolgingsplanLPS = {
+        ...oppfolgingsplanLPSDefaultVirksomhet,
+        virksomhetsnummer: VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
+      };
+      renderOppfolgingsplanerOversikt([
+        oppfolgingsplanLPSDefaultVirksomhet,
+        oppfolgingsplanLPSAnnenVirksomhet,
+      ]);
+
+      expect(screen.queryByText("Det er ingen aktive oppfølgingsplaner")).to.not
+        .exist;
+      expect(screen.queryByText("Be om oppfølgingsplan")).to.not.exist;
+      expect(screen.queryByRole("button", { name: "Send forespørsel" })).to.not
+        .exist;
+    });
+    it("Viser ikke be om oppfølgingsplan funksjonalitet om det finnes aktiv oppfølgingsplan fra eneste arbeidsgiver", () => {
+      renderOppfolgingsplanerOversikt([createOppfolgingsplanLps(10, false)]);
+
+      expect(screen.queryByText("Det er ingen aktive oppfølgingsplaner")).to.not
+        .exist;
+      expect(screen.queryByText("Be om oppfølgingsplan")).to.not.exist;
+      expect(screen.queryByRole("button", { name: "Send forespørsel" })).to.not
+        .exist;
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger til valg av arbeidsgiver når det er flere aktive nærmeste ledere for det aktive oppfølgingstilfellet.
Når det bare er én nærmeste leder blir det som før, dvs valget vises ikke:
![image](https://github.com/user-attachments/assets/8640b793-84d0-4945-9f53-8f3a73b24ced)

Dersom det er flere vises radio-knapper med validering:
![image](https://github.com/user-attachments/assets/97f69dd1-989e-4ad1-9c9a-7a69299fb10d)
![image](https://github.com/user-attachments/assets/cd6e5b3d-75b3-4a62-be23-40c20eb97424)


Tanker? Burde vi f.eks vise radio-knapp uansett om det er én eller flere?

TODO

- [x] Flere tester når visningen er landet