### PR TITLE
IS-3091: add week number on datepicker oppfolgingsoppgave and avvent aktivitetskrav

### DIFF
--- a/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
+++ b/src/components/oppfolgingsoppgave/OppfolgingsoppgaveModal.tsx
@@ -69,6 +69,7 @@ function logOppfolgingsgrunnSendt(oppfolgingsgrunn: Oppfolgingsgrunn) {
     },
   });
 }
+
 function logOppfolgingsoppgaveEdited(
   oppfolgingsgrunn: Oppfolgingsgrunn,
   existingOppfolgingsoppgave: OppfolgingsoppgaveResponseDTO,
@@ -303,7 +304,7 @@ export const OppfolgingsoppgaveModal = ({
             </Alert>
           )}
 
-          <DatePicker {...datepickerProps} strategy="fixed">
+          <DatePicker {...datepickerProps} strategy="fixed" showWeekNumber>
             <DatePicker.Input {...inputProps} label={texts.datepickerLabel} />
           </DatePicker>
         </Modal.Body>

--- a/src/sider/aktivitetskrav/vurdering/AvventFristDato.tsx
+++ b/src/sider/aktivitetskrav/vurdering/AvventFristDato.tsx
@@ -34,7 +34,7 @@ export const AvventFristDato = () => {
   });
 
   return (
-    <DatePicker {...datepickerProps} strategy="fixed">
+    <DatePicker {...datepickerProps} strategy="fixed" showWeekNumber>
       <DatePicker.Input
         id={field.name}
         {...inputProps}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- lagt til ukenummer på datepicker til oppfølgingsoppgave og avvent aktivitetskrav

### Screenshots 📸✨
Oppfølgingsoppgave:
Før:
<img width="842" alt="Skjermbilde 2025-02-14 kl  15 32 46" src="https://github.com/user-attachments/assets/072ddd31-fc5a-48ab-955d-270326ecc11d" />

Etter:
<img width="826" alt="Skjermbilde 2025-02-14 kl  14 28 57" src="https://github.com/user-attachments/assets/79e55048-d0cb-4f13-b3b2-f430c7f9ef70" />

Avvent aktivitetskrav:
Før:
<img width="811" alt="Skjermbilde 2025-02-14 kl  15 33 11" src="https://github.com/user-attachments/assets/3eb78d10-12df-4562-9797-5c1f1c4013b4" />

Etter:
<img width="828" alt="Skjermbilde 2025-02-14 kl  14 39 28" src="https://github.com/user-attachments/assets/c5f6bf82-3699-4ded-9cd1-689ee7ecfabe" />

