### PR TITLE
IS-3168: Lagt til informasjon om hvor det er mulig å oppdatere informasjon om tolk for sykmeldt

### DIFF
--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -19,7 +19,7 @@ interface TilrettelagtKommunikasjon {
 }
 
 interface Sprak {
-  value: string | null;
+  value: string;
 }
 
 /* https://pdl-docs.dev.intern.nav.no/ekstern/index.html#_sikkerhetstiltak */

--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -15,6 +15,7 @@ import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import { MotehistorikkPanel } from "@/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel";
 import { MoteSvarHistorikk } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk";
 import MotebehovHistorikk from "@/sider/dialogmoter/components/motehistorikk/MotebehovHistorikk";
+import { InfoOmTolk } from "@/sider/dialogmoter/motebehov/InfoOmTolk";
 
 const texts = {
   pageTitle: "Møtelandingsside",
@@ -50,6 +51,7 @@ export function Motelandingsside() {
         <Tredelt.Container>
           <Tredelt.FirstColumn>
             <DialogmoteOnskePanel />
+            <InfoOmTolk />
             <InnkallingDialogmotePanel aktivtDialogmote={aktivtDialogmote} />
             <DialogmoteFerdigstilteReferatPanel
               ferdigstilteMoter={historiskeDialogmoter.filter(

--- a/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
+++ b/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
@@ -6,13 +6,11 @@ import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import {
-  findFirst,
   getMotebehovInActiveTilfelle,
   onskerTolk,
   sorterMotebehovDataEtterDatoDesc,
 } from "@/utils/motebehovUtils";
 import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
-import { MotebehovInnmelder } from "@/data/motebehov/types/motebehovTypes";
 
 const texts = {
   header: "Det er meldt inn behov for tolk",
@@ -39,19 +37,9 @@ export const InfoOmTolk = () => {
     sortertMotebehov,
     latestOppfolgingstilfelle
   );
-  const arbeidstaker = findFirst(
-    MotebehovInnmelder.ARBEIDSTAKER,
-    motebehovInActiveTilfelle
-  );
-  const arbeidsgiver = findFirst(
-    MotebehovInnmelder.ARBEIDSGIVER,
-    motebehovInActiveTilfelle
-  );
-  const arbeidstakerOnskerTolk = onskerTolk(arbeidstaker);
-  const arbeidsgiverOnskerTolk = onskerTolk(arbeidsgiver);
+  const minstEnOnskerTolk = motebehovInActiveTilfelle.some(onskerTolk);
   const visInfoOmRegistrereTolkIPdl =
-    (arbeidstakerOnskerTolk || arbeidsgiverOnskerTolk) &&
-    !isTolkRegistrertIPdl(brukerinfo);
+    minstEnOnskerTolk && !isTolkRegistrertIPdl(brukerinfo);
 
   if (!visInfoOmRegistrereTolkIPdl) {
     return null;

--- a/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
+++ b/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
@@ -1,0 +1,79 @@
+import { BodyLong, Box, Heading, HStack } from "@navikt/ds-react";
+import { LanguageIcon } from "@navikt/aksel-icons";
+import { EksternLenke } from "@/components/EksternLenke";
+import React from "react";
+import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
+import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import {
+  findFirst,
+  getMotebehovInActiveTilfelle,
+  onskerTolk,
+  sorterMotebehovDataEtterDatoDesc,
+} from "@/utils/motebehovUtils";
+import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
+import { MotebehovInnmelder } from "@/data/motebehov/types/motebehovTypes";
+
+const texts = {
+  header: "Det er meldt inn behov for tolk",
+  body: "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere.",
+  url: "https://navno.sharepoint.com/sites/fag-og-ytelser-fagsystemer/SitePages/Endre%20person.aspx",
+  urlText: "Ønsker du å registrere behov for tolk på vedkommende, klikk her.",
+};
+
+export const isTolkRegistrertIPdl = (brukerinfo: BrukerinfoDTO): boolean => {
+  const { tilrettelagtKommunikasjon } = brukerinfo;
+  return !!(
+    tilrettelagtKommunikasjon &&
+    ((tilrettelagtKommunikasjon.tegnsprakTolk &&
+      tilrettelagtKommunikasjon.tegnsprakTolk.value) ||
+      (tilrettelagtKommunikasjon.talesprakTolk &&
+        tilrettelagtKommunikasjon.talesprakTolk.value))
+  );
+};
+
+export const InfoOmTolk = () => {
+  const { brukerinfo } = useBrukerinfoQuery();
+  const { data: motebehov } = useMotebehovQuery();
+  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
+  const sortertMotebehov = motebehov.sort(sorterMotebehovDataEtterDatoDesc);
+  const motebehovInActiveTilfelle = getMotebehovInActiveTilfelle(
+    sortertMotebehov,
+    latestOppfolgingstilfelle
+  );
+  const arbeidstaker = findFirst(
+    MotebehovInnmelder.ARBEIDSTAKER,
+    motebehovInActiveTilfelle
+  );
+  const arbeidsgiver = findFirst(
+    MotebehovInnmelder.ARBEIDSGIVER,
+    motebehovInActiveTilfelle
+  );
+  const arbeidstakerOnskerTolk = onskerTolk(arbeidstaker);
+  const arbeidsgiverOnskerTolk = onskerTolk(arbeidsgiver);
+  const visInfoOmRegistrereTolkIPdl =
+    (arbeidstakerOnskerTolk || arbeidsgiverOnskerTolk) &&
+    !isTolkRegistrertIPdl(brukerinfo);
+
+  return (
+    visInfoOmRegistrereTolkIPdl && (
+      <Box
+        background="surface-default"
+        className="flex flex-col mb-4 p-6 gap-6"
+      >
+        <Heading size={"medium"} level={"2"}>
+          <HStack>
+            {texts.header}
+            <LanguageIcon fontSize={"2rem"} />
+          </HStack>
+          <BodyLong>
+            {texts.body}
+            <EksternLenke href={texts.url} className={"pl-1"}>
+              {texts.urlText}
+            </EksternLenke>
+          </BodyLong>
+        </Heading>
+      </Box>
+    )
+  );
+};

--- a/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
+++ b/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
@@ -21,14 +21,12 @@ const texts = {
   urlText: "Ønsker du å registrere behov for tolk på vedkommende, klikk her.",
 };
 
-export const isTolkRegistrertIPdl = (brukerinfo: BrukerinfoDTO): boolean => {
+const isTolkRegistrertIPdl = (brukerinfo: BrukerinfoDTO): boolean => {
   const { tilrettelagtKommunikasjon } = brukerinfo;
   return !!(
     tilrettelagtKommunikasjon &&
-    ((tilrettelagtKommunikasjon.tegnsprakTolk &&
-      tilrettelagtKommunikasjon.tegnsprakTolk.value) ||
-      (tilrettelagtKommunikasjon.talesprakTolk &&
-        tilrettelagtKommunikasjon.talesprakTolk.value))
+    (tilrettelagtKommunikasjon.tegnsprakTolk ||
+      tilrettelagtKommunikasjon.talesprakTolk)
   );
 };
 

--- a/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
+++ b/src/sider/dialogmoter/motebehov/InfoOmTolk.tsx
@@ -53,25 +53,24 @@ export const InfoOmTolk = () => {
     (arbeidstakerOnskerTolk || arbeidsgiverOnskerTolk) &&
     !isTolkRegistrertIPdl(brukerinfo);
 
+  if (!visInfoOmRegistrereTolkIPdl) {
+    return null;
+  }
+
   return (
-    visInfoOmRegistrereTolkIPdl && (
-      <Box
-        background="surface-default"
-        className="flex flex-col mb-4 p-6 gap-6"
-      >
-        <Heading size={"medium"} level={"2"}>
-          <HStack>
-            {texts.header}
-            <LanguageIcon fontSize={"2rem"} />
-          </HStack>
-          <BodyLong>
-            {texts.body}
-            <EksternLenke href={texts.url} className={"pl-1"}>
-              {texts.urlText}
-            </EksternLenke>
-          </BodyLong>
-        </Heading>
-      </Box>
-    )
+    <Box background="surface-default" className="flex flex-col mb-4 p-6 gap-6">
+      <Heading size={"medium"} level={"2"}>
+        <HStack>
+          {texts.header}
+          <LanguageIcon fontSize={"2rem"} />
+        </HStack>
+        <BodyLong>
+          {texts.body}
+          <EksternLenke href={texts.url} className={"pl-1"}>
+            {texts.urlText}
+          </EksternLenke>
+        </BodyLong>
+      </Heading>
+    </Box>
   );
 };

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -110,15 +110,6 @@ export function isArbeidstakerMotebehov(motebehov: MotebehovVeilederDTO) {
   return motebehov.innmelderType === MotebehovInnmelder.ARBEIDSTAKER;
 }
 
-export const findFirst = (
-  innmelderType: MotebehovInnmelder,
-  motebehovsvar: MotebehovVeilederDTO[]
-): MotebehovVeilederDTO | undefined => {
-  return motebehovsvar.find(
-    (motebehov) => motebehov.innmelderType === innmelderType
-  );
-};
-
 export const onskerTolk = (
   motebehov: MotebehovVeilederDTO | undefined
 ): boolean => {

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -110,6 +110,25 @@ export function isArbeidstakerMotebehov(motebehov: MotebehovVeilederDTO) {
   return motebehov.innmelderType === MotebehovInnmelder.ARBEIDSTAKER;
 }
 
+export const findFirst = (
+  innmelderType: MotebehovInnmelder,
+  motebehovsvar: MotebehovVeilederDTO[]
+): MotebehovVeilederDTO | undefined => {
+  return motebehovsvar.find(
+    (motebehov) => motebehov.innmelderType === innmelderType
+  );
+};
+
+export const onskerTolk = (
+  motebehov: MotebehovVeilederDTO | undefined
+): boolean => {
+  return !!(
+    motebehov &&
+    motebehov.formValues.harMotebehov &&
+    motebehov.formValues.onskerTolk
+  );
+};
+
 export function mapMotebehovToMeldtMotebehovFormat(
   motebehov: MotebehovVeilederDTO[]
 ): MeldtMotebehov[] {

--- a/test/dialogmote/Motebehov/InfoOmTolkTest.tsx
+++ b/test/dialogmote/Motebehov/InfoOmTolkTest.tsx
@@ -1,0 +1,649 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { InfoOmTolk } from "@/sider/dialogmoter/motebehov/InfoOmTolk";
+import { beforeEach, describe, expect, it } from "vitest";
+import { queryClientWithMockData } from "../../testQueryClient";
+import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
+import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
+import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
+import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
+import { BrukerinfoDTO } from "@/data/navbruker/types/BrukerinfoDTO";
+import { brukerinfoMock } from "@/mocks/syfoperson/persondataMock";
+import {
+  defaultFormValue,
+  svartJaMotebehovArbeidstakerUbehandletMock,
+  svartNeiMotebehovArbeidsgiverUbehandletMock,
+} from "@/mocks/syfomotebehov/motebehovMock";
+import { currentOppfolgingstilfelle } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock";
+import { addWeeks } from "@/utils/datoUtils";
+
+let queryClient: QueryClient;
+
+const renderInfoOmTolk = () => {
+  render(
+    <QueryClientProvider client={queryClient}>
+      <InfoOmTolk />
+    </QueryClientProvider>
+  );
+};
+
+function mockMotebehov(
+  motebehov: MotebehovVeilederDTO[],
+  brukerinfo: BrukerinfoDTO
+) {
+  queryClient.setQueryData(
+    motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => motebehov
+  );
+  queryClient.setQueryData(
+    brukerQueryKeys.brukerinfo(ARBEIDSTAKER_DEFAULT.personIdent),
+    () => brukerinfo
+  );
+}
+
+const harIkkeTolkIPdl: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: null,
+};
+
+const harIkkeTolkIPdl2: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: null,
+    tegnsprakTolk: null,
+  },
+};
+
+const harIkkeTolkIPdl3: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: {
+      value: null,
+    },
+    tegnsprakTolk: {
+      value: null,
+    },
+  },
+};
+
+const harIkkeTolkIPdl4: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: {
+      value: null,
+    },
+    tegnsprakTolk: null,
+  },
+};
+
+const harIkkeTolkIPdl5: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: null,
+    tegnsprakTolk: {
+      value: null,
+    },
+  },
+};
+
+const harTolkIPdl: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: {
+      value: "EN",
+    },
+    tegnsprakTolk: {
+      value: null,
+    },
+  },
+};
+
+const harTolkIPdl2: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: {
+      value: null,
+    },
+    tegnsprakTolk: {
+      value: "EN",
+    },
+  },
+};
+
+const harTolkIPdl3: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: {
+      value: "EN",
+    },
+    tegnsprakTolk: {
+      value: "EN",
+    },
+  },
+};
+
+const harTolkIPdl4: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: {
+      value: "EN",
+    },
+    tegnsprakTolk: null,
+  },
+};
+
+const harTolkIPdl5: BrukerinfoDTO = {
+  ...brukerinfoMock,
+  tilrettelagtKommunikasjon: {
+    talesprakTolk: null,
+    tegnsprakTolk: {
+      value: "EN",
+    },
+  },
+};
+
+const arbeidstakerOnskerTolkInnenforTilfelle: MotebehovVeilederDTO = {
+  ...svartJaMotebehovArbeidstakerUbehandletMock,
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: true,
+  },
+};
+
+const arbeidsgiverOnskerTolkInnenforTilfelle: MotebehovVeilederDTO = {
+  ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: true,
+  },
+};
+
+const arbeidstakerOnskerIkkeTolkInnenforTilfelle: MotebehovVeilederDTO = {
+  ...svartJaMotebehovArbeidstakerUbehandletMock,
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: false,
+  },
+};
+
+const arbeidsgiverOnskerIkkeTolkInnenforTilfelle: MotebehovVeilederDTO = {
+  ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: false,
+  },
+};
+
+const arbeidstakerOnskerTolkUtenforTilfelle: MotebehovVeilederDTO = {
+  ...svartJaMotebehovArbeidstakerUbehandletMock,
+  opprettetDato: addWeeks(currentOppfolgingstilfelle.start, -2),
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: true,
+  },
+};
+
+const arbeidsgiverOnskerTolkUtenforTilfelle: MotebehovVeilederDTO = {
+  ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
+  opprettetDato: addWeeks(currentOppfolgingstilfelle.start, -2),
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: true,
+  },
+};
+
+const arbeidstakerOnskerIkkeTolkUtenforTilfelle: MotebehovVeilederDTO = {
+  ...svartJaMotebehovArbeidstakerUbehandletMock,
+  opprettetDato: addWeeks(currentOppfolgingstilfelle.start, -2),
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: false,
+  },
+};
+
+const arbeidsgiverOnskerIkkeTolkUtenforTilfelle: MotebehovVeilederDTO = {
+  ...svartNeiMotebehovArbeidsgiverUbehandletMock(),
+  opprettetDato: addWeeks(currentOppfolgingstilfelle.start, -2),
+  formValues: {
+    ...defaultFormValue,
+    harMotebehov: true,
+    onskerTolk: false,
+  },
+};
+
+describe("InfoOmTolk", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("Ingen møtebehov", () => {
+    it.each<BrukerinfoDTO>([
+      harTolkIPdl,
+      harTolkIPdl2,
+      harTolkIPdl3,
+      harTolkIPdl4,
+      harTolkIPdl5,
+      harIkkeTolkIPdl,
+      harIkkeTolkIPdl2,
+      harIkkeTolkIPdl3,
+      harIkkeTolkIPdl4,
+      harIkkeTolkIPdl5,
+    ])(
+      "Ingen møtebehov og med følgende informasjon i pdl: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+      (brukerinfo: BrukerinfoDTO) => {
+        mockMotebehov([], brukerinfo);
+
+        renderInfoOmTolk();
+
+        expect(
+          screen.queryByText(
+            "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+          )
+        ).to.not.exist;
+      }
+    );
+  });
+
+  describe("Noen har møtebehov innenfor aktivt oppfølgingstilfelle", () => {
+    describe("Arbeidsgiver", () => {
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+      ])(
+        "Arbeidsgiver har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidsgiverOnskerTolkInnenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidsgiver har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidsgiverOnskerTolkInnenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.getByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere.",
+              {
+                exact: false,
+              }
+            )
+          ).to.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidstaker har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [arbeidsgiverOnskerIkkeTolkInnenforTilfelle],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+    });
+
+    describe("Arbeidstaker", () => {
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+      ])(
+        "Arbeidstaker har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidstakerOnskerTolkInnenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidstaker har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidstakerOnskerTolkInnenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.getByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere.",
+              {
+                exact: false,
+              }
+            )
+          ).to.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidstaker har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [arbeidstakerOnskerIkkeTolkInnenforTilfelle],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+    });
+
+    describe("Arbeidsgiver og arbeidstaker ", () => {
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+      ])(
+        "Arbeidsgiver og arbeidstaker har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [
+              arbeidsgiverOnskerTolkInnenforTilfelle,
+              arbeidstakerOnskerTolkInnenforTilfelle,
+            ],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidsgiver og arbeidstaker har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [
+              arbeidsgiverOnskerTolkInnenforTilfelle,
+              arbeidstakerOnskerTolkInnenforTilfelle,
+            ],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.getByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere.",
+              {
+                exact: false,
+              }
+            )
+          ).to.exist;
+        }
+      );
+    });
+  });
+
+  describe(`Noen har møtebehov utenfor aktivt oppfølgingstilfelle`, () => {
+    describe(`Arbeidstaker`, () => {
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+      ])(
+        "Arbeidstaker har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidstakerOnskerTolkUtenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidstaker har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [arbeidstakerOnskerIkkeTolkUtenforTilfelle],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidstaker har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidstakerOnskerTolkUtenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+    });
+
+    describe(`Arbeidsgiver`, () => {
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+      ])(
+        "Arbeidsgiver har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidsgiverOnskerTolkUtenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidsgiver har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [arbeidsgiverOnskerIkkeTolkUtenforTilfelle],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidsgiver har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov([arbeidsgiverOnskerTolkUtenforTilfelle], brukerinfo);
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+    });
+
+    describe("Arbeidsgiver og arbeidstaker ", () => {
+      it.each<BrukerinfoDTO>([
+        harTolkIPdl,
+        harTolkIPdl2,
+        harTolkIPdl3,
+        harTolkIPdl4,
+        harTolkIPdl5,
+        harIkkeTolkIPdl,
+        harIkkeTolkIPdl2,
+        harIkkeTolkIPdl3,
+        harIkkeTolkIPdl4,
+        harIkkeTolkIPdl5,
+      ])(
+        "Arbeidsgiver og arbeidstaker har ønske om tolk og pdl har følgende informasjon (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
+        (brukerinfo: BrukerinfoDTO) => {
+          mockMotebehov(
+            [
+              arbeidsgiverOnskerTolkUtenforTilfelle,
+              arbeidstakerOnskerTolkUtenforTilfelle,
+            ],
+            brukerinfo
+          );
+
+          renderInfoOmTolk();
+
+          expect(
+            screen.queryByText(
+              "Det har blitt meldt inn et behov for tolk for dialogmøte, og det er ikke registrert tolk på den sykmeldte tidligere."
+            )
+          ).to.not.exist;
+        }
+      );
+    });
+  });
+});

