### PR TITLE
IS-3287: Change text for tilbakemelding and add Ny-tag

### DIFF
--- a/src/components/motebehov/BehandleMotebehovKnapp.tsx
+++ b/src/components/motebehov/BehandleMotebehovKnapp.tsx
@@ -15,6 +15,7 @@ import {
   Radio,
   RadioGroup,
   ReadMore,
+  Tag,
   VStack,
 } from "@navikt/ds-react";
 import { useBehandleMotebehovAndSendTilbakemelding } from "@/data/motebehov/useBehandleMotebehovAndSendTilbakemelding";
@@ -32,10 +33,21 @@ const texts = {
   vurdertMedTilbakemelding:
     "Jeg har vurdert møtebehovet og vil gi tilbakemelding til innmelder(e)",
   tilbakemeldingHeader:
-    "Vi sender en automatisk tilbakemelding til innmelder. Klikk her om du vil se hele teksten.",
+    "Dette er tilbakemeldingen vi sender automatisk til innmelder.",
   tilbakemelding:
-    "Vi har mottatt ditt ønske om dialogmøte med Nav. Vi vurderer at det på nåværende tidspunkt ikke er aktuelt at Nav kaller inn til et dialogmøte. Du kan når som helst melde inn et nytt behov i sykefraværsperioden.",
+    "Etter dialog med deg har vi kommet frem til at Nav ikke kaller inn til dialogmøte på nåværende tidspunkt. Du kan be om dialogmøte senere eller hvis det skjer endringer.",
 };
+
+function ReadMoreHeader() {
+  return (
+    <div>
+      <Tag variant="info" size="xsmall" className="w-fit mr-1">
+        Ny
+      </Tag>
+      {texts.tilbakemeldingHeader}
+    </div>
+  );
+}
 
 export default function BehandleMotebehovKnapp() {
   const { data: motebehovData } = useMotebehovQuery();
@@ -75,7 +87,7 @@ export default function BehandleMotebehovKnapp() {
         <Radio value={false}>{texts.vurdertUtenTilbakemelding}</Radio>
         <Radio value={true}>{texts.vurdertMedTilbakemelding}</Radio>
         {isTilbakemelding && (
-          <ReadMore size="small" header={texts.tilbakemeldingHeader}>
+          <ReadMore size="small" header={<ReadMoreHeader />} defaultOpen>
             {texts.tilbakemelding}
           </ReadMore>
         )}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Endret tekst som sendes til arbeidsgiver eller sykmeldt ved innmeldt møtebehov. Ettersom teksten inneholder info som sier noe om at veileder allerede har snakket med innmelder, så ble Stine og jeg enige om å legge på en Ny-tag og å gjøre ReadMore-komponenten default-åpen slik at veilederne får dette med seg.

EDIT: Flyttet Ny-tagen opp på headeren til ReadMore-elementet.

### Screenshots 📸✨

![image](https://github.com/user-attachments/assets/836c0175-ce50-4d80-8c07-9063ccf5eb10)
