### PR TITLE
IS-3034: Lagt til mellomrom mellom tall og prosenttegn

### DIFF
--- a/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeaderTags.tsx
@@ -78,7 +78,7 @@ export const PersonkortHeaderTags = () => {
         )}
         {uforegradData?.uforegrad && (
           <Tag variant="info" size="small">
-            {`Ufør ${uforegradData.uforegrad}%`}
+            {`Ufør ${uforegradData.uforegrad} %`}
           </Tag>
         )}
         {talesprakTolkSprakkode && (

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -317,7 +317,7 @@ describe("PersonkortHeader", () => {
     );
     renderPersonkortHeader();
 
-    expect(screen.getByText("Ufør 80%")).to.exist;
+    expect(screen.getByText("Ufør 80 %")).to.exist;
   });
 
   it("viser ikke uføregrad tag når null", () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Iht. [Språkrådet](https://sprakradet.no/spraksporsmal-og-svar/prosentteikn-og-mellomrom/) så skal det være mellomrom mellom tall og prosenttegn

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/ca195094-e091-48b6-8930-8791a1300c13)

