### PR TITLE
IS-3181: Fjernet sykepengestoppårsaker som er avviklet

### DIFF
--- a/src/data/pengestopp/types/FlaggPerson.ts
+++ b/src/data/pengestopp/types/FlaggPerson.ts
@@ -35,21 +35,13 @@ export interface EnhetNr {
   value: string;
 }
 
-/* Skal ikke lenger kunne velges (fra april 24). Oppgavene er overført fra NAV-kontor til NAY. */
-export enum DeprecatedSykepengestoppArsakType {
-  BESTRIDELSE_SYKMELDING = "BESTRIDELSE_SYKMELDING",
-  TILBAKEDATERT_SYKMELDING = "TILBAKEDATERT_SYKMELDING",
-}
-
 export enum ValidSykepengestoppArsakType {
   MEDISINSK_VILKAR = "MEDISINSK_VILKAR",
   AKTIVITETSKRAV = "AKTIVITETSKRAV",
   MANGLENDE_MEDVIRKING = "MANGLENDE_MEDVIRKING",
 }
 
-export type SykepengestoppArsakType =
-  | DeprecatedSykepengestoppArsakType
-  | ValidSykepengestoppArsakType;
+export type SykepengestoppArsakType = ValidSykepengestoppArsakType;
 
 export const validSykepengestoppArsakTekster: Record<
   ValidSykepengestoppArsakType,
@@ -68,10 +60,6 @@ export const sykepengestoppArsakTekster: Record<
   string
 > = {
   ...validSykepengestoppArsakTekster,
-  [DeprecatedSykepengestoppArsakType.BESTRIDELSE_SYKMELDING]:
-    "Bestridelse av sykmelding (§ 8-4 første ledd)",
-  [DeprecatedSykepengestoppArsakType.TILBAKEDATERT_SYKMELDING]:
-    "Tilbakedatert sykmelding (§ 8-7)",
 };
 
 export interface SykepengestoppArsak {

--- a/src/mocks/ispengestopp/pengestoppStatusMock.ts
+++ b/src/mocks/ispengestopp/pengestoppStatusMock.ts
@@ -5,7 +5,6 @@ import {
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
 import {
-  DeprecatedSykepengestoppArsakType,
   Status,
   StoppAutomatikk,
   Sykepengestopp,
@@ -16,9 +15,7 @@ const defaultStoppAutomatikk: StoppAutomatikk = {
   enhetNr: { value: ENHET_GAMLEOSLO.nummer },
   virksomhetNr: [{ value: VIRKSOMHET_PONTYPANDY.virksomhetsnummer }],
   sykmeldtFnr: { value: ARBEIDSTAKER_DEFAULT.personIdent },
-  arsakList: [
-    { type: DeprecatedSykepengestoppArsakType.BESTRIDELSE_SYKMELDING },
-  ],
+  arsakList: [{ type: ValidSykepengestoppArsakType.MANGLENDE_MEDVIRKING }],
 };
 
 export const defaultSykepengestopp: Sykepengestopp = {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Fjerner sykepengestoppårsaker som ikke lenger er i bruk. I en tidligere [PR](https://github.com/navikt/ispengestopp/pull/168) i ispengestopp så ble det endret slik at APIet filtrerer ut årsaker som er avviklet.



