### PR TITLE
IS: Removing usage of spred operator on query hooks

### DIFF
--- a/src/data/aktivitetskrav/aktivitetskravQueryHooks.ts
+++ b/src/data/aktivitetskrav/aktivitetskravQueryHooks.ts
@@ -30,8 +30,9 @@ export const useAktivitetskravQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };
 

--- a/src/data/arbeidsuforhet/arbeidsuforhetQueryHooks.ts
+++ b/src/data/arbeidsuforhet/arbeidsuforhetQueryHooks.ts
@@ -21,7 +21,8 @@ export function useGetArbeidsuforhetVurderingerQuery() {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 }

--- a/src/data/behandler/behandlereQueryHooks.ts
+++ b/src/data/behandler/behandlereQueryHooks.ts
@@ -20,8 +20,8 @@ export const useBehandlereQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
   };
 };
 
@@ -42,7 +42,6 @@ export const useSokBehandlereQuery = (searchstring: string) => {
   });
 
   return {
-    ...query,
     data: query.data || [],
   };
 };

--- a/src/data/behandlerdialog/behandlerdialogQueryHooks.ts
+++ b/src/data/behandlerdialog/behandlerdialogQueryHooks.ts
@@ -20,7 +20,8 @@ export const useBehandlerdialogQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data,
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };

--- a/src/data/dialogmote/dialogmoteQueryHooks.ts
+++ b/src/data/dialogmote/dialogmoteQueryHooks.ts
@@ -29,8 +29,9 @@ export const useDialogmoterQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
     aktivtDialogmote: useMemo(
       () => query.data?.find((mote) => isAktivtDialogmote(mote)),
       [query.data]

--- a/src/data/dialogmote/dialogmoteStatusEndringHistorikkQuery.ts
+++ b/src/data/dialogmote/dialogmoteStatusEndringHistorikkQuery.ts
@@ -17,7 +17,8 @@ export function useDialogmoteStatusEndringHistorikkQuery() {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 }

--- a/src/data/dialogmotekandidat/dialogmotekandidatQueryHooks.ts
+++ b/src/data/dialogmotekandidat/dialogmotekandidatQueryHooks.ts
@@ -51,12 +51,11 @@ export const useDialogmotekandidat = () => {
       query.data?.kandidat,
       query.data?.kandidatAt
     );
-
   const isKandidat: boolean =
     isNoFerdigstiltDialogmoteReferatAfterKandidatAt || false;
 
   return {
-    ...query,
+    data: query.data || {},
     isKandidat,
   };
 };

--- a/src/data/dialogmotekandidat/dialogmoteunntakQueryHooks.ts
+++ b/src/data/dialogmotekandidat/dialogmoteunntakQueryHooks.ts
@@ -19,7 +19,8 @@ export const useDialogmoteunntakQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };

--- a/src/data/fastlege/fastlegerQueryHooks.ts
+++ b/src/data/fastlege/fastlegerQueryHooks.ts
@@ -22,7 +22,6 @@ export const useFastlegerQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
     ikkeFunnet: query.data && query.data.length === 0,
     fastlege: useMemo(

--- a/src/data/frisktilarbeid/vedtakQuery.ts
+++ b/src/data/frisktilarbeid/vedtakQuery.ts
@@ -42,8 +42,8 @@ export const useVilkarForVedtakQuery = () => {
   });
 
   return {
-    isPending: query.isPending,
     data: query.data,
+    isPending: query.isPending,
     isRegisteredArbeidssoker: query.data?.isArbeidssoker,
   };
 };

--- a/src/data/historikk/historikkQueryHooks.ts
+++ b/src/data/historikk/historikkQueryHooks.ts
@@ -24,8 +24,9 @@ export const useHistorikkOppfolgingsplan = () => {
   });
 
   return {
-    ...query,
     data: mapHistorikkEvents(query.data || [], "OPPFOLGINGSPLAN"),
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };
 

--- a/src/data/leder/ledereQueryHooks.ts
+++ b/src/data/leder/ledereQueryHooks.ts
@@ -46,7 +46,8 @@ export const useLedereQuery = () => {
   };
 
   return {
-    ...query,
+    isLoading: query.isLoading,
+    isError: query.isError,
     getCurrentNarmesteLeder,
     currentLedere,
     formerLedere: useMemo(

--- a/src/data/manglendemedvirkning/manglendeMedvirkningQueryHooks.ts
+++ b/src/data/manglendemedvirkning/manglendeMedvirkningQueryHooks.ts
@@ -24,8 +24,9 @@ export const useManglendemedvirkningVurderingQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
     sisteVurdering: query.data?.[0],
   };
 };

