### PR TITLE
IS-3096: Show alert and modal when inaktiv personident

### DIFF
--- a/src/components/InaktivPersonident.tsx
+++ b/src/components/InaktivPersonident.tsx
@@ -54,6 +54,7 @@ export function InaktivPersonident() {
         </ChangeAktivBrukerLink>
       </Alert>
       <Modal
+        closeOnBackdropClick
         open={modalOpen}
         onClose={() => setModalOpen(false)}
         aria-label={texts.label}

--- a/src/components/InaktivPersonident.tsx
+++ b/src/components/InaktivPersonident.tsx
@@ -1,0 +1,79 @@
+import { Alert, BodyShort, Button, Link, Modal } from "@navikt/ds-react";
+import React, { ReactNode, useState } from "react";
+import { usePostAktivBruker } from "@/data/modiacontext/usePostAktivBruker";
+import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+
+interface ChangeAktivBrukerLinkProps {
+  personident: string;
+  children: ReactNode;
+}
+
+function ChangeAktivBrukerLink({
+  personident,
+  children,
+}: ChangeAktivBrukerLinkProps) {
+  const postAktivBruker = usePostAktivBruker();
+
+  return (
+    <Link
+      onClick={(event) => {
+        event.preventDefault();
+        postAktivBruker.mutate(personident, {
+          onSuccess: () => {
+            window.location.href = "/sykefravaer";
+          },
+        });
+      }}
+      href="/sykefravaer"
+    >
+      {children}
+    </Link>
+  );
+}
+
+const texts = {
+  intro: "Personen har byttet fødselsnummer/d-nummer. ",
+  link: (personident: string) =>
+    `Klikk her for å åpne person på aktivt f.nr/d.nr ${personident}.`,
+  label: "Inaktivt fødselsnummer/d-nummer",
+  close: "Lukk",
+};
+
+export function InaktivPersonident() {
+  const {
+    brukerinfo: { aktivPersonident },
+  } = useBrukerinfoQuery();
+  const [modalOpen, setModalOpen] = useState(true);
+
+  return (
+    <>
+      <Alert variant="error" contentMaxWidth={false}>
+        {texts.intro}
+        <ChangeAktivBrukerLink personident={aktivPersonident}>
+          {texts.link(aktivPersonident)}
+        </ChangeAktivBrukerLink>
+      </Alert>
+      <Modal
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+        aria-label={texts.label}
+        header={{
+          heading: texts.intro,
+          closeButton: false,
+          size: "small",
+        }}
+      >
+        <Modal.Body className="p-8">
+          <ChangeAktivBrukerLink personident={aktivPersonident}>
+            <BodyShort size="medium">{texts.link(aktivPersonident)}</BodyShort>
+          </ChangeAktivBrukerLink>
+        </Modal.Body>
+        <Modal.Footer className="self-center">
+          <Button variant="secondary" onClick={() => setModalOpen(false)}>
+            {texts.close}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}

--- a/src/data/modiacontext/usePostAktivBruker.ts
+++ b/src/data/modiacontext/usePostAktivBruker.ts
@@ -1,0 +1,12 @@
+import { useMutation } from "@tanstack/react-query";
+import { post } from "@/api/axios";
+import { MODIACONTEXTHOLDER_ROOT } from "@/apiConstants";
+
+export const usePostAktivBruker = () =>
+  useMutation({
+    mutationFn: (fnr: string) =>
+      post(`${MODIACONTEXTHOLDER_ROOT}/context`, {
+        verdi: fnr,
+        eventType: "NY_AKTIV_BRUKER",
+      }),
+  });

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -27,6 +27,7 @@ export const useBrukerinfoQuery = () => {
 
   const defaultData: BrukerinfoDTO = {
     navn: "",
+    aktivPersonident: "",
     arbeidssituasjon: "ARBEIDSTAKER",
     dodsdato: null,
     tilrettelagtKommunikasjon: {
@@ -39,6 +40,10 @@ export const useBrukerinfoQuery = () => {
   return {
     ...query,
     brukerinfo: query.data || defaultData,
+    isInaktivPersonident:
+      !!personident &&
+      !!query.data?.aktivPersonident &&
+      personident !== query.data.aktivPersonident,
   };
 };
 

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -6,6 +6,7 @@ export interface KontaktinfoDTO {
 
 export interface BrukerinfoDTO {
   navn: string;
+  aktivPersonident: string;
   arbeidssituasjon: string;
   dodsdato: string | null;
   tilrettelagtKommunikasjon: TilrettelagtKommunikasjon | null;

--- a/src/mocks/syfoperson/persondataMock.ts
+++ b/src/mocks/syfoperson/persondataMock.ts
@@ -12,6 +12,7 @@ export const kontaktinformasjonMock = {
 };
 
 export const brukerinfoMock: BrukerinfoDTO = {
+  aktivPersonident: ARBEIDSTAKER_DEFAULT.personIdent,
   navn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
   arbeidssituasjon: "ARBEIDSTAKER",
   dodsdato: null,

--- a/src/sider/Side.tsx
+++ b/src/sider/Side.tsx
@@ -14,6 +14,8 @@ import { Pride } from "@/components/festive/Pride";
 import { Oppfolgingsoppgave } from "@/components/oppfolgingsoppgave/Oppfolgingsoppgave";
 import { useDiskresjonskodeQuery } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
 import { TildeltVeileder } from "@/components/TildeltVeileder";
+import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { InaktivPersonident } from "@/components/InaktivPersonident";
 
 export const MODIA_HEADER_ID = "modia-header";
 
@@ -31,6 +33,7 @@ export default function Side({
   children,
 }: Props) {
   const { data: diskresjonskode } = useDiskresjonskodeQuery();
+  const { isInaktivPersonident } = useBrukerinfoQuery();
 
   useEffect(() => {
     Amplitude.logEvent({
@@ -45,11 +48,12 @@ export default function Side({
       title={tittel + (tittel.length > 0 ? " - Sykefravær" : "Sykefravær")}
     >
       <div className="mx-6 flex flex-col">
-        <div className="flex flex-col" id={MODIA_HEADER_ID}>
-          <div className="flex flex-row mb-2 w-full bg-surface-default">
+        <div className="flex flex-col gap-2" id={MODIA_HEADER_ID}>
+          <div className="flex flex-row w-full bg-surface-default">
             <OversiktLenker />
             <TildeltVeileder />
           </div>
+          {isInaktivPersonident && <InaktivPersonident />}
           {isPride() && <Pride>&nbsp;</Pride>}
           <Personkort />
         </div>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Viser error alert og modal dersom man åpner en person som har byttet fnr/dnr. Dvs at fnr/dnr man har lagt inn i dekoratøren ikke er den aktive personidenten til brukeren.

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/c0ac0b7a-9992-4830-9f94-11f1148a6d66)