### PR TITLE
IS-3061: Fix visning av møtebehov

### DIFF
--- a/src/mocks/syfomotebehov/motebehovMock.ts
+++ b/src/mocks/syfomotebehov/motebehovMock.ts
@@ -11,7 +11,7 @@ import {
 } from "@/data/motebehov/types/motebehovTypes";
 import { addDays } from "@/utils/datoUtils";
 
-const motebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
+const svartJaMotebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
   id: "11111111-ee10-44b6-bddf-54d049ef25f9",
   opprettetDato: addDays(new Date(), -25),
   aktorId: "1",
@@ -29,7 +29,7 @@ const motebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
   skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
 };
 
-export const motebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
+export const meldtMotebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
   id: "33333333-ee10-44b6-bddf-54d049ef25f2",
   opprettetDato: addDays(new Date(), -10),
   aktorId: "1",
@@ -47,26 +47,27 @@ export const motebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
 };
 
-export const motebehovArbeidsgiverMock: MotebehovVeilederDTO = {
-  id: "22222222-9e9b-40b0-bd1c-d1c39dc5f481",
-  opprettetDato: addDays(new Date(), -5),
-  aktorId: "1",
-  opprettetAv: "1902690001009",
-  opprettetAvNavn: "Are Arbeidsgiver",
-  arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
-  virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-  motebehovSvar: {
-    harMotebehov: false,
-    forklaring: "Jeg liker ikke møte!!",
-  },
-  tildeltEnhet: "0330",
-  behandletTidspunkt: null,
-  behandletVeilederIdent: null,
-  skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
-};
+export const svartNeiMotebehovArbeidsgiverUbehandletMock: MotebehovVeilederDTO =
+  {
+    id: "22222222-9e9b-40b0-bd1c-d1c39dc5f481",
+    opprettetDato: addDays(new Date(), -5),
+    aktorId: "1",
+    opprettetAv: "1902690001009",
+    opprettetAvNavn: "Are Arbeidsgiver",
+    arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    motebehovSvar: {
+      harMotebehov: false,
+      forklaring: "Jeg liker ikke møte!!",
+    },
+    tildeltEnhet: "0330",
+    behandletTidspunkt: null,
+    behandletVeilederIdent: null,
+    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+  };
 
 export const motebehovMock = [
-  motebehovArbeidstakerUbehandletMock,
-  motebehovArbeidstakerBehandletMock,
-  motebehovArbeidsgiverMock,
+  svartJaMotebehovArbeidstakerUbehandletMock,
+  meldtMotebehovArbeidstakerBehandletMock,
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
 ];

--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -5,7 +5,6 @@ import { InnkallingDialogmotePanel } from "./components/innkalling/InnkallingDia
 import SideLaster from "../../components/SideLaster";
 import { DialogmoteOnskePanel } from "./motebehov/DialogmoteOnskePanel";
 import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
-import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { DialogmoteFerdigstilteReferatPanel } from "@/sider/dialogmoter/components/DialogmoteFerdigstilteReferatPanel";
 import { DialogmoteStatus } from "@/data/dialogmote/types/dialogmoteTypes";
@@ -16,14 +15,6 @@ import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import { MotehistorikkPanel } from "@/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel";
 import { MoteSvarHistorikk } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk";
 import MotebehovHistorikk from "@/sider/dialogmoter/components/motehistorikk/MotebehovHistorikk";