--- a/test/dialogmote/Motebehov/InfoOmTolkTest.tsx
+++ b/test/dialogmote/Motebehov/InfoOmTolkTest.tsx
@@ -55,38 +55,6 @@ const harIkkeTolkIPdl2: BrukerinfoDTO = {
   },
 };
 
-const harIkkeTolkIPdl3: BrukerinfoDTO = {
-  ...brukerinfoMock,
-  tilrettelagtKommunikasjon: {
-    talesprakTolk: {
-      value: null,
-    },
-    tegnsprakTolk: {
-      value: null,
-    },
-  },
-};
-
-const harIkkeTolkIPdl4: BrukerinfoDTO = {
-  ...brukerinfoMock,
-  tilrettelagtKommunikasjon: {
-    talesprakTolk: {
-      value: null,
-    },
-    tegnsprakTolk: null,
-  },
-};
-
-const harIkkeTolkIPdl5: BrukerinfoDTO = {
-  ...brukerinfoMock,
-  tilrettelagtKommunikasjon: {
-    talesprakTolk: null,
-    tegnsprakTolk: {
-      value: null,
-    },
-  },
-};
-
 const harTolkIPdl: BrukerinfoDTO = {
   ...brukerinfoMock,
   tilrettelagtKommunikasjon: {
@@ -94,7 +62,7 @@ const harTolkIPdl: BrukerinfoDTO = {
       value: "EN",
     },
     tegnsprakTolk: {
-      value: null,
+      value: "EN",
     },
   },
 };
