### PR TITLE
IS-3112: Make pengestopp fields nullable

### DIFF
--- a/src/components/pengestopp/PengestoppHistorikk.tsx
+++ b/src/components/pengestopp/PengestoppHistorikk.tsx
@@ -22,10 +22,14 @@ const PengestoppHistorikk = ({ statusEndringList, sykmeldinger }: Props) => {
     sykmeldingerToArbeidsgiver(sykmeldinger)
   );
 
-  function getArbeidsgiverNavn(statusEndring: StatusEndring) {
-    return allArbeidsgivere.find(
-      (ag: Arbeidsgiver) => ag.orgnummer === statusEndring.virksomhetNr.value
-    )?.navn;
+  function getArbeidsgiverNavn(
+    statusEndring: StatusEndring
+  ): string | undefined {
+    return (
+      allArbeidsgivere.find(
+        (ag: Arbeidsgiver) => ag.orgnummer === statusEndring.virksomhetNr?.value
+      )?.navn ?? "Ukjent arbeidsgiver"
+    );
   }
 
   function getArsakText(statusEndring: StatusEndring) {

--- a/src/data/pengestopp/types/FlaggPerson.ts
+++ b/src/data/pengestopp/types/FlaggPerson.ts
@@ -95,7 +95,7 @@ export interface StatusEndring {
   sykmeldtFnr: SykmeldtFnr;
   arsakList: SykepengestoppArsak[];
   status: Status;
-  virksomhetNr: VirksomhetNr;
+  virksomhetNr: VirksomhetNr | undefined;
   opprettet: string;
-  enhetNr: EnhetNr;
+  enhetNr: EnhetNr | undefined;
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Disse har blitt nullable i backend så må håndtere at de kan være null i frontend også. 
Må merges før vi begynner å trykke automatisk på stoppknappen ved konsumering av vurderinger ([PR](https://github.com/navikt/ispengestopp/pull/161)) for at historikken på stoppknappetrykk som finnes på Sykmeldinger-siden ikke skal brekke.

### Screenshots 📸✨

