### PR TITLE
IS-3121: Endret tekster i skjemaet for å skrive innstilling ifm. arbeidsuførhet

### DIFF
--- a/src/sider/arbeidsuforhet/ArbeidsuforhetButtons.tsx
+++ b/src/sider/arbeidsuforhet/ArbeidsuforhetButtons.tsx
@@ -8,7 +8,7 @@ import {
 import React from "react";
 
 const texts = {
-  avslag: "Innstilling om avslag",
+  avslag: "Skriv innstilling om avslag",
   oppfylt: "Oppfylt",
   ikkeAktuell: "Ikke aktuell",
 };

--- a/src/sider/arbeidsuforhet/avslag/AvslagDatePicker.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagDatePicker.tsx
@@ -4,7 +4,7 @@ import { useController } from "react-hook-form";
 import { ArbeidsuforhetAvslagSkjemaValues } from "@/sider/arbeidsuforhet/avslag/AvslagForm";
 
 const texts = {
-  label: "Avslaget gjelder fra",
+  label: "Innstillingen gjelder fra",
   missingDate: "Vennligst angi dato",
 };
 

--- a/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
@@ -7,7 +7,7 @@ import {
   VurderingType,
 } from "@/data/arbeidsuforhet/arbeidsuforhetTypes";
 import {
-  BodyShort,
+  BodyLong,
   Box,
   Button,
   Heading,
@@ -22,9 +22,11 @@ import { arbeidsuforhetPath } from "@/routers/AppRouter";
 import { AvslagDatePicker } from "@/sider/arbeidsuforhet/avslag/AvslagDatePicker";
 import dayjs from "dayjs";
 import { useNotification } from "@/context/notification/NotificationContext";
+import { Paragraph } from "@/components/Paragraph";
 
 const texts = {
-  title: "Skriv innstilling til NAY",
+  title: "Skriv innstilling om avslag til NAY",
+  innstillingInfoLabel: "Når du skriver innstillingen",
   begrunnelseLabel: "Innstilling om avslag (obligatorisk)",
   info1:
     "Skriv kort hvilke opplysninger som ligger til grunn for avslaget, samt din vurdering av hvorfor vilkåret ikke er oppfylt og vurdering av eventuelle nye opplysninger.",
@@ -32,18 +34,25 @@ const texts = {
     "Hvis du har vurdert ordningen friskmelding til arbeidsformidling: skriv hvorfor ordningen ikke er aktuell og legg inn henvisning til §8-5.",
   afterSendInfo: {
     title: "Videre må du huske å:",
-    gosysoppgave: "Sende oppgave til NAY i Gosys.",
-    stoppknapp:
-      "Gi beskjed om avslag til ny saksbehandlingsløsning via Stoppknappen under fanen Sykmeldinger i Modia.",
+    gosysoppgave:
+      "Sende beskjed i Gosys til Nav Arbeid og Ytelser. Dette er for å gjøre saksbehandler oppmerksom på at det har kommet en innstilling og at utbetalingen skal stanses.",
+    gosysoppgaveListe: {
+      tema: "Tema: Sykepenger",
+      gjelder: "Gjelder: Behandle vedtak",
+      oppgavetype: "Oppgavetype: Vurder konsekvens for ytelse",
+      prioritet: "Prioritet: Høy",
+    },
   },
+  buttonDescriptionLabel:
+    "Send innstilling om avslag og stans automatisk utbetaling",
   buttonDescription:
-    "Når du trykker “Gi avslag” blir innstillingen journalført og kan sees i Gosys.",
+    "Når du sender innstillingen blir den journalført og kan sees i Gosys. Den automatiske utbetalingen til bruker stanses og oppgaven blir deretter plukket opp av saksbehandler fra Gosys",
   forhandsvisningLabel: "Forhåndsvis innstillingen",
   missingBegrunnelse: "Vennligst angi begrunnelse",
-  sendVarselButtonText: "Gi avslag",
+  sendVarselButtonText: "Send",
   avbrytButton: "Avbryt",
   success:
-    "Innstilling om avslag § 8-4 er lagret i historikken og blir journalført automatisk.",
+    "Innstilling om avslag § 8-4 er lagret i historikken og blir journalført automatisk. Automatisk utbetaling av sykepenger er stanset.",
 };
 
 const begrunnelseMaxLength = 5000;
@@ -96,8 +105,8 @@ export function AvslagForm({ varselSvarfrist }: Props) {
             {texts.title}
           </Heading>
           <AvslagDatePicker varselSvarfrist={varselSvarfrist} />
-          <BodyShort>{texts.info1}</BodyShort>
-          <BodyShort>{texts.info2}</BodyShort>
+          <Paragraph label={texts.innstillingInfoLabel} body={texts.info1} />
+          <BodyLong size={"small"}>{texts.info2}</BodyLong>
           <Textarea
             {...register("begrunnelse", {
               maxLength: begrunnelseMaxLength,
@@ -114,20 +123,29 @@ export function AvslagForm({ varselSvarfrist }: Props) {
             <SkjemaInnsendingFeil error={sendVurdering.error} />
           )}
           <List as="ul" title={texts.afterSendInfo.title}>
-            <List.Item className="ml-8">
-              {texts.afterSendInfo.gosysoppgave}
-            </List.Item>
-            <List.Item className="ml-8">
-              {texts.afterSendInfo.stoppknapp}
-            </List.Item>
+            {texts.afterSendInfo.gosysoppgave}
+            <List as="ul" className="ml-1">
+              <List.Item>
+                {texts.afterSendInfo.gosysoppgaveListe.tema}
+              </List.Item>
+              <List.Item>
+                {texts.afterSendInfo.gosysoppgaveListe.oppgavetype}
+              </List.Item>
+              <List.Item>
+                {texts.afterSendInfo.gosysoppgaveListe.gjelder}
+              </List.Item>
+              <List.Item>
+                {texts.afterSendInfo.gosysoppgaveListe.prioritet}
+              </List.Item>
+            </List>
           </List>
-          <BodyShort>{texts.buttonDescription}</BodyShort>
+          <Paragraph
+            label={texts.buttonDescriptionLabel}
+            body={texts.buttonDescription}
+          />
           <ButtonRow>
             <Button loading={sendVurdering.isPending} type="submit">
               {texts.sendVarselButtonText}
-            </Button>
-            <Button as={Link} to={arbeidsuforhetPath} variant="secondary">
-              {texts.avbrytButton}
             </Button>
             <Forhandsvisning
               contentLabel={texts.forhandsvisningLabel}
@@ -138,6 +156,9 @@ export function AvslagForm({ varselSvarfrist }: Props) {
                 })
               }
             />
+            <Button as={Link} to={arbeidsuforhetPath} variant="secondary">
+              {texts.avbrytButton}
+            </Button>
           </ButtonRow>
         </form>
       </FormProvider>

--- a/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
@@ -46,7 +46,7 @@ const texts = {
   buttonDescriptionLabel:
     "Send innstilling om avslag og stans automatisk utbetaling",
   buttonDescription:
-    "Når du sender innstillingen blir den journalført og kan sees i Gosys. Den automatiske utbetalingen til bruker stanses og oppgaven blir deretter plukket opp av saksbehandler fra Gosys",
+    "Når du sender innstillingen blir den journalført og kan sees i Gosys. Den automatiske utbetalingen til bruker stanses og oppgaven blir deretter plukket opp av saksbehandler fra Gosys.",
   forhandsvisningLabel: "Forhåndsvis innstillingen",
   missingBegrunnelse: "Vennligst angi begrunnelse",
   sendVarselButtonText: "Send",
@@ -122,7 +122,7 @@ export function AvslagForm({ varselSvarfrist }: Props) {
           {sendVurdering.isError && (
             <SkjemaInnsendingFeil error={sendVurdering.error} />
           )}
-          <List as="ul" title={texts.afterSendInfo.title}>
+          <List as="ul" title={texts.afterSendInfo.title} size={"small"}>
             {texts.afterSendInfo.gosysoppgave}
             <List as="ul" className="ml-1">
               <List.Item>

--- a/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
+++ b/src/sider/arbeidsuforhet/avslag/AvslagForm.tsx
@@ -27,7 +27,7 @@ import { Paragraph } from "@/components/Paragraph";
 const texts = {
   title: "Skriv innstilling om avslag til NAY",
   innstillingInfoLabel: "Når du skriver innstillingen",
-  begrunnelseLabel: "Innstilling om avslag (obligatorisk)",
+  begrunnelseLabel: "Begrunnelse (obligatorisk)",
   info1:
     "Skriv kort hvilke opplysninger som ligger til grunn for avslaget, samt din vurdering av hvorfor vilkåret ikke er oppfylt og vurdering av eventuelle nye opplysninger.",
   info2:

--- a/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
+++ b/test/arbeidsuforhet/ForhandsvarselSendtTest.tsx
@@ -65,7 +65,7 @@ describe("ForhandsvarselSendt", () => {
         .exist;
       expect(screen.getByRole("img", { name: "klokkeikon" })).to.exist;
       expect(
-        screen.getByRole("button", { name: "Innstilling om avslag" })
+        screen.getByRole("button", { name: "Skriv innstilling om avslag" })
       ).to.have.property("disabled", true);
       expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
       expect(screen.getByRole("button", { name: "Ikke aktuell" })).to.exist;
@@ -97,8 +97,9 @@ describe("ForhandsvarselSendt", () => {
           )} er gått ut. Trykk på Innstilling om avslag-knappen hvis vilkårene i § 8-4 ikke er oppfylt og rett til videre sykepenger skal avslås.`
         )
       ).to.exist;
-      expect(screen.getByRole("button", { name: "Innstilling om avslag" })).to
-        .exist;
+      expect(
+        screen.getByRole("button", { name: "Skriv innstilling om avslag" })
+      ).to.exist;
       expect(screen.getByRole("button", { name: "Oppfylt" })).to.exist;
       expect(screen.getByRole("button", { name: "Ikke aktuell" })).to.exist;
     });

--- a/test/arbeidsuforhet/avslag/ArbeidsuforhetAvslagTest.tsx
+++ b/test/arbeidsuforhet/avslag/ArbeidsuforhetAvslagTest.tsx
@@ -52,7 +52,7 @@ describe("AvslagSide", () => {
 
       renderArbeidsuforhetAvslagSide();
 
-      expect(screen.getByText("Skriv innstilling til NAY")).to.exist;
+      expect(screen.getByText("Skriv innstilling om avslag til NAY")).to.exist;
     });
 
     it("redirect to arbeidsuforhet page if latest arbeidsuforhet status is forhandsvarsel and frist is not utgatt", () => {

--- a/test/arbeidsuforhet/avslag/AvslagFormTest.tsx
+++ b/test/arbeidsuforhet/avslag/AvslagFormTest.tsx
@@ -37,7 +37,9 @@ describe("AvslagForm", () => {
 
       renderAvslagForm();
 
-      expect(screen.getByText("Avslaget gjelder fra")).to.exist;
+      expect(screen.getByText("Skriv innstilling om avslag til NAY")).to.exist;
+      expect(screen.getByText("Når du skriver innstillingen")).to.exist;
+      expect(screen.getByText("Innstillingen gjelder fra")).to.exist;
       expect(
         screen.getByText("Skriv kort hvilke opplysninger", { exact: false })
       ).to.exist;
@@ -53,7 +55,22 @@ describe("AvslagForm", () => {
         })
       ).to.exist;
       expect(screen.getByText("Videre må du huske å:")).to.exist;
-      expect(screen.getByRole("button", { name: "Gi avslag" })).to.exist;
+      expect(
+        screen.getByText(
+          "Sende beskjed i Gosys til Nav Arbeid og Ytelser. Dette er for å gjøre saksbehandler oppmerksom på at det har kommet en innstilling og at utbetalingen skal stanses."
+        )
+      ).to.exist;
+      expect(screen.getByText("Tema: Sykepenger")).to.exist;
+      expect(screen.getByText("Oppgavetype: Vurder konsekvens for ytelse")).to
+        .exist;
+      expect(screen.getByText("Gjelder: Behandle vedtak")).to.exist;
+      expect(screen.getByText("Prioritet: Høy")).to.exist;
+      expect(
+        screen.getByText(
+          "Send innstilling om avslag og stans automatisk utbetaling"
+        )
+      ).to.exist;
+      expect(screen.getByRole("button", { name: "Send" })).to.exist;
       expect(screen.getByRole("button", { name: "Avbryt" })).to.exist;
       expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
     });
@@ -63,7 +80,7 @@ describe("AvslagForm", () => {
     it("Gives errors when trying to send vurdering without date and begrunnelse", async () => {
       renderAvslagForm();
 
-      await clickButton("Gi avslag");
+      await clickButton("Send");
 
       expect(await screen.findByText("Vennligst angi dato")).to.exist;
       expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
@@ -74,13 +91,13 @@ describe("AvslagForm", () => {
       const begrunnelse = "Dette er en begrunnelse!";
       const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
       const fristDate = new Date(Date.now());
-      const dateLabel = "Avslaget gjelder fra";
+      const dateLabel = "Innstillingen gjelder fra";
       const dateInput = getTextInput(dateLabel);
       const begrunnelseInput = getTextInput(begrunnelseLabel);
 
       changeTextInput(dateInput, toDatePrettyPrint(fristDate) as string);
       changeTextInput(begrunnelseInput, begrunnelse);
-      await clickButton("Gi avslag");
+      await clickButton("Send");
 
       await waitFor(() => {
         const useSendVurderingArbeidsuforhet = queryClient
@@ -103,7 +120,7 @@ describe("AvslagForm", () => {
       const begrunnelse = "Dette er en begrunnelse!";
       const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
       const fristDate = new Date(Date.now());
-      const dateLabel = "Avslaget gjelder fra";
+      const dateLabel = "Innstillingen gjelder fra";
       const dateInput = getTextInput(dateLabel);
       const begrunnelseInput = getTextInput(begrunnelseLabel);
 

--- a/test/arbeidsuforhet/avslag/AvslagFormTest.tsx
+++ b/test/arbeidsuforhet/avslag/AvslagFormTest.tsx
@@ -33,7 +33,7 @@ describe("AvslagForm", () => {
 
   describe("Form components", () => {
     it("shows date picker, textarea, and buttons", () => {
-      const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
+      const begrunnelseLabel = "Begrunnelse (obligatorisk)";
 
       renderAvslagForm();
 
@@ -89,7 +89,7 @@ describe("AvslagForm", () => {
     it("Send vurdering with date and begrunnelse filled in, without reseting the form", async () => {
       renderAvslagForm();
       const begrunnelse = "Dette er en begrunnelse!";
-      const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
+      const begrunnelseLabel = "Begrunnelse (obligatorisk)";
       const fristDate = new Date(Date.now());
       const dateLabel = "Innstillingen gjelder fra";
       const dateInput = getTextInput(dateLabel);
@@ -118,7 +118,7 @@ describe("AvslagForm", () => {
     it("Forhåndsvis brev with begrunnelse", async () => {
       renderAvslagForm();
       const begrunnelse = "Dette er en begrunnelse!";
-      const begrunnelseLabel = "Innstilling om avslag (obligatorisk)";
+      const begrunnelseLabel = "Begrunnelse (obligatorisk)";
       const fristDate = new Date(Date.now());
       const dateLabel = "Innstillingen gjelder fra";
       const dateInput = getTextInput(dateLabel);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret tekster i skjemaet for å skrive innstilling ifm. arbeidsuførhet for å reflektere at man ikke lenger trenger å trykke manuelt på stoppknappen ettersom dette skal gjøres automatisk av backend ved innsendt innstilling.

Avhengig av: https://github.com/navikt/ispengestopp/pull/163

Satt denne som draft inntil videre, men er ferdig.

### Screenshots 📸✨
Før:
![image](https://github.com/user-attachments/assets/a1cd4379-27d6-451e-83f0-5702ebffbf3b)

Etter:
![image](https://github.com/user-attachments/assets/d92c3762-eddb-4c13-9755-27fd844c647b)