--- a/src/data/motebehov/motebehovQueryHooks.ts
+++ b/src/data/motebehov/motebehovQueryHooks.ts
@@ -23,7 +23,8 @@ export const useMotebehovQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data?.sort(sorterMotebehovDataEtterDatoDesc) || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -38,7 +38,7 @@ export const useBrukerinfoQuery = () => {
   };
 
   return {
-    ...query,
+    data: query.data,
     brukerinfo: query.data || defaultData,
     isInaktivPersonident:
       !!personident &&
@@ -59,7 +59,7 @@ export const useKontaktinfoQuery = () => {
   });
 
   return {
-    ...query,
+    data: query.data,
     brukerKanIkkeVarslesDigitalt: query.data?.skalHaVarsel === false,
     brukerKanVarslesDigitalt: query.data?.skalHaVarsel === true,
   };

--- a/src/data/oppfolgingsplan/oppfolgingsplanQueryHooks.ts
+++ b/src/data/oppfolgingsplan/oppfolgingsplanQueryHooks.ts
@@ -37,8 +37,10 @@ export const useOppfolgingsplanerQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isPending: query.isPending,
+    isError: query.isError,
     aktivePlaner: useMemo(
       () =>
         query.data?.filter(
@@ -63,8 +65,10 @@ export const useOppfolgingsplanerLPSQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isPending: query.isPending,
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };
 

--- a/src/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts
+++ b/src/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { get } from "@/api/axios";
 import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { ISOPPFOLGINGSTILFELLE_ROOT } from "@/apiConstants";
@@ -34,7 +34,9 @@ export const oppfolgingstilfellePersonQueryKeys = {
   ],
 };
 
-type OppfolgingstilfellePersonQuery = UseQueryResult & {
+type OppfolgingstilfellePersonQuery = {
+  isLoading: boolean;
+  isError: boolean;
   latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined;
   tilfellerDescendingStart: OppfolgingstilfelleDTO[];
   hasOppfolgingstilfelle: boolean;
@@ -69,7 +71,8 @@ export const useOppfolgingstilfellePersonQuery =
       query.data && isGjentakendeSykefravar(query.data.oppfolgingstilfelleList);
 
     return {
-      ...query,
+      isLoading: query.isLoading,
+      isError: query.isError,
       latestOppfolgingstilfelle,
       tilfellerDescendingStart,
       hasOppfolgingstilfelle: !!latestOppfolgingstilfelle,

--- a/src/data/pengestopp/pengestoppQueryHooks.ts
+++ b/src/data/pengestopp/pengestoppQueryHooks.ts
@@ -21,7 +21,6 @@ export const usePengestoppStatusQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
   };
 };

--- a/src/data/personoppgave/personoppgaveQueryHooks.ts
+++ b/src/data/personoppgave/personoppgaveQueryHooks.ts
@@ -21,7 +21,6 @@ export const usePersonoppgaverQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
   };
 };

--- a/src/data/senoppfolging/useSenOppfolgingKandidatQuery.ts
+++ b/src/data/senoppfolging/useSenOppfolgingKandidatQuery.ts
@@ -23,7 +23,9 @@ export const useSenOppfolgingKandidatQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isPending: query.isPending,
+    isError: query.isError,
   };
 };

--- a/src/data/sykepengesoknad/sykepengesoknadQueryHooks.ts
+++ b/src/data/sykepengesoknad/sykepengesoknadQueryHooks.ts
@@ -29,8 +29,9 @@ export const useSykepengesoknaderQuery = () => {
   });
 
   return {
-    ...query,
     data: query.data || [],
+    isLoading: query.isLoading,
+    isError: query.isError,
   };
 };
 

--- a/src/data/sykmelding/sykmeldingQueryHooks.ts
+++ b/src/data/sykmelding/sykmeldingQueryHooks.ts
@@ -26,7 +26,8 @@ export const useSykmeldingerQuery = () => {
   });
 
   return {
-    ...query,
+    isLoading: query.isLoading,
+    isError: query.isError,
     sykmeldinger: useMemo(
       () =>
         query.data?.map((sykmelding) =>

--- a/src/data/virksomhet/virksomhetQueryHooks.ts
+++ b/src/data/virksomhet/virksomhetQueryHooks.ts
@@ -22,7 +22,7 @@ export const useVirksomhetQuery = (virksomhetsnummer: string | undefined) => {
   });
 
   return {
-    ...query,
+    data: query.data,
     virksomhetsnavn: query.data && getVirksomhetsnavn(query.data),
   };
 };

--- a/test/components/TildeltVeilederTest.tsx
+++ b/test/components/TildeltVeilederTest.tsx
@@ -75,7 +75,7 @@ describe("TildeltVeileder", () => {
       });
       renderTildelVeileder();
 
-      await waitFor(() => expect(result.current.isSuccess).to.be.true);
+      await waitFor(() => expect(result.current.data).to.not.be.undefined);
       await screen.findByText("Ufordelt bruker");
     });
   });

