### PR TITLE
IS-3113: Lagt til statusendringer om stans av sykepenger til under historikken på siden manglende medvirkning

### DIFF
--- a/src/data/manglendemedvirkning/manglendeMedvirkningTypes.ts
+++ b/src/data/manglendemedvirkning/manglendeMedvirkningTypes.ts
@@ -1,4 +1,5 @@
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
+import { StatusEndring } from "@/data/pengestopp/types/FlaggPerson";
 
 interface VurderingRequestDTO {
   personident: string;
@@ -35,6 +36,8 @@ export type NewVurderingRequestDTO =
   | UnntakVurdering
   | IkkeAktuellVurdering;
 
+export type HistorikkEntry = VurderingResponseDTO | StatusEndring;
+
 export interface VurderingResponseDTO {
   uuid: string;
   personident: string;
@@ -66,7 +69,7 @@ export const typeTexts: {
 } = {
   [VurderingType.FORHANDSVARSEL]: "Forhåndsvarsel",
   [VurderingType.OPPFYLT]: "Oppfylt",
-  [VurderingType.STANS]: "Stans",
+  [VurderingType.STANS]: "Innstilling om stans",
   [VurderingType.IKKE_AKTUELL]: "Ikke aktuell",
   [VurderingType.UNNTAK]: "Unntak",
 };

--- a/src/mocks/ispengestopp/pengestoppStatusMock.ts
+++ b/src/mocks/ispengestopp/pengestoppStatusMock.ts
@@ -21,6 +21,16 @@ const defaultStoppAutomatikk: StoppAutomatikk = {
   ],
 };
 
+export const defaultStatusEndring: StatusEndring = {
+  veilederIdent: { value: VEILEDER_DEFAULT.ident },
+  sykmeldtFnr: { value: ARBEIDSTAKER_DEFAULT.personIdent },
+  status: Status.STOPP_AUTOMATIKK,
+  virksomhetNr: { value: VIRKSOMHET_PONTYPANDY.virksomhetsnummer },
+  opprettet: new Date().toString(),
+  enhetNr: { value: ENHET_GAMLEOSLO.nummer },
+  arsakList: [],
+};
+
 export const createStatusList = (
   created: Date,
   stoppAutomatikk = defaultStoppAutomatikk
@@ -28,7 +38,7 @@ export const createStatusList = (
   return stoppAutomatikk.virksomhetNr.map((virksomhet) => {
     return {
       veilederIdent: {
-        value: "A111111",
+        value: VEILEDER_DEFAULT.ident,
       },
       sykmeldtFnr: {
         value: ARBEIDSTAKER_DEFAULT.personIdent,
@@ -41,7 +51,8 @@ export const createStatusList = (
       enhetNr: {
         value: "1337",
       },
-    };
+      arsakList: stoppAutomatikk.arsakList,
+    } as StatusEndring;
   });
 };
 

--- a/src/sider/manglendemedvirkning/ManglendeMedVirkningStatusItem.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedVirkningStatusItem.tsx
@@ -15,7 +15,7 @@ import React from "react";
 
 const texts = {
   vurdertLabel: "Vurdert av",
-  statusStansLabel: "Melding om stans sendt",
+  statusStansLabel: "Automatisk utbetaling stanset",
 };
 
 interface StatusEndringItemProps {

--- a/src/sider/manglendemedvirkning/ManglendeMedVirkningStatusItem.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedVirkningStatusItem.tsx
@@ -1,0 +1,62 @@
+import {
+  Arbeidsgiver,
+  StatusEndring,
+} from "@/data/pengestopp/types/FlaggPerson";
+import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
+import {
+  sykmeldingerToArbeidsgiver,
+  uniqueArbeidsgivere,
+} from "@/utils/pengestoppUtils";
+import { Accordion, Label } from "@navikt/ds-react";
+import { Paragraph } from "@/components/Paragraph";
+import React from "react";
+
+const texts = {
+  vurdertLabel: "Vurdert av",
+  statusStansLabel: "Melding om stans sendt",
+};
+
+interface StatusEndringItemProps {
+  status: StatusEndring;
+}
+
+export default function StatusItem({ status }: StatusEndringItemProps) {
+  const { veilederIdent } = status;
+  const { data: veilederinfo } = useVeilederInfoQuery(veilederIdent.value);
+  const { sykmeldinger } = useSykmeldingerQuery();
+  const opprettet = new Date(status.opprettet);
+  const header = `${texts.statusStansLabel} - ${tilDatoMedManedNavn(
+    opprettet
+  )}`;
+
+  const allArbeidsgivere = uniqueArbeidsgivere(
+    sykmeldingerToArbeidsgiver(sykmeldinger)
+  );
+
+  function getArbeidsgiverNavn(statusEndring: StatusEndring) {
+    return allArbeidsgivere.find(
+      (ag: Arbeidsgiver) => ag.orgnummer === statusEndring.virksomhetNr?.value
+    )?.navn;
+  }
+
+  const arbeidsgiver = status.virksomhetNr
+    ? ` · Gjelder for: ${getArbeidsgiverNavn(status)}`
+    : ``;
+
+  return (
+    <Accordion.Item>
+      <Accordion.Header>{header}</Accordion.Header>
+      <Accordion.Content>
+        <Label size="small">{`${opprettet.getDate()}.${
+          opprettet.getMonth() + 1
+        }.${opprettet.getFullYear()} ${arbeidsgiver}`}</Label>
+        <Paragraph
+          label={texts.vurdertLabel}
+          body={veilederinfo?.fulltNavn() ?? ""}
+        />
+      </Accordion.Content>
+    </Accordion.Item>
+  );
+}

--- a/src/sider/manglendemedvirkning/ManglendeMedVirkningStatusItem.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedVirkningStatusItem.tsx
@@ -31,11 +31,11 @@ export default function StatusItem({ status }: StatusEndringItemProps) {
     opprettet
   )}`;
 
-  const allArbeidsgivere = uniqueArbeidsgivere(
-    sykmeldingerToArbeidsgiver(sykmeldinger)
-  );
-
   function getArbeidsgiverNavn(statusEndring: StatusEndring) {
+    const allArbeidsgivere = uniqueArbeidsgivere(
+      sykmeldingerToArbeidsgiver(sykmeldinger)
+    );
+
     return allArbeidsgivere.find(
       (ag: Arbeidsgiver) => ag.orgnummer === statusEndring.virksomhetNr?.value
     )?.navn;

--- a/src/sider/manglendemedvirkning/ManglendeMedvirkningHistorikk.tsx
+++ b/src/sider/manglendemedvirkning/ManglendeMedvirkningHistorikk.tsx
@@ -87,10 +87,10 @@ function isVurderingResponseDTO(
   return "vurderingType" in item;
 }
 
-function dateFromHistorikkEntry(a: HistorikkEntry) {
-  return isVurderingResponseDTO(a)
-    ? new Date(a.createdAt)
-    : new Date(a.opprettet);
+function dateFromHistorikkEntry(historikkEntry: HistorikkEntry) {
+  return isVurderingResponseDTO(historikkEntry)
+    ? new Date(historikkEntry.createdAt)
+    : new Date(historikkEntry.opprettet);
 }
 
 function sortHistorikkEntriesDesc(a: HistorikkEntry, b: HistorikkEntry) {

--- a/test/manglendemedvirkning/ManglendeMedvirkningHistorikkTest.tsx
+++ b/test/manglendemedvirkning/ManglendeMedvirkningHistorikkTest.tsx
@@ -279,7 +279,7 @@ describe("ManglendeMedvirkningHistorikk", () => {
         "Forhåndsvarsel - 21. februar 2025"
       );
       expect(accordionButtons[2].textContent).to.contain(
-        "Melding om stans sendt - 20. februar 2025"
+        "Automatisk utbetaling stanset - 20. februar 2025"
       );
       expect(accordionButtons[3].textContent).to.contain(
         "Innstilling om stans - 16. februar 2025"


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til statusendringer med årsakType: `MANGLENDE_MEDVIRKING` i historikken på siden manglende medvirkning. Disse statusendringer vil komme opp som: `Melding om stans sendt`.  Alle elementer i historikken sorteres synkende på dato (nyeste øverst).

Tanken i første omgang var å høre om dette er grei nok måte å løse det på. Visningen/Informasjonen man får fra vurdering og statusendring var ganske forskjellige så virka litt unødvendig å lage en felles komponent (litt slik som Historikk er lagt opp), men kan fint gjøre det om ønskelig.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/a537ffa8-ebf8-4a22-b346-b7fa2e302957)