### PR TITLE
IS-3035: add text om rutiner for sensitiv info i dialogmøtereferat

### DIFF
--- a/src/components/ExpansionCardFormField.tsx
+++ b/src/components/ExpansionCardFormField.tsx
@@ -28,7 +28,9 @@ export const ExpansionCardFormField = ({
       open={open}
       onToggle={() => setOpen(!open)}
     >
-      <ExpansionCard.Header>{heading}</ExpansionCard.Header>
+      <ExpansionCard.Header className="items-center">
+        {heading}
+      </ExpansionCard.Header>
       <ExpansionCard.Content>{children}</ExpansionCard.Content>
     </ExpansionCard>
   );

--- a/src/sider/dialogmoter/components/referat/DeltakerArbeidsgiverHeading.tsx
+++ b/src/sider/dialogmoter/components/referat/DeltakerArbeidsgiverHeading.tsx
@@ -10,7 +10,7 @@ export const DeltakerArbeidsgiverHeading = ({ children }: Props) => {
   return (
     <HStack gap="2">
       <PersonSuitIcon role="img" focusable={false} width={24} height={24} />
-      <Heading size="small">{children}</Heading>
+      <Heading size="xsmall">{children}</Heading>
     </HStack>
   );
 };

--- a/src/sider/dialogmoter/components/referat/DeltakerArbeidstakerHeading.tsx
+++ b/src/sider/dialogmoter/components/referat/DeltakerArbeidstakerHeading.tsx
@@ -9,7 +9,7 @@ export const DeltakerArbeidstakerHeading = () => {
   return (
     <HStack gap="2" className="pl-4">
       <PersonIcon role="img" focusable={false} width={24} height={24} />
-      <Heading size="small">{`Arbeidstaker: ${navbruker?.navn}`}</Heading>
+      <Heading size="xsmall">{`Arbeidstaker: ${navbruker?.navn}`}</Heading>
     </HStack>
   );
 };

--- a/src/sider/dialogmoter/components/referat/DeltakerBehandlerHeading.tsx
+++ b/src/sider/dialogmoter/components/referat/DeltakerBehandlerHeading.tsx
@@ -16,7 +16,7 @@ export const DeltakerBehandlerHeading = ({ children }: Props) => {
         src={MedisinskrinImage}
         alt="Medisinskrin-ikon"
       />
-      <Heading size="small">{children}</Heading>
+      <Heading size="xsmall">{children}</Heading>
     </HStack>
   );
 };

--- a/src/sider/dialogmoter/components/referat/DeltakerNavHeading.tsx
+++ b/src/sider/dialogmoter/components/referat/DeltakerNavHeading.tsx
@@ -9,7 +9,7 @@ export const DeltakerNavHeading = () => {
   return (
     <HStack gap="2" className="pl-4">
       <PersonPencilIcon role="img" focusable={false} width={24} height={24} />
-      <Heading size="small">{`Fra Nav: ${veilederinfo?.fulltNavn()}`}</Heading>
+      <Heading size="xsmall">{`Fra Nav: ${veilederinfo?.fulltNavn()}`}</Heading>
     </HStack>
   );
 };

--- a/src/sider/dialogmoter/components/referat/Referat.tsx
+++ b/src/sider/dialogmoter/components/referat/Referat.tsx
@@ -33,7 +33,7 @@ import {
   CheckboxGroup,
   Heading,
   HStack,
-  Link,
+  List,
   TextField,
   VStack,
 } from "@navikt/ds-react";
@@ -56,6 +56,7 @@ import { DeltakerBehandlerHeading } from "@/sider/dialogmoter/components/referat
 import { DeltakerArbeidsgiverHeading } from "@/sider/dialogmoter/components/referat/DeltakerArbeidsgiverHeading";
 import { ExpansionCardFormField } from "@/components/ExpansionCardFormField";
 import { PlusIcon, TrashIcon } from "@navikt/aksel-icons";
+import { EksternLenke } from "@/components/EksternLenke";
 
 export const MAX_LENGTH_SITUASJON = 6500;
 export const MAX_LENGTH_KONKLUSJON = 1500;
