### PR TITLE
IS-3168: Tatt i bruk nytt endepunkt for møtebehov og lagt til visning av nye felter

### DIFF
--- a/src/apiConstants.ts
+++ b/src/apiConstants.ts
@@ -23,7 +23,7 @@ export const ISPERSONOPPGAVE_ROOT = "/ispersonoppgave/api/v2";
 export const MODIACONTEXTHOLDER_ROOT = "/modiacontextholder/api";
 export const SYFOBEHANDLENDEENHET_ROOT =
   "/syfobehandlendeenhet/api/internad/v2";
-export const SYFOMOTEBEHOV_ROOT = "/syfomotebehov/api/internad/v3/veileder";
+export const SYFOMOTEBEHOV_ROOT = "/syfomotebehov/api/internad/v4/veileder";
 export const SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT =
   "/syfooppfolgingsplanservice/api/internad/v2";
 export const SYFOOPPFOLGINGSPLANSERVICE_V3_ROOT =

--- a/src/data/motebehov/motebehovQueryHooks.ts
+++ b/src/data/motebehov/motebehovQueryHooks.ts
@@ -4,7 +4,7 @@ import { get } from "@/api/axios";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { useQuery } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/utils";
-import { sorterMotebehovDataEtterDato } from "@/utils/motebehovUtils";
+import { sorterMotebehovDataEtterDatoDesc } from "@/utils/motebehovUtils";
 
 export const motebehovQueryKeys = {
   motebehov: (fnr: string) => ["motebehov", fnr],
@@ -24,6 +24,6 @@ export const useMotebehovQuery = () => {
 
   return {
     ...query,
-    data: query.data?.sort(sorterMotebehovDataEtterDato) || [],
+    data: query.data?.sort(sorterMotebehovDataEtterDatoDesc) || [],
   };
 };

--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -11,6 +11,9 @@ export interface MotebehovVeilederDTO {
   formValues: MotebehovFormValuesOutputDTO;
 }
 
+export type Virksomhetsnummer = string;
+export type InnsenderKey = [Virksomhetsnummer, MotebehovInnmelder];
+
 export interface MotebehovFormValuesOutputDTO {
   harMotebehov: boolean;
   formSnapshot: FormSnapshot | null;

--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -1,21 +1,25 @@
-export interface MotebehovSvarVeilederDTO {
-  harMotebehov: boolean;
-  forklaring: string | null;
-}
-
 export interface MotebehovVeilederDTO {
   id: string;
   opprettetDato: Date;
-  aktorId: string;
   opprettetAv: string;
   opprettetAvNavn: string | null;
   arbeidstakerFnr: string;
   virksomhetsnummer: string;
-  motebehovSvar: MotebehovSvarVeilederDTO;
-  tildeltEnhet: string | null;
   behandletTidspunkt: Date | null;
   behandletVeilederIdent: string | null;
-  skjemaType: MotebehovSkjemaType | null;
+  innmelderType: MotebehovInnmelder; //TODO: Usikker på når det kommer ARBEIDSTAKER | ARBEIDSGIVER,
+  skjemaType: MotebehovSkjemaType | null; // Skal tydeligvis ikke være nullable
+  formValues: MotebehovFormValuesOutputDTO;
+}
+
+export interface MotebehovFormValuesOutputDTO {
+  harMotebehov: boolean;
+  // formSnapshot: FormSnapshot?, //TODO: Usikker på om denne bare skal ignoreres
+  begrunnelse: string | null;
+  onskerSykmelderDeltar: boolean | null;
+  onskerSykmelderDeltarBegrunnelse: string | null;
+  onskerTolk: boolean | null;
+  tolkSprak: string | null;
 }
 
 export enum MotebehovSkjemaType {
@@ -31,11 +35,10 @@ export interface MeldtMotebehov {
   innmelder: MotebehovInnmelder;
   arbeidstakerFnr: string;
   virksomhetsnummer: string;
-  begrunnelse: string | null;
-  tildeltEnhet: string | null;
   behandletTidspunkt: Date | null;
   behandletVeilederIdent: string | null;
   skjemaType: MotebehovSkjemaType.MELD_BEHOV;
+  formValues: MotebehovFormValuesOutputDTO;
 }
 
 export interface SvarMotebehov {
@@ -46,11 +49,10 @@ export interface SvarMotebehov {
   innmelder: MotebehovInnmelder;
   arbeidstakerFnr: string;
   virksomhetsnummer: string;
-  motebehovSvar: MotebehovSvarVeilederDTO;
-  tildeltEnhet: string | null;
   behandletTidspunkt: Date | null;
   behandletVeilederIdent: string | null;
   skjemaType: MotebehovSkjemaType.SVAR_BEHOV;
+  formValues: MotebehovFormValuesOutputDTO;
 }
 
 export enum MotebehovInnmelder {

--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -1,25 +1,72 @@
 export interface MotebehovVeilederDTO {
   id: string;
   opprettetDato: Date;
-  opprettetAv: string;
   opprettetAvNavn: string | null;
   arbeidstakerFnr: string;
   virksomhetsnummer: string;
   behandletTidspunkt: Date | null;
   behandletVeilederIdent: string | null;
-  innmelderType: MotebehovInnmelder; //TODO: Usikker på når det kommer ARBEIDSTAKER | ARBEIDSGIVER,
-  skjemaType: MotebehovSkjemaType | null; // Skal tydeligvis ikke være nullable
+  innmelderType: MotebehovInnmelder;
+  skjemaType: MotebehovSkjemaType;
   formValues: MotebehovFormValuesOutputDTO;
 }
 
 export interface MotebehovFormValuesOutputDTO {
   harMotebehov: boolean;
-  // formSnapshot: FormSnapshot?, //TODO: Usikker på om denne bare skal ignoreres
+  formSnapshot: FormSnapshot | null;
   begrunnelse: string | null;
   onskerSykmelderDeltar: boolean | null;
   onskerSykmelderDeltarBegrunnelse: string | null;
   onskerTolk: boolean | null;
   tolkSprak: string | null;
+}
+
+export interface FormSnapshot {
+  formIdentifier: FormIdentifier;
+  formSemanticVersion: string;
+  fieldSnapshots: FieldSnapshot[];
+}
+
+export enum FormIdentifier {
+  MOTEBEHOV_ARBEIDSGIVER_SVAR = "motebehov-arbeidsgiver-svar",
+  MOTEBEHOV_ARBEIDSGIVER_MELD = "motebehov-arbeidsgiver-meld",
+  MOTEBEHOV_ARBEIDSTAKER_SVAR = "motebehov-arbeidstaker-svar",
+  MOTEBEHOV_ARBEIDSTAKER_MELD = "motebehov-arbeidstaker-meld",
+}
+
+export interface FieldSnapshot {
+  fieldId: string;
+  fieldLabel: string;
+  description: string | null;
+  fieldType: FormSnapshotFieldType;
+}
+
+export enum FormSnapshotFieldType {
+  TEXT = "TEXT",
+  CHECKBOX_SINGLE = "CHECKBOX_SINGLE",
+  RADIO_GROUP = "RADIO_GROUP",
+}
+
+export interface TextFieldSnapshot extends FieldSnapshot {
+  value: string;
+  wasRequired: boolean | null;
+}
+
+export interface SingleCheckboxFieldSnapshot extends FieldSnapshot {
+  value: boolean;
+}
+
+export interface RadioGroupFieldSnapshot extends FieldSnapshot {
+  selectedOptionId: string;
+  selectedOptionLabel: string;
+  options: FormSnapshotFieldOption[];
+  wasRequired: boolean | null;
+}
+
+export interface FormSnapshotFieldOption {
+  optionId: string;
+  optionLabel: string;
+  wasSelected: boolean;
 }
 
 export enum MotebehovSkjemaType {
@@ -30,7 +77,6 @@ export enum MotebehovSkjemaType {
 export interface MeldtMotebehov {
   id: string;
   opprettetDato: Date;
-  opprettetAv: string;
   opprettetAvNavn: string | null;
   innmelder: MotebehovInnmelder;
   arbeidstakerFnr: string;
@@ -44,7 +90,6 @@ export interface MeldtMotebehov {
 export interface SvarMotebehov {
   id: string;
   opprettetDato: Date;
-  opprettetAv: string;
   opprettetAvNavn: string | null;
   innmelder: MotebehovInnmelder;
   arbeidstakerFnr: string;

--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -39,7 +39,7 @@ export enum FormIdentifier {
 
 export interface FieldSnapshot {
   fieldId: string;
-  fieldLabel: string;
+  label: string;
   description: string | null;
   fieldType: FormSnapshotFieldType;
 }

--- a/src/hooks/historikk/useMotebehovHistorikk.ts
+++ b/src/hooks/historikk/useMotebehovHistorikk.ts
@@ -12,8 +12,8 @@ import {
 import { HistorikkHook } from "@/hooks/historikk/useHistorikk";
 
 function getTextForMeldtMotebehov(meldtMotebehov: MeldtMotebehov): string {
-  const meldtBehovBegrunnelse = meldtMotebehov.begrunnelse
-    ? `Begrunnelse: ${meldtMotebehov.begrunnelse}`
+  const meldtBehovBegrunnelse = meldtMotebehov.formValues.begrunnelse
+    ? `Begrunnelse: ${meldtMotebehov.formValues.begrunnelse}`
     : "";
 
   switch (meldtMotebehov.innmelder) {
@@ -55,11 +55,11 @@ function createHistorikkEventsFromMeldtMotebehov(
 }
 
 function getTextForSvarMotebehov(svarMotebehov: SvarMotebehov): string {
-  const svarResultat = svarMotebehov.motebehovSvar.harMotebehov
+  const svarResultat = svarMotebehov.formValues.harMotebehov
     ? "svarte ja på ønske om dialogmøte."
     : "svarte nei på ønske om dialogmøte.";
-  const svarForklaring = svarMotebehov.motebehovSvar.forklaring
-    ? `Svaret var: ${svarMotebehov.motebehovSvar.forklaring}`
+  const svarForklaring = svarMotebehov.formValues.begrunnelse
+    ? `Svaret var: ${svarMotebehov.formValues.begrunnelse}`
     : "";
 
   switch (svarMotebehov.innmelder) {

--- a/src/mocks/syfomotebehov/motebehovMock.ts
+++ b/src/mocks/syfomotebehov/motebehovMock.ts
@@ -1,70 +1,78 @@
 import {
   ARBEIDSTAKER_DEFAULT,
   ARBEIDSTAKER_DEFAULT_FULL_NAME,
-  ENHET_GRUNERLOKKA,
   VEILEDER_IDENT_DEFAULT,
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
 import {
+  MotebehovInnmelder,
   MotebehovSkjemaType,
   MotebehovVeilederDTO,
 } from "@/data/motebehov/types/motebehovTypes";
 import { addDays } from "@/utils/datoUtils";
 
-export const svartJaMotebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO =
-  {
-    id: "11111111-ee10-44b6-bddf-54d049ef25f9",
-    opprettetDato: addDays(new Date(), -25),
-    aktorId: "1",
-    opprettetAv: "1",
-    opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
-    arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
-    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-    motebehovSvar: {
-      harMotebehov: true,
-      forklaring: "Jeg svarer på møtebehov ved 17 uker",
-    },
-    tildeltEnhet: ENHET_GRUNERLOKKA.nummer,
-    behandletTidspunkt: null,
-    behandletVeilederIdent: null,
-    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
-  };
+export const svartJaMotebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
+  id: "11111111-ee10-44b6-bddf-54d049ef25f9",
+  opprettetDato: addDays(new Date(), -25),
+  opprettetAv: "1",
+  opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
+  arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
+  virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+  innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
+  behandletTidspunkt: null,
+  behandletVeilederIdent: null,
+  skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+  formValues: {
+    harMotebehov: true,
+    begrunnelse: "Jeg svarer på møtebehov ved 17 uker",
+    onskerSykmelderDeltar: null,
+    onskerSykmelderDeltarBegrunnelse: null,
+    onskerTolk: null,
+    tolkSprak: null,
+  },
+};
 
 export const meldtMotebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
   id: "33333333-ee10-44b6-bddf-54d049ef25f2",
   opprettetDato: addDays(new Date(), -10),
-  aktorId: "1",
   opprettetAv: "1",
   opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
   arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
   virksomhetsnummer: "000999000",
-  motebehovSvar: {
-    harMotebehov: true,
-    forklaring: "Møter er bra!",
-  },
-  tildeltEnhet: ENHET_GRUNERLOKKA.nummer,
+  innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
   behandletTidspunkt: addDays(new Date(), -1),
   behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
+  formValues: {
+    harMotebehov: true,
+    begrunnelse: "Møter er bra!",
+    onskerSykmelderDeltar: null,
+    onskerSykmelderDeltarBegrunnelse: null,
+    onskerTolk: null,
+    tolkSprak: null,
+  },
 };
 
 export const svartNeiMotebehovArbeidsgiverUbehandletMock: MotebehovVeilederDTO =
   {
     id: "22222222-9e9b-40b0-bd1c-d1c39dc5f481",
     opprettetDato: addDays(new Date(), -5),
-    aktorId: "1",
     opprettetAv: "1902690001009",
     opprettetAvNavn: "Are Arbeidsgiver",
     arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
     virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-    motebehovSvar: {
-      harMotebehov: false,
-      forklaring: "Jeg liker ikke møte!!",
-    },
-    tildeltEnhet: "0330",
     behandletTidspunkt: null,
     behandletVeilederIdent: null,
     skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+    innmelderType: MotebehovInnmelder.ARBEIDSGIVER,
+    formValues: {
+      harMotebehov: false,
+      begrunnelse: "Jeg liker ikke møte!!",
+      onskerSykmelderDeltar: null,
+      onskerSykmelderDeltarBegrunnelse: null,
+      onskerTolk: null,
+      tolkSprak: null,
+    },
   };
 
 export const motebehovMock = [

--- a/src/mocks/syfomotebehov/motebehovMock.ts
+++ b/src/mocks/syfomotebehov/motebehovMock.ts
@@ -224,15 +224,6 @@ export const svartJaMotebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO =
       MotebehovSkjemaType.SVAR_BEHOV,
       MotebehovInnmelder.ARBEIDSTAKER
     ),
-    // formValues: {
-    //   harMotebehov: true,
-    //   begrunnelse: "Jeg svarer på møtebehov ved 17 uker",
-    //   onskerSykmelderDeltar: null,
-    //   onskerSykmelderDeltarBegrunnelse: null,
-    //   onskerTolk: null,
-    //   tolkSprak: null,
-    //   formSnapshot: null,
-    // },
   };
 
 export const meldtMotebehovArbeidstakerBehandletMock = (

--- a/src/mocks/syfomotebehov/motebehovMock.ts
+++ b/src/mocks/syfomotebehov/motebehovMock.ts
@@ -5,78 +5,294 @@ import {
   VIRKSOMHET_PONTYPANDY,
 } from "../common/mockConstants";
 import {
+  FormIdentifier,
+  FormSnapshot,
+  FormSnapshotFieldOption,
+  FormSnapshotFieldType,
+  MotebehovFormValuesOutputDTO,
   MotebehovInnmelder,
   MotebehovSkjemaType,
   MotebehovVeilederDTO,
+  RadioGroupFieldSnapshot,
+  SingleCheckboxFieldSnapshot,
+  TextFieldSnapshot,
 } from "@/data/motebehov/types/motebehovTypes";
 import { addDays } from "@/utils/datoUtils";
 
-export const svartJaMotebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO = {
-  id: "11111111-ee10-44b6-bddf-54d049ef25f9",
-  opprettetDato: addDays(new Date(), -25),
-  opprettetAv: "1",
-  opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
-  arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
-  virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
-  innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
-  behandletTidspunkt: null,
-  behandletVeilederIdent: null,
-  skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
-  formValues: {
-    harMotebehov: true,
-    begrunnelse: "Jeg svarer på møtebehov ved 17 uker",
-    onskerSykmelderDeltar: null,
-    onskerSykmelderDeltarBegrunnelse: null,
-    onskerTolk: null,
-    tolkSprak: null,
-  },
+export const defaultBegrunnelse: TextFieldSnapshot = {
+  fieldId: "begrunnelseText",
+  fieldType: FormSnapshotFieldType.TEXT,
+  description:
+    "Hva ønsker du å ta opp i møtet? Hva tenker du at NAV kan bistå med? Ikke skriv sensitiv informasjon, for eksempel detaljerte opplysninger om helse.",
+  fieldLabel: "Begrunnelse",
+  value: "Møter er bra!",
+  wasRequired: true,
 };
 
-export const meldtMotebehovArbeidstakerBehandletMock: MotebehovVeilederDTO = {
-  id: "33333333-ee10-44b6-bddf-54d049ef25f2",
-  opprettetDato: addDays(new Date(), -10),
-  opprettetAv: "1",
-  opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
-  arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
-  virksomhetsnummer: "000999000",
-  innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
-  behandletTidspunkt: addDays(new Date(), -1),
-  behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
-  skjemaType: MotebehovSkjemaType.MELD_BEHOV,
-  formValues: {
-    harMotebehov: true,
-    begrunnelse: "Møter er bra!",
-    onskerSykmelderDeltar: null,
-    onskerSykmelderDeltarBegrunnelse: null,
-    onskerTolk: null,
-    tolkSprak: null,
-  },
+export const createBegrunnelse = (textValue: string): TextFieldSnapshot => ({
+  ...defaultBegrunnelse,
+  value: textValue,
+});
+
+export const createOnskerTolk = (
+  isChecked: boolean
+): SingleCheckboxFieldSnapshot => ({
+  ...defaultOnskerTolk,
+  value: isChecked,
+});
+
+export const createSykmelderDeltar = (
+  isChecked: boolean
+): SingleCheckboxFieldSnapshot => ({
+  ...defaultOnskerSykmelderDeltar,
+  value: isChecked,
+});
+
+export const createSykmelderDeltarBegrunnelse = (
+  textValue: string
+): TextFieldSnapshot => ({
+  ...defaultOnskerSykmelderDeltarBegrunnelse,
+  value: textValue,
+});
+
+export const createOnskerTolkBegrunnelse = (
+  textValue: string
+): TextFieldSnapshot => ({
+  ...defaultOnskerTolkBegrunnelse,
+  value: textValue,
+});
+
+export const defaultFormValue: MotebehovFormValuesOutputDTO = {
+  harMotebehov: false,
+  begrunnelse: null,
+  onskerSykmelderDeltar: null,
+  onskerSykmelderDeltarBegrunnelse: null,
+  onskerTolk: null,
+  tolkSprak: null,
+  formSnapshot: null,
 };
 
-export const svartNeiMotebehovArbeidsgiverUbehandletMock: MotebehovVeilederDTO =
+export const getFormIdentifier = (
+  motebehovSkjemaType: MotebehovSkjemaType,
+  motebehovInnmelder: MotebehovInnmelder
+): FormIdentifier => {
+  if (motebehovInnmelder === MotebehovInnmelder.ARBEIDSTAKER) {
+    switch (motebehovSkjemaType) {
+      case MotebehovSkjemaType.SVAR_BEHOV:
+        return FormIdentifier.MOTEBEHOV_ARBEIDSTAKER_SVAR;
+      case MotebehovSkjemaType.MELD_BEHOV:
+        return FormIdentifier.MOTEBEHOV_ARBEIDSTAKER_MELD;
+    }
+  } else {
+    switch (motebehovSkjemaType) {
+      case MotebehovSkjemaType.SVAR_BEHOV:
+        return FormIdentifier.MOTEBEHOV_ARBEIDSGIVER_SVAR;
+      case MotebehovSkjemaType.MELD_BEHOV:
+        return FormIdentifier.MOTEBEHOV_ARBEIDSGIVER_MELD;
+    }
+  }
+};
+
+export const createFormValues = (
   {
+    harMotebehov,
+    begrunnelse,
+    onskerSykmelderDeltar,
+    onskerSykmelderDeltarBegrunnelse,
+    onskerTolk,
+    tolkSprak,
+  }: MotebehovFormValuesOutputDTO,
+  motebehovSkjemaType: MotebehovSkjemaType,
+  motebehovInnmelder: MotebehovInnmelder
+): MotebehovFormValuesOutputDTO => ({
+  harMotebehov: harMotebehov,
+  begrunnelse: begrunnelse,
+  onskerSykmelderDeltar: onskerSykmelderDeltar,
+  onskerSykmelderDeltarBegrunnelse: onskerSykmelderDeltarBegrunnelse,
+  onskerTolk: onskerTolk,
+  tolkSprak: tolkSprak,
+  formSnapshot: {
+    ...defaultFormSnapshot,
+    formIdentifier: getFormIdentifier(motebehovSkjemaType, motebehovInnmelder),
+    fieldSnapshots: [
+      ...(motebehovSkjemaType === MotebehovSkjemaType.SVAR_BEHOV
+        ? [svarPaBehovForMote(harMotebehov)]
+        : []),
+      ...(begrunnelse ? [createBegrunnelse(begrunnelse)] : []),
+      ...(onskerSykmelderDeltar != null
+        ? [createSykmelderDeltar(onskerSykmelderDeltar)]
+        : []),
+      ...(onskerSykmelderDeltarBegrunnelse
+        ? [createSykmelderDeltarBegrunnelse(onskerSykmelderDeltarBegrunnelse)]
+        : []),
+      ...(onskerTolk != null ? [createOnskerTolk(onskerTolk)] : []),
+      ...(tolkSprak ? [createOnskerTolkBegrunnelse(tolkSprak)] : []),
+    ],
+  },
+});
+
+export const defaultOnskerTolk: SingleCheckboxFieldSnapshot = {
+  fieldId: "onskerTolkCheckbox",
+  fieldType: FormSnapshotFieldType.CHECKBOX_SINGLE,
+  description: null,
+  fieldLabel: "Vi har behov for tolk.",
+  value: true,
+};
+
+export const defaultOnskerTolkBegrunnelse: TextFieldSnapshot = {
+  fieldId: "onskerTolkBegrunnelseText",
+  fieldType: FormSnapshotFieldType.TEXT,
+  description: null,
+  fieldLabel: "Hva slags tolk har dere behov for?",
+  value: "Har behov for svensk tolk",
+  wasRequired: true,
+};
+
+export const defaultOnskerSykmelderDeltar: SingleCheckboxFieldSnapshot = {
+  fieldId: "onskerSykmelderDeltarCheckbox",
+  fieldType: FormSnapshotFieldType.CHECKBOX_SINGLE,
+  description: null,
+  fieldLabel: "Jeg ønsker at sykmelder (lege/behandler) også deltar i møtet.",
+  value: true,
+};
+
+export const defaultOnskerSykmelderDeltarBegrunnelse: TextFieldSnapshot = {
+  fieldId: "onskerSykmelderDeltarBegrunnelseText",
+  fieldType: FormSnapshotFieldType.TEXT,
+  description: null,
+  fieldLabel: "Hvorfor ønsker du at lege/behandler deltar i møtet?",
+  value: "Ønsker at legen min er tilstede",
+  wasRequired: true,
+};
+
+export const defaultFormSnapshot: FormSnapshot = {
+  formIdentifier: FormIdentifier.MOTEBEHOV_ARBEIDSTAKER_SVAR,
+  formSemanticVersion: "1.0.0",
+  fieldSnapshots: [],
+};
+
+const isJaValgt = (value: boolean): FormSnapshotFieldOption[] => [
+  {
+    optionId: "Ja",
+    optionLabel: "Ja, vi har behov for et dialogmøte.",
+    wasSelected: value,
+  },
+  {
+    optionId: "Nei",
+    optionLabel: "Nei, vi har ikke behov for et dialogmøte nå.",
+    wasSelected: !value,
+  },
+];
+
+export const svarPaBehovForMote = (
+  value: boolean
+): RadioGroupFieldSnapshot => ({
+  fieldId: "harBehovRadioGroup",
+  fieldType: FormSnapshotFieldType.RADIO_GROUP,
+  description:
+    "Du svarer på vegne av arbeidsgiver. Den ansatte har fått det samme spørsmålet og svarer på vegne av seg selv.",
+  fieldLabel: "Har dere behov for et dialogmøte med NAV?",
+  selectedOptionId: value ? "Ja" : "Nei",
+  selectedOptionLabel: value
+    ? "Ja, vi har behov for et dialogmøte."
+    : "Nei, vi har ikke behov for et dialogmøte nå.",
+  options: isJaValgt(value),
+  wasRequired: true,
+});
+
+export const svartJaMotebehovArbeidstakerUbehandletMock: MotebehovVeilederDTO =
+  {
+    id: "11111111-ee10-44b6-bddf-54d049ef25f9",
+    opprettetDato: addDays(new Date(), -25),
+    opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
+    arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+    innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
+    behandletTidspunkt: null,
+    behandletVeilederIdent: null,
+    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+    formValues: createFormValues(
+      {
+        ...defaultFormValue,
+        harMotebehov: true,
+        begrunnelse: "Jeg svarer på møtebehov ved 17 uker",
+        onskerSykmelderDeltar: null,
+        onskerSykmelderDeltarBegrunnelse: null,
+        onskerTolk: null,
+        tolkSprak: null,
+      },
+      MotebehovSkjemaType.SVAR_BEHOV,
+      MotebehovInnmelder.ARBEIDSTAKER
+    ),
+    // formValues: {
+    //   harMotebehov: true,
+    //   begrunnelse: "Jeg svarer på møtebehov ved 17 uker",
+    //   onskerSykmelderDeltar: null,
+    //   onskerSykmelderDeltarBegrunnelse: null,
+    //   onskerTolk: null,
+    //   tolkSprak: null,
+    //   formSnapshot: null,
+    // },
+  };
+
+export const meldtMotebehovArbeidstakerBehandletMock = (
+  skjemaType: MotebehovSkjemaType = MotebehovSkjemaType.MELD_BEHOV,
+  innmelderType: MotebehovInnmelder = MotebehovInnmelder.ARBEIDSTAKER
+): MotebehovVeilederDTO => {
+  return {
+    id: "33333333-ee10-44b6-bddf-54d049ef25f2",
+    opprettetDato: addDays(new Date(), -10),
+    opprettetAvNavn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
+    arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    virksomhetsnummer: "000999000",
+    innmelderType: innmelderType,
+    behandletTidspunkt: addDays(new Date(), -1),
+    behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
+    skjemaType: skjemaType,
+    formValues: createFormValues(
+      {
+        ...defaultFormValue,
+        harMotebehov: true,
+        begrunnelse: "Møter er bra!",
+        onskerSykmelderDeltar: true,
+        onskerSykmelderDeltarBegrunnelse: "Ønsker at legen min er tilstede",
+        onskerTolk: true,
+        tolkSprak: "Har behov for svensk tolk",
+      },
+      skjemaType,
+      innmelderType
+    ),
+  };
+};
+
+export const svartNeiMotebehovArbeidsgiverUbehandletMock = (
+  skjemaType: MotebehovSkjemaType = MotebehovSkjemaType.SVAR_BEHOV,
+  innmelderType: MotebehovInnmelder = MotebehovInnmelder.ARBEIDSGIVER
+): MotebehovVeilederDTO => {
+  return {
     id: "22222222-9e9b-40b0-bd1c-d1c39dc5f481",
     opprettetDato: addDays(new Date(), -5),
-    opprettetAv: "1902690001009",
     opprettetAvNavn: "Are Arbeidsgiver",
     arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
     virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
     behandletTidspunkt: null,
     behandletVeilederIdent: null,
-    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
-    innmelderType: MotebehovInnmelder.ARBEIDSGIVER,
-    formValues: {
-      harMotebehov: false,
-      begrunnelse: "Jeg liker ikke møte!!",
-      onskerSykmelderDeltar: null,
-      onskerSykmelderDeltarBegrunnelse: null,
-      onskerTolk: null,
-      tolkSprak: null,
-    },
+    skjemaType: skjemaType,
+    innmelderType: innmelderType,
+    formValues: createFormValues(
+      {
+        ...defaultFormValue,
+        harMotebehov: false,
+        begrunnelse: "Jeg liker ikke møte!!",
+      },
+      skjemaType,
+      innmelderType
+    ),
   };
+};
 
 export const motebehovMock = [
   svartJaMotebehovArbeidstakerUbehandletMock,
-  meldtMotebehovArbeidstakerBehandletMock,
-  svartNeiMotebehovArbeidsgiverUbehandletMock,
+  meldtMotebehovArbeidstakerBehandletMock(),
+  svartNeiMotebehovArbeidsgiverUbehandletMock(),
 ];

--- a/src/mocks/syfomotebehov/motebehovMock.ts
+++ b/src/mocks/syfomotebehov/motebehovMock.ts
@@ -24,7 +24,7 @@ export const defaultBegrunnelse: TextFieldSnapshot = {
   fieldType: FormSnapshotFieldType.TEXT,
   description:
     "Hva ønsker du å ta opp i møtet? Hva tenker du at NAV kan bistå med? Ikke skriv sensitiv informasjon, for eksempel detaljerte opplysninger om helse.",
-  fieldLabel: "Begrunnelse",
+  label: "Begrunnelse",
   value: "Møter er bra!",
   wasRequired: true,
 };
@@ -135,7 +135,7 @@ export const defaultOnskerTolk: SingleCheckboxFieldSnapshot = {
   fieldId: "onskerTolkCheckbox",
   fieldType: FormSnapshotFieldType.CHECKBOX_SINGLE,
   description: null,
-  fieldLabel: "Vi har behov for tolk.",
+  label: "Vi har behov for tolk.",
   value: true,
 };
 
@@ -143,7 +143,7 @@ export const defaultOnskerTolkBegrunnelse: TextFieldSnapshot = {
   fieldId: "onskerTolkBegrunnelseText",
   fieldType: FormSnapshotFieldType.TEXT,
   description: null,
-  fieldLabel: "Hva slags tolk har dere behov for?",
+  label: "Hva slags tolk har dere behov for?",
   value: "Har behov for svensk tolk",
   wasRequired: true,
 };
@@ -152,7 +152,7 @@ export const defaultOnskerSykmelderDeltar: SingleCheckboxFieldSnapshot = {
   fieldId: "onskerSykmelderDeltarCheckbox",
   fieldType: FormSnapshotFieldType.CHECKBOX_SINGLE,
   description: null,
-  fieldLabel: "Jeg ønsker at sykmelder (lege/behandler) også deltar i møtet.",
+  label: "Jeg ønsker at sykmelder (lege/behandler) også deltar i møtet.",
   value: true,
 };
 
@@ -160,7 +160,7 @@ export const defaultOnskerSykmelderDeltarBegrunnelse: TextFieldSnapshot = {
   fieldId: "onskerSykmelderDeltarBegrunnelseText",
   fieldType: FormSnapshotFieldType.TEXT,
   description: null,
-  fieldLabel: "Hvorfor ønsker du at lege/behandler deltar i møtet?",
+  label: "Hvorfor ønsker du at lege/behandler deltar i møtet?",
   value: "Ønsker at legen min er tilstede",
   wasRequired: true,
 };
@@ -191,7 +191,7 @@ export const svarPaBehovForMote = (
   fieldType: FormSnapshotFieldType.RADIO_GROUP,
   description:
     "Du svarer på vegne av arbeidsgiver. Den ansatte har fått det samme spørsmålet og svarer på vegne av seg selv.",
-  fieldLabel: "Har dere behov for et dialogmøte med NAV?",
+  label: "Har dere behov for et dialogmøte med NAV?",
   selectedOptionId: value ? "Ja" : "Nei",
   selectedOptionLabel: value
     ? "Ja, vi har behov for et dialogmøte."

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -97,7 +97,7 @@ export const MotebehovKvitteringInnholdArbeidstaker = ({
 }: MotebehovKvitteringInnholdArbeidstakerProps) => {
   const sykmeldt = useNavBrukerData();
   const arbeidstakerOnskerMote =
-    arbeidstakersMotebehov?.motebehovSvar?.harMotebehov;
+    arbeidstakersMotebehov?.formValues.harMotebehov;
   const skjemaTypeMotebehov =
     skjemaType ?? arbeidstakersMotebehov?.skjemaType ?? null;
 
@@ -146,7 +146,7 @@ export function MotebehovArbeidsgiverKvittering({
   motebehov: MotebehovVeilederDTO;
   skjemaType?: MotebehovSkjemaType | null;
 }) {
-  const arbeidsgiverOnskerMote = motebehov.motebehovSvar.harMotebehov;
+  const arbeidsgiverOnskerMote = motebehov.formValues.harMotebehov;
   const skjemaTypeMotebehov = skjemaType ?? motebehov.skjemaType;
   const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverNavnEllerTomStreng(
     motebehov.opprettetAvNavn

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -3,7 +3,7 @@ import {
   getMotebehovInActiveTilfelle,
   isArbeidstakerMotebehov,
   motebehovUbehandlet,
-  sorterMotebehovDataEtterDato,
+  sorterMotebehovDataEtterDatoDesc,
 } from "@/utils/motebehovUtils";
 import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
 import {
@@ -318,7 +318,7 @@ export default function MotebehovKvittering() {
   const { data: motebehov } = useMotebehovQuery();
   const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
 
-  const sortertMotebehov = motebehov.sort(sorterMotebehovDataEtterDato);
+  const sortertMotebehov = motebehov.sort(sorterMotebehovDataEtterDatoDesc);
   const motebehovInActiveTilfelle = getMotebehovInActiveTilfelle(
     sortertMotebehov,
     latestOppfolgingstilfelle

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -226,7 +226,7 @@ function MotebehovInCurrentTilfelle({
   }
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex flex-col gap-6">
       <MotebehovKvitteringInnholdArbeidstaker
         arbeidstakersMotebehov={motebehovArbeidstaker}
         skjemaType={findSkjemaType(motebehovArbeidstaker)}

--- a/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
@@ -36,7 +36,7 @@ export default function MotebehovKvitteringInnhold({
   tekst,
 }: Props) {
   return (
-    <Box padding={"3"} borderRadius={"medium"} shadow={"medium"}>
+    <Box padding={"3"} borderRadius={"medium"}>
       <VStack gap={"4"}>
         <HStack>
           <img

--- a/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
@@ -5,7 +5,8 @@ import {
   MotebehovKanIkkeImage,
   MotebehovKanImage,
 } from "../../../../img/ImageComponents";
-import { VStack } from "@navikt/ds-react";
+import { Box, HStack, VStack } from "@navikt/ds-react";
+import { MotebehovSkjemasvar } from "@/sider/dialogmoter/motebehov/skjema/MotebehovSkjemasvar";
 
 const setSvarIkon = (deltakerOnskerMote?: boolean): string => {
   switch (deltakerOnskerMote) {
@@ -35,20 +36,18 @@ export default function MotebehovKvitteringInnhold({
   tekst,
 }: Props) {
   return (
-    <div className="flex items-center">
-      <img
-        src={setSvarIkon(deltakerOnskerMote)}
-        alt={ikonAltTekst}
-        className="mr-4 w-6"
-      />
-      <VStack>
-        {tekst}
-        {motebehov?.formValues.begrunnelse && (
-          <VStack>
-            <i>{motebehov?.formValues.begrunnelse}</i>
-          </VStack>
-        )}
+    <Box padding={"3"} borderRadius={"medium"} shadow={"medium"}>
+      <VStack gap={"4"}>
+        <HStack>
+          <img
+            src={setSvarIkon(deltakerOnskerMote)}
+            alt={ikonAltTekst}
+            className="mr-4 w-6"
+          />
+          <div>{tekst}</div>
+        </HStack>
+        {motebehov && <MotebehovSkjemasvar motebehov={motebehov} />}
       </VStack>
-    </div>
+    </Box>
   );
 }

--- a/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
@@ -43,9 +43,9 @@ export default function MotebehovKvitteringInnhold({
       />
       <VStack>
         {tekst}
-        {motebehov?.motebehovSvar?.forklaring && (
+        {motebehov?.formValues.begrunnelse && (
           <VStack>
-            <i>{motebehov?.motebehovSvar?.forklaring}</i>
+            <i>{motebehov?.formValues.begrunnelse}</i>
           </VStack>
         )}
       </VStack>

--- a/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvitteringInnhold.tsx
@@ -36,7 +36,7 @@ export default function MotebehovKvitteringInnhold({
   tekst,
 }: Props) {
   return (
-    <Box padding={"3"} borderRadius={"medium"}>
+    <Box padding={"3"}>
       <VStack gap={"4"}>
         <HStack>
           <img

--- a/src/sider/dialogmoter/motebehov/skjema/CheckboxSvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/CheckboxSvar.tsx
@@ -1,0 +1,13 @@
+import { SingleCheckboxFieldSnapshot } from "@/data/motebehov/types/motebehovTypes";
+import { Checkbox } from "@navikt/ds-react";
+import React from "react";
+
+interface Props {
+  checkboxSvar: SingleCheckboxFieldSnapshot;
+}
+
+export const CheckboxSvar = ({ checkboxSvar }: Props) => (
+  <Checkbox checked={checkboxSvar.value} size={"small"} readOnly={true}>
+    {checkboxSvar.fieldLabel}
+  </Checkbox>
+);

--- a/src/sider/dialogmoter/motebehov/skjema/CheckboxSvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/CheckboxSvar.tsx
@@ -8,6 +8,6 @@ interface Props {
 
 export const CheckboxSvar = ({ checkboxSvar }: Props) => (
   <Checkbox checked={checkboxSvar.value} size={"small"} readOnly={true}>
-    {checkboxSvar.fieldLabel}
+    {checkboxSvar.label}
   </Checkbox>
 );

--- a/src/sider/dialogmoter/motebehov/skjema/MotebehovSkjemasvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/MotebehovSkjemasvar.tsx
@@ -1,0 +1,37 @@
+import {
+  FormSnapshotFieldType,
+  MotebehovVeilederDTO,
+  RadioGroupFieldSnapshot,
+  SingleCheckboxFieldSnapshot,
+  TextFieldSnapshot,
+} from "@/data/motebehov/types/motebehovTypes";
+import { TextSvar } from "@/sider/dialogmoter/motebehov/skjema/TextSvar";
+import { CheckboxSvar } from "@/sider/dialogmoter/motebehov/skjema/CheckboxSvar";
+import { RadioGroupSvar } from "@/sider/dialogmoter/motebehov/skjema/RadioGroupSvar";
+import React from "react";
+
+interface Props {
+  motebehov: MotebehovVeilederDTO;
+}
+
+export const MotebehovSkjemasvar = ({ motebehov }: Props) =>
+  motebehov.formValues.formSnapshot?.fieldSnapshots.map((field, index) => {
+    switch (field.fieldType) {
+      case FormSnapshotFieldType.TEXT:
+        return <TextSvar key={index} textSvar={field as TextFieldSnapshot} />;
+      case FormSnapshotFieldType.CHECKBOX_SINGLE:
+        return (
+          <CheckboxSvar
+            key={index}
+            checkboxSvar={field as SingleCheckboxFieldSnapshot}
+          />
+        );
+      case FormSnapshotFieldType.RADIO_GROUP:
+        return (
+          <RadioGroupSvar
+            key={index}
+            radioGroupSvar={field as RadioGroupFieldSnapshot}
+          />
+        );
+    }
+  });

--- a/src/sider/dialogmoter/motebehov/skjema/RadioGroupSvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/RadioGroupSvar.tsx
@@ -1,0 +1,22 @@
+import { RadioGroupFieldSnapshot } from "@/data/motebehov/types/motebehovTypes";
+import { Radio, RadioGroup } from "@navikt/ds-react";
+import React from "react";
+
+interface Props {
+  radioGroupSvar: RadioGroupFieldSnapshot;
+}
+
+export const RadioGroupSvar = ({ radioGroupSvar }: Props) => (
+  <RadioGroup
+    readOnly={true}
+    legend={radioGroupSvar.fieldLabel}
+    value={radioGroupSvar.selectedOptionId}
+    size={"small"}
+  >
+    {radioGroupSvar.options.map((field, index) => (
+      <Radio key={index} value={field.optionId} size={"small"} readOnly={true}>
+        {field.optionLabel}
+      </Radio>
+    ))}
+  </RadioGroup>
+);

--- a/src/sider/dialogmoter/motebehov/skjema/RadioGroupSvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/RadioGroupSvar.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const RadioGroupSvar = ({ radioGroupSvar }: Props) => (
   <RadioGroup
     readOnly={true}
-    legend={radioGroupSvar.fieldLabel}
+    legend={radioGroupSvar.label}
     value={radioGroupSvar.selectedOptionId}
     size={"small"}
   >

--- a/src/sider/dialogmoter/motebehov/skjema/TextSvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/TextSvar.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const TextSvar = ({ textSvar }: Props) => (
   <Textarea
-    label={textSvar.fieldLabel}
+    label={textSvar.label}
     value={textSvar.value}
     size={"small"}
     readOnly={true}

--- a/src/sider/dialogmoter/motebehov/skjema/TextSvar.tsx
+++ b/src/sider/dialogmoter/motebehov/skjema/TextSvar.tsx
@@ -1,0 +1,17 @@
+import { TextFieldSnapshot } from "@/data/motebehov/types/motebehovTypes";
+import { Textarea } from "@navikt/ds-react";
+import React from "react";
+
+interface Props {
+  textSvar: TextFieldSnapshot;
+}
+
+export const TextSvar = ({ textSvar }: Props) => (
+  <Textarea
+    label={textSvar.fieldLabel}
+    value={textSvar.value}
+    size={"small"}
+    readOnly={true}
+    minRows={1}
+  />
+);

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -66,7 +66,7 @@ export function fjerneDuplikatInnsendereMotebehov(
 ): MotebehovVeilederDTO[] {
   return motebehovListe.filter((motebehov, index) => {
     const funnetIndex = motebehovListe.findIndex((motebehovInner) => {
-      return motebehovInner.opprettetAv === motebehov.opprettetAv;
+      return motebehovInner.innmelderType === motebehov.innmelderType;
     });
     return funnetIndex >= index;
   });
@@ -116,7 +116,6 @@ export function mapMotebehovToMeldtMotebehovFormat(
       return {
         id: motebehov.id,
         opprettetDato: motebehov.opprettetDato,
-        opprettetAv: motebehov.opprettetAv,
         opprettetAvNavn: motebehov.opprettetAvNavn,
         innmelder: isArbeidstakerMotebehov(motebehov)
           ? MotebehovInnmelder.ARBEIDSTAKER
@@ -142,7 +141,6 @@ export function mapMotebehovToSvarMotebehovFormat(
       return {
         id: motebehov.id,
         opprettetDato: motebehov.opprettetDato,
-        opprettetAv: motebehov.opprettetAv,
         opprettetAvNavn: motebehov.opprettetAvNavn,
         innmelder: isArbeidstakerMotebehov(motebehov)
           ? MotebehovInnmelder.ARBEIDSTAKER

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -117,9 +117,7 @@ export function mapMotebehovToMeldtMotebehovFormat(
         id: motebehov.id,
         opprettetDato: motebehov.opprettetDato,
         opprettetAvNavn: motebehov.opprettetAvNavn,
-        innmelder: isArbeidstakerMotebehov(motebehov)
-          ? MotebehovInnmelder.ARBEIDSTAKER
-          : MotebehovInnmelder.ARBEIDSGIVER,
+        innmelder: motebehov.innmelderType,
         arbeidstakerFnr: motebehov.arbeidstakerFnr,
         virksomhetsnummer: motebehov.virksomhetsnummer,
         formValues: motebehov.formValues,
@@ -142,9 +140,7 @@ export function mapMotebehovToSvarMotebehovFormat(
         id: motebehov.id,
         opprettetDato: motebehov.opprettetDato,
         opprettetAvNavn: motebehov.opprettetAvNavn,
-        innmelder: isArbeidstakerMotebehov(motebehov)
-          ? MotebehovInnmelder.ARBEIDSTAKER
-          : MotebehovInnmelder.ARBEIDSGIVER,
+        innmelder: motebehov.innmelderType,
         arbeidstakerFnr: motebehov.arbeidstakerFnr,
         virksomhetsnummer: motebehov.virksomhetsnummer,
         formValues: motebehov.formValues,

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -1,4 +1,5 @@
 import {
+  InnsenderKey,
   MeldtMotebehov,
   MotebehovInnmelder,
   MotebehovSkjemaType,
@@ -8,7 +9,7 @@ import {
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { MotebehovTilbakemeldingDTO } from "@/data/motebehov/useBehandleMotebehovAndSendTilbakemelding";
 
-export const sorterMotebehovDataEtterDato = (
+export const sorterMotebehovDataEtterDatoDesc = (
   a: MotebehovVeilederDTO,
   b: MotebehovVeilederDTO
 ): number => {
@@ -64,12 +65,16 @@ export const hentSistBehandletMotebehov = (
 export function fjerneDuplikatInnsendereMotebehov(
   motebehovListe: MotebehovVeilederDTO[]
 ): MotebehovVeilederDTO[] {
-  return motebehovListe.filter((motebehov, index) => {
-    const funnetIndex = motebehovListe.findIndex((motebehovInner) => {
-      return motebehovInner.innmelderType === motebehov.innmelderType;
-    });
-    return funnetIndex >= index;
+  const unikeInnsendere = new Map<string, MotebehovVeilederDTO>();
+  motebehovListe.forEach((motebehov) => {
+    const { virksomhetsnummer, innmelderType } = motebehov;
+    const key: InnsenderKey = [virksomhetsnummer, innmelderType];
+    const keyAsString = JSON.stringify(key);
+    if (!unikeInnsendere.get(keyAsString)) {
+      unikeInnsendere.set(keyAsString, motebehov);
+    }
   });
+  return [...unikeInnsendere.values()];
 }
 
 export const motebehovlisteMedKunJaSvar = (

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -25,8 +25,7 @@ export const motebehovUbehandlet = (
 ): MotebehovVeilederDTO[] => {
   return motebehovListe.filter(
     (motebehov) =>
-      motebehov.motebehovSvar &&
-      motebehov.motebehovSvar.harMotebehov &&
+      motebehov.formValues.harMotebehov &&
       !motebehov.behandletTidspunkt &&
       !motebehov.behandletVeilederIdent
   );
@@ -77,8 +76,7 @@ export const motebehovlisteMedKunJaSvar = (
   motebehovliste: MotebehovVeilederDTO[]
 ): MotebehovVeilederDTO[] => {
   return motebehovliste.filter(
-    (motebehov) =>
-      motebehov.motebehovSvar && motebehov.motebehovSvar.harMotebehov
+    (motebehov) => motebehov.formValues.harMotebehov
   );
 };
 
@@ -104,7 +102,7 @@ export const toMotebehovTilbakemeldingDTO = (
 };
 
 export function isArbeidstakerMotebehov(motebehov: MotebehovVeilederDTO) {
-  return motebehov.opprettetAv === motebehov.aktorId;
+  return motebehov.innmelderType === MotebehovInnmelder.ARBEIDSTAKER;
 }
 
 export function mapMotebehovToMeldtMotebehovFormat(
@@ -125,8 +123,7 @@ export function mapMotebehovToMeldtMotebehovFormat(
           : MotebehovInnmelder.ARBEIDSGIVER,
         arbeidstakerFnr: motebehov.arbeidstakerFnr,
         virksomhetsnummer: motebehov.virksomhetsnummer,
-        begrunnelse: motebehov.motebehovSvar.forklaring,
-        tildeltEnhet: motebehov.tildeltEnhet,
+        formValues: motebehov.formValues,
         behandletTidspunkt: motebehov.behandletTidspunkt,
         behandletVeilederIdent: motebehov.behandletVeilederIdent,
         skjemaType: MotebehovSkjemaType.MELD_BEHOV,
@@ -152,8 +149,7 @@ export function mapMotebehovToSvarMotebehovFormat(
           : MotebehovInnmelder.ARBEIDSGIVER,
         arbeidstakerFnr: motebehov.arbeidstakerFnr,
         virksomhetsnummer: motebehov.virksomhetsnummer,
-        motebehovSvar: motebehov.motebehovSvar,
-        tildeltEnhet: motebehov.tildeltEnhet,
+        formValues: motebehov.formValues,
         behandletTidspunkt: motebehov.behandletTidspunkt,
         behandletVeilederIdent: motebehov.behandletVeilederIdent,
         skjemaType: MotebehovSkjemaType.SVAR_BEHOV,

--- a/test/containers/MotelandingssideContainerTest.tsx
+++ b/test/containers/MotelandingssideContainerTest.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import Motelandingsside from "@/sider/dialogmoter/Motelandingsside";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { dialogmoterQueryKeys } from "@/data/dialogmote/dialogmoteQueryHooks";
@@ -21,21 +21,35 @@ import { MemoryRouter } from "react-router-dom";
 import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { dialogmoteunntakQueryKeys } from "@/data/dialogmotekandidat/dialogmoteunntakQueryHooks";
 import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
+import {
+  MotebehovInnmelder,
+  MotebehovSkjemaType,
+  MotebehovVeilederDTO,
+} from "@/data/motebehov/types/motebehovTypes";
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: any;
 
-const motebehovData = [
+const motebehovData: MotebehovVeilederDTO[] = [
   {
-    UUID: "33333333-c987-4b57-a401-a3915ec11411",
     id: "33333333-ee10-44b6-bddf-54d049ef25f2",
-    opprettetDato: "2019-01-08T13:53:57.047+01:00",
-    aktorId: "1",
+    opprettetDato: new Date(),
     opprettetAv: "1",
     virksomhetsnummer: "000999000",
-    tildeltEnhet: "0330",
-    behandletTidspunkt: "2019-01-10T13:53:57.047+01:00",
+    behandletTidspunkt: new Date(),
     behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
+    opprettetAvNavn: VEILEDER_IDENT_DEFAULT.toString(),
+    arbeidstakerFnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
+    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+    formValues: {
+      harMotebehov: false,
+      begrunnelse: null,
+      onskerSykmelderDeltar: null,
+      onskerSykmelderDeltarBegrunnelse: null,
+      onskerTolk: null,
+      tolkSprak: null,
+    },
   },
 ];
 

--- a/test/containers/MotelandingssideContainerTest.tsx
+++ b/test/containers/MotelandingssideContainerTest.tsx
@@ -26,6 +26,7 @@ import {
   MotebehovSkjemaType,
   MotebehovVeilederDTO,
 } from "@/data/motebehov/types/motebehovTypes";
+import { defaultFormValue } from "@/mocks/syfomotebehov/motebehovMock";
 
 const fnr = ARBEIDSTAKER_DEFAULT.personIdent;
 let queryClient: any;
@@ -42,13 +43,7 @@ const motebehovData: MotebehovVeilederDTO[] = [
     innmelderType: MotebehovInnmelder.ARBEIDSTAKER,
     skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
     formValues: {
-      harMotebehov: false,
-      begrunnelse: null,
-      onskerSykmelderDeltar: null,
-      onskerSykmelderDeltarBegrunnelse: null,
-      onskerTolk: null,
-      tolkSprak: null,
-      formSnapshot: null,
+      ...defaultFormValue,
     },
   },
 ];

--- a/test/containers/MotelandingssideContainerTest.tsx
+++ b/test/containers/MotelandingssideContainerTest.tsx
@@ -34,7 +34,6 @@ const motebehovData: MotebehovVeilederDTO[] = [
   {
     id: "33333333-ee10-44b6-bddf-54d049ef25f2",
     opprettetDato: new Date(),
-    opprettetAv: "1",
     virksomhetsnummer: "000999000",
     behandletTidspunkt: new Date(),
     behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
@@ -49,6 +48,7 @@ const motebehovData: MotebehovVeilederDTO[] = [
       onskerSykmelderDeltarBegrunnelse: null,
       onskerTolk: null,
       tolkSprak: null,
+      formSnapshot: null,
     },
   },
 ];

--- a/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
+++ b/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
@@ -9,8 +9,9 @@ import {
   VEILEDER_IDENT_DEFAULT,
 } from "@/mocks/common/mockConstants";
 import {
+  defaultFormValue,
   svartJaMotebehovArbeidstakerUbehandletMock,
-  svartNeiMotebehovArbeidsgiverUbehandletMock,
+  svartNeiMotebehovArbeidsgiverUbehandletMock
 } from "@/mocks/syfomotebehov/motebehovMock";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { addDays, addWeeks, toDatePrettyPrint } from "@/utils/datoUtils";
@@ -46,7 +47,7 @@ const arbeidstakerSvarJaBehandlet: MotebehovVeilederDTO = {
 const tidligereOppfolgingstilfelle = {
   arbeidstakerSvarJa: arbeidstakerSvarJaBehandlet,
   arbeidsgiverSvarNeiUbehandlet: {
-    ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+    ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
     opprettetDato: datoUtenforOppfolgingstilfelle,
   },
 };
@@ -55,12 +56,9 @@ const arbeidstakerSvarNeiUbehandlet: MotebehovVeilederDTO = {
   ...svartJaMotebehovArbeidstakerUbehandletMock,
   opprettetDato: datoInnenforOppfolgingstilfelle,
   formValues: {
+    ...defaultFormValue,
     harMotebehov: false,
     begrunnelse: "Trenger ikke møte",
-    onskerSykmelderDeltar: null,
-    onskerSykmelderDeltarBegrunnelse: null,
-    onskerTolk: null,
-    tolkSprak: null,
   }
 };
 
@@ -71,7 +69,7 @@ const nyttOppfolgingstilfelle = {
     behandletVeilederIdent: VEILEDER_IDENT_DEFAULT,
   },
   arbeidsgiverSvarNeiUbehandlet: {
-    ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+    ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
     opprettetDato: datoInnenforOppfolgingstilfelle,
   },
 };

--- a/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
+++ b/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
@@ -11,7 +11,7 @@ import {
 import {
   defaultFormValue,
   svartJaMotebehovArbeidstakerUbehandletMock,
-  svartNeiMotebehovArbeidsgiverUbehandletMock
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
 } from "@/mocks/syfomotebehov/motebehovMock";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import { addDays, addWeeks, toDatePrettyPrint } from "@/utils/datoUtils";
@@ -59,7 +59,7 @@ const arbeidstakerSvarNeiUbehandlet: MotebehovVeilederDTO = {
     ...defaultFormValue,
     harMotebehov: false,
     begrunnelse: "Trenger ikke møte",
-  }
+  },
 };
 
 const nyttOppfolgingstilfelle = {

--- a/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
+++ b/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
@@ -54,10 +54,14 @@ const tidligereOppfolgingstilfelle = {
 const arbeidstakerSvarNeiUbehandlet: MotebehovVeilederDTO = {
   ...svartJaMotebehovArbeidstakerUbehandletMock,
   opprettetDato: datoInnenforOppfolgingstilfelle,
-  motebehovSvar: {
+  formValues: {
     harMotebehov: false,
-    forklaring: "Trenger ikke møte",
-  },
+    begrunnelse: "Trenger ikke møte",
+    onskerSykmelderDeltar: null,
+    onskerSykmelderDeltarBegrunnelse: null,
+    onskerTolk: null,
+    tolkSprak: null,
+  }
 };
 
 const nyttOppfolgingstilfelle = {

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -39,9 +39,13 @@ function mockMotebehov(motebehov: MotebehovVeilederDTO[]) {
 const motebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
   ...meldtMotebehovArbeidstakerBehandletMock,
   opprettetDato: addDays(new Date(), -25),
-  motebehovSvar: {
+  formValues: {
     harMotebehov: true,
-    forklaring: "Jeg, arbeidstaker, har behov for møte.",
+    begrunnelse: "Jeg, arbeidstaker, har behov for møte.",
+    onskerSykmelderDeltar: null,
+    onskerSykmelderDeltarBegrunnelse: null,
+    onskerTolk: null,
+    tolkSprak: null,
   },
   behandletTidspunkt: null,
   behandletVeilederIdent: null,
@@ -51,9 +55,13 @@ const motebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
 const motebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
   ...svartNeiMotebehovArbeidsgiverUbehandletMock,
   opprettetDato: addDays(new Date(), -25),
-  motebehovSvar: {
+  formValues: {
     harMotebehov: true,
-    forklaring: "Jeg, arbeidsgiver, har behov for møte.",
+    begrunnelse: "Jeg, arbeidsgiver, har behov for møte.",
+    onskerSykmelderDeltar: null,
+    onskerSykmelderDeltarBegrunnelse: null,
+    onskerTolk: null,
+    tolkSprak: null,
   },
   behandletTidspunkt: null,
   behandletVeilederIdent: null,
@@ -64,9 +72,13 @@ const motebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO
   {
     ...meldtMotebehovArbeidstakerBehandletMock,
     opprettetDato: addDays(new Date(), -25),
-    motebehovSvar: {
+    formValues: {
       harMotebehov: true,
-      forklaring: "Jeg, arbeidstaker, svarer ja til møte.",
+      begrunnelse: "Jeg, arbeidstaker, svarer ja til møte.",
+      onskerSykmelderDeltar: null,
+      onskerSykmelderDeltarBegrunnelse: null,
+      onskerTolk: null,
+      tolkSprak: null,
     },
     behandletTidspunkt: null,
     behandletVeilederIdent: null,
@@ -77,9 +89,13 @@ const motebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock: MotebehovVeilederDT
   {
     ...svartNeiMotebehovArbeidsgiverUbehandletMock,
     opprettetDato: addDays(new Date(), -25),
-    motebehovSvar: {
+    formValues: {
       harMotebehov: false,
-      forklaring: "Jeg, arbeidsgiver, svarer nei til møte.",
+      begrunnelse: "Jeg, arbeidsgiver, svarer nei til møte.",
+      onskerSykmelderDeltar: null,
+      onskerSykmelderDeltarBegrunnelse: null,
+      onskerTolk: null,
+      tolkSprak: null,
     },
     behandletTidspunkt: null,
     behandletVeilederIdent: null,

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -10,10 +10,14 @@ import {
   VEILEDER_IDENT_DEFAULT,
 } from "@/mocks/common/mockConstants";
 import {
-  svartNeiMotebehovArbeidsgiverUbehandletMock,
+  createFormValues,
+  defaultFormValue,
   meldtMotebehovArbeidstakerBehandletMock,
+  svartJaMotebehovArbeidstakerUbehandletMock,
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
 } from "@/mocks/syfomotebehov/motebehovMock";
 import {
+  MotebehovInnmelder,
   MotebehovSkjemaType,
   MotebehovVeilederDTO,
 } from "@/data/motebehov/types/motebehovTypes";
@@ -37,32 +41,34 @@ function mockMotebehov(motebehov: MotebehovVeilederDTO[]) {
 }
 
 const motebehovArbeidstakerInTilfelleUbehandletMock: MotebehovVeilederDTO = {
-  ...meldtMotebehovArbeidstakerBehandletMock,
+  ...meldtMotebehovArbeidstakerBehandletMock(),
   opprettetDato: addDays(new Date(), -25),
-  formValues: {
-    harMotebehov: true,
-    begrunnelse: "Jeg, arbeidstaker, har behov for møte.",
-    onskerSykmelderDeltar: null,
-    onskerSykmelderDeltarBegrunnelse: null,
-    onskerTolk: null,
-    tolkSprak: null,
-  },
+  formValues: createFormValues(
+    {
+      ...defaultFormValue,
+      harMotebehov: true,
+      begrunnelse: "Jeg, arbeidstaker, har behov for møte.",
+    },
+    MotebehovSkjemaType.MELD_BEHOV,
+    MotebehovInnmelder.ARBEIDSTAKER
+  ),
   behandletTidspunkt: null,
   behandletVeilederIdent: null,
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
 };
 
 const motebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
-  ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+  ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
   opprettetDato: addDays(new Date(), -25),
-  formValues: {
-    harMotebehov: true,
-    begrunnelse: "Jeg, arbeidsgiver, har behov for møte.",
-    onskerSykmelderDeltar: null,
-    onskerSykmelderDeltarBegrunnelse: null,
-    onskerTolk: null,
-    tolkSprak: null,
-  },
+  formValues: createFormValues(
+    {
+      ...defaultFormValue,
+      harMotebehov: true,
+      begrunnelse: "Jeg, arbeidsgiver, har behov for møte.",
+    },
+    MotebehovSkjemaType.MELD_BEHOV,
+    MotebehovInnmelder.ARBEIDSGIVER
+  ),
   behandletTidspunkt: null,
   behandletVeilederIdent: null,
   skjemaType: MotebehovSkjemaType.MELD_BEHOV,
@@ -70,16 +76,17 @@ const motebehovArbeidsgiverInTilfelleUbehandletMock: MotebehovVeilederDTO = {
 
 const motebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO =
   {
-    ...meldtMotebehovArbeidstakerBehandletMock,
+    ...meldtMotebehovArbeidstakerBehandletMock(),
     opprettetDato: addDays(new Date(), -25),
-    formValues: {
-      harMotebehov: true,
-      begrunnelse: "Jeg, arbeidstaker, svarer ja til møte.",
-      onskerSykmelderDeltar: null,
-      onskerSykmelderDeltarBegrunnelse: null,
-      onskerTolk: null,
-      tolkSprak: null,
-    },
+    formValues: createFormValues(
+      {
+        ...defaultFormValue,
+        harMotebehov: true,
+        begrunnelse: "Møter er bra!",
+      },
+      MotebehovSkjemaType.SVAR_BEHOV,
+      MotebehovInnmelder.ARBEIDSTAKER
+    ),
     behandletTidspunkt: null,
     behandletVeilederIdent: null,
     skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
@@ -87,19 +94,21 @@ const motebehovArbeidstakerInTilfelleSvartJaUbehandletMock: MotebehovVeilederDTO
 
 const motebehovArbeidsgiverInTilfelleSvartNeiUbehandletMock: MotebehovVeilederDTO =
   {
-    ...svartNeiMotebehovArbeidsgiverUbehandletMock,
+    ...svartNeiMotebehovArbeidsgiverUbehandletMock(
+      MotebehovSkjemaType.SVAR_BEHOV
+    ),
     opprettetDato: addDays(new Date(), -25),
-    formValues: {
-      harMotebehov: false,
-      begrunnelse: "Jeg, arbeidsgiver, svarer nei til møte.",
-      onskerSykmelderDeltar: null,
-      onskerSykmelderDeltarBegrunnelse: null,
-      onskerTolk: null,
-      tolkSprak: null,
-    },
+    formValues: createFormValues(
+      {
+        ...defaultFormValue,
+        harMotebehov: false,
+        begrunnelse: "Jeg, arbeidsgiver, svarer nei til møte.",
+      },
+      MotebehovSkjemaType.SVAR_BEHOV,
+      MotebehovInnmelder.ARBEIDSGIVER
+    ),
     behandletTidspunkt: null,
     behandletVeilederIdent: null,
-    skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
   };
 
 function createMotebehovBehandlet(motebehov: MotebehovVeilederDTO) {
@@ -261,7 +270,7 @@ describe("MotebehovKvittering", () => {
         exact: false,
       })
     ).to.exist;
-    expect(screen.getByText("Jeg, arbeidstaker, svarer ja til møte.")).to.exist;
+    expect(screen.getByText("Møter er bra!")).to.exist;
 
     expect(screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke svart.")).to
       .exist;
@@ -306,5 +315,418 @@ describe("MotebehovKvittering", () => {
         "Alle tidligere møtebehov er behandlet, se møtebehovhistorikken for flere detaljer."
       )
     ).to.exist;
+  });
+
+  describe("MotebehovKvittering visning av readonly skjema", () => {
+    describe("Meld behov", () => {
+      it("Arbeidstaker har meldt inn behov for møte", () => {
+        const arbeidstaker = {
+          ...meldtMotebehovArbeidstakerBehandletMock(),
+        };
+
+        mockMotebehov([arbeidstaker]);
+
+        renderMotebehovKvittering();
+
+        expect(
+          screen.getByText("Samuel Sam Jones, har meldt behov", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(screen.getByText("Begrunnelse")).to.exist;
+        expect(screen.getByText("Møter er bra!")).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp(
+              "Jeg ønsker at sykmelder \\(lege/behandler\\) også deltar i møtet\\."
+            ),
+            checked: true,
+          })
+        ).to.exist;
+        expect(
+          screen.getByText(
+            "Hvorfor ønsker du at lege/behandler deltar i møtet?"
+          )
+        ).to.exist;
+        expect(screen.getByText("Ønsker at legen min er tilstede")).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp("Vi har behov for tolk."),
+            checked: true,
+          })
+        ).to.exist;
+        expect(screen.getByText("Hva slags tolk har dere behov for?")).to.exist;
+        expect(screen.getByText("Har behov for svensk tolk")).to.exist;
+        expect(
+          screen.getByText("Tatten Tattover, har ikke meldt behov", {
+            exact: false,
+          })
+        ).to.exist;
+      });
+    });
+
+    describe("Svar behov", () => {
+      it("Arbeidsgiver og arbeidstaker har svart på alle spørsmål ifm. møtebehov (dialogmøte 2)", () => {
+        const arbeidstaker = {
+          ...svartJaMotebehovArbeidstakerUbehandletMock,
+          skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+          formValues: createFormValues(
+            {
+              ...defaultFormValue,
+              harMotebehov: true,
+              begrunnelse: "Møter er bra!",
+              onskerSykmelderDeltar: true,
+              onskerSykmelderDeltarBegrunnelse:
+                "Ønsker at legen min er tilstede",
+              onskerTolk: true,
+              tolkSprak: "Har behov for svensk tolk",
+            },
+            MotebehovSkjemaType.SVAR_BEHOV,
+            MotebehovInnmelder.ARBEIDSTAKER
+          ),
+        };
+
+        const arbeidsgiver = {
+          ...svartNeiMotebehovArbeidsgiverUbehandletMock(
+            MotebehovSkjemaType.SVAR_BEHOV
+          ),
+          formValues: createFormValues(
+            {
+              ...defaultFormValue,
+              harMotebehov: true,
+              begrunnelse: "Jeg liker ikke møte!!",
+              onskerSykmelderDeltar: true,
+              onskerSykmelderDeltarBegrunnelse: "Ønsker lege tilstede",
+              onskerTolk: true,
+              tolkSprak: "Svensk",
+            },
+            MotebehovSkjemaType.SVAR_BEHOV,
+            MotebehovInnmelder.ARBEIDSGIVER
+          ),
+        };
+
+        mockMotebehov([arbeidsgiver, arbeidstaker]);
+
+        renderMotebehovKvittering();
+
+        expect(
+          screen.getByText("Samuel Sam Jones, har svart JA", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getAllByRole("group", {
+            name: RegExp("Har dere behov for et dialogmøte med NAV?"),
+          })[0]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Ja, vi har behov for et dialogmøte.",
+            checked: true,
+          })[0]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Nei, vi har ikke behov for et dialogmøte nå.",
+          })[0]
+        ).to.exist;
+        expect(screen.getAllByText("Begrunnelse")[0]).to.exist;
+        expect(screen.getByText("Møter er bra!")).to.exist;
+        expect(
+          screen.getAllByRole("checkbox", {
+            name: RegExp(
+              "Jeg ønsker at sykmelder \\(lege/behandler\\) også deltar i møtet\\."
+            ),
+            checked: true,
+          })[0]
+        ).to.exist;
+        expect(
+          screen.getAllByText(
+            "Hvorfor ønsker du at lege/behandler deltar i møtet?"
+          )[0]
+        ).to.exist;
+        expect(screen.getByText("Ønsker at legen min er tilstede")).to.exist;
+        expect(
+          screen.getAllByRole("checkbox", {
+            name: RegExp("Vi har behov for tolk."),
+            checked: true,
+          })[0]
+        ).to.exist;
+        expect(screen.getAllByText("Hva slags tolk har dere behov for?")[0]).to
+          .exist;
+        expect(screen.getByText("Har behov for svensk tolk")).to.exist;
+
+        expect(
+          screen.getByText("Are Arbeidsgiver, har svart JA", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getAllByRole("group", {
+            name: RegExp("Har dere behov for et dialogmøte med NAV?"),
+          })[1]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Ja, vi har behov for et dialogmøte.",
+            checked: true,
+          })[1]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Nei, vi har ikke behov for et dialogmøte nå.",
+          })[1]
+        ).to.exist;
+        expect(screen.getAllByText("Begrunnelse")[1]).to.exist;
+        expect(screen.getByText("Jeg liker ikke møte!!")).to.exist;
+        expect(
+          screen.getAllByRole("checkbox", {
+            name: RegExp(
+              "Jeg ønsker at sykmelder \\(lege/behandler\\) også deltar i møtet\\."
+            ),
+            checked: true,
+          })[1]
+        ).to.exist;
+        expect(
+          screen.getAllByText(
+            "Hvorfor ønsker du at lege/behandler deltar i møtet?"
+          )[1]
+        ).to.exist;
+        expect(screen.getByText("Ønsker lege tilstede")).to.exist;
+        expect(
+          screen.getAllByRole("checkbox", {
+            name: RegExp("Vi har behov for tolk."),
+            checked: true,
+          })[1]
+        ).to.exist;
+        expect(screen.getAllByText("Hva slags tolk har dere behov for?")[1]).to
+          .exist;
+        expect(screen.getByText("Svensk")).to.exist;
+      });
+
+      it("Arbeidsgiver og arbeidstaker har svart variende på spørsmål møtebehov (dialogmøte 2)", () => {
+        const arbeidstaker = {
+          ...svartJaMotebehovArbeidstakerUbehandletMock,
+          skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+          formValues: createFormValues(
+            {
+              ...defaultFormValue,
+              harMotebehov: true,
+              begrunnelse: "Møter er bra!",
+              onskerSykmelderDeltar: true,
+              onskerSykmelderDeltarBegrunnelse:
+                "Ønsker at legen min er tilstede",
+              onskerTolk: false,
+            },
+            MotebehovSkjemaType.SVAR_BEHOV,
+            MotebehovInnmelder.ARBEIDSTAKER
+          ),
+        };
+
+        const arbeidsgiver = {
+          ...svartNeiMotebehovArbeidsgiverUbehandletMock(
+            MotebehovSkjemaType.SVAR_BEHOV
+          ),
+          formValues: createFormValues(
+            {
+              ...defaultFormValue,
+              harMotebehov: true,
+              begrunnelse: "Jeg liker ikke møte!!",
+              onskerSykmelderDeltar: false,
+              onskerTolk: true,
+              tolkSprak: "Svensk",
+            },
+            MotebehovSkjemaType.SVAR_BEHOV,
+            MotebehovInnmelder.ARBEIDSGIVER
+          ),
+        };
+
+        mockMotebehov([arbeidsgiver, arbeidstaker]);
+
+        renderMotebehovKvittering();
+
+        expect(
+          screen.getByText("Samuel Sam Jones, har svart JA", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getAllByRole("group", {
+            name: RegExp("Har dere behov for et dialogmøte med NAV?"),
+          })[0]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Ja, vi har behov for et dialogmøte.",
+            checked: true,
+          })[0]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Nei, vi har ikke behov for et dialogmøte nå.",
+          })[0]
+        ).to.exist;
+        expect(screen.getAllByText("Begrunnelse")[0]).to.exist;
+        expect(screen.getByText("Møter er bra!")).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp(
+              "Jeg ønsker at sykmelder \\(lege/behandler\\) også deltar i møtet\\."
+            ),
+            checked: true,
+          })
+        ).to.exist;
+        expect(
+          screen.getByText(
+            "Hvorfor ønsker du at lege/behandler deltar i møtet?"
+          )
+        ).to.exist;
+        expect(screen.getByText("Ønsker at legen min er tilstede")).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp("Vi har behov for tolk."),
+            checked: false,
+          })
+        ).to.exist;
+
+        expect(
+          screen.getByText("Are Arbeidsgiver, har svart JA", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getAllByRole("group", {
+            name: RegExp("Har dere behov for et dialogmøte med NAV?"),
+          })[1]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Ja, vi har behov for et dialogmøte.",
+            checked: true,
+          })[1]
+        ).to.exist;
+        expect(
+          screen.getAllByRole("radio", {
+            name: "Nei, vi har ikke behov for et dialogmøte nå.",
+          })[1]
+        ).to.exist;
+        expect(screen.getAllByText("Begrunnelse")[1]).to.exist;
+        expect(screen.getByText("Jeg liker ikke møte!!")).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp(
+              "Jeg ønsker at sykmelder \\(lege/behandler\\) også deltar i møtet\\."
+            ),
+            checked: true,
+          })
+        ).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp("Vi har behov for tolk."),
+            checked: true,
+          })
+        ).to.exist;
+        expect(screen.getByText("Hva slags tolk har dere behov for?")).to.exist;
+        expect(screen.getByText("Svensk")).to.exist;
+      });
+
+      it("Arbeidstaker har svart ja på sykmelder tilstede uten begrunnelse", () => {
+        const arbeidstaker = {
+          ...svartJaMotebehovArbeidstakerUbehandletMock,
+          skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
+          formValues: createFormValues(
+            {
+              ...defaultFormValue,
+              harMotebehov: true,
+              begrunnelse: "Møter er bra!",
+              onskerSykmelderDeltar: true,
+              onskerTolk: false,
+            },
+            MotebehovSkjemaType.SVAR_BEHOV,
+            MotebehovInnmelder.ARBEIDSTAKER
+          ),
+        };
+
+        const arbeidsgiver = {
+          ...svartNeiMotebehovArbeidsgiverUbehandletMock(
+            MotebehovSkjemaType.SVAR_BEHOV
+          ),
+          formValues: createFormValues(
+            {
+              ...defaultFormValue,
+              harMotebehov: false,
+            },
+            MotebehovSkjemaType.SVAR_BEHOV,
+            MotebehovInnmelder.ARBEIDSGIVER
+          ),
+        };
+
+        mockMotebehov([arbeidsgiver, arbeidstaker]);
+
+        renderMotebehovKvittering();
+
+        expect(
+          screen.getByText("Samuel Sam Jones, har svart JA", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getAllByRole("group", {
+            name: RegExp("Har dere behov for et dialogmøte med NAV?"),
+          })[0]
+        ).to.exist;
+        expect(
+          screen.getByRole("radio", {
+            name: "Ja, vi har behov for et dialogmøte.",
+            checked: true,
+          })
+        ).to.exist;
+        expect(
+          screen.getByRole("radio", {
+            name: "Nei, vi har ikke behov for et dialogmøte nå.",
+            checked: false,
+          })
+        ).to.exist;
+        expect(screen.getByText("Begrunnelse")).to.exist;
+        expect(screen.getByText("Møter er bra!")).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp(
+              "Jeg ønsker at sykmelder \\(lege/behandler\\) også deltar i møtet\\."
+            ),
+            checked: true,
+          })
+        ).to.exist;
+        expect(
+          screen.getByRole("checkbox", {
+            name: RegExp("Vi har behov for tolk."),
+            checked: false,
+          })
+        ).to.exist;
+
+        expect(
+          screen.getByText("Are Arbeidsgiver, har svart NEI", {
+            exact: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getAllByRole("group", {
+            name: RegExp("Har dere behov for et dialogmøte med NAV?"),
+          })[1]
+        ).to.exist;
+        expect(
+          screen.getByRole("radio", {
+            name: "Ja, vi har behov for et dialogmøte.",
+            checked: false,
+          })
+        ).to.exist;
+        expect(
+          screen.getByRole("radio", {
+            name: "Nei, vi har ikke behov for et dialogmøte nå.",
+            checked: true,
+          })
+        ).to.exist;
+      });
+    });
   });
 });

--- a/test/dialogmote/MotebehovHistorikkTest.tsx
+++ b/test/dialogmote/MotebehovHistorikkTest.tsx
@@ -58,7 +58,7 @@ describe("MotebehovHistorikk", () => {
   it("viser kun møtebehov fra arbeidsgiver", () => {
     queryClient.setQueryData(
       motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [svartNeiMotebehovArbeidsgiverUbehandletMock]
+      () => [svartNeiMotebehovArbeidsgiverUbehandletMock()]
     );
 
     renderMotebehovHistorikk();
@@ -71,7 +71,7 @@ describe("MotebehovHistorikk", () => {
   it("viser kun møtebehov fra arbeidstaker", () => {
     queryClient.setQueryData(
       motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [meldtMotebehovArbeidstakerBehandletMock]
+      () => [meldtMotebehovArbeidstakerBehandletMock()]
     );
 
     renderMotebehovHistorikk();
@@ -84,7 +84,7 @@ describe("MotebehovHistorikk", () => {
   it("viser at møtebehovet er behandlet", () => {
     queryClient.setQueryData(
       motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
-      () => [meldtMotebehovArbeidstakerBehandletMock]
+      () => [meldtMotebehovArbeidstakerBehandletMock()]
     );
 
     renderMotebehovHistorikk();

--- a/test/utils/motebehovUtilsTest.ts
+++ b/test/utils/motebehovUtilsTest.ts
@@ -1,9 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { hentSistBehandletMotebehov } from "@/utils/motebehovUtils";
+import {
+  fjerneDuplikatInnsendereMotebehov,
+  hentSistBehandletMotebehov,
+} from "@/utils/motebehovUtils";
 import {
   meldtMotebehovArbeidstakerBehandletMock,
   svartJaMotebehovArbeidstakerUbehandletMock,
 } from "@/mocks/syfomotebehov/motebehovMock";
+import {
+  MotebehovInnmelder,
+  MotebehovVeilederDTO,
+  Virksomhetsnummer,
+} from "@/data/motebehov/types/motebehovTypes";
+import {
+  VIRKSOMHET_BRANNOGBIL,
+  VIRKSOMHET_PONTYPANDY,
+} from "@/mocks/common/mockConstants";
 
 describe("motebehovUtils", () => {
   describe("hentSistBehandletMotebehov", () => {
@@ -35,6 +47,146 @@ describe("motebehovUtils", () => {
       expect(
         hentSistBehandletMotebehov([motebehovBehandlet1, motebehovBehandlet2])
       ).to.be.deep.equal(motebehovBehandlet2);
+    });
+  });
+  describe("fjerneDuplikatInnsendereMotebehov", () => {
+    const ARBEIDSTAKER = MotebehovInnmelder.ARBEIDSTAKER;
+    const ARBEIDSGIVER = MotebehovInnmelder.ARBEIDSGIVER;
+
+    const PONTYPANDY_VIRKSOMHETSNR = VIRKSOMHET_PONTYPANDY.virksomhetsnummer;
+    const BRANNOGBIL_VIRKSOMHETSNR = VIRKSOMHET_BRANNOGBIL.virksomhetsnummer;
+
+    const motebehov = (
+      virksomhetsnummer: Virksomhetsnummer,
+      innmelderType: MotebehovInnmelder,
+      opprettetDato: string
+    ): MotebehovVeilederDTO => {
+      return {
+        ...svartJaMotebehovArbeidstakerUbehandletMock,
+        virksomhetsnummer: virksomhetsnummer,
+        innmelderType: innmelderType,
+        opprettetDato: new Date(opprettetDato),
+      };
+    };
+
+    it("Arbeidsgiver og arbeidstaker ved samme virksomhet", () => {
+      const motebehovListe: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+      ];
+
+      const expected: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+      ];
+
+      const actual = fjerneDuplikatInnsendereMotebehov(motebehovListe);
+
+      expect(actual).to.be.deep.equal(expected);
+    });
+
+    it("Flere forekomster av arbeidsgiver og arbeidstaker ved samme virksomhet - Velger første unike forekomst", () => {
+      const motebehovListe: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-18"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-10"),
+      ];
+
+      const expected: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-18"),
+      ];
+
+      const actual = fjerneDuplikatInnsendereMotebehov(motebehovListe);
+
+      expect(actual).to.be.deep.equal(expected);
+    });
+
+    it("Flere forekomster (inkl. tid) av arbeidsgiver og arbeidstaker ved samme virksomhet - Velger første unike forekomst", () => {
+      const motebehovListe: MotebehovVeilederDTO[] = [
+        motebehov(
+          PONTYPANDY_VIRKSOMHETSNR,
+          ARBEIDSGIVER,
+          "2025-04-20T15:05:00.000Z"
+        ),
+        motebehov(
+          PONTYPANDY_VIRKSOMHETSNR,
+          ARBEIDSGIVER,
+          "2025-04-20T15:00:00.000Z"
+        ),
+        motebehov(
+          PONTYPANDY_VIRKSOMHETSNR,
+          ARBEIDSTAKER,
+          "2025-04-19T14:15:00.000Z"
+        ),
+        motebehov(
+          PONTYPANDY_VIRKSOMHETSNR,
+          ARBEIDSTAKER,
+          "2025-04-19T14:10:00.000Z"
+        ),
+      ];
+
+      const expected: MotebehovVeilederDTO[] = [
+        motebehov(
+          PONTYPANDY_VIRKSOMHETSNR,
+          ARBEIDSGIVER,
+          "2025-04-20T15:05:00.000Z"
+        ),
+        motebehov(
+          PONTYPANDY_VIRKSOMHETSNR,
+          ARBEIDSTAKER,
+          "2025-04-19T14:15:00.000Z"
+        ),
+      ];
+
+      const actual = fjerneDuplikatInnsendereMotebehov(motebehovListe);
+
+      expect(actual).to.be.deep.equal(expected);
+    });
+
+    it("Miks av arbeidsgiver og arbeidstaker ved forskjellige virksomheter", () => {
+      const motebehovListe: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-18"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-10"),
+      ];
+
+      const expected: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-18"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-10"),
+      ];
+
+      const actual = fjerneDuplikatInnsendereMotebehov(motebehovListe);
+
+      expect(actual).to.be.deep.equal(expected);
+    });
+
+    it("Miks av arbeidsgiver og arbeidstaker ved forskjellige virksomheter med flere forekomster fra hver - Velger første unike forekomst", () => {
+      const motebehovListe: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-19"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-18"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-17"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-14"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-10"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-09"),
+      ];
+
+      const expected: MotebehovVeilederDTO[] = [
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-20"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-18"),
+        motebehov(PONTYPANDY_VIRKSOMHETSNR, ARBEIDSTAKER, "2025-04-15"),
+        motebehov(BRANNOGBIL_VIRKSOMHETSNR, ARBEIDSGIVER, "2025-04-10"),
+      ];
+
+      const actual = fjerneDuplikatInnsendereMotebehov(motebehovListe);
+
+      expect(actual).to.be.deep.equal(expected);
     });
   });
 });

--- a/test/utils/motebehovUtilsTest.ts
+++ b/test/utils/motebehovUtilsTest.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
 import { hentSistBehandletMotebehov } from "@/utils/motebehovUtils";
+import {
+  meldtMotebehovArbeidstakerBehandletMock,
+  svartJaMotebehovArbeidstakerUbehandletMock,
+} from "@/mocks/syfomotebehov/motebehovMock";
 
 describe("motebehovUtils", () => {
   describe("hentSistBehandletMotebehov", () => {
@@ -8,9 +12,11 @@ describe("motebehovUtils", () => {
     });
     it("Returnerer ingen motebehov i lista når ingen er behandlet", () => {
       const motebehovUbehandlet1 = {
+        ...svartJaMotebehovArbeidstakerUbehandletMock,
         behandletTidspunkt: null,
       };
       const motebehovUbehandlet2 = {
+        ...svartJaMotebehovArbeidstakerUbehandletMock,
         behandletTidspunkt: null,
       };
       expect(
@@ -19,10 +25,12 @@ describe("motebehovUtils", () => {
     });
     it("Returnerer motebehov med siste behandlet tidspunkt", () => {
       const motebehovBehandlet1 = {
-        behandletTidspunkt: "2021-04-03T15:18:24.000Z",
+        ...meldtMotebehovArbeidstakerBehandletMock(),
+        behandletTidspunkt: new Date("2021-04-03T15:18:24.000Z"),
       };
       const motebehovBehandlet2 = {
-        behandletTidspunkt: "2021-04-08T15:18:24.000Z",
+        ...meldtMotebehovArbeidstakerBehandletMock(),
+        behandletTidspunkt: new Date("2021-04-08T15:18:24.000Z"),
       };
       expect(
         hentSistBehandletMotebehov([motebehovBehandlet1, motebehovBehandlet2])


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Tatt i bruk nytt endepunkt for møtebehov. Nye som leveres og fremvises:
- Ønske om at sykmelder er tilstede og begrunnelse
- Ønske om tolk og begrunnelse

Mye av endringene er relatert til nye typer og mocking av korrekte data (iht. hva som faktisk er forventet å få av respons). APIet leverer informasjonen på to forskjellige format: 
- Flatt (samme som i dag, men ligger i `MotebehovFormValuesOutputDTO`) 
- Liste med skjemaelementer (inkl. selve spørsmålet og svaret, se `FormSnapshot` og subklasser av `FieldSnapshot`

Det er det siste som er implementert i PRen. Som betyr at spørsmål og svar presenteres som et skjema slik brukeren så det, men visningen er ikke identisk. 

Denne kan ikke merges før esyfo prodsetter ny løsning

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/e2475819-fe95-4ad9-abcf-9f9159233d86)


