### PR TITLE
IS-3130: Fjernet modal for å stanse automatisk utbetaling av sykepenger

### DIFF
--- a/src/components/pengestopp/Pengestopp.tsx
+++ b/src/components/pengestopp/Pengestopp.tsx
@@ -1,27 +1,15 @@
 import * as React from "react";
-import { useState } from "react";
-import PengestoppModal from "./PengestoppModal";
 import PengestoppHistorikk from "./PengestoppHistorikk";
 import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat";
-import {
-  Arbeidsgiver,
-  Status,
-  StatusEndring,
-} from "@/data/pengestopp/types/FlaggPerson";
-import { unikeArbeidsgivereMedSykmeldingSiste3Maneder } from "@/utils/pengestoppUtils";
+import { Status, StatusEndring } from "@/data/pengestopp/types/FlaggPerson";
 import { usePengestoppStatusQuery } from "@/data/pengestopp/pengestoppQueryHooks";
-import { Alert, BodyShort, Box, Button } from "@navikt/ds-react";
+import { Alert, BodyShort, Box, Heading } from "@navikt/ds-react";
 
 export const texts = {
-  stansSykepenger: "Stanse sykepenger?",
-  explanation:
-    "Her sender du beskjed til Nav Arbeid og ytelser om stans av sykepenger. Foreløpig må du også lage notat i Gosys med begrunnelse",
   hentingFeiletMessage:
     "Vi har problemer med baksystemene. Du kan sende beskjeden, men det vil ikke bli synlig her før vi er tilbake i normal drift",
-  sykmeldtNotEligibleError:
-    "Den sykmeldte behandles ikke i vedtaksløsningen. Du må sende en “Vurder konsekvens for ytelse”-oppgave i Gosys, jf servicerutinene.",
-  gosys: "Se Gosys for detaljer",
   beskjeder: "Tidligere sendte beskjeder om stans av sykepenger",
+  ingenBeskjeder: "Ingen beskjeder",
 };
 
 interface IPengestoppProps {
@@ -29,64 +17,28 @@ interface IPengestoppProps {
 }
 
 const Pengestopp = ({ sykmeldinger }: IPengestoppProps) => {
-  const [modalIsOpen, setModalIsOpen] = useState(false);
   const { data: statusEndringList, isError } = usePengestoppStatusQuery();
-  const [sykmeldtNotEligible, setSykmeldtNotEligible] = useState(false);
-
-  const toggleModal = (isOpen: boolean, arbeidsgivere: Arbeidsgiver[]) => {
-    if (arbeidsgivere.length === 0) {
-      setSykmeldtNotEligible(true);
-    } else {
-      setSykmeldtNotEligible(false);
-      setModalIsOpen(isOpen);
-    }
-  };
-
   const pengestopp: StatusEndring | undefined = statusEndringList.find(
     (statusEndring: StatusEndring) =>
       statusEndring.status === Status.STOPP_AUTOMATIKK
   );
 
-  const uniqueArbeidsgivereWithSykmeldingLast3Months =
-    unikeArbeidsgivereMedSykmeldingSiste3Maneder(sykmeldinger);
-
   return (
     <Box background="surface-default" padding="4" className="mb-4">
+      <Heading size="small">{texts.beskjeder}</Heading>
       {isError && (
         <Alert variant="error" size="small" className="mb-4">
           {texts.hentingFeiletMessage}
         </Alert>
       )}
-      {sykmeldtNotEligible && (
-        <Alert variant="error" size="small" className="mb-4">
-          {texts.sykmeldtNotEligibleError}
-        </Alert>
-      )}
-      <Button
-        variant="secondary"
-        onClick={() =>
-          toggleModal(true, uniqueArbeidsgivereWithSykmeldingLast3Months)
-        }
-      >
-        {texts.stansSykepenger}
-      </Button>
-      <BodyShort className="my-4" size="small">
-        {texts.explanation}
-      </BodyShort>
-      {pengestopp?.status === Status.STOPP_AUTOMATIKK && (
+      {pengestopp?.status === Status.STOPP_AUTOMATIKK ? (
         <PengestoppHistorikk
           statusEndringList={statusEndringList}
           sykmeldinger={sykmeldinger}
         />
+      ) : (
+        <BodyShort size={"small"}>{texts.ingenBeskjeder}</BodyShort>
       )}
-      <p>{texts.gosys}</p>
-      <PengestoppModal
-        arbeidsgivere={uniqueArbeidsgivereWithSykmeldingLast3Months}
-        isOpen={modalIsOpen}
-        onModalClose={() =>
-          toggleModal(false, uniqueArbeidsgivereWithSykmeldingLast3Months)
-        }
-      />
     </Box>
   );
 };

--- a/src/components/pengestopp/PengestoppHistorikk.tsx
+++ b/src/components/pengestopp/PengestoppHistorikk.tsx
@@ -9,8 +9,7 @@ import {
   uniqueArbeidsgivere,
 } from "@/utils/pengestoppUtils";
 import { SykmeldingOldFormat } from "@/data/sykmelding/types/SykmeldingOldFormat";
-import { texts } from "./Pengestopp";
-import { Box, Heading, Label } from "@navikt/ds-react";
+import { Box, Label } from "@navikt/ds-react";
 
 interface Props {
   statusEndringList: StatusEndring[];
@@ -40,7 +39,6 @@ const PengestoppHistorikk = ({ statusEndringList, sykmeldinger }: Props) => {
 
   return (
     <>
-      <Heading size="small">{texts.beskjeder}</Heading>
       {statusEndringList.map((statusEndring: StatusEndring, index: number) => {
         const opprettet = new Date(statusEndring.opprettet);
         return (

--- a/src/mocks/ispengestopp/mockIspengestopp.ts
+++ b/src/mocks/ispengestopp/mockIspengestopp.ts
@@ -1,9 +1,8 @@
 import { ISPENGESTOPP_ROOT } from "@/apiConstants";
-import { createStatusList } from "./pengestoppStatusMock";
+import { statusEndringer } from "./pengestoppStatusMock";
 import { http, HttpResponse } from "msw";
-import { StoppAutomatikk } from "@/data/pengestopp/types/FlaggPerson";
 
-let STATUSLIST: any;
+const STATUSLIST = statusEndringer;
 
 export const mockIspengestopp = [
   http.get(`${ISPENGESTOPP_ROOT}/person/status`, () => {
@@ -11,13 +10,4 @@ export const mockIspengestopp = [
       ? new HttpResponse(null, { status: 204 })
       : HttpResponse.json(STATUSLIST);
   }),
-  http.post<object, StoppAutomatikk>(
-    `${ISPENGESTOPP_ROOT}/person/flagg`,
-    async ({ request }) => {
-      const body = await request.json();
-      STATUSLIST = createStatusList(new Date(), body);
-
-      return new HttpResponse(null, { status: 201 });
-    }
-  ),
 ];

--- a/src/mocks/ispengestopp/pengestoppStatusMock.ts
+++ b/src/mocks/ispengestopp/pengestoppStatusMock.ts
@@ -1,12 +1,15 @@
 import {
   ARBEIDSTAKER_DEFAULT,
   ENHET_GAMLEOSLO,
+  VEILEDER_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
 import {
   DeprecatedSykepengestoppArsakType,
   Status,
+  StatusEndring,
   StoppAutomatikk,
+  ValidSykepengestoppArsakType,
 } from "@/data/pengestopp/types/FlaggPerson";
 
 const defaultStoppAutomatikk: StoppAutomatikk = {
@@ -41,3 +44,38 @@ export const createStatusList = (
     };
   });
 };
+
+const defaultStatusEndringStoppAutomatikk: StatusEndring = {
+  veilederIdent: {
+    value: VEILEDER_DEFAULT.ident,
+  },
+  sykmeldtFnr: {
+    value: ARBEIDSTAKER_DEFAULT.personIdent,
+  },
+  status: Status.STOPP_AUTOMATIKK,
+  virksomhetNr: {
+    value: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+  },
+  opprettet: new Date().toISOString(),
+  enhetNr: {
+    value: "1337",
+  },
+  arsakList: [{ type: ValidSykepengestoppArsakType.MANGLENDE_MEDVIRKING }],
+};
+
+export const statusEndringer = [
+  defaultStatusEndringStoppAutomatikk,
+  {
+    ...defaultStatusEndringStoppAutomatikk,
+    arsakList: [
+      { type: ValidSykepengestoppArsakType.AKTIVITETSKRAV },
+      { type: ValidSykepengestoppArsakType.MEDISINSK_VILKAR },
+    ],
+  },
+  {
+    ...defaultStatusEndringStoppAutomatikk,
+    arsakList: [
+      { type: DeprecatedSykepengestoppArsakType.TILBAKEDATERT_SYKMELDING },
+    ],
+  },
+];

--- a/test/pengestopp/PengestoppTest.tsx
+++ b/test/pengestopp/PengestoppTest.tsx
@@ -71,29 +71,6 @@ describe("Pengestopp", () => {
     );
   });
 
-  it("viser ikke valg for bestridelse og tilbakedatering i modal", () => {
-    renderPengestopp();
-
-    expect(
-      screen.getByRole("checkbox", {
-        name: /Aktivitetskravet/,
-        hidden: true,
-      })
-    ).to.exist;
-    expect(
-      screen.queryByRole("checkbox", {
-        name: /Bestridelse av sykmelding/,
-        hidden: true,
-      })
-    ).to.not.exist;
-    expect(
-      screen.queryByRole("checkbox", {
-        name: /Tilbakedatering sykmelding/,
-        hidden: true,
-      })
-    ).to.not.exist;
-  });
-
   it("viser bestridelse og tilbakedatering i historikk", () => {
     renderPengestopp();
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Fjernet modal for å stanse sykepenger ettersom aktivitetskrav var siste mulige valg.

Jeg har fjernet annen kode jeg anså som nødvendig og tenkte resten kunne slettes når dette med historikken er på plass på alle sidene ettersom denne siden er fortsatt eneste sted hvor det er mulig å se hvorvidt automatisk utbetaling er stanset tidligere.

La også inn informasjon om at det ikke finnes noen beskjeder i stedet for at det hele bare ikke vises. Dette er ment litt midlertidig så antar at det ikke skal være slik veldig lenge.

Avhengig av: https://github.com/navikt/syfomodiaperson/pull/1665

### Screenshots 📸✨
**Før**
![image](https://github.com/user-attachments/assets/4569b901-f5cf-433f-854b-5b9e4ba8f499)

**Etter**
Beskjeder:
![image](https://github.com/user-attachments/assets/59c65ad8-1c95-49d6-9f80-993f8fe110f2)

Ingen beskjeder:
![image](https://github.com/user-attachments/assets/cc68a5aa-9091-4eba-b0ca-38a61657e293)
