### PR TITLE
IS-3151: Gjort sykmeldinger mer utskriftsvennlig

### DIFF
--- a/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
+++ b/src/components/utdragFraSykefravaeret/Sykmeldinger.tsx
@@ -78,7 +78,7 @@ const UtvidbarSykmelding = ({ sykmelding }: UtvidbarSykmeldingProps) => {
           <SykmeldingTittelbeskrivelse sykmelding={sykmelding} />
         </ExpansionCard.Title>
       </StyledExpantionCardHeader>
-      <ExpansionCard.Content>
+      <ExpansionCard.Content className={"print:block"}>
         <SykmeldingUtdragFraSykefravaretVisning sykmelding={sykmelding} />
       </ExpansionCard.Content>
     </ExpansionCard>
@@ -110,7 +110,7 @@ const SykmeldingTittelbeskrivelse = ({ sykmelding }: UtvidbarTittelProps) => {
   const erUtenArbeidsgiver = erSykmeldingUtenArbeidsgiver(sykmelding);
 
   return (
-    <div className="w-full flex flex-col">
+    <div className="w-full flex flex-col print:z-10">
       <div className="flex justify-between mb-2">
         <div>
           {periode}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Fikset slik at tekst for sykmeldinger er synlig hvis man skal skrive det ut.

Det er litt uheldig at det er grå tekst på løsningen, men det virker som det er noe css som jeg potensielt ikke får overstyrt (eller mer sannsynlig at jeg ikke vet hva som skal overstyres). Tenkte jeg skulle høre med Aksel. Mao. så er denne PRen litt for å i hvert fall gjøre innholdet synlig i første omgang.

### Screenshots 📸✨

Før:
![image](https://github.com/user-attachments/assets/bbdd4df1-b67c-4166-9e7a-ec082cf738fb)

Etter:
![image](https://github.com/user-attachments/assets/4bf36958-060c-45e7-bb93-f2cfe6780046)