-import {
-  getMotebehovInActiveTilfelle,
-  getUbehandletSvarOgMeldtBehov,
-  sorterMotebehovDataEtterDato,
-} from "@/utils/motebehovUtils";
-import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
-import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
-import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 
 const texts = {
   pageTitle: "Møtelandingsside",
@@ -42,41 +33,14 @@ export function Motelandingsside() {
     isError: henterDialogmoteunntakFeilet,
     isLoading: henterDialogmoteunntak,
   } = useDialogmoteunntakQuery();
-  const useGetMotebehov = useMotebehovQuery();
   const { isLoading: henterLedere, isError: henterLedereFeilet } =
     useLedereQuery();
 
-  const henter =
-    henterDialogmoter ||
-    henterDialogmoteunntak ||
-    useGetMotebehov.isLoading ||
-    henterLedere;
+  const henter = henterDialogmoter || henterDialogmoteunntak || henterLedere;
   const hentingFeilet =
     henterLedereFeilet ||
-    useGetMotebehov.isError ||
     henterDialogmoterFeilet ||
     henterDialogmoteunntakFeilet;
-
-  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
-
-  function showDialogmotebehovPanel(
-    motebehov: MotebehovVeilederDTO[],
-    latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
-  ): boolean {
-    const motebehovInLatestOppfolgingstilfelle = getMotebehovInActiveTilfelle(
-      motebehov?.sort(sorterMotebehovDataEtterDato),
-      latestOppfolgingstilfelle
-    );
-
-    if (
-      motebehovInLatestOppfolgingstilfelle.length > 0 &&
-      latestOppfolgingstilfelle
-    ) {
-      return true;
-    } else {
-      return getUbehandletSvarOgMeldtBehov(motebehov).length > 0;
-    }
-  }
 
   return (
     <Side tittel={texts.pageTitle} aktivtMenypunkt={Menypunkter.DIALOGMOTE}>
@@ -85,10 +49,7 @@ export function Motelandingsside() {
 
         <Tredelt.Container>
           <Tredelt.FirstColumn>
-            {showDialogmotebehovPanel(
-              useGetMotebehov.data,
-              latestOppfolgingstilfelle
-            ) && <DialogmoteOnskePanel />}
+            <DialogmoteOnskePanel />
             <InnkallingDialogmotePanel aktivtDialogmote={aktivtDialogmote} />
             <DialogmoteFerdigstilteReferatPanel
               ferdigstilteMoter={historiskeDialogmoter.filter(

--- a/src/sider/dialogmoter/motebehov/DialogmoteOnskePanel.tsx
+++ b/src/sider/dialogmoter/motebehov/DialogmoteOnskePanel.tsx
@@ -5,7 +5,7 @@ import { DialogmotePanel } from "@/sider/dialogmoter/components/DialogmotePanel"
 import React from "react";
 
 const texts = {
-  onskerOmDialogmote: "Behov om dialogmøte",
+  onskerOmDialogmote: "Behov for dialogmøte",
 };
 
 export const DialogmoteOnskePanel = () => {

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -25,7 +25,7 @@ export const arbeidsgiverNavnEllerTomStreng = (lederNavn: string | null) => {
   return lederNavn ? `${lederNavn}` : "";
 };
 
-export const setSvarTekst = (
+export const getSvarTekst = (
   skjemaType: MotebehovSkjemaType | null,
   deltakerOnskerMote?: boolean
 ) => {
@@ -74,7 +74,7 @@ const composePersonSvarText = (
   harMotebehov?: boolean,
   svarOpprettetDato?: Date
 ) => {
-  const svarResultat = setSvarTekst(skjemaType, harMotebehov);
+  const svarResultat = getSvarTekst(skjemaType, harMotebehov);
   const opprettetDato = svarOpprettetDato
     ? " - " + tilLesbarDatoMedArUtenManedNavn(svarOpprettetDato)
     : undefined;
@@ -277,28 +277,34 @@ function UbehandledeMotebehovUtenforTilfelle({
   const ubehandledeEldreMotebehov = getUbehandletSvarOgMeldtBehov(
     sorterteMotebehovUtenforTilfelle
   );
-  const motebehovArbeidstaker = ubehandledeEldreMotebehov.find(
+  const ubehandletMotebehovArbeidstaker = ubehandledeEldreMotebehov.find(
     isArbeidstakerMotebehov
   );
-  const motebehovArbeidsgiver = ubehandledeEldreMotebehov.find(
+  const ubehandletMotebehovArbeidsgiver = ubehandledeEldreMotebehov.find(
     (motebehov) => !isArbeidstakerMotebehov(motebehov)
   );
 
-  return motebehovArbeidstaker || motebehovArbeidsgiver ? (
+  const harUbehandledeMotebehov = !!(
+    (ubehandletMotebehovArbeidstaker || ubehandletMotebehovArbeidsgiver) &&
+    (ubehandletMotebehovArbeidstaker?.motebehovSvar?.harMotebehov ||
+      ubehandletMotebehovArbeidsgiver?.motebehovSvar?.harMotebehov)
+  );
+
+  return harUbehandledeMotebehov ? (
     <div className="flex flex-col gap-2">
       <BodyShort size="small">
         Ubehandlede møtebehov fra tidligere oppfølgingstilfelle:
       </BodyShort>
-      {motebehovArbeidstaker && (
+      {ubehandletMotebehovArbeidstaker && (
         <MotebehovKvitteringInnholdArbeidstaker
-          arbeidstakersMotebehov={motebehovArbeidstaker}
-          skjemaType={motebehovArbeidstaker?.skjemaType ?? null}
+          arbeidstakersMotebehov={ubehandletMotebehovArbeidstaker}
+          skjemaType={ubehandletMotebehovArbeidstaker?.skjemaType ?? null}
         />
       )}
-      {motebehovArbeidsgiver && (
+      {ubehandletMotebehovArbeidsgiver && (
         <MotebehovArbeidsgiverKvittering
-          motebehov={motebehovArbeidsgiver}
-          skjemaType={motebehovArbeidsgiver?.skjemaType ?? null}
+          motebehov={ubehandletMotebehovArbeidsgiver}
+          skjemaType={ubehandletMotebehovArbeidsgiver?.skjemaType ?? null}
         />
       )}
     </div>

--- a/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
@@ -48,6 +48,8 @@ export default function MotebehovKvitteringInnhold({
             <i>{motebehov?.motebehovSvar?.forklaring}</i>
           </VStack>
         )}
+        {motebehov?.behandletTidspunkt &&
+          "Behandlet: " + motebehov?.behandletTidspunkt}
       </VStack>
     </div>
   );

--- a/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
@@ -35,7 +35,7 @@ export default function MotebehovKvitteringInnhold({
   tekst,
 }: Props) {
   return (
-    <div className="flex items-center mt-4">
+    <div className="flex items-center">
       <img
         src={setSvarIkon(deltakerOnskerMote)}
         alt={ikonAltTekst}
@@ -48,8 +48,6 @@ export default function MotebehovKvitteringInnhold({
             <i>{motebehov?.motebehovSvar?.forklaring}</i>
           </VStack>
         )}
-        {motebehov?.behandletTidspunkt &&
-          "Behandlet: " + motebehov?.behandletTidspunkt}
       </VStack>
     </div>
   );

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner.tsx
@@ -18,7 +18,7 @@ const texts = {
   ingenAktiveOppfolgingsplaner: "Det er ingen aktive oppfølgingsplaner",
 };
 
-function activeNarmesteLederForCurrentOppfolgingstilfelle(
+export function activeNarmesteLederForCurrentOppfolgingstilfelle(
   ledere: NarmesteLederRelasjonDTO[],
   oppfolgingsTilfelle: OppfolgingstilfelleDTO
 ): NarmesteLederRelasjonDTO[] {

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -93,6 +93,15 @@ export const motebehovUbehandlet = (
   );
 };
 
+export const getUbehandletSvarOgMeldtBehov = (
+  motebehovListe: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO[] => {
+  return motebehovListe.filter(
+    (motebehov) =>
+      !motebehov.behandletTidspunkt && !motebehov.behandletVeilederIdent
+  );
+};
+
 const erAlleMotebehovSvarBehandlet = (
   motebehovListe: MotebehovVeilederDTO[]
 ): boolean => {
@@ -173,6 +182,17 @@ export const motebehovFromLatestActiveTilfelle = (
   } else {
     return motebehovUbehandlet(sortertMotebehovListe);
   }
+};
+
+export const getMotebehovInActiveTilfelle = (
+  sortertMotebehovListe: MotebehovVeilederDTO[],
+  latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
+): MotebehovVeilederDTO[] => {
+  return sortertMotebehovListe.filter(
+    (motebehov) =>
+      latestOppfolgingstilfelle &&
+      motebehov.opprettetDato >= latestOppfolgingstilfelle.start
+  );
 };
 
 export const toMotebehovTilbakemeldingDTO = (

--- a/test/containers/MotelandingssideContainerTest.tsx
+++ b/test/containers/MotelandingssideContainerTest.tsx
@@ -21,11 +21,6 @@ import { MemoryRouter } from "react-router-dom";
 import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { dialogmoteunntakQueryKeys } from "@/data/dialogmotekandidat/dialogmoteunntakQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
-import {
-  svartNeiMotebehovArbeidsgiverUbehandletMock,
-  meldtMotebehovArbeidstakerBehandletMock,
-} from "@/mocks/syfomotebehov/motebehovMock";
-import { addDays } from "@/utils/datoUtils";
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: any;
@@ -118,103 +113,5 @@ describe("MotelandingssideSide", () => {
         name: "Planlegg nytt dialogmøte",
       })
     ).to.exist;
-  });
-
-  it("Viser ønskepanel når det finnes møtebehov innenfor tilfelle", () => {
-    queryClient.setQueryData(
-      tilgangQueryKeys.tilgang(fnr),
-      () => tilgangBrukerMock
-    );
-    queryClient.setQueryData(
-      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [
-        {
-          ...meldtMotebehovArbeidstakerBehandletMock,
-          opprettetDato: addDays(new Date(), -1),
-          behandletTidspunkt: null,
-          behandletVeilederIdent: null,
-        },
-      ]
-    );
-    renderMotelandingsside();
-
-    expect(
-      screen.getByRole("heading", {
-        name: "Behov om dialogmøte",
-      })
-    ).to.exist;
-  });
-
-  it("Viser ønskepanel når det finnes behandlet møtebehov innenfor tilfelle", () => {
-    queryClient.setQueryData(
-      tilgangQueryKeys.tilgang(fnr),
-      () => tilgangBrukerMock
-    );
-    queryClient.setQueryData(
-      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [
-        {
-          ...svartNeiMotebehovArbeidsgiverUbehandletMock,
-          opprettetDato: addDays(new Date(), -2),
-          behandletTidspunkt: addDays(new Date(), -1),
-          behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
-        },
-        {
-          ...meldtMotebehovArbeidstakerBehandletMock,
-        },
-      ]
-    );
-    renderMotelandingsside();
-
-    expect(
-      screen.getByRole("heading", {
-        name: "Behov om dialogmøte",
-      })
-    ).to.exist;
-  });
-  it("Viser ønskepanel når det finnes ubehandlet møtebehov utenfor tilfelle", () => {
-    queryClient.setQueryData(
-      tilgangQueryKeys.tilgang(fnr),
-      () => tilgangBrukerMock
-    );
-    queryClient.setQueryData(
-      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [
-        {
-          ...meldtMotebehovArbeidstakerBehandletMock,
-          opprettetDato: addDays(new Date(), -50),
-          behandletTidspunkt: null,
-          behandletVeilederIdent: null,
-        },
-      ]
-    );
-    renderMotelandingsside();
-
-    expect(
-      screen.getByRole("heading", {
-        name: "Behov om dialogmøte",
-      })
-    ).to.exist;
-  });
-
-  it("Viser ikke ønskepanel når det finnes ubehandlet møtebehov utenfor tilfelle", () => {
-    queryClient.setQueryData(
-      tilgangQueryKeys.tilgang(fnr),
-      () => tilgangBrukerMock
-    );
-    queryClient.setQueryData(
-      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [
-        {
-          ...meldtMotebehovArbeidstakerBehandletMock,
-          opprettetDato: addDays(new Date(), -5),
-          behandletTidspunkt: addDays(new Date(), -1),
-          behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
-        },
-      ]
-    );
-    renderMotelandingsside();
-
-    expect(screen.queryByText("Behov om dialogmøte")).to.not.exist;
   });
 });

--- a/test/containers/MotelandingssideContainerTest.tsx
+++ b/test/containers/MotelandingssideContainerTest.tsx
@@ -21,6 +21,11 @@ import { MemoryRouter } from "react-router-dom";
 import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { dialogmoteunntakQueryKeys } from "@/data/dialogmotekandidat/dialogmoteunntakQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
+import {
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
+  meldtMotebehovArbeidstakerBehandletMock,
+} from "@/mocks/syfomotebehov/motebehovMock";
+import { addDays } from "@/utils/datoUtils";
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: any;
@@ -113,5 +118,103 @@ describe("MotelandingssideSide", () => {
         name: "Planlegg nytt dialogmøte",
       })
     ).to.exist;
+  });
+
+  it("Viser ønskepanel når det finnes møtebehov innenfor tilfelle", () => {
+    queryClient.setQueryData(
+      tilgangQueryKeys.tilgang(fnr),
+      () => tilgangBrukerMock
+    );
+    queryClient.setQueryData(
+      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...meldtMotebehovArbeidstakerBehandletMock,
+          opprettetDato: addDays(new Date(), -1),
+          behandletTidspunkt: null,
+          behandletVeilederIdent: null,
+        },
+      ]
+    );
+    renderMotelandingsside();
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Behov om dialogmøte",
+      })
+    ).to.exist;
+  });
+
+  it("Viser ønskepanel når det finnes behandlet møtebehov innenfor tilfelle", () => {
+    queryClient.setQueryData(
+      tilgangQueryKeys.tilgang(fnr),
+      () => tilgangBrukerMock
+    );
+    queryClient.setQueryData(
+      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+          opprettetDato: addDays(new Date(), -2),
+          behandletTidspunkt: addDays(new Date(), -1),
+          behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
+        },
+        {
+          ...meldtMotebehovArbeidstakerBehandletMock,
+        },
+      ]
+    );
+    renderMotelandingsside();
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Behov om dialogmøte",
+      })
+    ).to.exist;
+  });
+  it("Viser ønskepanel når det finnes ubehandlet møtebehov utenfor tilfelle", () => {
+    queryClient.setQueryData(
+      tilgangQueryKeys.tilgang(fnr),
+      () => tilgangBrukerMock
+    );
+    queryClient.setQueryData(
+      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...meldtMotebehovArbeidstakerBehandletMock,
+          opprettetDato: addDays(new Date(), -50),
+          behandletTidspunkt: null,
+          behandletVeilederIdent: null,
+        },
+      ]
+    );
+    renderMotelandingsside();
+
+    expect(
+      screen.getByRole("heading", {
+        name: "Behov om dialogmøte",
+      })
+    ).to.exist;
+  });
+
+  it("Viser ikke ønskepanel når det finnes ubehandlet møtebehov utenfor tilfelle", () => {
+    queryClient.setQueryData(
+      tilgangQueryKeys.tilgang(fnr),
+      () => tilgangBrukerMock
+    );
+    queryClient.setQueryData(
+      motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => [
+        {
+          ...meldtMotebehovArbeidstakerBehandletMock,
+          opprettetDato: addDays(new Date(), -5),
+          behandletTidspunkt: addDays(new Date(), -1),
+          behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
+        },
+      ]
+    );
+    renderMotelandingsside();
+
+    expect(screen.queryByText("Behov om dialogmøte")).to.not.exist;
   });
 });

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -276,4 +276,19 @@ describe("MotebehovKvittering", () => {
     expect(screen.getByText("Jeg, arbeidsgiver, svarer nei til møte.")).to
       .exist;
   });