--- a/test/data/aktivitetskravQueryHooksTest.tsx
+++ b/test/data/aktivitetskravQueryHooksTest.tsx
@@ -1,6 +1,6 @@
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
 import { aktivitetskravMock } from "@/mocks/isaktivitetskrav/aktivitetskravMock";
 import { stubAktivitetskravApi } from "../stubs/stubIsaktivitetskrav";
@@ -24,8 +24,7 @@ describe("aktivitetskravqueryHook tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.not.be.undefined;
     expect(result.current.data?.length).to.equal(aktivitetskravMock.length);
   });

--- a/test/data/behandlendeEnhetQueryHooksTest.tsx
+++ b/test/data/behandlendeEnhetQueryHooksTest.tsx
@@ -21,8 +21,7 @@ describe("behandlendeEnhetQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
     expect(result.current.data?.geografiskEnhet).to.deep.equal(
       behandlendeEnhetMockResponse.geografiskEnhet
     );

--- a/test/data/behandlereDialogmeldingQueryHooksTest.tsx
+++ b/test/data/behandlereDialogmeldingQueryHooksTest.tsx
@@ -1,6 +1,6 @@
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { stubBehandlereDialogmeldingApi } from "../stubs/stubIsdialogmelding";
 import { behandlereDialogmeldingMock } from "@/mocks/isdialogmelding/behandlereDialogmeldingMock";
 import { useBehandlereQuery } from "@/data/behandler/behandlereQueryHooks";
@@ -21,8 +21,7 @@ describe("behandlereQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(behandlereDialogmeldingMock);
   });
 });

--- a/test/data/dialogmoteQueryHooksTest.tsx
+++ b/test/data/dialogmoteQueryHooksTest.tsx
@@ -1,6 +1,6 @@
 import { stubDialogmoterApi } from "../stubs/stubIsdialogmote";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useDialogmoterQuery } from "@/data/dialogmote/dialogmoteQueryHooks";
 import { dialogmoterMock } from "@/mocks/isdialogmote/dialogmoterMock";
 import { queryHookWrapper } from "./queryHookTestUtils";
@@ -22,8 +22,7 @@ describe("dialogmoteQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(dialogmoterMock);
   });
 });

--- a/test/data/dialogmoteunntak/dialogmoteunntakQueryHooksTest.tsx
+++ b/test/data/dialogmoteunntak/dialogmoteunntakQueryHooksTest.tsx
@@ -1,4 +1,4 @@
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { queryHookWrapper } from "../queryHookTestUtils";
 import { dialogmotekandidatMock } from "@/mocks/isdialogmotekandidat/dialogmotekandidatMock";
@@ -24,8 +24,7 @@ describe("dialogmotekandidatQuery tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(dialogmotekandidatMock);
   });
 });

--- a/test/data/diskresjonskodeQueryHooksTest.tsx
+++ b/test/data/diskresjonskodeQueryHooksTest.tsx
@@ -1,6 +1,6 @@
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { stubDiskresjonskodeApi } from "../stubs/stubSyfoperson";
 import { useDiskresjonskodeQuery } from "@/data/diskresjonskode/diskresjonskodeQueryHooks";
 import { testQueryClient } from "../testQueryClient";
@@ -20,7 +20,7 @@ describe("diskresjonskodeQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
 
     expect(result.current.data).to.deep.equal("7");
   });

--- a/test/data/egenansattQueryHooksTest.tsx
+++ b/test/data/egenansattQueryHooksTest.tsx
@@ -1,6 +1,6 @@
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { stubEgenansattApi } from "../stubs/stubSyfoperson";
 import { useEgenansattQuery } from "@/data/egenansatt/egenansattQueryHooks";
 import { testQueryClient } from "../testQueryClient";
@@ -20,7 +20,7 @@ describe("egenansattQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
 
     expect(result.current.data).to.deep.equal(true);
   });

--- a/test/data/fastlegerQueryHooksTest.tsx
+++ b/test/data/fastlegerQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { stubFastlegerApi } from "../stubs/stubFastlegeRest";
 import { useFastlegerQuery } from "@/data/fastlege/fastlegerQueryHooks";
 import { fastlegerMock } from "@/mocks/fastlegerest/fastlegerMock";
