### PR TITLE
IS-3247: Filter invalid sykmelding

### DIFF
--- a/src/mocks/syfosmregister/sykmeldingerMock.ts
+++ b/src/mocks/syfosmregister/sykmeldingerMock.ts
@@ -187,6 +187,112 @@ const SYKMELDING_MYE_INFO = {
   harRedusertArbeidsgiverperiode: true,
 };
 
+const SYKMELDING_INVALID = {
+  id: "0baf68f6-d926-431a-85fa-245bba515e42",
+  mottattTidspunkt: "2020-10-14T20:00:00Z",
+  behandlingsutfall: {
+    status: "INVALID",
+    ruleHits: [
+      {
+        messageForSender: "For lang",
+        messageForUser: "For lang",
+        ruleName: "INVALID",
+        ruleStatus: "INVALID",
+      },
+    ],
+  },
+  legekontorOrgnummer: "223456789",
+  sykmeldingsperioder: [
+    {
+      fom: dayjs(new Date()).subtract(10, "days").toJSON(),
+      tom: dayjs(new Date()).add(360, "days").toJSON(),
+      gradert: null,
+      behandlingsdager: null,
+      innspillTilArbeidsgiver: null,
+      type: "AKTIVITET_IKKE_MULIG",
+      aktivitetIkkeMulig: {
+        medisinskArsak: {
+          beskrivelse: "andre årsaker til sykefravær",
+          arsak: ["AKTIVITET_FORHINDRER_BEDRING"],
+        },
+        arbeidsrelatertArsak: {
+          beskrivelse: "andre årsaker til sykefravær",
+          arsak: ["ANNET"],
+        },
+      },
+      reisetilskudd: false,
+    },
+  ],
+  sykmeldingStatus: {
+    statusEvent: "APEN",
+    timestamp: "2020-10-22T05:58:56.351983Z",
+    arbeidsgiver: null,
+  },
+  medisinskVurdering: {
+    hovedDiagnose: {
+      kode: "L87",
+      system: "ICPC-2",
+      tekst: "Bursitt/tendinitt/synovitt IKA",
+    },
+    biDiagnoser: [
+      {
+        kode: "L87",
+        system: "ICPC-2",
+        tekst: "Bursitt/tendinitt/synovitt IKA",
+      },
+    ],
+    annenFraversArsak: null,
+    svangerskap: false,
+    yrkesskade: false,
+    yrkesskadeDato: "2020-10-15",
+  },
+  skjermesForPasient: false,
+  prognose: {
+    arbeidsforEtterPeriode: true,
+    hensynArbeidsplassen: "Må ta det pent",
+    erIArbeid: {
+      egetArbeidPaSikt: true,
+      annetArbeidPaSikt: true,
+      arbeidFOM: "2020-10-15",
+      vurderingsdato: "2020-10-15",
+    },
+    erIkkeIArbeid: null,
+  },
+  tiltakArbeidsplassen: null,
+  tiltakNAV:
+    "Pasienten har plager som er kommet tilbake etter operasjon. Det er nylig tatt MR bildet som viser forandringer i hånd som mulig må opereres. Venter på time. Det er mulig sykemledingen vil vare utover aktuell sm periode. ",
+  andreTiltak: null,
+  meldingTilNAV: null,
+  meldingTilArbeidsgiver: null,
+  kontaktMedPasient: {
+    kontaktDato: null,
+    begrunnelseIkkeKontakt: null,
+  },
+  behandletTidspunkt: "2020-10-14T22:00:00Z",
+  behandler: {
+    fornavn: "Frida",
+    mellomnavn: "Perma",
+    etternavn: "Frost",
+    aktoerId: "190269000101",
+    fnr: "99900011122",
+    hpr: null,
+    her: null,
+    adresse: {
+      gate: "Kirkegårdsveien 3",
+      postnummer: 1348,
+      kommune: "Rykkinn",
+      postboks: null,
+      land: "Country",
+    },
+    tlf: "tel:94431152",
+  },
+  syketilfelleStartDato: "2020-10-15",
+  navnFastlege: "Victor Frankenstein",
+  egenmeldt: false,
+  papirsykmelding: false,
+  harRedusertArbeidsgiverperiode: false,
+};
+
 export const sykmeldingerMock = [
   {
     id: "1111a750-7f39-4974-9a06-fa1775f987d1",
@@ -1038,7 +1144,7 @@ export const sykmeldingerMock = [
           },
         },
         fom: "2020-03-22",
-        tom: "2020-006-22",
+        tom: "2020-06-22",
         gradert: null,
         behandlingsdager: null,
         innspillTilArbeidsgiver: null,
@@ -1874,110 +1980,6 @@ export const sykmeldingerMock = [
       land: "NO",
     },
   },