+  it("viser ingen møtebehov når nei-svar utenfor tilfelle, fordi disse kan ikke behandles", () => {
+    const motebehovArbeidsgiverUtenforTilfelleUbehandlet =
+      createMotebehovUtenforTilfelle(
+        motebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock
+      );
+
+    mockMotebehov([motebehovArbeidsgiverUtenforTilfelleUbehandlet]);
+
+    renderMotebehovKvittering();
+    expect(
+      screen.getByText(
+        "Alle tidligere møtebehov er behandlet, se møtebehovhistorikken for flere detaljer."
+      )
+    ).to.exist;
+  });
 });

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -36,7 +36,7 @@ function mockMotebehov(motebehov: MotebehovVeilederDTO[]) {
   );
 }
 
-const MotebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
+const motebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
   ...meldtMotebehovArbeidstakerBehandletMock,
   opprettetDato: addDays(new Date(), -25),
   motebehovSvar: {
@@ -48,7 +48,7 @@ const MotebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
 };
 
-const MotebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
+const motebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
   ...svartNeiMotebehovArbeidsgiverUbehandletMock,
   opprettetDato: addDays(new Date(), -25),
   motebehovSvar: {
@@ -60,7 +60,7 @@ const MotebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
 };
 
-const MotebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO =
+const motebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO =
   {
     ...meldtMotebehovArbeidstakerBehandletMock,
     opprettetDato: addDays(new Date(), -25),
@@ -73,7 +73,7 @@ const MotebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO
     skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
   };
 