@@ -22,7 +22,7 @@ describe("fastlegerQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.empty);
 
     expect(result.current.data).to.deep.equal(fastlegerMock);
     expect(result.current.fastlege).to.deep.equal(fastlegerMock[0]);

--- a/test/data/historikkQueryHooksTest.tsx
+++ b/test/data/historikkQueryHooksTest.tsx
@@ -21,15 +21,13 @@ describe("historikkQueryHooks", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     const expectedHistorikkEvents = [...historikkoppfolgingsplanMock].map(
       (historikkEvent) => ({
         ...historikkEvent,
         kilde: "OPPFOLGINGSPLAN",
       })
     );
-
     expect(result.current.data).to.deep.equal(expectedHistorikkEvents);
   });
 });

--- a/test/data/ledereQueryHooksTest.tsx
+++ b/test/data/ledereQueryHooksTest.tsx
@@ -1,7 +1,7 @@
 import { NarmesteLederRelasjonStatus } from "@/data/leder/ledereTypes";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { stubNarmestelederApi } from "../stubs/stubIsnarmesteleder";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { testQueryClient } from "../testQueryClient";
@@ -46,9 +46,10 @@ describe("ledereQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
-    expect(result.current.data).to.deep.equal(ledereData);
+    await waitFor(() =>
+      expect(result.current.allLedere?.length).to.be.greaterThan(0)
+    );
+    expect(result.current.allLedere).to.deep.equal(ledereData);
     expect(result.current.allLedere).to.deep.equal(ledereData);
     expect(result.current.currentLedere).to.deep.equal(currentLedere);
     expect(result.current.formerLedere).to.deep.equal(formerLedere);

--- a/test/data/maksdatoQueryTest.tsx
+++ b/test/data/maksdatoQueryTest.tsx
@@ -1,6 +1,6 @@
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { testQueryClient } from "../testQueryClient";
 import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 import { maksdato, maksdatoMock } from "@/mocks/syfoperson/persondataMock";
@@ -21,8 +21,7 @@ describe("maksdatoQuery", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
     expect(result.current.data?.maxDate?.id).to.deep.equal(
       maksdatoMock.maxDate.id
     );

--- a/test/data/oppfolgingsplanQueryHooksTest.tsx
+++ b/test/data/oppfolgingsplanQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import {
   useDokumentinfoQuery,
@@ -34,8 +34,7 @@ describe("oppfolgingsplanQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(oppfolgingsplanMock);
   });
 
@@ -48,8 +47,7 @@ describe("oppfolgingsplanQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(oppfolgingsplanerLPSMock(today));
   });
 
@@ -66,7 +64,7 @@ describe("oppfolgingsplanQueryHooks tests", () => {
       }
     );
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
 
     expect(result.current.data).to.deep.equal(dokumentinfoMock);
   });

--- a/test/data/oppfolgingstilfellePersonQueryHooksTest.tsx
+++ b/test/data/oppfolgingstilfellePersonQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { stubOppfolgingstilfellePersonApi } from "../stubs/stubIsoppfolgingstilfelle";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
@@ -21,7 +21,9 @@ describe("oppfolgingstilfellePersonQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(
+      () => expect(result.current.latestOppfolgingstilfelle).to.not.be.undefined
+    );
 
     expect(result.current.latestOppfolgingstilfelle).to.exist;
     expect(result.current.hasActiveOppfolgingstilfelle).to.be.true;

--- a/test/data/pengestoppQueryHooksTest.tsx
+++ b/test/data/pengestoppQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { usePengestoppStatusQuery } from "@/data/pengestopp/pengestoppQueryHooks";
 import { createStatusList } from "@/mocks/ispengestopp/pengestoppStatusMock";
@@ -24,8 +24,7 @@ describe("pengestoppQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(createStatusList(today));
   });
 });

--- a/test/data/personAdresseQueryHooksTest.tsx
+++ b/test/data/personAdresseQueryHooksTest.tsx
@@ -1,7 +1,7 @@
 import { stubPersonadresseApi } from "../stubs/stubSyfoperson";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { usePersonAdresseQuery } from "@/data/personinfo/personAdresseQueryHooks";
 import { personAdresseMock } from "@/mocks/syfoperson/personAdresseMock";
 import { testQueryClient } from "../testQueryClient";
@@ -21,7 +21,7 @@ describe("personAdresseQueryHooks", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
 
     expect(result.current.data).to.deep.equal(personAdresseMock);
   });

