### PR TITLE
IS-3229: Change text and button for removing oppgave from oversikt

### DIFF
--- a/src/sider/frisktilarbeid/VedtakFattet.tsx
+++ b/src/sider/frisktilarbeid/VedtakFattet.tsx
@@ -18,12 +18,10 @@ import { useNotification } from "@/context/notification/NotificationContext";
 const texts = {
   heading: (startDate: string, endDate: string) =>
     `Fattet vedtak varer fra ${startDate} til ${endDate}`,
-  avslutt:
-    "Etter at du avslutter oppgaven her, fjernes oppgaven fra oversikten og du trenger ikke å foreta deg noe mer.",
   videreOppfolging:
     "Videre oppfølging vil skje i aktivitetsplanen basert på bistandsbehovet i §14a-vedtaket.",
-  button: "Avslutt oppgave",
-  oppgaveAvsluttetAlert:
+  button: "Fjern oppgaven fra oversikten",
+  oppgaveFjernetAlert:
     "Oppgaven om vedtak er ferdigbehandlet, og er fjernet fra oversikten.",
   infotrygdAlert:
     "Overføring til Infotrygd feilet. Sjekk Infotrygd og registrer vedtaket manuelt om nødvendig.",
@@ -58,10 +56,10 @@ export function VedtakFattet({
   const vedtakEndDateText = tilLesbarDatoMedArUtenManedNavn(tom);
   const { notification, setNotification } = useNotification();
 
-  function handleAvsluttOppgaveOnClick() {
+  function handleFjernOppgaveOnClick() {
     ferdigbehandleVedtak.mutate(undefined, {
       onSuccess: () => {
-        setNotification({ message: texts.oppgaveAvsluttetAlert });
+        setNotification({ message: texts.oppgaveFjernetAlert });
         setIsNyVurderingStarted(false);
       },
     });
@@ -87,11 +85,11 @@ export function VedtakFattet({
           {`${texts.heading(vedtakStartDateText, vedtakEndDateText)} `}
         </Heading>
         <BodyShort>{texts.videreOppfolging}</BodyShort>
-        <BodyShort>{texts.avslutt}</BodyShort>
         <Button
           className="w-fit"
+          variant="secondary"
           loading={ferdigbehandleVedtak.isPending}
-          onClick={() => handleAvsluttOppgaveOnClick()}
+          onClick={() => handleFjernOppgaveOnClick()}
         >
           {texts.button}
         </Button>

--- a/test/frisktilarbeid/FriskmeldingTilArbeidsformidlingTest.tsx
+++ b/test/frisktilarbeid/FriskmeldingTilArbeidsformidlingTest.tsx
@@ -46,13 +46,13 @@ describe("FriskmeldingTilArbeidsformidling", () => {
     queryClient = queryClientWithMockData();
   });
 
-  it("viser avslutt oppgave når vedtak har startet", () => {
+  it("viser mulighet for å fjerne oppgaven fra oversikten når vedtak har startet", () => {
     const vedtak = createVedtak(new Date());
     mockVedtak([vedtak]);
 
     renderFriskmeldingTilArbeidsformidling();
 
-    expect(getButton("Avslutt oppgave")).to.exist;
+    expect(getButton("Fjern oppgaven fra oversikten")).to.exist;
   });
 
   it("viser ferdigbehandlet vedtak når det finnes", () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endrer tekst på knapp fra "Avslutt oppgave" til "Fjern oppgaven fra oversikten" for å forhåpentligvis gjøre det enklere for veileder å forstå hva som skjer når de trykker på knappen. Vi ønsker ikke at de skal tro at de avslutter selve vedtaket.

### Screenshots 📸✨

Før
![Screenshot 2025-05-20 at 14 04 09](https://github.com/user-attachments/assets/dfdbcde2-ded0-46f8-b9e0-6e6cc68488d4)


Etter
![Screenshot 2025-05-20 at 14 03 39](https://github.com/user-attachments/assets/ab24b93e-f36d-47cf-8cf2-cfa34120976b)