-  {
-    id: "0baf68f6-d926-431a-85fa-245bba515e42",
-    mottattTidspunkt: "2020-10-14T20:00:00Z",
-    behandlingsutfall: {
-      status: "INVALID",
-      ruleHits: [
-        {
-          messageForSender: "For lang",
-          messageForUser: "For lang",
-          ruleName: "INVALID",
-          ruleStatus: "INVALID",
-        },
-      ],
-    },
-    legekontorOrgnummer: "223456789",
-    sykmeldingsperioder: [
-      {
-        fom: dayjs(new Date()).subtract(10, "days").toJSON(),
-        tom: dayjs(new Date()).add(360, "days").toJSON(),
-        gradert: null,
-        behandlingsdager: null,
-        innspillTilArbeidsgiver: null,
-        type: "AKTIVITET_IKKE_MULIG",
-        aktivitetIkkeMulig: {
-          medisinskArsak: {
-            beskrivelse: "andre årsaker til sykefravær",
-            arsak: ["AKTIVITET_FORHINDRER_BEDRING"],
-          },
-          arbeidsrelatertArsak: {
-            beskrivelse: "andre årsaker til sykefravær",
-            arsak: ["ANNET"],
-          },
-        },
-        reisetilskudd: false,
-      },
-    ],
-    sykmeldingStatus: {
-      statusEvent: "APEN",
-      timestamp: "2020-10-22T05:58:56.351983Z",
-      arbeidsgiver: null,
-    },
-    medisinskVurdering: {
-      hovedDiagnose: {
-        kode: "L87",
-        system: "ICPC-2",
-        tekst: "Bursitt/tendinitt/synovitt IKA",
-      },
-      biDiagnoser: [
-        {
-          kode: "L87",
-          system: "ICPC-2",
-          tekst: "Bursitt/tendinitt/synovitt IKA",
-        },
-      ],
-      annenFraversArsak: null,
-      svangerskap: false,
-      yrkesskade: false,
-      yrkesskadeDato: "2020-10-15",
-    },
-    skjermesForPasient: false,
-    prognose: {
-      arbeidsforEtterPeriode: true,
-      hensynArbeidsplassen: "Må ta det pent",
-      erIArbeid: {
-        egetArbeidPaSikt: true,
-        annetArbeidPaSikt: true,
-        arbeidFOM: "2020-10-15",
-        vurderingsdato: "2020-10-15",
-      },
-      erIkkeIArbeid: null,
-    },
-    tiltakArbeidsplassen: null,
-    tiltakNAV:
-      "Pasienten har plager som er kommet tilbake etter operasjon. Det er nylig tatt MR bildet som viser forandringer i hånd som mulig må opereres. Venter på time. Det er mulig sykemledingen vil vare utover aktuell sm periode. ",
-    andreTiltak: null,
-    meldingTilNAV: null,
-    meldingTilArbeidsgiver: null,
-    kontaktMedPasient: {
-      kontaktDato: null,
-      begrunnelseIkkeKontakt: null,
-    },
-    behandletTidspunkt: "2020-10-14T22:00:00Z",
-    behandler: {
-      fornavn: "Frida",
-      mellomnavn: "Perma",
-      etternavn: "Frost",
-      aktoerId: "190269000101",
-      fnr: "99900011122",
-      hpr: null,
-      her: null,
-      adresse: {
-        gate: "Kirkegårdsveien 3",
-        postnummer: 1348,
-        kommune: "Rykkinn",
-        postboks: null,
-        land: "Country",
-      },
-      tlf: "tel:94431152",
-    },
-    syketilfelleStartDato: "2020-10-15",
-    navnFastlege: "Victor Frankenstein",
-    egenmeldt: false,
-    papirsykmelding: false,
-    harRedusertArbeidsgiverperiode: false,
-  },
   SYKMELDING_MYE_INFO,
+  SYKMELDING_INVALID,
 ];

