### PR TITLE
IS-3194: Remove meldekort from vedtakstekst

### DIFF
--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -30,15 +30,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
   nyttigInfo: {
     header: "Nyttig informasjon",
     part1:
-      "Sykepengene blir utbetalt etter at du har sendt meldekort. Du sender meldekort til Nav hver 14.dag.",
-    meldekortInfo: {
-      header: "På meldekortet må du føre opp:",
-      bulletPoint1: "Alle timer du har arbeidet",
-      bulletPoint2:
-        "Antall dager du har deltatt på tiltak, kurs eller har vært under utdanning",
-      bulletPoint3:
-        "Antall dager du har vært syk, og derfor ute av stand til å arbeide eller delta på tiltak",
-    },
+      "Sykepengene blir utbetalt etter at du har sendt søknad. Du sender søknad til Nav hver 14. dag.",
     part2:
       "Utbetalingen stanser når du får ny jobb, eller hvis du velger å takke nei til et aktuelt tilbud om en jobb.",
     part3:

--- a/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
+++ b/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
@@ -1,7 +1,6 @@
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
 import {
-  createBulletPoints,
   createHeaderH1,
   createParagraph,
   createParagraphWithTitle,
@@ -53,12 +52,6 @@ export const useFriskmeldingTilArbeidsformidlingDocument = (): {
       createParagraphWithTitle(
         vedtakTexts.nyttigInfo.header,
         vedtakTexts.nyttigInfo.part1
-      ),
-      createParagraph(vedtakTexts.nyttigInfo.meldekortInfo.header),
-      createBulletPoints(
-        vedtakTexts.nyttigInfo.meldekortInfo.bulletPoint1,
-        vedtakTexts.nyttigInfo.meldekortInfo.bulletPoint2,
-        vedtakTexts.nyttigInfo.meldekortInfo.bulletPoint3
       ),
       createParagraph(vedtakTexts.nyttigInfo.part2),
       createParagraph(vedtakTexts.nyttigInfo.part3),

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -104,21 +104,9 @@ export const getExpectedVedtakDocument = ({
     {
       title: "Nyttig informasjon",
       texts: [
-        "Sykepengene blir utbetalt etter at du har sendt meldekort. Du sender meldekort til Nav hver 14.dag.",
+        "Sykepengene blir utbetalt etter at du har sendt søknad. Du sender søknad til Nav hver 14. dag.",
       ],
       type: DocumentComponentType.PARAGRAPH,
-    },
-    {
-      texts: ["På meldekortet må du føre opp:"],
-      type: DocumentComponentType.PARAGRAPH,
-    },
-    {
-      type: DocumentComponentType.BULLET_POINTS,
-      texts: [
-        "Alle timer du har arbeidet",
-        "Antall dager du har deltatt på tiltak, kurs eller har vært under utdanning",
-        "Antall dager du har vært syk, og derfor ute av stand til å arbeide eller delta på tiltak",
-      ],
     },
     {
       texts: [


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Fjerner meldekort informasjon fra vedtaksbrevet om friskmelding til arbeidsformidling.
- Se screenshot – Det er kun det som er innrammet i den røde firkantet som er fjernet/endret.

### Screenshots 📸✨
Før
![Screenshot 2025-03-21 at 13 33 02](https://github.com/user-attachments/assets/8f79ea62-129a-4af2-89cc-a4e1d4f0722b)


Etter
![Screenshot 2025-03-21 at 13 58 14](https://github.com/user-attachments/assets/d2d16553-a45f-4126-a78a-651ba8897d5a)