@@ -69,12 +70,25 @@ export const texts = {
   save: "Lagre",
   send: "Lagre og send",
   abort: "Avbryt",
-  digitalReferat:
-    "Referatet formidles her på nav.no. Det er bare de arbeidstakerne som har reservert seg mot digital kommunikasjon, som vil få referatet i posten.",
-  personvern:
-    "Du må aldri skrive sensitive opplysninger om helse, diagnose, behandling og prognose. Dette gjelder også hvis arbeidstakeren er åpen om helsen og snakket om den i møtet. Se artikkel 9, Lov om behandling av personopplysninger. ",
-  personvernLenketekst:
-    "Du kan også lese mer om dette på Navet (åpnes i ny fane).",
+  personvern: {
+    title:
+      "Du må aldri skrive sensitive opplysninger i referatet. Sensitive opplysninger som har betydning for saken må likevel dokumenteres.",
+    bulletPoint: {
+      one: (
+        <>
+          For <b> personbrukere</b> gjøres dette i personoversikten eller
+          aktivitetsplanen.{" "}
+        </>
+      ),
+      two: (
+        <>
+          Samtaler med <b>andre typer brukere</b> (for eksempel arbeidsgivere)
+          skrives i Gosys.{" "}
+        </>
+      ),
+    },
+  },
+  personvernLenketekst: "Les mer om rutinen på Navet.",
   forhandsvisningContentLabel: "Forhåndsvis referat fra dialogmøte",
   referatSaved: "Referatet er lagret",
   fritekster: {
@@ -144,7 +158,7 @@ export const texts = {
 };
 
 const personvernUrl =
-  "https://navno.sharepoint.com/sites/fag-og-ytelser-veileder-for-arbeidsrettet-brukeroppfolging/SitePages/Sykmeldt-med-arbeidsgiver-%E2%80%93-avholde-dialogm%C3%B8te.aspx";
+  "https://navno.sharepoint.com/sites/fag-og-ytelser-fagsystemer/SitePages/Rutine-for-dialogen-i-Modia,-Ditt-NAV-og-Gosys.aspx";
 
 export const valideringsTexts = {
   situasjonMissing: "Vennligst angi situasjon og muligheter",
@@ -353,14 +367,13 @@ const Referat = ({ dialogmote, mode }: ReferatProps): ReactElement => {
             debouncedAutoSave(getValues());
           }}
         >
-          <Heading size="large" className="mb-8">
+          <Heading level="2" size="medium" className="mb-8">
             {header}
           </Heading>
-          <Alert variant="info" size="small" className="mb-8 [&>*]:max-w-fit">
-            {texts.digitalReferat}
-          </Alert>
           <VStack gap="4">
-            <Heading size="medium">{texts.deltakere.title}</Heading>
+            <Heading level="3" size="small">
+              {texts.deltakere.title}
+            </Heading>
             <DeltakerArbeidstakerHeading />
             <DeltakerNavHeading />
             <ExpansionCardFormField
@@ -458,6 +471,7 @@ const Referat = ({ dialogmote, mode }: ReferatProps): ReactElement => {
               <Button
                 type="button"
                 variant="secondary"
+                size="small"
                 icon={<PlusIcon title="Pluss ikon" />}
                 onClick={() => append({ funksjon: "", navn: "" })}
               >
@@ -465,21 +479,15 @@ const Referat = ({ dialogmote, mode }: ReferatProps): ReactElement => {
               </Button>
             </VStack>
           </VStack>
-          <Alert
-            variant="warning"
-            size="small"
-            inline
-            className="mt-16 mb-8 [&>*]:max-w-fit"
-          >
-            {texts.personvern}
-            <Link
-              target="_blank"
-              rel="noopener noreferrer"
-              href={personvernUrl}
-            >
+          <div className="my-8">
+            <List as="ul" size="small" description={texts.personvern.title}>
+              <List.Item>{texts.personvern.bulletPoint.one}</List.Item>
+              <List.Item>{texts.personvern.bulletPoint.two}</List.Item>
+            </List>
+            <EksternLenke href={personvernUrl}>
               {texts.personvernLenketekst}
-            </Link>
-          </Alert>
+            </EksternLenke>
+          </div>
           <MalformRadioGroup />
           {showToast && (
             <div className="mb-4 font-bold flex gap-2">


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endret teksten på warning om sensitiv informasjon i referatet slik at rutinene for dokumentasjon av sensitiv informasjon kommer tydelig frem. Denne dokumentasjonen gjøres foreløpig andre steder, som feks i personoversikten, aktivitetsplanen eller gosys. Veiledere bruker arena, men dette er feil.  
- Endret linken til en mer generell link om rutiner for dialogen i Modia, Min side og Gosys, som vi antar er vanskeligere å finne for veileder. Den forrige linken var en mer intern side om dialogmøter på navet under sykefraværsoppfølging. 
- Byttet fra warning til vanlig tekst siden dette er noe som alltid skal stå der. 
- Fjernet den info boksen helt øverst, fordi den stjal litt oppmerksomhet og teksten er ifølge Stine selvforklarende og unødvendig. 
- Også gjort noen finjusteringer på størrelsen på teksten i deltaker i møtet. Dette kunne sikkert vært et felles komponent, siden endringen nå måtte gjøres mange steder. 

### Screenshots 📸✨
Før:
![Skjermbilde 2025-02-18 kl  09 09 24](https://github.com/user-attachments/assets/2e6e6961-913d-4d42-a717-8e91830516ac)

Etter:
![Skjermbilde 2025-02-25 kl  10 15 25](https://github.com/user-attachments/assets/8f68d7d5-2690-454b-9db7-b656c7ea279c)