--- a/src/mocks/syfosmregister/sykmeldingerMock.ts
+++ b/src/mocks/syfosmregister/sykmeldingerMock.ts
@@ -1874,5 +1874,110 @@ export const sykmeldingerMock = [
       land: "NO",
     },
   },
+  {
+    id: "0baf68f6-d926-431a-85fa-245bba515e42",
+    mottattTidspunkt: "2020-10-14T20:00:00Z",
+    behandlingsutfall: {
+      status: "INVALID",
+      ruleHits: [
+        {
+          messageForSender: "For lang",
+          messageForUser: "For lang",
+          ruleName: "INVALID",
+          ruleStatus: "INVALID",
+        },
+      ],
+    },
+    legekontorOrgnummer: "223456789",
+    sykmeldingsperioder: [
+      {
+        fom: dayjs(new Date()).subtract(10, "days").toJSON(),
+        tom: dayjs(new Date()).add(360, "days").toJSON(),
+        gradert: null,
+        behandlingsdager: null,
+        innspillTilArbeidsgiver: null,
+        type: "AKTIVITET_IKKE_MULIG",
+        aktivitetIkkeMulig: {
+          medisinskArsak: {
+            beskrivelse: "andre årsaker til sykefravær",
+            arsak: ["AKTIVITET_FORHINDRER_BEDRING"],
+          },
+          arbeidsrelatertArsak: {
+            beskrivelse: "andre årsaker til sykefravær",
+            arsak: ["ANNET"],
+          },
+        },
+        reisetilskudd: false,
+      },
+    ],
+    sykmeldingStatus: {
+      statusEvent: "APEN",
+      timestamp: "2020-10-22T05:58:56.351983Z",
+      arbeidsgiver: null,
+    },
+    medisinskVurdering: {
+      hovedDiagnose: {
+        kode: "L87",
+        system: "ICPC-2",
+        tekst: "Bursitt/tendinitt/synovitt IKA",
+      },
+      biDiagnoser: [
+        {
+          kode: "L87",
+          system: "ICPC-2",
+          tekst: "Bursitt/tendinitt/synovitt IKA",
+        },
+      ],
+      annenFraversArsak: null,
+      svangerskap: false,
+      yrkesskade: false,
+      yrkesskadeDato: "2020-10-15",
+    },
+    skjermesForPasient: false,
+    prognose: {
+      arbeidsforEtterPeriode: true,
+      hensynArbeidsplassen: "Må ta det pent",
+      erIArbeid: {
+        egetArbeidPaSikt: true,
+        annetArbeidPaSikt: true,
+        arbeidFOM: "2020-10-15",
+        vurderingsdato: "2020-10-15",
+      },
+      erIkkeIArbeid: null,
+    },
+    tiltakArbeidsplassen: null,
+    tiltakNAV:
+      "Pasienten har plager som er kommet tilbake etter operasjon. Det er nylig tatt MR bildet som viser forandringer i hånd som mulig må opereres. Venter på time. Det er mulig sykemledingen vil vare utover aktuell sm periode. ",
+    andreTiltak: null,
+    meldingTilNAV: null,
+    meldingTilArbeidsgiver: null,
+    kontaktMedPasient: {
+      kontaktDato: null,
+      begrunnelseIkkeKontakt: null,
+    },
+    behandletTidspunkt: "2020-10-14T22:00:00Z",
+    behandler: {
+      fornavn: "Frida",
+      mellomnavn: "Perma",
+      etternavn: "Frost",
+      aktoerId: "190269000101",
+      fnr: "99900011122",
+      hpr: null,
+      her: null,
+      adresse: {
+        gate: "Kirkegårdsveien 3",
+        postnummer: 1348,
+        kommune: "Rykkinn",
+        postboks: null,
+        land: "Country",
+      },
+      tlf: "tel:94431152",
+    },
+    syketilfelleStartDato: "2020-10-15",
+    navnFastlege: "Victor Frankenstein",
+    egenmeldt: false,
+    papirsykmelding: false,
+    harRedusertArbeidsgiverperiode: false,
+  },
   SYKMELDING_MYE_INFO,
 ];

--- a/src/utils/sykmeldinger/sykmeldingUtils.ts
+++ b/src/utils/sykmeldinger/sykmeldingUtils.ts
@@ -6,6 +6,7 @@ import {
   SykmeldingPeriodeDTO,
   SykmeldingStatus,
 } from "@/data/sykmelding/types/SykmeldingOldFormat";
