### PR TITLE
IS-3120: Fjernet muligheten for å velge arbeidsuførhet som årsak ved bruk av stoppknappen

### DIFF
--- a/src/components/pengestopp/PengestoppModal.tsx
+++ b/src/components/pengestopp/PengestoppModal.tsx
@@ -68,10 +68,9 @@ const PengestoppModal = ({ isOpen, arbeidsgivere, onModalClose }: Props) => {
 
   const tittel = isSuccess ? texts.stoppedTittel : texts.notStoppedTittel;
 
-  const manuellStoppknapp = [
-    ValidSykepengestoppArsakType.MEDISINSK_VILKAR,
-    ValidSykepengestoppArsakType.AKTIVITETSKRAV,
-  ].map((value) => value.toString());
+  const manuellStoppknapp = [ValidSykepengestoppArsakType.AKTIVITETSKRAV].map(
+    (value) => value.toString()
+  );
 
   return (
     <form onSubmit={handleSubmit(submit)}>

--- a/test/pengestopp/PengestoppTest.tsx
+++ b/test/pengestopp/PengestoppTest.tsx
@@ -76,12 +76,6 @@ describe("Pengestopp", () => {
 
     expect(
       screen.getByRole("checkbox", {
-        name: /Medisinsk vilkår/,
-        hidden: true,
-      })
-    ).to.exist;
-    expect(
-      screen.getByRole("checkbox", {
         name: /Aktivitetskravet/,
         hidden: true,
       })


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Fjernet muligheten for å velge arbeidsuførhet som årsak ved bruk av stoppknappen

Relatert til (og må merges først): https://github.com/navikt/syfomodiaperson/pull/1661

### Screenshots 📸✨
Før:
![image](https://github.com/user-attachments/assets/3aa4d865-8714-4975-b43e-1f1bba2cb65a)

Etter:
![image](https://github.com/user-attachments/assets/8e9ddf7f-db06-4237-b4c5-3d5975350cba)