### PR TITLE
IS-3097: Endret slik at menyen ser lik ut det som er i syfooversikt

### DIFF
--- a/src/components/LinkAsTab.tsx
+++ b/src/components/LinkAsTab.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from "react";
+import { Link } from "@navikt/ds-react";
+
+interface Props {
+  href: string;
+  label: ReactNode;
+  icon?: ReactNode;
+}
+export default function LinkAsTab({ href, label, icon }: Props) {
+  return (
+    <Link
+      className={
+        "navds-tabs__tab text-text-default no-underline text-center focus-visible:bg-transparent active:bg-transparent active:text-text-default active:shadow-[inset_0_-3px_0_0] active:shadow-border-subtle-hover"
+      }
+      href={href}
+    >
+      <span className={"navds-tabs__tab-inner"}>
+        <span aria-hidden={!!label}>{icon}</span>
+        {label}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/TildeltVeileder.tsx
+++ b/src/components/TildeltVeileder.tsx
@@ -233,7 +233,7 @@ export function TildeltVeileder() {
   const veilederBrukerKnytningQuery = useGetVeilederBrukerKnytning();
   const veilederIdent = veilederBrukerKnytningQuery.data?.tildeltVeilederident;
   return veilederBrukerKnytningQuery.isSuccess ? (
-    <div className="ml-auto">
+    <div className="ml-auto my-auto mr-5">
       <b>{texts.tildeltVeileder}</b>
       {veilederIdent ? (
         <VeilederNavn tildeltVeilederident={veilederIdent} />

--- a/src/components/personkort/OversiktLenker.tsx
+++ b/src/components/personkort/OversiktLenker.tsx
@@ -17,19 +17,19 @@ export const OversiktLenker = (): ReactElement => {
       <Tabs.List>
         <LinkAsTab
           href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}
-          label={<Heading size="small">{texts.oversikt}</Heading>}
+          label={<Heading size="xsmall">{texts.oversikt}</Heading>}
         />
         <LinkAsTab
           href={fullNaisUrlIntern("syfooversikt", "/enhet")}
-          label={<Heading size="small">{texts.enhetensOversikt}</Heading>}
+          label={<Heading size="xsmall">{texts.enhetensOversikt}</Heading>}
         />
         <LinkAsTab
           href={fullNaisUrlIntern("syfomoteoversikt")}
-          label={<Heading size="small">{texts.moter}</Heading>}
+          label={<Heading size="xsmall">{texts.moter}</Heading>}
         />
         <LinkAsTab
           href={fullNaisUrlIntern("syfooversikt", "/sok")}
-          label={<Heading size="small">{texts.sokSykmeldt}</Heading>}
+          label={<Heading size="xsmall">{texts.sokSykmeldt}</Heading>}
           icon={<MagnifyingGlassIcon />}
         />
       </Tabs.List>

--- a/src/components/personkort/OversiktLenker.tsx
+++ b/src/components/personkort/OversiktLenker.tsx
@@ -1,6 +1,7 @@
 import { fullNaisUrlIntern } from "@/utils/miljoUtil";
 import React, { ReactElement } from "react";
-import { Link } from "@navikt/ds-react";
+import { Heading, Tabs } from "@navikt/ds-react";
+import LinkAsTab from "@/components/LinkAsTab";
 import { MagnifyingGlassIcon } from "@navikt/aksel-icons";
 
 const texts = {
@@ -10,18 +11,28 @@ const texts = {
   sokSykmeldt: "Søk etter sykmeldt",
 };
 
-export const OversiktLenker = (): ReactElement => (
-  <div className="flex gap-8">
-    <Link href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}>
-      {texts.oversikt}
-    </Link>
-    <Link href={fullNaisUrlIntern("syfooversikt", "/enhet")}>
-      {texts.enhetensOversikt}
-    </Link>
-    <Link href={fullNaisUrlIntern("syfooversikt", "/sok")}>
-      <MagnifyingGlassIcon />
-      {texts.sokSykmeldt}
-    </Link>
-    <Link href={fullNaisUrlIntern("syfomoteoversikt")}>{texts.moter}</Link>
-  </div>
-);
+export const OversiktLenker = (): ReactElement => {
+  return (
+    <Tabs>
+      <Tabs.List>
+        <LinkAsTab
+          href={fullNaisUrlIntern("syfooversikt", "/minoversikt")}
+          label={<Heading size="small">{texts.oversikt}</Heading>}
+        />
+        <LinkAsTab
+          href={fullNaisUrlIntern("syfooversikt", "/enhet")}
+          label={<Heading size="small">{texts.enhetensOversikt}</Heading>}
+        />
+        <LinkAsTab
+          href={fullNaisUrlIntern("syfomoteoversikt")}
+          label={<Heading size="small">{texts.moter}</Heading>}
+        />
+        <LinkAsTab
+          href={fullNaisUrlIntern("syfooversikt", "/sok")}
+          label={<Heading size="small">{texts.sokSykmeldt}</Heading>}
+          icon={<MagnifyingGlassIcon />}
+        />
+      </Tabs.List>
+    </Tabs>
+  );
+};

--- a/src/sider/Side.tsx
+++ b/src/sider/Side.tsx
@@ -46,7 +46,7 @@ export default function Side({
     >
       <div className="mx-6 flex flex-col">
         <div className="flex flex-col" id={MODIA_HEADER_ID}>
-          <div className="flex flex-row mt-4 mb-2 w-full">
+          <div className="flex flex-row mb-2 w-full bg-surface-default">
             <OversiktLenker />
             <TildeltVeileder />
           </div>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret slik at menyen ser lik ut det som er i syfooversikt og endret rekkefølgen slik at søk er sist

Relatert PR: https://github.com/navikt/syfooversikt/pull/604

### Screenshots 📸✨
Før:
![image](https://github.com/user-attachments/assets/502921e3-b1ac-4198-b8d6-475019a10ac9)

Etter:
![image](https://github.com/user-attachments/assets/f7831041-d848-40b2-bca3-a7ddf2ea4528)