+import { BehandlingsutfallStatusDTO } from "@/data/sykmelding/types/BehandlingsutfallStatusDTO";
 import { manederMellomDatoer } from "@/utils/datoUtils";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import dayjs from "dayjs";
@@ -207,9 +208,11 @@ export const newAndActivatedSykmeldinger = (
 ) => {
   return sykmeldinger.filter((sykmelding) => {
     return (
-      sykmelding.status === SykmeldingStatus.BEKREFTET ||
-      sykmelding.status === SykmeldingStatus.SENDT ||
-      sykmelding.status === SykmeldingStatus.NY
+      sykmelding.behandlingsutfall.status !=
+        BehandlingsutfallStatusDTO.INVALID &&
+      (sykmelding.status === SykmeldingStatus.BEKREFTET ||
+        sykmelding.status === SykmeldingStatus.SENDT ||
+        sykmelding.status === SykmeldingStatus.NY)
     );
   });
 };

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -890,6 +890,7 @@ describe("sykmeldingUtils", () => {
       SykmeldingStatus.AVBRUTT,
       SykmeldingStatus.TIL_SENDING,
     ];
+    const unwantedBehandlingsutfall = [BehandlingsutfallStatusDTO.INVALID];
 
     const sykmeldingListContainsStatuser = (
       sykmeldinger: SykmeldingOldFormat[],
@@ -900,7 +901,7 @@ describe("sykmeldingUtils", () => {
       });
     };
 
-    it("Returns a list containing only sykmeldinger with status SENDT, BEKREFTET, and NY", () => {
+    it("Returns a list containing no INVALID sykmeldinger only sykmeldinger with status SENDT, BEKREFTET, and NY", () => {
       const sykmeldinglistWithEveryStatus: SykmeldingOldFormat[] = Object.keys(
         SykmeldingStatus
       ).map((status) => {
@@ -945,6 +946,27 @@ describe("sykmeldingUtils", () => {
             status,
           } as SykmeldingOldFormat;
         });
+
+      const newAndUsedSykmeldinger = newAndActivatedSykmeldinger(
+        sykmeldinglistWithEveryStatus
+      );
+
+      expect(newAndUsedSykmeldinger.length).to.equal(0);
+    });
+    it("Returns an empty list if only unwanted behandlingsutfall in sykmelding list", () => {
+      const sykmeldinglistWithEveryStatus: SykmeldingOldFormat[] = Object.keys(
+        SykmeldingStatus
+      ).map((status) => {
+        return {
+          ...baseSykmelding,
+          status,
+          behandlingsutfall: {
+            status: BehandlingsutfallStatusDTO.INVALID,
+            begrunnelse: "Begrunnelse",
+            ruleHits: [],
+          },
+        } as SykmeldingOldFormat;
+      });
 
       const newAndUsedSykmeldinger = newAndActivatedSykmeldinger(
         sykmeldinglistWithEveryStatus

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -952,7 +952,7 @@ describe("sykmeldingUtils", () => {
 
       expect(newAndUsedSykmeldinger.length).to.equal(0);
     });
-    it("Returns an empty list if only unwanted behandlingsutfall in sykmelding list", () => {
+    it("Returns an empty list if only invalid behandlingsutfall in sykmelding list", () => {
       const sykmeldinglistWithEveryStatus: SykmeldingOldFormat[] = Object.keys(
         SykmeldingStatus
       ).map((status) => {

--- a/test/utils/sykmeldingUtilsTest.ts
+++ b/test/utils/sykmeldingUtilsTest.ts
@@ -890,7 +890,6 @@ describe("sykmeldingUtils", () => {
       SykmeldingStatus.AVBRUTT,
       SykmeldingStatus.TIL_SENDING,
     ];
-    const unwantedBehandlingsutfall = [BehandlingsutfallStatusDTO.INVALID];
 
     const sykmeldingListContainsStatuser = (
       sykmeldinger: SykmeldingOldFormat[],


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Fikset slik at nøkkelinfo ikke inkluderer sykmeldinger som er avvist av Nav, hverken i grafen eller i opplistingen nedenfor. Men hvis man velger "Sykmeldinger" i menyen vil man fortsatt kunne se avviste sykmeldinger.

### Screenshots 📸✨


![nokkelinfo](https://github.com/user-attachments/assets/494eecb1-1b10-4509-810b-e5d28ebf0248)