@@ -103,37 +71,13 @@ const harTolkIPdl2: BrukerinfoDTO = {
   ...brukerinfoMock,
   tilrettelagtKommunikasjon: {
     talesprakTolk: {
-      value: null,
-    },
-    tegnsprakTolk: {
-      value: "EN",
-    },
-  },
-};
-
-const harTolkIPdl3: BrukerinfoDTO = {
-  ...brukerinfoMock,
-  tilrettelagtKommunikasjon: {
-    talesprakTolk: {
-      value: "EN",
-    },
-    tegnsprakTolk: {
-      value: "EN",
-    },
-  },
-};
-
-const harTolkIPdl4: BrukerinfoDTO = {
-  ...brukerinfoMock,
-  tilrettelagtKommunikasjon: {
-    talesprakTolk: {
       value: "EN",
     },
     tegnsprakTolk: null,
   },
 };
 
-const harTolkIPdl5: BrukerinfoDTO = {
+const harTolkIPdl3: BrukerinfoDTO = {
   ...brukerinfoMock,
   tilrettelagtKommunikasjon: {
     talesprakTolk: null,
@@ -229,13 +173,8 @@ describe("InfoOmTolk", () => {
       harTolkIPdl,
       harTolkIPdl2,
       harTolkIPdl3,
-      harTolkIPdl4,
-      harTolkIPdl5,
       harIkkeTolkIPdl,
       harIkkeTolkIPdl2,
-      harIkkeTolkIPdl3,
-      harIkkeTolkIPdl4,
-      harIkkeTolkIPdl5,
     ])(
       "Ingen møtebehov og med følgende informasjon i pdl: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
       (brukerinfo: BrukerinfoDTO) => {
@@ -254,13 +193,7 @@ describe("InfoOmTolk", () => {
 
   describe("Noen har møtebehov innenfor aktivt oppfølgingstilfelle", () => {
     describe("Arbeidsgiver", () => {
-      it.each<BrukerinfoDTO>([
-        harTolkIPdl,
-        harTolkIPdl2,
-        harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harTolkIPdl, harTolkIPdl2, harTolkIPdl3])(
         "Arbeidsgiver har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov([arbeidsgiverOnskerTolkInnenforTilfelle], brukerinfo);
@@ -275,13 +208,7 @@ describe("InfoOmTolk", () => {
         }
       );
 
-      it.each<BrukerinfoDTO>([
-        harIkkeTolkIPdl,
-        harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harIkkeTolkIPdl, harIkkeTolkIPdl2])(
         "Arbeidsgiver har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov([arbeidsgiverOnskerTolkInnenforTilfelle], brukerinfo);
@@ -303,13 +230,8 @@ describe("InfoOmTolk", () => {
         harTolkIPdl,
         harTolkIPdl2,
         harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
         harIkkeTolkIPdl,
         harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
       ])(
         "Arbeidstaker har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
@@ -330,13 +252,7 @@ describe("InfoOmTolk", () => {
     });
 
     describe("Arbeidstaker", () => {
-      it.each<BrukerinfoDTO>([
-        harTolkIPdl,
-        harTolkIPdl2,
-        harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harTolkIPdl, harTolkIPdl2, harTolkIPdl3])(
         "Arbeidstaker har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov([arbeidstakerOnskerTolkInnenforTilfelle], brukerinfo);
@@ -351,13 +267,7 @@ describe("InfoOmTolk", () => {
         }
       );
 
-      it.each<BrukerinfoDTO>([
-        harIkkeTolkIPdl,
-        harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harIkkeTolkIPdl, harIkkeTolkIPdl2])(
         "Arbeidstaker har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov([arbeidstakerOnskerTolkInnenforTilfelle], brukerinfo);
@@ -379,13 +289,8 @@ describe("InfoOmTolk", () => {
         harTolkIPdl,
         harTolkIPdl2,
         harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
         harIkkeTolkIPdl,
         harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
       ])(
         "Arbeidstaker har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
@@ -406,13 +311,7 @@ describe("InfoOmTolk", () => {
     });
 
     describe("Arbeidsgiver og arbeidstaker ", () => {
-      it.each<BrukerinfoDTO>([
-        harTolkIPdl,
-        harTolkIPdl2,
-        harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harTolkIPdl, harTolkIPdl2, harTolkIPdl3])(
         "Arbeidsgiver og arbeidstaker har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov(
@@ -433,13 +332,7 @@ describe("InfoOmTolk", () => {
         }
       );
 
-      it.each<BrukerinfoDTO>([
-        harIkkeTolkIPdl,
-        harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harIkkeTolkIPdl, harIkkeTolkIPdl2])(
         "Arbeidsgiver og arbeidstaker har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov(
@@ -467,13 +360,7 @@ describe("InfoOmTolk", () => {
 
   describe(`Noen har møtebehov utenfor aktivt oppfølgingstilfelle`, () => {
     describe(`Arbeidstaker`, () => {
-      it.each<BrukerinfoDTO>([
-        harTolkIPdl,
-        harTolkIPdl2,
-        harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harTolkIPdl, harTolkIPdl2, harTolkIPdl3])(
         "Arbeidstaker har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov([arbeidstakerOnskerTolkUtenforTilfelle], brukerinfo);
@@ -488,13 +375,7 @@ describe("InfoOmTolk", () => {
         }
       );
 
-      it.each<BrukerinfoDTO>([
-        harIkkeTolkIPdl,
-        harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harIkkeTolkIPdl, harIkkeTolkIPdl2])(
         "Arbeidstaker har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov(
@@ -516,13 +397,8 @@ describe("InfoOmTolk", () => {
         harTolkIPdl,
         harTolkIPdl2,
         harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
         harIkkeTolkIPdl,
         harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
       ])(
         "Arbeidstaker har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
@@ -540,13 +416,7 @@ describe("InfoOmTolk", () => {
     });
 
     describe(`Arbeidsgiver`, () => {
-      it.each<BrukerinfoDTO>([
-        harTolkIPdl,
-        harTolkIPdl2,
-        harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harTolkIPdl, harTolkIPdl2, harTolkIPdl3])(
         "Arbeidsgiver har ønske om tolk og pdl har denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov([arbeidsgiverOnskerTolkUtenforTilfelle], brukerinfo);
@@ -561,13 +431,7 @@ describe("InfoOmTolk", () => {
         }
       );
 
-      it.each<BrukerinfoDTO>([
-        harIkkeTolkIPdl,
-        harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
-      ])(
+      it.each<BrukerinfoDTO>([harIkkeTolkIPdl, harIkkeTolkIPdl2])(
         "Arbeidsgiver har ønske om tolk og pdl har ikke denne informasjonen (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
           mockMotebehov(
@@ -589,13 +453,8 @@ describe("InfoOmTolk", () => {
         harTolkIPdl,
         harTolkIPdl2,
         harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
         harIkkeTolkIPdl,
         harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
       ])(
         "Arbeidsgiver har ikke ønske om tolk og pdl har følgende informasjon: (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {
@@ -617,13 +476,8 @@ describe("InfoOmTolk", () => {
         harTolkIPdl,
         harTolkIPdl2,
         harTolkIPdl3,
-        harTolkIPdl4,
-        harTolkIPdl5,
         harIkkeTolkIPdl,
         harIkkeTolkIPdl2,
-        harIkkeTolkIPdl3,
-        harIkkeTolkIPdl4,
-        harIkkeTolkIPdl5,
       ])(
         "Arbeidsgiver og arbeidstaker har ønske om tolk og pdl har følgende informasjon (talesprakTolk: $tilrettelagtKommunikasjon.talesprakTolk, tegnsprakTolk: $tilrettelagtKommunikasjon.tegnsprakTolk) - Ikke vis informasjon om tolk",
         (brukerinfo: BrukerinfoDTO) => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til en egen boks med informasjon om hvor veileder kan oppdatere informasjon om tolk for den sykmeldte. Denne boksen vises hvis det ikke er registrert noe informasjon om tolk på den sykmeldte i pdl og det er ytret ønske om tolk fra den sykmeldte og/eller arbeidsgiver

Fortsettelse av https://github.com/navikt/syfomodiaperson/pull/1694, men ble skilt ut ettersom det ikke hastet.

### Screenshots 📸✨
![image](https://github.com/user-attachments/assets/f653e8b5-f3bd-4e8b-89fa-4604014fa279)

