### PR TITLE
IS-3297: Endret tekster i 8-5 brevet

### DIFF
--- a/src/components/document/DocumentComponentVisning.tsx
+++ b/src/components/document/DocumentComponentVisning.tsx
@@ -75,7 +75,7 @@ const DocumentComponentParagraph = (texts: string[], title?: string) => {
 
 export const DocumentComponentBulletPoints = (texts: string[]) => {
   return (
-    <List size={"small"}>
+    <List size="small">
       {texts.map((text, index) => (
         <List.Item key={index}>{text}</List.Item>
       ))}

--- a/src/components/document/DocumentComponentVisning.tsx
+++ b/src/components/document/DocumentComponentVisning.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/data/documentcomponent/documentComponentTypes";
 import { FlexRow, PaddingSize } from "@/components/Layout";
 import styled from "styled-components";
-import { BodyLong, Heading, Label, Link } from "@navikt/ds-react";
+import { BodyLong, Heading, Label, Link, List } from "@navikt/ds-react";
 import { DocumentComponentHeaderH1 } from "@/components/document/DocumentComponentHeaderH1";
 
 const Paragraph = styled.div`
@@ -75,13 +75,11 @@ const DocumentComponentParagraph = (texts: string[], title?: string) => {
 
 export const DocumentComponentBulletPoints = (texts: string[]) => {
   return (
-    <ul>
+    <List size={"small"}>
       {texts.map((text, index) => (
-        <BodyLong size="small" key={index} as={"li"}>
-          {text}
-        </BodyLong>
+        <List.Item key={index}>{text}</List.Item>
       ))}
-    </ul>
+    </List>
   );
 };
 

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -52,7 +52,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
     header: "Dine rettigheter",
     innsyn: {
       header: "Rett til innsyn:",
-      body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller 55 55 33 33.",
+      body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller telefon 55 55 33 33.",
     },
     klage: {
       header: "Rett til å klage:",

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -46,7 +46,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
   },
   sporsmal: {
     header: "Har du spørsmål?",
-    body: "Hvis du har spørsmål, kan du kontakte oss via: nav.no/kontaktoss/endringer.",
+    body: "Hvis du har spørsmål, kan du kontakte oss via: nav.no/kontaktoss.",
   },
   dineRettigheter: {
     header: "Dine rettigheter",

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -32,7 +32,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
   },
   farNyJobb: {
     header: "Hvis du får en ny jobb underveis",
-    body: "Hvis du får en ny jobb underveis hvor du tjener like mye eller mer enn sykepengene du får fra Nav, eller du begynner å jobbe mer enn 80 % av det du gjorde før du ble sykmeldt, vil du ikke ha rett på sykepenger lenger. Da stanser Nav utbetalingen din.",
+    body: "Hvis du får en ny jobb hvor du tjener like mye eller mer enn sykepengene du får fra Nav, vil du ikke ha rett på sykepenger lenger. Dette gjelder også hvis du begynner å jobbe mer enn 80 % av det du gjorde før du ble sykmeldt.",
   },
   ikkeFarNyJobb: {
     header: "Hvis du ikke finner ny jobb",

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -52,7 +52,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
     header: "Dine rettigheter",
     innsyn: {
       header: "Rett til innsyn:",
-      body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no eller kontakte oss på nav.no/kontaktoss.",
+      body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller 55 55 33 33.",
     },
     klage: {
       header: "Rett til å klage:",

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -1,4 +1,7 @@
-import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import {
+  tilDatoMedManedNavn,
+  tilLesbarDatoMedArUtenManedNavn,
+} from "@/utils/datoUtils";
 
 export type VedtakTextsValues = {
   fom: Date | undefined;
@@ -7,51 +10,62 @@ export type VedtakTextsValues = {
 
 export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
   header: "Vedtak om friskmelding til arbeidsformidling",
-  intro:
-    "Vi har vurdert at du oppfyller vilkårene for rett til friskmelding til arbeidsformidling. Dette betyr at du får utbetalt sykepenger i en periode mens du søker ny jobb.",
-  periode: `For deg gjelder dette perioden ${toReadableDateOrEmpty(
-    fom
-  )} til ${toReadableDateOrEmpty(tom)}.`,
+  innvilget: {
+    header: "Du har fått innvilget friskmelding til arbeidsformidling",
+    intro:
+      "Du oppfyller vilkårene for friskmelding til arbeidsformidling og kan få sykepenger fra Nav mens du ser etter ny jobb.",
+    periode: `Vedtaket gjelder for perioden: ${toReadableDateOrEmpty(
+      fom
+    )} - ${toReadableDateOrEmpty(tom)}.`,
+  },
   maksdato: `Siden din maksdato for sykepenger er beregnet til ${tilLesbarDatoMedArUtenManedNavn(
     tom
   )}, vil du ikke få sykepenger etter denne datoen.`,
-  arbeidssoker: {
-    part1: `Et vilkår for å motta sykepenger i denne perioden er at du har registrert deg som arbeidssøker hos Nav.`,
-    part2: "For å registrere deg går du inn på nav.no/arbeid/registrering.",
-  },
-  hjemmel: "Dette vedtaket er gjort etter folketrygdloven paragraf 8-5.",
-  behandler:
-    "Nav har ikke delt informasjon med legen din om at du er innvilget ordningen friskmeldt til arbeidsformidling. Du må gjerne selv informere legen din om dette. Legen din trenger ikke å skrive ut sykmelding i perioden vedtaket gjelder.",
   begrunnelse: {
-    header: "Begrunnelse",
-    part1:
-      "For at du skal ha rett til sykepenger, er det vanligvis et krav at du er for syk til å jobbe. I utgangspunktet har du ikke rett til sykepenger hvis du kan utføre en annen jobb enn den du er sykmeldt fra. Ordningen friskmelding til arbeidsformidling gjør at du likevel kan få sykepenger i opptil 12 uker mens du søker ny jobb.",
+    header: "Begrunnelse for vedtaket",
+    body: "Helsen din er slik at du kan komme tilbake i arbeid, men ikke til den jobben du har vært sykmeldt fra. Nå har du selv valgt å avslutte jobben, og benytte deg av ordningen friskmelding til arbeidsformidling. Dette vedtaket er gjort etter folketrygdloven § 8-5.",
   },
-  nyttigInfo: {
-    header: "Nyttig informasjon",
-    part1:
-      "Sykepengene blir utbetalt etter at du har sendt søknad. Du sender søknad til Nav hver 14. dag.",
-    part2:
-      "Utbetalingen stanser når du får ny jobb, eller hvis du velger å takke nei til et aktuelt tilbud om en jobb.",
-    part3:
-      "Hvis du ikke har fått ny jobb innen perioden din med sykepenger er over, kan det være aktuelt for deg å søke om dagpenger. Du må i så fall huske å sende en søknad om dagpenger før perioden med sykepenger er over.",
-    part4: "Les mer på nav.no/arbeidsledig.",
+  sykmelding: {
+    header: "Sykmelding fra legen",
+    body: "Nav har ikke delt informasjonen om vedtaket med legen din. Du trenger ikke sykmelding i perioden vedtaket gjelder for, med mindre du blir syk underveis. Da må du ta kontakt med legen din.",
+  },
+  forAFaSykepenger: {
+    header: "Hva du må gjøre for å få sykepenger",
+    body: "For å få sykepenger gjennom friskmelding til arbeidsformidling må du være registrert som arbeidssøker hos Nav og søke om sykepenger hver 14. dag. Du kan da få sykepenger i opptil 12 uker mens du søker etter ny jobb. Du vil få beskjed fra oss når søknaden er klar til å fylles ut. Hvis du ikke lenger ønsker å motta sykepenger fra Nav, må du gi beskjed om det i søknaden. ",
+  },
+  farNyJobb: {
+    header: "Hvis du får en ny jobb underveis",
+    body: "Hvis du får en ny jobb underveis hvor du tjener like mye eller mer enn sykepengene du får fra Nav, eller du begynner å jobbe mer enn 80 % av det du gjorde før du ble sykmeldt, vil du ikke ha rett på sykepenger lenger. Da stanser Nav utbetalingen din.",
+  },
+  ikkeFarNyJobb: {
+    header: "Hvis du ikke finner ny jobb",
+    body: "Hvis du ikke har fått jobb i løpet av perioden vedtaket gjelder for, kan det være aktuelt for deg å søke om dagpenger. Husk å sende søknaden før sykepengeperioden er slutt.",
+    lesMer: "Du kan lese mer om dagpenger på: nav.no/dagpenger#arbeidsledig",
+  },
+  endringSituasjon: {
+    header: "Hvis situasjonen din endrer seg",
+    body: "Endringer i livssituasjonen din kan påvirke retten din til sykepenger. Dersom du gir mangelfulle eller feilaktige opplysninger, kan det føre til at du må betale tilbake penger.",
+    lesMer: "Les mer om dette på: nav.no/endringer.",
   },
   sporsmal: {
-    header: "Spørsmål eller endringer",
-    body: "Hvis det skjer en endring i din situasjon, kan det påvirke din rett til utbetaling av sykepenger. Mangelfulle eller feilaktige opplysninger kan medføre krav om tilbakebetaling av sykepenger. Se nav.no/endringer.",
+    header: "Har du spørsmål?",
+    body: "Hvis du har spørsmål, kan du kontakte oss via: nav.no/kontaktoss/endringer.",
   },
-  kontakt:
-    "Har du spørsmål om saken din kan du kontakte oss på nav.no/kontaktoss.",
-  innsyn: {
-    header: "Rett til innsyn",
-    body: "Du har rett til innsyn i sakens opplysninger. Dette får du ved å logge deg inn på nav.no, eller ved å ta kontakt nav.no/kontaktoss.",
-  },
-  klage: {
-    header: "Du har rett til å klage",
-    body: "Hvis du ikke er enig i resultatet, kan du klage innen seks uker fra den datoen du mottok dette brevet. Les mer på nav.no/klagerettigheter og nav.no/klage#sykepenger.",
+  dineRettigheter: {
+    header: "Dine rettigheter",
+    innsyn: {
+      header: "Rett til innsyn:",
+      body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no eller kontakte oss på nav.no/kontaktoss.",
+    },
+    klage: {
+      header: "Rett til å klage:",
+      body: "Hvis du ikke er enig i vedtaket, kan du klage innen seks uker fra du mottok dette brevet.",
+      lesMer: "Les mer om hvordan du klager her:",
+      url: "nav.no/klagerettigheter",
+      urlSykepenger: "nav.no/klage#sykepenger",
+    },
   },
 });
 
 const toReadableDateOrEmpty = (date: Date | undefined) =>
-  date ? tilLesbarDatoMedArUtenManedNavn(date) : "";
+  date ? tilDatoMedManedNavn(date) : "";

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -1,7 +1,4 @@
-import {
-  tilDatoMedManedNavn,
-  tilLesbarDatoMedArUtenManedNavn,
-} from "@/utils/datoUtils";
+import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 
 export type VedtakTextsValues = {
   fom: Date | undefined;

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -31,7 +31,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
   },
   forAFaSykepenger: {
     header: "Hva du må gjøre for å få sykepenger",
-    body: "For å få sykepenger gjennom friskmelding til arbeidsformidling må du være registrert som arbeidssøker hos Nav og søke om sykepenger hver 14. dag. Du kan da få sykepenger i opptil 12 uker mens du søker etter ny jobb. Du vil få beskjed fra oss når søknaden er klar til å fylles ut. Hvis du ikke lenger ønsker å motta sykepenger fra Nav, må du gi beskjed om det i søknaden. ",
+    body: "For å få sykepenger gjennom friskmelding til arbeidsformidling må du være registrert som arbeidssøker hos Nav og søke om sykepenger hver 14. dag. Du kan da få sykepenger i opptil 12 uker mens du søker etter ny jobb. Du vil få beskjed fra oss når søknaden er klar til å fylles ut. Hvis du ikke lenger ønsker å motta sykepenger fra Nav, må du gi beskjed om det i søknaden.",
   },
   farNyJobb: {
     header: "Hvis du får en ny jobb underveis",

--- a/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
+++ b/src/data/frisktilarbeid/frisktilarbeidDocumentTexts.ts
@@ -18,7 +18,7 @@ export const getVedtakTexts = ({ fom, tom }: VedtakTextsValues) => ({
       fom
     )} - ${toReadableDateOrEmpty(tom)}.`,
   },
-  maksdato: `Siden din maksdato for sykepenger er beregnet til ${tilLesbarDatoMedArUtenManedNavn(
+  maksdato: `Siden din maksdato for sykepenger er beregnet til ${toReadableDateOrEmpty(
     tom
   )}, vil du ikke få sykepenger etter denne datoen.`,
   begrunnelse: {

--- a/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
+++ b/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
@@ -20,7 +20,7 @@ type VedtakDocumentValues = VedtakTextsValues & {
 export const useFriskmeldingTilArbeidsformidlingDocument = (): {
   getVedtakDocument(values: VedtakDocumentValues): DocumentComponentDto[];
 } => {
-  const { getHilsen, getBrukerNavnFnr } = useDocumentComponents();
+  const { getHilsen } = useDocumentComponents();
 
   const getVedtakDocument = (
     values: VedtakDocumentValues

--- a/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
+++ b/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
@@ -1,9 +1,11 @@
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
 import { useDocumentComponents } from "@/hooks/useDocumentComponents";
 import {
+  createBulletPoints,
   createHeaderH1,
+  createHeaderH2,
+  createHeaderH3,
   createParagraph,
-  createParagraphWithTitle,
 } from "@/utils/documentComponentUtils";
 import {
   getVedtakTexts,
@@ -25,50 +27,49 @@ export const useFriskmeldingTilArbeidsformidlingDocument = (): {
   ): DocumentComponentDto[] => {
     const vedtakTexts = getVedtakTexts(values);
     const documentComponentDtos = [
-      createHeaderH1(vedtakTexts.header),
       getBrukerNavnFnr(),
-      createParagraph(vedtakTexts.intro),
-      createParagraph(vedtakTexts.periode),
+      createHeaderH1(vedtakTexts.header),
+      createHeaderH2(vedtakTexts.innvilget.header),
+      createParagraph(vedtakTexts.innvilget.intro),
+      createParagraph(vedtakTexts.innvilget.periode),
     ];
 
     if (values.tilDatoIsMaxDato) {
       documentComponentDtos.push(createParagraph(vedtakTexts.maksdato));
     }
 
-    documentComponentDtos.push(
-      createParagraph(
-        vedtakTexts.arbeidssoker.part1,
-        vedtakTexts.arbeidssoker.part2
-      ),
-      createParagraph(vedtakTexts.hjemmel),
-      createParagraphWithTitle(
-        vedtakTexts.begrunnelse.header,
-        values.begrunnelse ? values.begrunnelse : ""
-      )
-    );
+    documentComponentDtos.push(createHeaderH2(vedtakTexts.begrunnelse.header));
+    if (values.begrunnelse) {
+      documentComponentDtos.push(createParagraph(values.begrunnelse));
+    }
+    documentComponentDtos.push(createParagraph(vedtakTexts.begrunnelse.body));
 
     documentComponentDtos.push(
-      createParagraph(vedtakTexts.begrunnelse.part1),
-      createParagraphWithTitle(
-        vedtakTexts.nyttigInfo.header,
-        vedtakTexts.nyttigInfo.part1
+      createHeaderH2(vedtakTexts.sykmelding.header),
+      createParagraph(vedtakTexts.sykmelding.body),
+      createHeaderH2(vedtakTexts.forAFaSykepenger.header),
+      createParagraph(vedtakTexts.forAFaSykepenger.body),
+      createHeaderH2(vedtakTexts.farNyJobb.header),
+      createParagraph(vedtakTexts.farNyJobb.body),
+      createHeaderH2(vedtakTexts.ikkeFarNyJobb.header),
+      createParagraph(
+        vedtakTexts.ikkeFarNyJobb.body,
+        vedtakTexts.ikkeFarNyJobb.lesMer
       ),
-      createParagraph(vedtakTexts.nyttigInfo.part2),
-      createParagraph(vedtakTexts.nyttigInfo.part3),
-      createParagraph(vedtakTexts.nyttigInfo.part4),
-      createParagraph(vedtakTexts.behandler),
-      createParagraphWithTitle(
-        vedtakTexts.sporsmal.header,
-        vedtakTexts.sporsmal.body
-      ),
-      createParagraph(vedtakTexts.kontakt),
-      createParagraphWithTitle(
-        vedtakTexts.innsyn.header,
-        vedtakTexts.innsyn.body
-      ),
-      createParagraphWithTitle(
-        vedtakTexts.klage.header,
-        vedtakTexts.klage.body
+      createHeaderH2(vedtakTexts.endringSituasjon.header),
+      createParagraph(vedtakTexts.endringSituasjon.body),
+      createParagraph(vedtakTexts.endringSituasjon.lesMer),
+      createHeaderH2(vedtakTexts.sporsmal.header),
+      createParagraph(vedtakTexts.sporsmal.body),
+      createHeaderH2(vedtakTexts.dineRettigheter.header),
+      createHeaderH3(vedtakTexts.dineRettigheter.innsyn.header),
+      createParagraph(vedtakTexts.dineRettigheter.innsyn.body),
+      createHeaderH3(vedtakTexts.dineRettigheter.klage.header),
+      createParagraph(vedtakTexts.dineRettigheter.klage.body),
+      createParagraph(vedtakTexts.dineRettigheter.klage.lesMer),
+      createBulletPoints(
+        vedtakTexts.dineRettigheter.klage.url,
+        vedtakTexts.dineRettigheter.klage.urlSykepenger
       ),
       getHilsen()
     );

--- a/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
+++ b/src/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument.ts
@@ -27,7 +27,6 @@ export const useFriskmeldingTilArbeidsformidlingDocument = (): {
   ): DocumentComponentDto[] => {
     const vedtakTexts = getVedtakTexts(values);
     const documentComponentDtos = [
-      getBrukerNavnFnr(),
       createHeaderH1(vedtakTexts.header),
       createHeaderH2(vedtakTexts.innvilget.header),
       createParagraph(vedtakTexts.innvilget.intro),

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -7,7 +7,11 @@ import {
   ARBEIDSTAKER_DEFAULT_FULL_NAME,
   VEILEDER_DEFAULT,
 } from "@/mocks/common/mockConstants";
-import { addWeeks, tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import {
+  addWeeks,
+  tilDatoMedManedNavn,
+  tilLesbarDatoMedArUtenManedNavn,
+} from "@/utils/datoUtils";
 import {
   DocumentComponentDto,
   DocumentComponentType,
@@ -44,26 +48,30 @@ export const getExpectedVedtakDocument = ({
 }: ExpectedVedtakDocumentOptions): DocumentComponentDto[] => {
   return [
     {
-      texts: ["Vedtak om friskmelding til arbeidsformidling"],
-      type: DocumentComponentType.HEADER_H1,
-    },
-    {
       texts: [
         `${ARBEIDSTAKER_DEFAULT_FULL_NAME}, ${ARBEIDSTAKER_DEFAULT.personIdent}`,
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
+      texts: ["Vedtak om friskmelding til arbeidsformidling"],
+      type: DocumentComponentType.HEADER_H1,
+    },
+    {
+      texts: ["Du har fått innvilget friskmelding til arbeidsformidling"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
       texts: [
-        "Vi har vurdert at du oppfyller vilkårene for rett til friskmelding til arbeidsformidling. Dette betyr at du får utbetalt sykepenger i en periode mens du søker ny jobb.",
+        "Du oppfyller vilkårene for friskmelding til arbeidsformidling og kan få sykepenger fra Nav mens du ser etter ny jobb.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
       texts: [
-        `For deg gjelder dette perioden ${tilLesbarDatoMedArUtenManedNavn(
+        `Vedtaket gjelder for perioden: ${tilDatoMedManedNavn(
           fom
-        )} til ${tilLesbarDatoMedArUtenManedNavn(tom)}.`,
+        )} - ${tilDatoMedManedNavn(tom)}.`,
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
@@ -80,82 +88,115 @@ export const getExpectedVedtakDocument = ({
         ]
       : []),
     {
-      texts: [
-        `Et vilkår for å motta sykepenger i denne perioden er at du har registrert deg som arbeidssøker hos Nav.`,
-        "For å registrere deg går du inn på nav.no/arbeid/registrering.",
-      ],
-      type: DocumentComponentType.PARAGRAPH,
-    },
-    {
-      texts: ["Dette vedtaket er gjort etter folketrygdloven paragraf 8-5."],
-      type: DocumentComponentType.PARAGRAPH,
+      texts: ["Begrunnelse for vedtaket"],
+      type: DocumentComponentType.HEADER_H2,
     },
     {
       texts: [begrunnelse],
       type: DocumentComponentType.PARAGRAPH,
-      title: "Begrunnelse",
     },
     {
       texts: [
-        "For at du skal ha rett til sykepenger, er det vanligvis et krav at du er for syk til å jobbe. I utgangspunktet har du ikke rett til sykepenger hvis du kan utføre en annen jobb enn den du er sykmeldt fra. Ordningen friskmelding til arbeidsformidling gjør at du likevel kan få sykepenger i opptil 12 uker mens du søker ny jobb.",
+        "Helsen din er slik at du kan komme tilbake i arbeid, men ikke til den jobben du har vært sykmeldt fra. Nå har du selv valgt å avslutte jobben, og benytte deg av ordningen friskmelding til arbeidsformidling. Dette vedtaket er gjort etter folketrygdloven § 8-5.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
-      title: "Nyttig informasjon",
+      texts: ["Sykmelding fra legen"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
       texts: [
-        "Sykepengene blir utbetalt etter at du har sendt søknad. Du sender søknad til Nav hver 14. dag.",
+        "Nav har ikke delt informasjonen om vedtaket med legen din. Du trenger ikke sykmelding i perioden vedtaket gjelder for, med mindre du blir syk underveis. Da må du ta kontakt med legen din.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
+      texts: ["Hva du må gjøre for å få sykepenger"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
       texts: [
-        "Utbetalingen stanser når du får ny jobb, eller hvis du velger å takke nei til et aktuelt tilbud om en jobb.",
+        "For å få sykepenger gjennom friskmelding til arbeidsformidling må du være registrert som arbeidssøker hos Nav og søke om sykepenger hver 14. dag. Du kan da få sykepenger i opptil 12 uker mens du søker etter ny jobb. Du vil få beskjed fra oss når søknaden er klar til å fylles ut. Hvis du ikke lenger ønsker å motta sykepenger fra Nav, må du gi beskjed om det i søknaden. ",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
+      texts: ["Hvis du får en ny jobb underveis"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
       texts: [
-        "Hvis du ikke har fått ny jobb innen perioden din med sykepenger er over, kan det være aktuelt for deg å søke om dagpenger. Du må i så fall huske å sende en søknad om dagpenger før perioden med sykepenger er over.",
+        "Hvis du får en ny jobb underveis hvor du tjener like mye eller mer enn sykepengene du får fra Nav, eller du begynner å jobbe mer enn 80 % av det du gjorde før du ble sykmeldt, vil du ikke ha rett på sykepenger lenger. Da stanser Nav utbetalingen din.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
-      texts: ["Les mer på nav.no/arbeidsledig."],
-      type: DocumentComponentType.PARAGRAPH,
+      texts: ["Hvis du ikke finner ny jobb"],
+      type: DocumentComponentType.HEADER_H2,
     },
     {
       texts: [
-        "Nav har ikke delt informasjon med legen din om at du er innvilget ordningen friskmeldt til arbeidsformidling. Du må gjerne selv informere legen din om dette. Legen din trenger ikke å skrive ut sykmelding i perioden vedtaket gjelder.",
+        "Hvis du ikke har fått jobb i løpet av perioden vedtaket gjelder for, kan det være aktuelt for deg å søke om dagpenger. Husk å sende søknaden før sykepengeperioden er slutt.",
+        "Du kan lese mer om dagpenger på: nav.no/dagpenger#arbeidsledig",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
-      title: "Spørsmål eller endringer",
+      texts: ["Hvis situasjonen din endrer seg"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
       texts: [
-        "Hvis det skjer en endring i din situasjon, kan det påvirke din rett til utbetaling av sykepenger. Mangelfulle eller feilaktige opplysninger kan medføre krav om tilbakebetaling av sykepenger. Se nav.no/endringer.",
+        "Endringer i livssituasjonen din kan påvirke retten din til sykepenger. Dersom du gir mangelfulle eller feilaktige opplysninger, kan det føre til at du må betale tilbake penger.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
+      texts: ["Les mer om dette på: nav.no/endringer."],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: ["Har du spørsmål?"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
       texts: [
-        "Har du spørsmål om saken din kan du kontakte oss på nav.no/kontaktoss.",
+        "Hvis du har spørsmål, kan du kontakte oss via: nav.no/kontaktoss/endringer.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
-      title: "Rett til innsyn",
+      texts: ["Dine rettigheter"],
+      type: DocumentComponentType.HEADER_H2,
+    },
+    {
+      texts: ["Rett til innsyn:"],
+      type: DocumentComponentType.HEADER_H3,
+    },
+    {
       texts: [
-        "Du har rett til innsyn i sakens opplysninger. Dette får du ved å logge deg inn på nav.no, eller ved å ta kontakt nav.no/kontaktoss.",
+        "Du kan se opplysninger i saken ved å logge deg inn på nav.no eller kontakte oss på nav.no/kontaktoss.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },
     {
-      title: "Du har rett til å klage",
+      texts: ["Rett til å klage:"],
+      type: DocumentComponentType.HEADER_H3,
+    },
+    {
       texts: [
-        "Hvis du ikke er enig i resultatet, kan du klage innen seks uker fra den datoen du mottok dette brevet. Les mer på nav.no/klagerettigheter og nav.no/klage#sykepenger.",
+        "Hvis du ikke er enig i vedtaket, kan du klage innen seks uker fra du mottok dette brevet.",
       ],
       type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: ["Les mer om hvordan du klager her:"],
+      type: DocumentComponentType.PARAGRAPH,
+    },
+    {
+      texts: ["nav.no/klagerettigheter", "nav.no/klage#sykepenger"],
+      type: DocumentComponentType.BULLET_POINTS,
     },
     {
       texts: ["Med vennlig hilsen", VEILEDER_DEFAULT.fulltNavn(), "Nav"],

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -162,7 +162,7 @@ export const getExpectedVedtakDocument = ({
     },
     {
       texts: [
-        "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller 55 55 33 33.",
+        "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller telefon 55 55 33 33.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -162,7 +162,7 @@ export const getExpectedVedtakDocument = ({
     },
     {
       texts: [
-        "Du kan se opplysninger i saken ved å logge deg inn på nav.no eller kontakte oss på nav.no/kontaktoss.",
+        "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller 55 55 33 33.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -117,7 +117,7 @@ export const getExpectedVedtakDocument = ({
     },
     {
       texts: [
-        "For å få sykepenger gjennom friskmelding til arbeidsformidling må du være registrert som arbeidssøker hos Nav og søke om sykepenger hver 14. dag. Du kan da få sykepenger i opptil 12 uker mens du søker etter ny jobb. Du vil få beskjed fra oss når søknaden er klar til å fylles ut. Hvis du ikke lenger ønsker å motta sykepenger fra Nav, må du gi beskjed om det i søknaden. ",
+        "For å få sykepenger gjennom friskmelding til arbeidsformidling må du være registrert som arbeidssøker hos Nav og søke om sykepenger hver 14. dag. Du kan da få sykepenger i opptil 12 uker mens du søker etter ny jobb. Du vil få beskjed fra oss når søknaden er klar til å fylles ut. Hvis du ikke lenger ønsker å motta sykepenger fra Nav, må du gi beskjed om det i søknaden.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -7,11 +7,7 @@ import {
   ARBEIDSTAKER_DEFAULT_FULL_NAME,
   VEILEDER_DEFAULT,
 } from "@/mocks/common/mockConstants";
-import {
-  addWeeks,
-  tilDatoMedManedNavn,
-  tilLesbarDatoMedArUtenManedNavn,
-} from "@/utils/datoUtils";
+import { addWeeks, tilDatoMedManedNavn } from "@/utils/datoUtils";
 import {
   DocumentComponentDto,
   DocumentComponentType,
@@ -79,7 +75,7 @@ export const getExpectedVedtakDocument = ({
       ? [
           {
             texts: [
-              `Siden din maksdato for sykepenger er beregnet til ${tilLesbarDatoMedArUtenManedNavn(
+              `Siden din maksdato for sykepenger er beregnet til ${tilDatoMedManedNavn(
                 tom
               )}, vil du ikke få sykepenger etter denne datoen.`,
             ],

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -44,12 +44,6 @@ export const getExpectedVedtakDocument = ({
 }: ExpectedVedtakDocumentOptions): DocumentComponentDto[] => {
   return [
     {
-      texts: [
-        `${ARBEIDSTAKER_DEFAULT_FULL_NAME}, ${ARBEIDSTAKER_DEFAULT.personIdent}`,
-      ],
-      type: DocumentComponentType.PARAGRAPH,
-    },
-    {
       texts: ["Vedtak om friskmelding til arbeidsformidling"],
       type: DocumentComponentType.HEADER_H1,
     },
@@ -158,7 +152,7 @@ export const getExpectedVedtakDocument = ({
     },
     {
       texts: [
-        "Hvis du har spørsmål, kan du kontakte oss via: nav.no/kontaktoss/endringer.",
+        "Hvis du har spørsmål, kan du kontakte oss via: nav.no/kontaktoss.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -2,11 +2,7 @@ import {
   InfotrygdStatus,
   VedtakResponseDTO,
 } from "@/data/frisktilarbeid/frisktilarbeidTypes";
-import {
-  ARBEIDSTAKER_DEFAULT,
-  ARBEIDSTAKER_DEFAULT_FULL_NAME,
-  VEILEDER_DEFAULT,
-} from "@/mocks/common/mockConstants";
+import { VEILEDER_DEFAULT } from "@/mocks/common/mockConstants";
 import { addWeeks, tilDatoMedManedNavn } from "@/utils/datoUtils";
 import {
   DocumentComponentDto,

--- a/test/frisktilarbeid/frisktilarbeidTestData.ts
+++ b/test/frisktilarbeid/frisktilarbeidTestData.ts
@@ -113,7 +113,7 @@ export const getExpectedVedtakDocument = ({
     },
     {
       texts: [
-        "Hvis du får en ny jobb underveis hvor du tjener like mye eller mer enn sykepengene du får fra Nav, eller du begynner å jobbe mer enn 80 % av det du gjorde før du ble sykmeldt, vil du ikke ha rett på sykepenger lenger. Da stanser Nav utbetalingen din.",
+        "Hvis du får en ny jobb hvor du tjener like mye eller mer enn sykepengene du får fra Nav, vil du ikke ha rett på sykepenger lenger. Dette gjelder også hvis du begynner å jobbe mer enn 80 % av det du gjorde før du ble sykmeldt.",
       ],
       type: DocumentComponentType.PARAGRAPH,
     },


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret tekster i 8-5 brevet

Venter på avklaring av:
- [x] Tekst og evt. plassering for hvis til dato er samme som maksdato
- [x] Plassering av begrunnelsen til veileder

### Screenshots 📸✨
Før ([vedtak-om-friskmelding-til-arbeidsformidling-gammel.pdf](https://github.com/user-attachments/files/20571566/vedtak-om-friskmelding-til-arbeidsformidling-gammel.pdf)):
![image](https://github.com/user-attachments/assets/357bbf59-aa5a-4450-bddd-272b00c8c6c2)

Etter ([vedtak-om-friskmelding-til-arbeidsformidling-ny.pdf](https://github.com/user-attachments/files/20571593/vedtak-om-friskmelding-til-arbeidsformidling-ny.pdf)):
![image](https://github.com/user-attachments/assets/b13c3d08-f8da-4326-9670-aca426757615)