--- a/test/data/personBrukerinfoQueryHooksTest.tsx
+++ b/test/data/personBrukerinfoQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { stubPersoninfoApi } from "../stubs/stubSyfoperson";
 import { useBrukerinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
@@ -21,8 +21,7 @@ describe("navbrukerQueryHooks", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
     expect(result.current.data).to.deep.equal(brukerinfoMock);
   });
 });

--- a/test/data/personoppgaveQueryHooksTest.tsx
+++ b/test/data/personoppgaveQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { stubPersonoppgaveApi } from "../stubs/stubIspersonoppgave";
@@ -22,8 +22,7 @@ describe("personoppgaveQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(personoppgaverMock());
   });
 });

--- a/test/data/sykepengesoknadQueryHooksTest.tsx
+++ b/test/data/sykepengesoknadQueryHooksTest.tsx
@@ -25,8 +25,7 @@ describe("sykepengesoknadQueryHooks", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.empty);
     expect(result.current.data).to.deep.equal(
       (soknaderMock as unknown as SykepengesoknadDTO[]).map(parseSoknad)
     );

--- a/test/data/sykmeldingQueryHooksTest.tsx
+++ b/test/data/sykmeldingQueryHooksTest.tsx
@@ -1,6 +1,6 @@
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { useSykmeldingerQuery } from "@/data/sykmelding/sykmeldingQueryHooks";
 import { stubSykmeldingApi } from "../stubs/stubSyfosmregister";
 import { sykmeldingerMock } from "@/mocks/syfosmregister/sykmeldingerMock";
@@ -30,8 +30,7 @@ describe("sykmeldingQueryHooks", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.sykmeldinger).to.not.be.empty);
     expect(result.current.sykmeldinger).to.deep.equal(
       sykmeldingerMockData.map((value) =>
         newSMFormat2OldFormat(value, ARBEIDSTAKER_DEFAULT.personIdent)

--- a/test/data/tilgangQueryHooksTest.tsx
+++ b/test/data/tilgangQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { stubTilgangApi } from "../stubs/stubIstilgangskontroll";
 import { useTilgangQuery } from "@/data/tilgang/tilgangQueryHooks";
@@ -22,7 +22,7 @@ describe("tilgangQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
     expect(result.current.data).to.deep.equal(tilgangBrukerMock);
   });
 });

--- a/test/data/unleash/unleashQueryHooksTest.tsx
+++ b/test/data/unleash/unleashQueryHooksTest.tsx
@@ -3,7 +3,7 @@ import { stubFeatureTogglesApi } from "../../stubs/stubUnleash";
 import { queryHookWrapper } from "../queryHookTestUtils";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { mockUnleashResponse } from "@/mocks/unleashMocks";
 
 let queryClient: any;

--- a/test/data/veilederinfoQueryHooksTest.tsx
+++ b/test/data/veilederinfoQueryHooksTest.tsx
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   useAktivVeilederinfoQuery,
   useVeilederInfoQuery,
@@ -26,7 +26,7 @@ describe("veilederinfoQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
 
     expect(result.current.data).to.deep.equal(VEILEDER_DEFAULT);
   });
@@ -43,7 +43,7 @@ describe("veilederinfoQueryHooks tests", () => {
       }
     );
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
 
     expect(result.current.data).to.deep.equal(VEILEDER_DEFAULT);
   });

--- a/test/data/virksomhetQueryHooksTest.tsx
+++ b/test/data/virksomhetQueryHooksTest.tsx
@@ -1,7 +1,7 @@
 import { stubVirksomhetApi } from "../stubs/stubEreg";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
-import { expect, describe, it, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { virksomhetMock } from "@/mocks/ereg/virksomhetMock";
 import { queryHookWrapper } from "./queryHookTestUtils";
 import { VIRKSOMHET_PONTYPANDY } from "@/mocks/common/mockConstants";
@@ -25,8 +25,7 @@ describe("virksomhetQueryHooks tests", () => {
       wrapper,
     });
 
-    await waitFor(() => expect(result.current.isSuccess).to.be.true);
-
+    await waitFor(() => expect(result.current.data).to.not.be.undefined);
     expect(result.current.data).to.deep.equal(virksomhetMock());
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Fjerner bruk av spread operatoren på query hooks. Altså `...query`. Denne tar med seg alt av endringer som skjer på properties i `UseQueryResult` typen, altså `isLoading`, `isPending`, `status`, osv. Hver endring i en av propertiene her vil føre til en rerender der hooken blir brukt. Så potensielt så slipper vi en del unødvendige rerenders.