-const MotebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock: MotebehovVeilederDTO =
+const motebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock: MotebehovVeilederDTO =
   {
     ...svartNeiMotebehovArbeidsgiverUbehandletMock,
     opprettetDato: addDays(new Date(), -25),
@@ -109,17 +109,17 @@ describe("MotebehovKvittering", () => {
     mockMotebehov([]);
 
     renderMotebehovKvittering();
-    expect(screen.getByText("Ingen tidligere møtebehov")).to.exist; //TODO: Hva ønsker vi skal vises i dette tilfelle?
+    expect(screen.getByText("Ingen tidligere møtebehov")).to.exist;
   });
   it("viser meldt møtebehov fra arbeidsgiver og sykmeldt innenfor tilfelle", () => {
     mockMotebehov([
-      MotebehovArbeidstakerInTilfelleUbehandletMock,
-      MotebehovArbeidsgiverInTilfelleUbehandletMock,
+      motebehovArbeidstakerInTilfelleUbehandletMock,
+      motebehovArbeidsgiverInTilfelleUbehandletMock,
     ]);
 
     renderMotebehovKvittering();
 
-    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(screen.getByAltText("Sykmeldt Meldt behov.")).to.exist;
     expect(
       screen.getByText("Samuel Sam Jones, har meldt behov", {
         exact: false,
@@ -127,7 +127,7 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
     expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart ja.")).to
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Meldt behov.")).to
       .exist;
     expect(
       screen.getByText("Are Arbeidsgiver, har meldt behov", {
@@ -137,10 +137,10 @@ describe("MotebehovKvittering", () => {
     expect(screen.getByText("Jeg, arbeidsgiver, har behov for møte.")).to.exist;
   });
   it("viser meldt møtebehov fra arbeidsgiver og sykmeldt når kun sykmeldt har meldt behov innenfor tilfelle", () => {
-    mockMotebehov([MotebehovArbeidstakerInTilfelleUbehandletMock]);
+    mockMotebehov([motebehovArbeidstakerInTilfelleUbehandletMock]);
 
     renderMotebehovKvittering();
-    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(screen.getByAltText("Sykmeldt Meldt behov.")).to.exist;
     expect(
       screen.getByText("Samuel Sam Jones, har meldt behov", {
         exact: false,
@@ -148,8 +148,9 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
     expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke svart.")).to
-      .exist;
+    expect(
+      screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke meldt behov.")
+    ).to.exist;
     expect(
       screen.getByText("Tatten Tattover, har ikke meldt behov", {
         exact: false,
@@ -157,17 +158,17 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
   });
   it("viser meldt møtebehov fra arbeidsgiver og sykmeldt når kun arbeidsgiver har meldt behov innenfor tilfelle", () => {
-    mockMotebehov([MotebehovArbeidsgiverInTilfelleUbehandletMock]);
+    mockMotebehov([motebehovArbeidsgiverInTilfelleUbehandletMock]);
 
     renderMotebehovKvittering();
-    expect(screen.getByAltText("Sykmeldt Ikke svart.")).to.exist;
+    expect(screen.getByAltText("Sykmeldt Ikke meldt behov.")).to.exist;
     expect(
       screen.getByText("Samuel Sam Jones, har ikke meldt behov", {
         exact: false,
       })
     ).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart ja.")).to
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Meldt behov.")).to
       .exist;
     expect(
       screen.getByText("Are Arbeidsgiver, har meldt behov", {
@@ -178,13 +179,13 @@ describe("MotebehovKvittering", () => {
   });
   it("viser ingen møtebehov når ingen ubehandlede behov utenfor tilfelle", () => {
     const motebehovArbeidstakerInTilfelleBehandlet = createMotebehovBehandlet(
-      MotebehovArbeidstakerInTilfelleUbehandletMock
+      motebehovArbeidstakerInTilfelleUbehandletMock
     );
     const motebehovArbeidstakerUtenforTilfelleBehandlet =
       createMotebehovUtenforTilfelle(motebehovArbeidstakerInTilfelleBehandlet);
 
     const motebehovArbeidsgiverInTilfelleBehandlet = createMotebehovBehandlet(
-      MotebehovArbeidsgiverInTilfelleUbehandletMock
+      motebehovArbeidsgiverInTilfelleUbehandletMock
     );
     const motebehovArbeidsgiverUtenforTilfelleBehandlet =
       createMotebehovUtenforTilfelle(motebehovArbeidsgiverInTilfelleBehandlet);
@@ -195,16 +196,20 @@ describe("MotebehovKvittering", () => {
     ]);
 
     renderMotebehovKvittering();
-    expect(screen.getByText("Ingen tidligere møtebehov")).to.exist; //TODO: Hva ønsker vi skal vises i dette tilfelle?
+    expect(
+      screen.getByText(
+        "Alle tidligere møtebehov er behandlet, se møtebehovhistorikken for flere detaljer."
+      )
+    ).to.exist;
   });
   it("viser ubehandlede møtebehov når det finnes ubehandlede behov utenfor tilfelle", () => {
     const motebehovArbeidstakerUtenforTilfelleUbehandlet =
       createMotebehovUtenforTilfelle(
-        MotebehovArbeidstakerInTilfelleUbehandletMock
+        motebehovArbeidstakerInTilfelleUbehandletMock
       );
     const motebehovArbeidsgiverUtenforTilfelleUbehandlet =
       createMotebehovUtenforTilfelle(
-        MotebehovArbeidsgiverInTilfelleUbehandletMock
+        motebehovArbeidsgiverInTilfelleUbehandletMock
       );
 
     mockMotebehov([
@@ -213,7 +218,7 @@ describe("MotebehovKvittering", () => {
     ]);
 
     renderMotebehovKvittering();
-    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(screen.getByAltText("Sykmeldt Meldt behov.")).to.exist;
     expect(
       screen.getByText("Samuel Sam Jones, har meldt behov", {
         exact: false,
@@ -221,7 +226,7 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
     expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart ja.")).to
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Meldt behov.")).to
       .exist;
     expect(
       screen.getByText("Are Arbeidsgiver, har meldt behov", {
@@ -231,7 +236,7 @@ describe("MotebehovKvittering", () => {
     expect(screen.getByText("Jeg, arbeidsgiver, har behov for møte.")).to.exist;
   });
   it("viser svar møtebehov fra arbeidsgiver og sykmeldt når kun sykmeldt har svart behov innenfor tilfelle", () => {
-    mockMotebehov([MotebehovArbeidstakerInTilfelleSvartJaUbehandletMock]);
+    mockMotebehov([motebehovArbeidstakerInTilfelleSvartJaUbehandletMock]);
 
     renderMotebehovKvittering();
     expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
@@ -251,7 +256,7 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
   });
   it("viser svar møtebehov fra arbeidsgiver og sykmeldt når kun arbeidsgiver har svart behov innenfor tilfelle", () => {
-    mockMotebehov([MotebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock]);
+    mockMotebehov([motebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock]);
 
     renderMotebehovKvittering();
     expect(screen.getByAltText("Sykmeldt Ikke svart.")).to.exist;

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -1,0 +1,274 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { queryClientWithMockData } from "../../testQueryClient";
+import React from "react";
+import MotebehovKvittering from "@/sider/dialogmoter/motebehov/MotebehovKvittering";
+import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
+import {
+  ARBEIDSTAKER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
+} from "@/mocks/common/mockConstants";
+import {
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
+  meldtMotebehovArbeidstakerBehandletMock,
+} from "@/mocks/syfomotebehov/motebehovMock";
+import {
+  MotebehovSkjemaType,
+  MotebehovVeilederDTO,
+} from "@/data/motebehov/types/motebehovTypes";
+import { addDays, addWeeks } from "@/utils/datoUtils";
+
+let queryClient: QueryClient;
+
+const renderMotebehovKvittering = () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MotebehovKvittering />
+    </QueryClientProvider>
+  );
+};
+
+function mockMotebehov(motebehov: MotebehovVeilederDTO[]) {
+  queryClient.setQueryData(
+    motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => motebehov
+  );
+}
+
+const MotebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
+  ...meldtMotebehovArbeidstakerBehandletMock,
+  opprettetDato: addDays(new Date(), -25),
+  motebehovSvar: {
+    harMotebehov: true,
+    forklaring: "Jeg, arbeidstaker, har behov for møte.",
+  },
+  behandletTidspunkt: null,
+  behandletVeilederIdent: null,
+  skjemaType: MotebehovSkjemaType.MELD_BEHOV,
+};
+
+const MotebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
+  ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+  opprettetDato: addDays(new Date(), -25),
+  motebehovSvar: {
+    harMotebehov: true,
+    forklaring: "Jeg, arbeidsgiver, har behov for møte.",
+  },
+  behandletTidspunkt: null,
+  behandletVeilederIdent: null,
+  skjemaType: MotebehovSkjemaType.MELD_BEHOV,
+};
+
+const MotebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO =
+  {
+    ...meldtMotebehovArbeidstakerBehandletMock,
+    opprettetDato: addDays(new Date(), -25),
+    motebehovSvar: {
+      harMotebehov: true,
+      forklaring: "Jeg, arbeidstaker, svarer ja til møte.",
+    },
+    behandletTidspunkt: null,
+    behandletVeilederIdent: null,
+    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+  };
+
+const MotebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock: MotebehovVeilederDTO =
+  {
+    ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+    opprettetDato: addDays(new Date(), -25),
+    motebehovSvar: {
+      harMotebehov: false,
+      forklaring: "Jeg, arbeidsgiver, svarer nei til møte.",
+    },
+    behandletTidspunkt: null,
+    behandletVeilederIdent: null,
+    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+  };
+
+function createMotebehovBehandlet(motebehov: MotebehovVeilederDTO) {
+  return {
+    ...motebehov,
+    behandletTidspunkt: addDays(new Date(), -1),
+    behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
+  };
+}
+
+function createMotebehovUtenforTilfelle(motebehov: MotebehovVeilederDTO) {
+  return {
+    ...motebehov,
+    opprettetDato: addWeeks(new Date(), -50),
+  };
+}
+
+describe("MotebehovKvittering", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+  it("Ingen møtebehov", () => {
+    mockMotebehov([]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByText("Ingen tidligere møtebehov")).to.exist; //TODO: Hva ønsker vi skal vises i dette tilfelle?
+  });
+  it("viser meldt møtebehov fra arbeidsgiver og sykmeldt innenfor tilfelle", () => {
+    mockMotebehov([
+      MotebehovArbeidstakerInTilfelleUbehandletMock,
+      MotebehovArbeidsgiverInTilfelleUbehandletMock,
+    ]);
+
+    renderMotebehovKvittering();
+
+    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(
+      screen.getByText("Samuel Sam Jones, har meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
+
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart ja.")).to
+      .exist;
+    expect(
+      screen.getByText("Are Arbeidsgiver, har meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidsgiver, har behov for møte.")).to.exist;
+  });
+  it("viser meldt møtebehov fra arbeidsgiver og sykmeldt når kun sykmeldt har meldt behov innenfor tilfelle", () => {
+    mockMotebehov([MotebehovArbeidstakerInTilfelleUbehandletMock]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(
+      screen.getByText("Samuel Sam Jones, har meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
+
+    expect(screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke svart.")).to
+      .exist;
+    expect(
+      screen.getByText("Tatten Tattover, har ikke meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+  });
+  it("viser meldt møtebehov fra arbeidsgiver og sykmeldt når kun arbeidsgiver har meldt behov innenfor tilfelle", () => {
+    mockMotebehov([MotebehovArbeidsgiverInTilfelleUbehandletMock]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByAltText("Sykmeldt Ikke svart.")).to.exist;
+    expect(
+      screen.getByText("Samuel Sam Jones, har ikke meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart ja.")).to
+      .exist;
+    expect(
+      screen.getByText("Are Arbeidsgiver, har meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidsgiver, har behov for møte.")).to.exist;
+  });
+  it("viser ingen møtebehov når ingen ubehandlede behov utenfor tilfelle", () => {
+    const motebehovArbeidstakerInTilfelleBehandlet = createMotebehovBehandlet(
+      MotebehovArbeidstakerInTilfelleUbehandletMock
+    );
+    const motebehovArbeidstakerUtenforTilfelleBehandlet =
+      createMotebehovUtenforTilfelle(motebehovArbeidstakerInTilfelleBehandlet);
+
+    const motebehovArbeidsgiverInTilfelleBehandlet = createMotebehovBehandlet(
+      MotebehovArbeidsgiverInTilfelleUbehandletMock
+    );
+    const motebehovArbeidsgiverUtenforTilfelleBehandlet =
+      createMotebehovUtenforTilfelle(motebehovArbeidsgiverInTilfelleBehandlet);
+
+    mockMotebehov([
+      motebehovArbeidstakerUtenforTilfelleBehandlet,
+      motebehovArbeidsgiverUtenforTilfelleBehandlet,
+    ]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByText("Ingen tidligere møtebehov")).to.exist; //TODO: Hva ønsker vi skal vises i dette tilfelle?
+  });
+  it("viser ubehandlede møtebehov når det finnes ubehandlede behov utenfor tilfelle", () => {
+    const motebehovArbeidstakerUtenforTilfelleUbehandlet =
+      createMotebehovUtenforTilfelle(
+        MotebehovArbeidstakerInTilfelleUbehandletMock
+      );
+    const motebehovArbeidsgiverUtenforTilfelleUbehandlet =
+      createMotebehovUtenforTilfelle(
+        MotebehovArbeidsgiverInTilfelleUbehandletMock
+      );
+
+    mockMotebehov([
+      motebehovArbeidstakerUtenforTilfelleUbehandlet,
+      motebehovArbeidsgiverUtenforTilfelleUbehandlet,
+    ]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(
+      screen.getByText("Samuel Sam Jones, har meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
+
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart ja.")).to
+      .exist;
+    expect(
+      screen.getByText("Are Arbeidsgiver, har meldt behov", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidsgiver, har behov for møte.")).to.exist;
+  });
+  it("viser svar møtebehov fra arbeidsgiver og sykmeldt når kun sykmeldt har svart behov innenfor tilfelle", () => {
+    mockMotebehov([MotebehovArbeidstakerInTilfelleSvartJaUbehandletMock]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByAltText("Sykmeldt Svart ja.")).to.exist;
+    expect(
+      screen.getByText("Samuel Sam Jones, har svart JA", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidstaker, svarer ja til møte.")).to.exist;
+
+    expect(screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke svart.")).to
+      .exist;
+    expect(
+      screen.getByText("Tatten Tattover, har ikke svart", {
+        exact: false,
+      })
+    ).to.exist;
+  });
+  it("viser svar møtebehov fra arbeidsgiver og sykmeldt når kun arbeidsgiver har svart behov innenfor tilfelle", () => {
+    mockMotebehov([MotebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock]);
+
+    renderMotebehovKvittering();
+    expect(screen.getByAltText("Sykmeldt Ikke svart.")).to.exist;
+    expect(
+      screen.getByText("Samuel Sam Jones, har ikke svart", {
+        exact: false,
+      })
+    ).to.exist;
+
+    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart nei.")).to
+      .exist;
+    expect(
+      screen.getByText("Are Arbeidsgiver, har svart NEI", {
+        exact: false,
+      })
+    ).to.exist;
+    expect(screen.getByText("Jeg, arbeidsgiver, svarer nei til møte.")).to
+      .exist;
+  });
+});

--- a/test/dialogmote/MotebehovHistorikkTest.tsx
+++ b/test/dialogmote/MotebehovHistorikkTest.tsx
@@ -7,8 +7,8 @@ import MotebehovHistorikk from "@/sider/dialogmoter/components/motehistorikk/Mot
 import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
 import {
-  motebehovArbeidsgiverMock,
-  motebehovArbeidstakerBehandletMock,
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
+  meldtMotebehovArbeidstakerBehandletMock,
   motebehovMock,
 } from "@/mocks/syfomotebehov/motebehovMock";
 
@@ -58,7 +58,7 @@ describe("MotebehovHistorikk", () => {
   it("viser kun møtebehov fra arbeidsgiver", () => {
     queryClient.setQueryData(
       motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [motebehovArbeidsgiverMock]
+      () => [svartNeiMotebehovArbeidsgiverUbehandletMock]
     );
 
     renderMotebehovHistorikk();
@@ -71,7 +71,7 @@ describe("MotebehovHistorikk", () => {
   it("viser kun møtebehov fra arbeidstaker", () => {
     queryClient.setQueryData(
       motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [motebehovArbeidstakerBehandletMock]
+      () => [meldtMotebehovArbeidstakerBehandletMock]
     );
 
     renderMotebehovHistorikk();
@@ -84,7 +84,7 @@ describe("MotebehovHistorikk", () => {
   it("viser at møtebehovet er behandlet", () => {
     queryClient.setQueryData(
       motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [motebehovArbeidstakerBehandletMock]
+      () => [meldtMotebehovArbeidstakerBehandletMock]
     );
 
     renderMotebehovHistorikk();


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret visningslogikk for møtebehovpanelet på dialogmøtesiden. 
- Konsekvent skille på meldt behov og svar behov, dermed fikset slik at det:
    - Vises svar fra arbeidsgiver og arbeidstaker i aktivt oppfølgingstilfelle, også hvis en av de ikke har svart
    - Vises meldt behov fra arbeidsgiver og arbeidstaker i aktivt oppfølgingstilfelle, også hvis en av de ikke har meldt behov
- Endret visningslogikk for motebehov i tilfelle slik at det: 
    - Viser ikke behandlet behov utenfor tilfelle

### Screenshots 📸✨
<details> <summary> Foreløpig utseende: </summary>
Meldt behov innenfor tilfelle:

![image](https://github.com/user-attachments/assets/83ff678f-ef0a-4075-adfa-766e1208e9f2)

Svart behov innenfor tilfelle: 
<img width="1004" alt="Skjermbilde 2025-02-11 kl  16 17 09" src="https://github.com/user-attachments/assets/094e064d-2624-4122-a0ca-60584be99bca" />

Ubehandlet behov utenfor tilfelle:
![image](https://github.com/user-attachments/assets/e87659b8-3d53-44db-aaf8-8e9e4ddc3be9)

Behandlet behov utenfor tilfelle:
![image](https://github.com/user-attachments/assets/7cc501eb-5411-4841-94ef-18ebc55916fa)

Ingen tidligere møtebehov:

<img width="1458" alt="Skjermbilde 2025-02-13 kl  10 09 27" src="https://github.com/user-attachments/assets/ecb53a77-c191-48bb-a56e-cb074a3a0ca2" />


</details>