### PR TITLE
IS-3101: add ukenummer i datepickers

### DIFF
--- a/src/sider/arbeidsuforhet/avslag/AvslagDatePicker.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagDatePicker.tsx
@@ -30,7 +30,7 @@ export function AvslagDatePicker({ varselSvarfrist }: Props) {
   });
 
   return (
-    <DatePicker {...datepickerProps} strategy="fixed">
+    <DatePicker {...datepickerProps} strategy="fixed" showWeekNumber>
       <DatePicker.Input
         {...inputProps}
         size="small"

--- a/src/sider/dialogmoter/components/DialogmoteDato.tsx
+++ b/src/sider/dialogmoter/components/DialogmoteDato.tsx
@@ -30,7 +30,7 @@ export const DialogmoteDato = () => {
   });
 
   return (
-    <DatePicker {...datepickerProps} strategy="fixed">
+    <DatePicker {...datepickerProps} strategy="fixed" showWeekNumber>
       <DatePicker.Input
         id={field.name}
         {...inputProps}

--- a/src/sider/frisktilarbeid/VedtakFraDato.tsx
+++ b/src/sider/frisktilarbeid/VedtakFraDato.tsx
@@ -33,7 +33,7 @@ export const VedtakFraDato = ({ tilDato }: VedtakFraDatoProps) => {
   });
 
   return (
-    <DatePicker {...fraDatoDatePicker.datepickerProps}>
+    <DatePicker {...fraDatoDatePicker.datepickerProps} showWeekNumber>
       <DatePicker.Input
         {...fraDatoDatePicker.inputProps}
         label={texts.fraDatoLabel}

--- a/src/sider/manglendemedvirkning/stans/StansdatoDatePicker.tsx
+++ b/src/sider/manglendemedvirkning/stans/StansdatoDatePicker.tsx
@@ -28,7 +28,7 @@ export function StansdatoDatePicker({ varselSvarfrist }: Props) {
   });
 
   return (
-    <DatePicker {...datepickerProps}>
+    <DatePicker {...datepickerProps} showWeekNumber>
       <DatePicker.Input
         {...inputProps}
         label={texts.label}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til ukenummer i datepickers på: 
- Dialogmøteinnkalling
- Stansdato 8-4 og 8-8
- 8-5 Friskmelding til arbeidsformidling

### Screenshots 📸✨
<details>
<summary>Sånn ser det ut etter at nummeret er lagt til i kalenderne: </summary>

![Skjermbilde 2025-03-05 kl  09 46 47](https://github.com/user-attachments/assets/86b1f654-b193-468b-84be-5cbe5040839d)
![Skjermbilde 2025-03-05 kl  09 50 51](https://github.com/user-attachments/assets/3080aad8-a44b-43cf-aad7-6f062dcf5e8e)
![Skjermbilde 2025-03-05 kl  09 51 09](https://github.com/user-attachments/assets/3cf1d8be-3a97-4a55-9a2c-8403bb23af0f)
![Skjermbilde 2025-03-05 kl  09 52 56](https://github.com/user-attachments/assets/965f01cb-0ebd-4375-9f3d-96281b44ff79)
![Skjermbilde 2025-03-05 kl  09 54 25](https://github.com/user-attachments/assets/bdc99084-da69-4e85-b19c-0c014ec71dab)
</details>