### PR TITLE
IS-3311: Move infobox

### DIFF
--- a/src/components/motebehov/BehandleMotebehovKnapp.tsx
+++ b/src/components/motebehov/BehandleMotebehovKnapp.tsx
@@ -78,6 +78,7 @@ export default function BehandleMotebehovKnapp() {
   );
   return ubehandledeMotebehov.length !== 0 ? (
     <VStack className="flex gap-4">
+      {minstEnHarMeldtBehov && <HjelpetekstVedMeldtBehov />}
       <RadioGroup
         defaultValue={false}
         size="small"
@@ -101,7 +102,6 @@ export default function BehandleMotebehovKnapp() {
           }
         />
       )}
-      {minstEnHarMeldtBehov && <HjelpetekstVedMeldtBehov />}
       <Button
         className="w-max"
         loading={

--- a/src/components/motebehov/HjelpetekstVedMeldtBehov.tsx
+++ b/src/components/motebehov/HjelpetekstVedMeldtBehov.tsx
@@ -13,7 +13,7 @@ const texts = {
 
 export default function HjelpetekstVedMeldtBehov() {
   return (
-    <Accordion>
+    <Accordion size="small" headingSize="xsmall" className="mb-4">
       <Accordion.Item>
         <Accordion.Header>{texts.header}</Accordion.Header>
         <Accordion.Content>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Flytter infoboks slik at veiledere ikke skal bli forvirret om informasjonen i infoboks sendes med som informasjon til innmelder av møtebehov

### Screenshots 📸✨

Før

![Screenshot 2025-06-13 at 14 28 41](https://github.com/user-attachments/assets/de79ea52-079b-4504-9a9a-788f5306ea1c)

Etter

![Screenshot 2025-06-13 at 14 27 11](https://github.com/user-attachments/assets/9080e22c-7468-408f-a155-f78d828b34db)
