### PR TITLE
IS-3114: Fjernet muligheten for å velge manglende medvirkning som årsak ved bruk av stoppknappen

### DIFF
--- a/src/components/pengestopp/PengestoppModal.tsx
+++ b/src/components/pengestopp/PengestoppModal.tsx
@@ -3,6 +3,7 @@ import {
   Arbeidsgiver,
   SykepengestoppArsakType,
   validSykepengestoppArsakTekster,
+  ValidSykepengestoppArsakType,
 } from "@/data/pengestopp/types/FlaggPerson";
 import { useFlaggPerson } from "@/data/pengestopp/useFlaggPerson";
 import {
@@ -67,6 +68,11 @@ const PengestoppModal = ({ isOpen, arbeidsgivere, onModalClose }: Props) => {
 
   const tittel = isSuccess ? texts.stoppedTittel : texts.notStoppedTittel;
 
+  const manuellStoppknapp = [
+    ValidSykepengestoppArsakType.MEDISINSK_VILKAR,
+    ValidSykepengestoppArsakType.AKTIVITETSKRAV,
+  ].map((value) => value.toString());
+
   return (
     <form onSubmit={handleSubmit(submit)}>
       <Modal
@@ -107,17 +113,18 @@ const PengestoppModal = ({ isOpen, arbeidsgivere, onModalClose }: Props) => {
                 error={errors.arsaker?.message}
               >
                 {Object.entries(validSykepengestoppArsakTekster).map(
-                  ([type, text], index: number) => (
-                    <Checkbox
-                      key={index}
-                      value={type}
-                      {...register("arsaker", {
-                        required: texts.arsak.submitError,
-                      })}
-                    >
-                      {text}
-                    </Checkbox>
-                  )
+                  ([type, text], index: number) =>
+                    manuellStoppknapp.includes(type) ? (
+                      <Checkbox
+                        key={index}
+                        value={type}
+                        {...register("arsaker", {
+                          required: texts.arsak.submitError,
+                        })}
+                      >
+                        {text}
+                      </Checkbox>
+                    ) : null
                 )}
               </CheckboxGroup>
               <div className="flex gap-4">

--- a/test/pengestopp/PengestoppTest.tsx
+++ b/test/pengestopp/PengestoppTest.tsx
@@ -82,12 +82,6 @@ describe("Pengestopp", () => {
     ).to.exist;
     expect(
       screen.getByRole("checkbox", {
-        name: /Manglende medvirkning/,
-        hidden: true,
-      })
-    ).to.exist;
-    expect(
-      screen.getByRole("checkbox", {
         name: /Aktivitetskravet/,
         hidden: true,
       })


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Fjernet muligheten for å velge manglende medvirkning som årsak ved bruk av stoppknappen

Relatert til: https://github.com/navikt/syfomodiaperson/pull/1655

### Screenshots 📸✨
Før:
![image](https://github.com/user-attachments/assets/351b65c7-89d3-41f7-a6a3-7968fa12fe83)

Etter:
![image](https://github.com/user-attachments/assets/59ae083b-d9fa-405c-a1ad-a542e6260e66)

