### PR TITLE
IS-3132: Endret tekster i skjemaet for å skrive innstilling ifm. aktivitetskrav

### DIFF
--- a/src/sider/aktivitetskrav/useAktivitetskravNotificationAlert.ts
+++ b/src/sider/aktivitetskrav/useAktivitetskravNotificationAlert.ts
@@ -27,7 +27,7 @@ export const useAktivitetskravNotificationAlert = () => {
         return `Det er vurdert at aktivitetskravet ikke er oppfylt for ${brukersNavn} ${today}.`;
       }
       case AktivitetskravStatus.INNSTILLING_OM_STANS: {
-        return `Det er vurdert innstilling om stans for aktivitetskravet for ${brukersNavn} ${today}.`;
+        return `Innstilling om stans § 8-8 aktivitetsplikten er lagret i historikken og blir journalført automatisk. Automatisk utbetaling av sykepenger er stanset.`;
       }
       case AktivitetskravStatus.IKKE_AKTUELL: {
         return `Det er vurdert at aktivitetskravet ikke er aktuelt for ${brukersNavn} ${today}.`;

--- a/src/sider/aktivitetskrav/vurdering/InnstillingOmStansSkjema.tsx
+++ b/src/sider/aktivitetskrav/vurdering/InnstillingOmStansSkjema.tsx
@@ -4,38 +4,41 @@ import {
 } from "@/data/aktivitetskrav/aktivitetskravTypes";
 import React from "react";
 import { useVurderAktivitetskrav } from "@/data/aktivitetskrav/useVurderAktivitetskrav";
-import {
-  Alert,
-  BodyShort,
-  Button,
-  Heading,
-  List,
-  Textarea,
-} from "@navikt/ds-react";
+import { Alert, Button, Heading, List, Textarea } from "@navikt/ds-react";
 import { useAktivitetskravNotificationAlert } from "@/sider/aktivitetskrav/useAktivitetskravNotificationAlert";
 import { FormProvider, useForm } from "react-hook-form";
 import { StansdatoDatePicker } from "@/sider/aktivitetskrav/vurdering/StansdatoDatePicker";
 import { useAktivitetskravVurderingDocument } from "@/hooks/aktivitetskrav/useAktivitetskravVurderingDocument";
 import { defaultErrorTexts } from "@/api/errors";
+import { Paragraph } from "@/components/Paragraph";
 
 const texts = {
-  sendInnstilling: "Send innstilling",
+  sendInnstilling: "Send",
   avbryt: "Avbryt",
-  title: "Innstilling om stans",
+  title: "Skriv innstilling om stans til NAY",
+  innstillingInfoLabel: "Når du skriver innstillingen",
+  innstillingInfoDescription:
+    "Skriv kort om hvilke opplysninger som ligger til grunn for stans av sykepenger, samt din vurdering av hvorfor aktivitetsplikten ikke er oppfylt og vurdering av eventuelle nye opplysninger.",
   form: {
     begrunnelseLabel: "Begrunnelse (obligatorisk)",
-    begrunnelseDescription:
-      "Skriv kort om hvilke opplysninger som ligger til grunn for stans av sykepenger, samt din vurdering av hvorfor aktivitetsplikten ikke er oppfylt og vurdering av eventuelle nye opplysninger.",
     missingBegrunnelse: "Vennligst angi begrunnelse",
   },
   afterSendInfo: {
-    title: "Etter innstilling er sendt må du:",
+    title: "Videre må du huske å:",
     gosysoppgave: "Sende oppgave til NAY i Gosys.",
+    gosysoppgaveListe: {
+      tema: "Tema: Sykepenger",
+      gjelder: "Gjelder: Aktivitetskrav",
+      oppgavetype: "Oppgavetype: Vurder konsekvens for ytelse",
+      prioritet: "Prioritet: Høy",
+    },
     stoppknapp:
       "Gi beskjed om stans til ny saksbehandlingsløsning via Stoppknappen under fanen Sykmeldinger i Modia.",
-    innstillingenBlirJournalfort:
-      "Innstillingen blir journalført og kan sees i Gosys.",
   },
+  buttonDescriptionLabel:
+    "Send innstilling om stans og stans automatisk utbetaling",
+  buttonDescription:
+    "Når du sender innstillingen blir den journalført og kan sees i Gosys. Den automatiske utbetalingen til bruker stanses og oppgaven blir deretter plukket opp av saksbehandler fra Gosys.",
 };
 
 const begrunnelseMaxLength = 5000;
@@ -91,6 +94,11 @@ export default function InnstillingOmStansSkjema({
 
         <StansdatoDatePicker varselSvarfrist={varselSvarfrist} />
 
+        <Paragraph
+          label={texts.innstillingInfoLabel}
+          body={texts.innstillingInfoDescription}
+        />
+
         <Textarea
           {...register("begrunnelse", {
             maxLength: begrunnelseMaxLength,
@@ -98,21 +106,32 @@ export default function InnstillingOmStansSkjema({
           })}
           value={watch("begrunnelse")}
           label={texts.form.begrunnelseLabel}
-          description={texts.form.begrunnelseDescription}
           error={errors.begrunnelse?.message}
           size="small"
           minRows={6}
           maxLength={begrunnelseMaxLength}
         />
 
-        <List as="ul" size="small" title={texts.afterSendInfo.title}>
-          <List.Item>{texts.afterSendInfo.gosysoppgave}</List.Item>
-          <List.Item>{texts.afterSendInfo.stoppknapp}</List.Item>
+        <List as="ul" title={texts.afterSendInfo.title} size={"small"}>
+          {texts.afterSendInfo.gosysoppgave}
+          <List as="ul" className="ml-1">
+            <List.Item>{texts.afterSendInfo.gosysoppgaveListe.tema}</List.Item>
+            <List.Item>
+              {texts.afterSendInfo.gosysoppgaveListe.oppgavetype}
+            </List.Item>
+            <List.Item>
+              {texts.afterSendInfo.gosysoppgaveListe.gjelder}
+            </List.Item>
+            <List.Item>
+              {texts.afterSendInfo.gosysoppgaveListe.prioritet}
+            </List.Item>
+          </List>
         </List>
 
-        <BodyShort>
-          {texts.afterSendInfo.innstillingenBlirJournalfort}
-        </BodyShort>
+        <Paragraph
+          label={texts.buttonDescriptionLabel}
+          body={texts.buttonDescription}
+        />
 
         {vurderAktivitetskrav.isError && (
           <Alert variant="error" size="small">

--- a/src/sider/aktivitetskrav/vurdering/StansdatoDatePicker.tsx
+++ b/src/sider/aktivitetskrav/vurdering/StansdatoDatePicker.tsx
@@ -4,8 +4,7 @@ import React from "react";
 import { FormValues } from "@/sider/aktivitetskrav/vurdering/InnstillingOmStansSkjema";
 
 const texts = {
-  label: "Velg dato for stans (obligatorisk)",
-  description: "Første mulige dato for stans er svarfristen i forhåndsvarselet",
+  label: "Innstillingen gjelder fra",
   missingStansdatoError: "Vennligst angi dato for stans",
 };
 
@@ -32,7 +31,6 @@ export function StansdatoDatePicker({ varselSvarfrist }: Props) {
       <DatePicker.Input
         {...inputProps}
         label={texts.label}
-        description={texts.description}
         error={fieldState.error?.message}
         size="small"
       />

--- a/src/sider/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
+++ b/src/sider/aktivitetskrav/vurdering/VurderAktivitetskravTabs.tsx
@@ -15,7 +15,7 @@ const texts = {
   unntak: "Sett unntak",
   oppfylt: "Er i aktivitet",
   forhandsvarsel: "Send forhåndsvarsel",
-  innstillingOmStans: "Innstilling om stans",
+  innstillingOmStans: "Skriv innstilling om stans",
 };
 
 const StyledTabs = styled(Tabs)`

--- a/test/aktivitetskrav/vurdering/AktivitetskravForhandsvarselTest.tsx
+++ b/test/aktivitetskrav/vurdering/AktivitetskravForhandsvarselTest.tsx
@@ -243,11 +243,11 @@ describe("VurderAktivitetskrav forhåndsvarsel", () => {
       renderVurderAktivitetskrav(expiredForhandsvarselAktivitetskrav);
       stubVurderAktivitetskravApi(expiredForhandsvarselAktivitetskrav.uuid);
 
-      await clickTab("Innstilling om stans");
+      await clickTab("Skriv innstilling om stans");
 
       expect(
         screen.getByRole("heading", {
-          name: "Innstilling om stans",
+          name: "Skriv innstilling om stans til NAY",
         })
       ).to.exist;
     });

--- a/test/aktivitetskrav/vurdering/VurderAktivitetskravTest.tsx
+++ b/test/aktivitetskrav/vurdering/VurderAktivitetskravTest.tsx
@@ -106,7 +106,7 @@ describe("VurderAktivitetskrav", () => {
     expect(screen.queryByRole("tab", { name: "Er i aktivitet" })).to.exist;
     expect(screen.queryByRole("tab", { name: "Send forhåndsvarsel" })).to.not
       .exist;
-    expect(screen.queryByRole("tab", { name: "Innstilling om stans" })).to
+    expect(screen.queryByRole("tab", { name: "Skriv innstilling om stans" })).to
       .exist;
   });
 
@@ -415,9 +415,9 @@ describe("VurderAktivitetskrav", () => {
       renderVurderAktivitetskrav(expiredForhandsvarselAktivitetskrav);
       stubVurderAktivitetskravApi(expiredForhandsvarselAktivitetskrav.uuid);
 
-      await clickTab("Innstilling om stans");
+      await clickTab("Skriv innstilling om stans");
 
-      await clickButton("Send innstilling");
+      await clickButton("Send");
 
       expect(await screen.findByText("Vennligst angi dato for stans")).to.exist;
       expect(await screen.findByText("Vennligst angi begrunnelse")).to.exist;
@@ -426,14 +426,17 @@ describe("VurderAktivitetskrav", () => {
       renderVurderAktivitetskrav(expiredForhandsvarselAktivitetskrav);
       stubVurderAktivitetskravApi(expiredForhandsvarselAktivitetskrav.uuid);
 
-      await clickTab("Innstilling om stans");
+      await clickTab("Skriv innstilling om stans");
 
-      expect(screen.getByRole("heading", { name: "Innstilling om stans" })).to
-        .exist;
+      expect(
+        screen.getByRole("heading", {
+          name: "Skriv innstilling om stans til NAY",
+        })
+      ).to.exist;
 
       const today = dayjs();
       const datoInput = screen.getByRole("textbox", {
-        name: "Velg dato for stans (obligatorisk)",
+        name: "Innstillingen gjelder fra",
         hidden: true,
       });
       changeTextInput(datoInput, today.format("DD.MM.YYYY"));
@@ -442,7 +445,7 @@ describe("VurderAktivitetskrav", () => {
       const beskrivelse = "Flott beskrivelse";
       changeTextInput(beskrivelseInput, beskrivelse);
 
-      await clickButton("Send innstilling");
+      await clickButton("Send");
 
       const innstillingOmStansMutation = queryClient
         .getMutationCache()


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret tekster i skjemaet for å skrive innstilling ifm. aktivitetskrav for å reflektere at man ikke lenger trenger å trykke manuelt på stoppknappen ettersom dette skal gjøres automatisk av backend ved innsendt innstilling.

Avhengig av: https://github.com/navikt/ispengestopp/pull/164

Satt denne som draft inntil videre, men er ferdig.

### Screenshots 📸✨
**Før**
Skjema:
![image](https://github.com/user-attachments/assets/085fcd97-41fc-4c2b-8adf-c0d659e91393)

**Etter**
Skjema:
![image](https://github.com/user-attachments/assets/569b3b45-ccbe-4bc3-863a-d0650b9b9769)

Ved innsendt innstilling:
![image](https://github.com/user-attachments/assets/a9d862df-7be8-415d-859f-1a9bf256ba9e)


