### PR TITLE
IS-3087: Forespørsel om oppfølgingsplan i Historikk

### DIFF
--- a/src/data/historikk/types/historikkTypes.ts
+++ b/src/data/historikk/types/historikkTypes.ts
@@ -12,7 +12,8 @@ export type HistorikkEventType =
   | "SEN_OPPFOLGING"
   | "DIALOGMOTEKANDIDAT"
   | "OPPFOLGINGSOPPGAVE"
-  | "OPPFOLGINGSPLAN_LPS";
+  | "OPPFOLGINGSPLAN_LPS"
+  | "OPPFOLGINGSPLAN_FORESPORSEL";
 
 export interface HistorikkEvent {
   opprettetAv?: string;

--- a/src/hooks/historikk/useAktivitetskravHistorikk.ts
+++ b/src/hooks/historikk/useAktivitetskravHistorikk.ts
@@ -6,6 +6,7 @@ import {
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function getTextForHistorikk(
   historikk: AktivitetskravHistorikkDTO,
@@ -55,28 +56,22 @@ function createHistorikkEventsFromAktivitetskrav(
     });
 }
 
-interface AktivitetskravHistorikk {
-  isAktivitetskravHistorikkLoading: boolean;
-  isAktivitetskravHistorikkError: boolean;
-  aktivitetskravHistorikk: HistorikkEvent[];
-}
-
-export function useAktivitetskravHistorikk(): AktivitetskravHistorikk {
+export function useAktivitetskravHistorikk(): HistorikkHook {
   const { brukerinfo: person } = useBrukerinfoQuery();
   const {
     data: aktivitetskravHistorikk,
-    isLoading: isAktivitetskravHistorikkLoading,
-    isError: isAktivitetskravHistorikkError,
+    isLoading,
+    isError,
   } = useAktivitetskravHistorikkQuery();
 
-  const aktivitetskravHistorikkEvents = createHistorikkEventsFromAktivitetskrav(
+  const events = createHistorikkEventsFromAktivitetskrav(
     aktivitetskravHistorikk || [],
     person
   );
 
   return {
-    isAktivitetskravHistorikkLoading,
-    isAktivitetskravHistorikkError,
-    aktivitetskravHistorikk: aktivitetskravHistorikkEvents,
+    isLoading,
+    isError,
+    events,
   };
 }

--- a/src/hooks/historikk/useArbeidsuforhetHistorikk.ts
+++ b/src/hooks/historikk/useArbeidsuforhetHistorikk.ts
@@ -4,6 +4,7 @@ import {
   VurderingResponseDTO as ArbeidsuforhetVurderinger,
   VurderingType as ArbeidsuforhetVurderingType,
 } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function arbeidsuforhetText(
   veilederident: string,
@@ -36,17 +37,11 @@ function createHistorikkEventsFromArbeidsuforhet(
   );
 }
 
-interface ArbeidsuforhetHistorikk {
-  isArbeidsuforhetHistorikkLoading: boolean;
-  isArbeidsuforhetHistorikkError: boolean;
-  arbeidsuforhetHistorikk: HistorikkEvent[];
-}
-
-export function useArbeidsuforhetHistorikk(): ArbeidsuforhetHistorikk {
+export function useArbeidsuforhetHistorikk(): HistorikkHook {
   const {
     data: arbeidsuforhetVurderinger,
-    isLoading: isArbeidsuforhetLoading,
-    isError: isArbeidsuforhetError,
+    isLoading,
+    isError,
   } = useGetArbeidsuforhetVurderingerQuery();
 
   const arbeidsuforhetHistorikk = createHistorikkEventsFromArbeidsuforhet(
@@ -54,8 +49,8 @@ export function useArbeidsuforhetHistorikk(): ArbeidsuforhetHistorikk {
   );
 
   return {
-    isArbeidsuforhetHistorikkLoading: isArbeidsuforhetLoading,
-    isArbeidsuforhetHistorikkError: isArbeidsuforhetError,
-    arbeidsuforhetHistorikk,
+    isLoading,
+    isError,
+    events: arbeidsuforhetHistorikk,
   };
 }

--- a/src/hooks/historikk/useDialogmoteStatusEndringHistorikk.ts
+++ b/src/hooks/historikk/useDialogmoteStatusEndringHistorikk.ts
@@ -2,6 +2,7 @@ import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
 import { useDialogmoteStatusEndringHistorikkQuery } from "@/data/dialogmote/dialogmoteStatusEndringHistorikkQuery";
 import { DialogmoteStatusEndringDTO } from "@/data/dialogmote/types/dialogmoteStatusEndringTypes";
 import { DialogmoteStatus } from "@/data/dialogmote/types/dialogmoteTypes";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function getDialogmoteStatusEndringText(
   statusendring: DialogmoteStatusEndringDTO
@@ -33,13 +34,7 @@ function createHistorikkEvents(
   });
 }
 
-interface DialogmoteStatusEndringHistorikk {
-  isLoading: boolean;
-  isError: boolean;
-  events: HistorikkEvent[];
-}
-
-export function useDialogmoteStatusEndringHistorikk(): DialogmoteStatusEndringHistorikk {
+export function useDialogmoteStatusEndringHistorikk(): HistorikkHook {
   const {
     data: statusendringer,
     isLoading,

--- a/src/hooks/historikk/useDialogmotekandidatHistorikk.ts
+++ b/src/hooks/historikk/useDialogmotekandidatHistorikk.ts
@@ -6,6 +6,7 @@ import {
 } from "@/data/dialogmotekandidat/dialogmotekandidatTypes";
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
 import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function getDialogmotekandidatHistorikkText(
   { type, vurdertAv }: DialogmotekandidatHistorikkDTO,
@@ -35,18 +36,12 @@ function createHistorikkEventsFromDialogmotekandidatHistorikk(
   }));
 }
 
-interface DialogmotekandidatHistorikk {
-  isDialogmotekandidatHistorikkLoading: boolean;
-  isDialogmotekandidatHistorikkError: boolean;
-  dialogmotekandidatHistorikk: HistorikkEvent[];
-}
-
-export function useDialogmotekandidatHistorikk(): DialogmotekandidatHistorikk {
+export function useDialogmotekandidatHistorikk(): HistorikkHook {
   const { brukerinfo: person } = useBrukerinfoQuery();
   const {
     data: dialogmotekandidatHistorikk,
-    isLoading: isDialogmotekandidatHistorikkLoading,
-    isError: isDialogmotekandidatHistorikkError,
+    isLoading,
+    isError,
   } = useDialogmotekandidatHistorikkQuery();
 
   const dialogmotekandidatHistorikkEvents =
@@ -56,8 +51,8 @@ export function useDialogmotekandidatHistorikk(): DialogmotekandidatHistorikk {
     );
 
   return {
-    isDialogmotekandidatHistorikkLoading,
-    isDialogmotekandidatHistorikkError,
-    dialogmotekandidatHistorikk: dialogmotekandidatHistorikkEvents,
+    isLoading,
+    isError,
+    events: dialogmotekandidatHistorikkEvents,
   };
 }

--- a/src/hooks/historikk/useFriskmeldingTilArbeidsformidligVedtakHistorikk.ts
+++ b/src/hooks/historikk/useFriskmeldingTilArbeidsformidligVedtakHistorikk.ts
@@ -2,6 +2,7 @@ import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
 import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
 import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function friskTilArbeidText(vedtak: VedtakResponseDTO): string {
   const fom = tilLesbarDatoMedArUtenManedNavn(vedtak.fom);
@@ -22,25 +23,15 @@ function createHistorikkEventsFromFriskTilArbeid(
   });
 }
 
-interface VedtakHistorikk {
-  isVedtakHistorikkLoading: boolean;
-  isVedtakHistorikkError: boolean;
-  vedtakHistorikk: HistorikkEvent[];
-}
-
-export function useVedtakHistorikk(): VedtakHistorikk {
-  const {
-    data: vedtak,
-    isLoading: isVedtakLoading,
-    isError: isVedtakError,
-  } = useVedtakQuery();
+export function useVedtakHistorikk(): HistorikkHook {
+  const { data: vedtak, isLoading, isError } = useVedtakQuery();
 
   const frisktilarbeidHistorikk =
     createHistorikkEventsFromFriskTilArbeid(vedtak);
 
   return {
-    isVedtakHistorikkLoading: isVedtakLoading,
-    isVedtakHistorikkError: isVedtakError,
-    vedtakHistorikk: frisktilarbeidHistorikk,
+    isLoading,
+    isError,
+    events: frisktilarbeidHistorikk,
   };
 }

--- a/src/hooks/historikk/useHistorikk.ts
+++ b/src/hooks/historikk/useHistorikk.ts
@@ -13,105 +13,47 @@ import { useOppfolgingsplanHistorikk } from "@/hooks/historikk/useOppfolgingspla
 import { useOppfolgingsoppgaveHistorikk } from "@/hooks/historikk/useOppfolgingsoppgaveHistorikk";
 import { useMotebehovHistorikk } from "@/hooks/historikk/useMotebehovHistorikk";
 
-interface HistorikkHook {
-  isHistorikkLoading: boolean;
-  isHistorikkError: boolean;
-  historikkEvents: HistorikkEvent[];
+export interface HistorikkHook {
+  isLoading: boolean;
+  isError: boolean;
+  events: HistorikkEvent[];
 }
 
 export function useHistorikk(): HistorikkHook {
   const motebehovHistorikk = useMotebehovHistorikk();
-
   const oppfolgingsplanHistorikk = useOppfolgingsplanHistorikk();
-
-  const { lederHistorikk, isLedereHistorikkLoading, isLedereHistorikkError } =
-    useLedereHistorikk();
-
-  const {
-    aktivitetskravHistorikk,
-    isAktivitetskravHistorikkLoading,
-    isAktivitetskravHistorikkError,
-  } = useAktivitetskravHistorikk();
-
-  const {
-    arbeidsuforhetHistorikk,
-    isArbeidsuforhetHistorikkLoading,
-    isArbeidsuforhetHistorikkError,
-  } = useArbeidsuforhetHistorikk();
-
-  const {
-    manglendeMedvirkningHistorikk,
-    isManglendeMedvirkningHistorikkLoading,
-    isManglendeMedvirkningHistorikkError,
-  } = useManglendeMedvirkningHistorikk();
-
-  const { vedtakHistorikk, isVedtakHistorikkLoading, isVedtakHistorikkError } =
-    useVedtakHistorikk();
-
+  const ledereHistorikk = useLedereHistorikk();
+  const aktivitetskravHistorikk = useAktivitetskravHistorikk();
+  const arbeidsuforhetHistorikk = useArbeidsuforhetHistorikk();
+  const manglendeMedvirkningHistorikk = useManglendeMedvirkningHistorikk();
+  const vedtakHistorikk = useVedtakHistorikk();
   const veilederTildelingHistorikk = useVeilederTildelingHistorikk();
-
-  const {
-    dialogmotekandidatHistorikk,
-    isDialogmotekandidatHistorikkLoading,
-    isDialogmotekandidatHistorikkError,
-  } = useDialogmotekandidatHistorikk();
-
+  const dialogmotekandidatHistorikk = useDialogmotekandidatHistorikk();
   const dialogMedBehandlerHistorikk = useDialogMedBehandlerHistorikk();
-
   const senOppfolgingHistorikk = useSenOppfolgingHistorikk();
-
   const dialogmoteStatusEndringHistorikk =
     useDialogmoteStatusEndringHistorikk();
-
   const oppfolgingsoppgaveHistorikk = useOppfolgingsoppgaveHistorikk();
 
-  const historikkEvents = motebehovHistorikk.events
-    .concat(oppfolgingsplanHistorikk.events)
-    .concat(lederHistorikk)
-    .concat(aktivitetskravHistorikk)
-    .concat(arbeidsuforhetHistorikk)
-    .concat(manglendeMedvirkningHistorikk)
-    .concat(vedtakHistorikk)
-    .concat(veilederTildelingHistorikk.events)
-    .concat(dialogMedBehandlerHistorikk.events)
-    .concat(senOppfolgingHistorikk.events)
-    .concat(dialogmotekandidatHistorikk)
-    .concat(oppfolgingsoppgaveHistorikk.events)
-    .concat(dialogmoteStatusEndringHistorikk.events);
-
-  const isHistorikkLoading =
-    oppfolgingsplanHistorikk.isLoading ||
-    motebehovHistorikk.isLoading ||
-    isLedereHistorikkLoading ||
-    isAktivitetskravHistorikkLoading ||
-    isArbeidsuforhetHistorikkLoading ||
-    isManglendeMedvirkningHistorikkLoading ||
-    isVedtakHistorikkLoading ||
-    veilederTildelingHistorikk.isLoading ||
-    dialogMedBehandlerHistorikk.isLoading ||
-    senOppfolgingHistorikk.isLoading ||
-    isDialogmotekandidatHistorikkLoading ||
-    oppfolgingsoppgaveHistorikk.isLoading ||
-    dialogmoteStatusEndringHistorikk.isLoading;
-
-  const isHistorikkError =
-    motebehovHistorikk.isError ||
-    oppfolgingsplanHistorikk.isError ||
-    isLedereHistorikkError ||
-    isAktivitetskravHistorikkError ||
-    isArbeidsuforhetHistorikkError ||
-    isManglendeMedvirkningHistorikkError ||
-    isVedtakHistorikkError ||
-    veilederTildelingHistorikk.isError ||
-    dialogMedBehandlerHistorikk.isError ||
-    senOppfolgingHistorikk.isError ||
-    isDialogmotekandidatHistorikkError ||
-    oppfolgingsoppgaveHistorikk.isError ||
-    dialogmoteStatusEndringHistorikk.isError;
+  const historikk: HistorikkHook[] = [
+    motebehovHistorikk,
+    oppfolgingsplanHistorikk,
+    ledereHistorikk,
+    aktivitetskravHistorikk,
+    arbeidsuforhetHistorikk,
+    manglendeMedvirkningHistorikk,
+    vedtakHistorikk,
+    veilederTildelingHistorikk,
+    dialogMedBehandlerHistorikk,
+    senOppfolgingHistorikk,
+    dialogmotekandidatHistorikk,
+    oppfolgingsoppgaveHistorikk,
+    dialogmoteStatusEndringHistorikk,
+  ];
 
   return {
-    historikkEvents,
-    isHistorikkLoading,
-    isHistorikkError,
+    events: historikk.map((value) => value.events).flat(),
+    isLoading: historikk.some((value) => value.isLoading),
+    isError: historikk.some((value) => value.isError),
   };
 }

--- a/src/hooks/historikk/useLedereHistorikk.ts
+++ b/src/hooks/historikk/useLedereHistorikk.ts
@@ -2,6 +2,7 @@ import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { useMemo } from "react";
 import { NarmesteLederRelasjonDTO } from "@/data/leder/ledereTypes";
 import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function createHistorikkEventsFromLedere(
   ledere: NarmesteLederRelasjonDTO[]
@@ -14,19 +15,8 @@ function createHistorikkEventsFromLedere(
   }));
 }
 
-interface LedereHistorikk {
-  isLedereHistorikkLoading: boolean;
-  isLedereHistorikkError: boolean;
-  lederHistorikk: HistorikkEvent[];
-}
-
-export function useLedereHistorikk(): LedereHistorikk {
-  const {
-    isLoading: isLedereLoading,
-    isError: isLedereError,
-    currentLedere,
-    formerLedere,
-  } = useLedereQuery();
+export function useLedereHistorikk(): HistorikkHook {
+  const { isLoading, isError, currentLedere, formerLedere } = useLedereQuery();
 
   const allLedere = useMemo(
     () => [...currentLedere, ...formerLedere],
@@ -36,8 +26,8 @@ export function useLedereHistorikk(): LedereHistorikk {
   const lederHistorikk = createHistorikkEventsFromLedere(allLedere);
 
   return {
-    isLedereHistorikkLoading: isLedereLoading,
-    isLedereHistorikkError: isLedereError,
-    lederHistorikk,
+    isLoading,
+    isError,
+    events: lederHistorikk,
   };
 }

--- a/src/hooks/historikk/useManglendeMedvirkningHistorikk.ts
+++ b/src/hooks/historikk/useManglendeMedvirkningHistorikk.ts
@@ -4,6 +4,7 @@ import {
   VurderingResponseDTO as ManglendemedvirkningVurdering,
   VurderingType as ManglendemedvirkningVurderingType,
 } from "@/data/manglendemedvirkning/manglendeMedvirkningTypes";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function manglendemedvirkningText(
   veilederident: string,
@@ -41,27 +42,14 @@ function createHistorikkEventsFromManglendemedvirkning(
   );
 }
 
-interface ManglendeMedvirkningHistorikk {
-  isManglendeMedvirkningHistorikkLoading: boolean;
-  isManglendeMedvirkningHistorikkError: boolean;
-  manglendeMedvirkningHistorikk: HistorikkEvent[];
-}
-
-export function useManglendeMedvirkningHistorikk(): ManglendeMedvirkningHistorikk {
-  const {
-    data: manglendemedvirkningVurderinger,
-    isLoading: isManglendemedvirkningLoading,
-    isError: isManglendemedvirkningError,
-  } = useManglendemedvirkningVurderingQuery();
-
+export function useManglendeMedvirkningHistorikk(): HistorikkHook {
+  const { data, isLoading, isError } = useManglendemedvirkningVurderingQuery();
   const manglendeMedvirkningHistorikk =
-    createHistorikkEventsFromManglendemedvirkning(
-      manglendemedvirkningVurderinger
-    );
+    createHistorikkEventsFromManglendemedvirkning(data);
 
   return {
-    isManglendeMedvirkningHistorikkLoading: isManglendemedvirkningLoading,
-    isManglendeMedvirkningHistorikkError: isManglendemedvirkningError,
-    manglendeMedvirkningHistorikk,
+    isLoading,
+    isError,
+    events: manglendeMedvirkningHistorikk,
   };
 }

--- a/src/hooks/historikk/useMotebehovHistorikk.ts
+++ b/src/hooks/historikk/useMotebehovHistorikk.ts
@@ -9,6 +9,7 @@ import {
   MotebehovInnmelder,
   SvarMotebehov,
 } from "@/data/motebehov/types/motebehovTypes";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function getTextForMeldtMotebehov(meldtMotebehov: MeldtMotebehov): string {
   const meldtBehovBegrunnelse = meldtMotebehov.begrunnelse
@@ -99,13 +100,7 @@ function createHistorikkEventsFromSvarMotebehov(
   return svarMotebehovEvents;
 }
 
-interface MotebehovHistorikk {
-  isLoading: boolean;
-  isError: boolean;
-  events: HistorikkEvent[];
-}
-
-export function useMotebehovHistorikk(): MotebehovHistorikk {
+export function useMotebehovHistorikk(): HistorikkHook {
   const motebehov = useMotebehovQuery();
   const meldtMotebehov = mapMotebehovToMeldtMotebehovFormat(motebehov.data);
   const svarMotebehov = mapMotebehovToSvarMotebehovFormat(motebehov.data);

--- a/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsoppgaveHistorikk.ts
@@ -4,12 +4,7 @@ import {
   OppfolgingsoppgaveResponseDTO,
 } from "@/data/oppfolgingsoppgave/types";
 import { useOppfolgingsoppgaver } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
-
-interface OppfolgingsoppgaveHistorikk {
-  isLoading: boolean;
-  isError: boolean;
-  events: HistorikkEvent[];
-}
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function createHistorikkEvents(
   oppfolgingsoppgaver: OppfolgingsoppgaveResponseDTO[]
@@ -57,18 +52,18 @@ function createHistorikkEvents(
   return historikkEvents;
 }
 
-export function useOppfolgingsoppgaveHistorikk(): OppfolgingsoppgaveHistorikk {
+export function useOppfolgingsoppgaveHistorikk(): HistorikkHook {
   const {
     oppfolgingsoppgaver: oppfolgingsoppgaver,
-    isLoading: isOppfolgingsoppgaverLoading,
-    isError: isOppfolgingsoppgaverError,
+    isLoading,
+    isError,
   } = useOppfolgingsoppgaver();
 
   const historikkEvents = createHistorikkEvents(oppfolgingsoppgaver || []);
 
   return {
-    isLoading: isOppfolgingsoppgaverLoading,
-    isError: isOppfolgingsoppgaverError,
+    isLoading,
+    isError,
     events: historikkEvents,
   };
 }

--- a/src/hooks/historikk/useSenOppfolgingHistorikk.ts
+++ b/src/hooks/historikk/useSenOppfolgingHistorikk.ts
@@ -5,14 +5,9 @@ import {
   SenOppfolgingVurderingType,
 } from "@/data/senoppfolging/senOppfolgingTypes";
 import { useSenOppfolgingKandidatQuery } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 const OPPRETTET_AV_SYSTEM_DEFAULT = "SYSTEM";
-
-interface SenOppfolgingHistorikk {
-  isLoading: boolean;
-  isError: boolean;
-  events: HistorikkEvent[];
-}
 
 function createHistorikkEvents(
   senOppfolgingKandidater: SenOppfolgingKandidatResponseDTO[]
@@ -61,18 +56,18 @@ function createHistorikkEvents(
   });
 }
 
-export function useSenOppfolgingHistorikk(): SenOppfolgingHistorikk {
+export function useSenOppfolgingHistorikk(): HistorikkHook {
   const {
     data: senOppfolgingKandidater,
-    isLoading: isSenOppfolgingKandidatLoading,
-    isError: isSenOppfolgingKandidatError,
+    isLoading,
+    isError,
   } = useSenOppfolgingKandidatQuery();
 
   const historikkEvents = createHistorikkEvents(senOppfolgingKandidater);
 
   return {
-    isLoading: isSenOppfolgingKandidatLoading,
-    isError: isSenOppfolgingKandidatError,
+    isLoading,
+    isError,
     events: historikkEvents,
   };
 }

--- a/src/hooks/historikk/useVeilederTildelingHistorikk.ts
+++ b/src/hooks/historikk/useVeilederTildelingHistorikk.ts
@@ -3,6 +3,7 @@ import {
   useVeilederTildelingHistorikkData,
   VeilederTildelingHistorikkDTO,
 } from "@/data/veilederbrukerknytning/useGetVeilederBrukerKnytning";
+import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function createHistorikkEventsFromVeilederTildelingHistorikk(
   veilederTildelingHistorikkDTO: VeilederTildelingHistorikkDTO[]
@@ -26,13 +27,7 @@ function getHistorikkTekst(value: VeilederTildelingHistorikkDTO): string {
   }
 }
 
-interface VeilederTildelingHistorikk {
-  isLoading: boolean;
-  isError: boolean;
-  events: HistorikkEvent[];
-}
-
-export function useVeilederTildelingHistorikk(): VeilederTildelingHistorikk {
+export function useVeilederTildelingHistorikk(): HistorikkHook {
   const {
     data: events,
     isLoading,

--- a/src/mocks/common/mockConstants.ts
+++ b/src/mocks/common/mockConstants.ts
@@ -107,7 +107,7 @@ export const NARMESTE_LEDER_DEFAULT = {
   personident: "02690001009",
 };
 
-const ANNEN_NARMESTE_LEDER = {
+export const ANNEN_NARMESTE_LEDER = {
   navn: "Sara Sjef",
   personident: "02790001009",
 };

--- a/src/mocks/isoppfolgingsplan/oppfolgingsplanForesporselMocks.ts
+++ b/src/mocks/isoppfolgingsplan/oppfolgingsplanForesporselMocks.ts
@@ -1,0 +1,30 @@
+import { OppfolgingsplanForesporselResponse } from "@/data/oppfolgingsplan/oppfolgingsplanForesporselHooks";
+import { addWeeks } from "@/utils/datoUtils";
+import { generateUUID } from "@/utils/utils";
+import {
+  ANNEN_NARMESTE_LEDER,
+  ARBEIDSTAKER_DEFAULT,
+  NARMESTE_LEDER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
+  VIRKSOMHET_BRANNOGBIL,
+  VIRKSOMHET_ENTERPRISE,
+} from "@/mocks/common/mockConstants";
+
+const foresporsel: OppfolgingsplanForesporselResponse = {
+  createdAt: addWeeks(new Date(), -1),
+  uuid: generateUUID(),
+  arbeidstakerPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
+  document: [],
+  veilederident: VEILEDER_IDENT_DEFAULT,
+  narmestelederPersonident: NARMESTE_LEDER_DEFAULT.personident,
+  virksomhetsnummer: VIRKSOMHET_ENTERPRISE.virksomhetsnummer,
+};
+const otherForesporsel: OppfolgingsplanForesporselResponse = {
+  ...foresporsel,
+  uuid: generateUUID(),
+  createdAt: addWeeks(new Date(), -2),
+  narmestelederPersonident: ANNEN_NARMESTE_LEDER.personident,
+  virksomhetsnummer: VIRKSOMHET_BRANNOGBIL.virksomhetsnummer,
+};
+
+export const mockForesporseler = [otherForesporsel, foresporsel];

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -44,7 +44,7 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
     case "OPPFOLGINGSPLAN_LPS":
       return <Tag variant="alt3">Oppfølgingsplan LPS</Tag>;
     case "OPPFOLGINGSPLAN_FORESPORSEL":
-      return <Tag variant="alt3">Be om oppfølgingsplan</Tag>;
+      return <Tag variant="alt3">Bedt om oppfølgingsplan</Tag>;
     case "LEDER":
       return <Tag variant="alt2">Leder</Tag>;
     case "VEILEDER_TILDELING":

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -43,6 +43,8 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
       return <Tag variant="alt3">Oppfølgingsplan</Tag>;
     case "OPPFOLGINGSPLAN_LPS":
       return <Tag variant="alt3">Oppfølgingsplan LPS</Tag>;
+    case "OPPFOLGINGSPLAN_FORESPORSEL":
+      return <Tag variant="alt3">Be om oppfølgingsplan</Tag>;
     case "LEDER":
       return <Tag variant="alt2">Leder</Tag>;
     case "VEILEDER_TILDELING":

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -44,7 +44,7 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
     case "OPPFOLGINGSPLAN_LPS":
       return <Tag variant="alt3">Oppfølgingsplan LPS</Tag>;
     case "OPPFOLGINGSPLAN_FORESPORSEL":
-      return <Tag variant="alt3">Bedt om oppfølgingsplan</Tag>;
+      return <Tag variant="alt3">Forespørsel oppfølgingsplan</Tag>;
     case "LEDER":
       return <Tag variant="alt2">Leder</Tag>;
     case "VEILEDER_TILDELING":

--- a/src/sider/historikk/container/HistorikkContainer.tsx
+++ b/src/sider/historikk/container/HistorikkContainer.tsx
@@ -23,8 +23,7 @@ const texts = {
 };
 
 export default function HistorikkContainer(): ReactElement {
-  const { historikkEvents, isHistorikkLoading, isHistorikkError } =
-    useHistorikk();
+  const { events, isLoading, isError } = useHistorikk();
   const {
     tilfellerDescendingStart,
     isLoading: isTilfellerLoading,
@@ -40,7 +39,7 @@ export default function HistorikkContainer(): ReactElement {
     toggles.isHistorikkFlexjarEnabled && !hasGivenFeedback;
 
   const tilfeller = tilfellerDescendingStart || [];
-  const ingenHistorikk = tilfeller.length === 0 || historikkEvents.length === 0;
+  const ingenHistorikk = tilfeller.length === 0 || events.length === 0;
 
   return (
     <Side
@@ -49,8 +48,8 @@ export default function HistorikkContainer(): ReactElement {
       flexjar={isFlexjarVisible && !ingenHistorikk && <HistorikkFlexjar />}
     >
       <SideLaster
-        henter={isHistorikkLoading || isTilfellerLoading}
-        hentingFeilet={isHistorikkError || isTilfellerError}
+        henter={isLoading || isTilfellerLoading}
+        hentingFeilet={isError || isTilfellerError}
         className="flex flex-col"
       >
         <Sidetopp tittel={texts.topp} />
@@ -60,7 +59,7 @@ export default function HistorikkContainer(): ReactElement {
             melding={texts.ingenHistorikk.melding}
           />
         ) : (
-          <Historikk historikkEvents={historikkEvents} tilfeller={tilfeller} />
+          <Historikk historikkEvents={events} tilfeller={tilfeller} />
         )}
       </SideLaster>
     </Side>

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -903,7 +903,9 @@ describe("Historikk", () => {
       renderHistorikk();
 
       expect(await screen.findAllByText("Historikk")).to.exist;
-      expect(screen.getAllByText("Bedt om oppfølgingsplan")).to.have.length(2);
+      expect(screen.getAllByText("Forespørsel oppfølgingsplan")).to.have.length(
+        2
+      );
       expect(
         screen.getByText(
           `Z990000 ba om oppfølgingsplan fra ${VIRKSOMHET_ENTERPRISE.virksomhetsnummer}.`

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -903,7 +903,7 @@ describe("Historikk", () => {
       renderHistorikk();
 
       expect(await screen.findAllByText("Historikk")).to.exist;
-      expect(screen.getAllByText("Be om oppfølgingsplan")).to.have.length(2);
+      expect(screen.getAllByText("Bedt om oppfølgingsplan")).to.have.length(2);
       expect(
         screen.getByText(
           `Z990000 ba om oppfølgingsplan fra ${VIRKSOMHET_ENTERPRISE.virksomhetsnummer}.`

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -14,6 +14,8 @@ import {
   VEILEDER_TILDELING_HISTORIKK_ANNEN,
   VEILEDER_TILDELING_HISTORIKK_DEFAULT,
   VEILEDER_TILDELING_HISTORIKK_SYSTEM,
+  VIRKSOMHET_BRANNOGBIL,
+  VIRKSOMHET_ENTERPRISE,
 } from "@/mocks/common/mockConstants";
 import { historikkQueryKeys } from "@/data/historikk/historikkQueryHooks";
 import { aktivitetskravQueryKeys } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
@@ -53,6 +55,8 @@ import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes"
 import { addWeeks, tilLesbarPeriodeMedArstall } from "@/utils/datoUtils";
 import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
 import { motebehovMock } from "@/mocks/syfomotebehov/motebehovMock";
+import { oppfolgingsplanForesporselQueryKeys } from "@/data/oppfolgingsplan/oppfolgingsplanForesporselHooks";
+import { mockForesporseler } from "@/mocks/isoppfolgingsplan/oppfolgingsplanForesporselMocks";
 
 let queryClient: QueryClient;
 
@@ -138,6 +142,12 @@ function setupTestdataHistorikk() {
   );
   queryClient.setQueryData(
     oppfolgingsoppgaverQueryKeys.oppfolgingsoppgaver(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
+    () => []
+  );
+  queryClient.setQueryData(
+    oppfolgingsplanForesporselQueryKeys.foresporsel(
       ARBEIDSTAKER_DEFAULT.personIdent
     ),
     () => []
@@ -878,6 +888,32 @@ describe("Historikk", () => {
       ).to.exist;
       expect(screen.getByText("Z990000 vurderte behovet for dialogmøte")).to
         .exist;
+    });
+  });
+
+  describe("Forespørsel om oppfølgingsplan", () => {
+    it("viser forespørseler om oppfølgingsplan", async () => {
+      queryClient.setQueryData(
+        oppfolgingsplanForesporselQueryKeys.foresporsel(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => mockForesporseler
+      );
+
+      renderHistorikk();
+
+      expect(await screen.findAllByText("Historikk")).to.exist;
+      expect(screen.getAllByText("Be om oppfølgingsplan")).to.have.length(2);
+      expect(
+        screen.getByText(
+          `Z990000 ba om oppfølgingsplan fra ${VIRKSOMHET_ENTERPRISE.virksomhetsnummer}.`
+        )
+      ).to.exist;
+      expect(
+        screen.getByText(
+          `Z990000 ba om oppfølgingsplan fra ${VIRKSOMHET_BRANNOGBIL.virksomhetsnummer}.`
+        )
+      ).to.exist;
     });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Lagt til forespørsler om oppfølgingsplan i på Historikk-siden.
Forenklet sjekk på `isLoading` / `isError` i `useHistorikk` og refaktorerte/forenklet historikk-hooks slik at alle returnerer `HistorikkHook` i stedet for sine egne "duplikate" typer. 

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/64e6adea-60d8-4a26-845b-e959e5dedfe4)


