### PR TITLE
IS-3171: Use new endpoint for tildeling of oppfolgingsenhet

### DIFF
--- a/src/components/personkort/PersonkortEnhet.tsx
+++ b/src/components/personkort/PersonkortEnhet.tsx
@@ -35,13 +35,15 @@ const PersonkortEnhet = () => {
         <AppSpinner />
       ) : behandlendeenhet ? (
         <PersonkortElement
-          tittel={behandlendeenhet.navn}
+          tittel={behandlendeenhet.oppfolgingsenhet.navn}
           icon={<img src={KontorByggImage} alt={"Kontorbygg"} />}
         >
           <StyledPersonkortElement>
             <PersonkortInformasjon
               informasjonNokkelTekster={informasjonNokkelTekster}
-              informasjon={{ enhetId: behandlendeenhet.enhetId }}
+              informasjon={{
+                enhetId: behandlendeenhet.oppfolgingsenhet.enhetId,
+              }}
             />
             <PersonkortChangeEnhet behandlendeEnhet={behandlendeenhet} />
           </StyledPersonkortElement>

--- a/src/components/personkort/useChangeEnhet.tsx
+++ b/src/components/personkort/useChangeEnhet.tsx
@@ -1,22 +1,27 @@
 import { SYFOBEHANDLENDEENHET_ROOT } from "@/apiConstants";
 import { post } from "@/api/axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { PersonDTO } from "@/data/behandlendeenhet/types/BehandlendeEnhet";
 import { behandlendeEnhetQueryKeys } from "@/data/behandlendeenhet/behandlendeEnhetQueryHooks";
+import {
+  TildelOppfolgingsenhetRequestDTO,
+  TildelOppfolgingsenhetResponseDTO,
+} from "@/data/behandlendeenhet/types/BehandlendeEnhetDTOs";
 
 export const useChangeEnhet = (fnr: string) => {
   const queryClient = useQueryClient();
-  const path = `${SYFOBEHANDLENDEENHET_ROOT}/person`;
-  const postChangeEnhet = (person: PersonDTO) => post<PersonDTO>(path, person);
+  const path = `${SYFOBEHANDLENDEENHET_ROOT}/oppfolgingsenhet-tildelinger`;
+  const postChangeEnhet = (requestDTO: TildelOppfolgingsenhetRequestDTO) =>
+    post<TildelOppfolgingsenhetResponseDTO>(path, requestDTO);
   const behandlendeEnhetQueryKey =
     behandlendeEnhetQueryKeys.behandlendeEnhet(fnr);
 
   return useMutation({
     mutationFn: postChangeEnhet,
-    onSuccess: (data: PersonDTO) => {
+    onSuccess: (data: TildelOppfolgingsenhetResponseDTO) => {
       queryClient.setQueryData(behandlendeEnhetQueryKey, data);
+      return queryClient.invalidateQueries({
+        queryKey: behandlendeEnhetQueryKey,
+      });
     },
-    onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: behandlendeEnhetQueryKey }),
   });
 };

--- a/src/data/behandlendeenhet/behandlendeEnhetQueryHooks.ts
+++ b/src/data/behandlendeenhet/behandlendeEnhetQueryHooks.ts
@@ -1,9 +1,9 @@
 import { SYFOBEHANDLENDEENHET_ROOT } from "@/apiConstants";
 import { get } from "@/api/axios";
-import { BehandlendeEnhet } from "@/data/behandlendeenhet/types/BehandlendeEnhet";
 import { useQuery } from "@tanstack/react-query";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { minutesToMillis } from "@/utils/utils";
+import { BehandlendeEnhetResponseDTO } from "@/data/behandlendeenhet/types/BehandlendeEnhetDTOs";
 
 export const behandlendeEnhetQueryKeys = {
   behandlendeEnhet: (fnr: string) => ["behandlendeenhet", fnr],
@@ -12,7 +12,8 @@ export const behandlendeEnhetQueryKeys = {
 export const useBehandlendeEnhetQuery = () => {
   const fnr = useValgtPersonident();
   const path = `${SYFOBEHANDLENDEENHET_ROOT}/personident`;
-  const fetchBehandlendeEnhet = () => get<BehandlendeEnhet>(path, fnr);
+  const fetchBehandlendeEnhet = () =>
+    get<BehandlendeEnhetResponseDTO>(path, fnr);
   return useQuery({
     queryKey: behandlendeEnhetQueryKeys.behandlendeEnhet(fnr),
     queryFn: fetchBehandlendeEnhet,

--- a/src/data/behandlendeenhet/types/BehandlendeEnhet.ts
+++ b/src/data/behandlendeenhet/types/BehandlendeEnhet.ts
@@ -1,9 +1,0 @@
-export interface BehandlendeEnhet {
-  enhetId: string;
-  navn: string;
-}
-
-export interface PersonDTO {
-  personident: string;
-  isNavUtland: boolean;
-}

--- a/src/data/behandlendeenhet/types/BehandlendeEnhetDTOs.ts
+++ b/src/data/behandlendeenhet/types/BehandlendeEnhetDTOs.ts
@@ -1,0 +1,30 @@
+export interface BehandlendeEnhetResponseDTO {
+  geografiskEnhet: Enhet;
+  oppfolgingsenhet: Enhet;
+}
+
+export interface Enhet {
+  enhetId: string;
+  navn: string;
+}
+
+export interface TildelOppfolgingsenhetRequestDTO {
+  personidenter: string[];
+  oppfolgingsenhet: string;
+}
+
+export interface TildelOppfolgingsenhetResponseDTO {
+  tildelinger: TildelOppfolgingsenhetDTO[];
+  errors: ErrorDTO[];
+}
+
+export interface TildelOppfolgingsenhetDTO {
+  personident: string;
+  oppfolgingsenhet: string | null;
+}
+
+export interface ErrorDTO {
+  personident: string;
+  errorMessage: string | null;
+  errorCode: number | null;
+}

--- a/src/mocks/syfobehandlendeenhet/behandlendeEnhetMock.ts
+++ b/src/mocks/syfobehandlendeenhet/behandlendeEnhetMock.ts
@@ -1,18 +1,16 @@
 import { ENHET_GRUNERLOKKA, ENHET_NAV_UTLAND } from "../common/mockConstants";
-import { PersonDTO } from "@/data/behandlendeenhet/types/BehandlendeEnhet";
-import { DEFAULT_GODKJENT_FNR } from "../util/requestUtil";
 
-export const behandlendeEnhetMock = {
+const behandlendeEnhetMock = {
   enhetId: ENHET_GRUNERLOKKA.nummer,
   navn: ENHET_GRUNERLOKKA.navn,
 };
 
-export const behandlendeEnhetNavUtlandMock = {
+const behandlendeEnhetNavUtlandMock = {
   enhetId: ENHET_NAV_UTLAND.nummer,
   navn: ENHET_NAV_UTLAND.navn,
 };
 
-export const personDTOMock: PersonDTO = {
-  personident: DEFAULT_GODKJENT_FNR,
-  isNavUtland: true,
+export const behandlendeEnhetMockResponse = {
+  geografiskEnhet: behandlendeEnhetMock,
+  oppfolgingsenhet: behandlendeEnhetNavUtlandMock,
 };

--- a/test/components/personkort/PersonkortEnhetTest.tsx
+++ b/test/components/personkort/PersonkortEnhetTest.tsx
@@ -2,21 +2,16 @@ import React from "react";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import PersonkortEnhet from "@/components/personkort/PersonkortEnhet";
-import {
-  stubBehandlendeEnhetApi,
-  stubChangeEnhetApi,
-} from "../../stubs/stubSyfobehandlendeEnhet";
-import { expect, describe, it, beforeEach } from "vitest";
+import { stubBehandlendeEnhetApi } from "../../stubs/stubSyfobehandlendeEnhet";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryClientWithAktivBruker } from "../../testQueryClient";
-import { PersonDTO } from "@/data/behandlendeenhet/types/BehandlendeEnhet";
-import { DEFAULT_GODKJENT_FNR } from "@/mocks/util/requestUtil";
+import { BehandlendeEnhetResponseDTO } from "@/data/behandlendeenhet/types/BehandlendeEnhetDTOs";
 
 let queryClient: any;
 
-const enhet = { enhetId: "1234", navn: "Nav Drammen" };
-const person: PersonDTO = {
-  personident: DEFAULT_GODKJENT_FNR,
-  isNavUtland: false,
+const behandlendeEnhetUtenOverstyring: BehandlendeEnhetResponseDTO = {
+  geografiskEnhet: { enhetId: "1234", navn: "Nav Drammen" },
+  oppfolgingsenhet: { enhetId: "1234", navn: "Nav Drammen" },
 };
 
 const renderPersonkortEnhet = () =>
@@ -32,7 +27,7 @@ describe("PersonkortEnhet", () => {
   });
 
   it("viser behandlende enhet fra API", async () => {
-    stubBehandlendeEnhetApi(enhet);
+    stubBehandlendeEnhetApi(behandlendeEnhetUtenOverstyring);
     renderPersonkortEnhet();
 
     expect(await screen.findByText("Nav Drammen")).to.exist;
@@ -51,8 +46,7 @@ describe("PersonkortEnhet", () => {
   });
 
   it("viser endre enhet til Nav utland", async () => {
-    stubBehandlendeEnhetApi(enhet);
-    stubChangeEnhetApi(person);
+    stubBehandlendeEnhetApi(behandlendeEnhetUtenOverstyring);
     renderPersonkortEnhet();
 
     expect(await screen.findByRole("button", { name: "Endre til Nav utland" }))
@@ -60,13 +54,17 @@ describe("PersonkortEnhet", () => {
   });
 
   it("viser endre enhet til geografisk enhet hvis allerede Nav utland", async () => {
-    const utlandEnhet = { enhetId: "0393", navn: "Nav Utland" };
+    const utlandEnhet: BehandlendeEnhetResponseDTO = {
+      geografiskEnhet: { enhetId: "1235", navn: "Nav Asker" },
+      oppfolgingsenhet: { enhetId: "0393", navn: "Nav Utland" },
+    };
     stubBehandlendeEnhetApi(utlandEnhet);
-    stubChangeEnhetApi(person);
     renderPersonkortEnhet();
 
     expect(
-      await screen.findByRole("button", { name: "Endre til geografisk enhet" })
+      await screen.findByRole("button", {
+        name: "Endre til geografisk enhet (1235)",
+      })
     ).to.exist;
   });
 });

--- a/test/components/personkort/PersonkortVisningTest.tsx
+++ b/test/components/personkort/PersonkortVisningTest.tsx
@@ -13,6 +13,7 @@ import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
 import { daysFromToday } from "../../testUtils";
 import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils";
+import { behandlendeEnhetMockResponse } from "@/mocks/syfobehandlendeenhet/behandlendeEnhetMock";
 
 let queryClient: any;
 
@@ -50,15 +51,12 @@ describe("PersonkortVisning", () => {
   });
 
   it("Skal vise VisningEnhet, dersom visning for enhet er valgt", async () => {
-    const enhetNavn = "Nav Drammen";
+    const enhetNavn = "NAV Oppfølging utland";
     queryClient.setQueryData(
       behandlendeEnhetQueryKeys.behandlendeEnhet(
         ARBEIDSTAKER_DEFAULT.personIdent
       ),
-      () => ({
-        navn: enhetNavn,
-        enhetId: "1234",
-      })
+      () => behandlendeEnhetMockResponse
     );
     render(
       <QueryClientProvider client={queryClient}>

--- a/test/data/behandlendeEnhetQueryHooksTest.tsx
+++ b/test/data/behandlendeEnhetQueryHooksTest.tsx
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { stubBehandlendeEnhetApi } from "../stubs/stubSyfobehandlendeEnhet";
 import { useBehandlendeEnhetQuery } from "@/data/behandlendeenhet/behandlendeEnhetQueryHooks";
-import { behandlendeEnhetMock } from "@/mocks/syfobehandlendeenhet/behandlendeEnhetMock";
+import { behandlendeEnhetMockResponse } from "@/mocks/syfobehandlendeenhet/behandlendeEnhetMock";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { testQueryClient } from "../testQueryClient";
 
@@ -14,7 +14,7 @@ describe("behandlendeEnhetQueryHooks tests", () => {
   });
 
   it("loads behandlende enhet for valgt personident", async () => {
-    stubBehandlendeEnhetApi(behandlendeEnhetMock);
+    stubBehandlendeEnhetApi(behandlendeEnhetMockResponse);
     const wrapper = queryHookWrapper(queryClient);
 
     const { result } = renderHook(() => useBehandlendeEnhetQuery(), {
@@ -23,6 +23,6 @@ describe("behandlendeEnhetQueryHooks tests", () => {
 
     await waitFor(() => expect(result.current.isSuccess).to.be.true);
 
-    expect(result.current.data).to.deep.equal(behandlendeEnhetMock);
+    expect(result.current.data).to.deep.equal(behandlendeEnhetMockResponse);
   });
 });

--- a/test/stubs/stubSyfobehandlendeEnhet.ts
+++ b/test/stubs/stubSyfobehandlendeEnhet.ts
@@ -1,21 +1,13 @@
 import { SYFOBEHANDLENDEENHET_ROOT } from "@/apiConstants";
-import {
-  BehandlendeEnhet,
-  PersonDTO,
-} from "@/data/behandlendeenhet/types/BehandlendeEnhet";
 import { mockServer } from "../setup";
 import { http, HttpResponse } from "msw";
+import { BehandlendeEnhetResponseDTO } from "@/data/behandlendeenhet/types/BehandlendeEnhetDTOs";
 
-export const stubBehandlendeEnhetApi = (enhet?: BehandlendeEnhet) =>
+export const stubBehandlendeEnhetApi = (
+  behandlendeEnhet?: BehandlendeEnhetResponseDTO
+) =>
   mockServer.use(
     http.get(`*${SYFOBEHANDLENDEENHET_ROOT}/personident`, () =>
-      HttpResponse.json(enhet)
-    )
-  );
-
-export const stubChangeEnhetApi = (person?: PersonDTO) =>
-  mockServer.use(
-    http.post(`*${SYFOBEHANDLENDEENHET_ROOT}/person`, () =>
-      HttpResponse.json(person)
+      HttpResponse.json(behandlendeEnhet)
     )
   );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fjernet bruk av `/person` endepunktet og byttet ut med `/oppfolgingsenhet-tildelinger`.

- [x] Teste i dev

### Screenshots 📸✨

To visuelle endringer her: 
Nr 1: La på hva som er den geografiske enheten i knappen, slik at dette er synlig før man gjør flyttingen. Dette skal nok uansett endres på etterhvert, så tenker det er en forbedring uten for mye risiko.
<img width="639" alt="image" src="https://github.com/user-attachments/assets/c9fac69e-4b80-4d47-b8d2-2e44575bc798" />

Nr 2: Viser feilmelding når noe går galt, og lukker ikke modalen med en gang kallet går:
<img width="993" alt="image" src="https://github.com/user-attachments/assets/390c5d50-d3b2-40b8-8145-0a101f9ef0f3" />


