### PR TITLE
IS-3321: Endre DM referat standardtekst om okonomisk stotte

### DIFF
--- a/src/sider/dialogmoter/hooks/dialogmoteTexts.ts
+++ b/src/sider/dialogmoter/hooks/dialogmoteTexts.ts
@@ -325,7 +325,7 @@ export const referatStandardTekster: Record<StandardtekstKey, StandardTekst> = {
   },
   [StandardtekstKey.OKONOMISK_STOTTE]: {
     label: "Hjelp til å søke om annen økonomisk støtte",
-    text: "Klarer du ikke å komme tilbake i arbeid før den siste dagen du har rett til sykepenger, trenger vi et nytt dialogmøte. Da vil vi snakke sammen om hvordan du eventuelt kan søke om annen økonomisk støtte fra Nav.",
+    text: "Dersom du ikke kan komme tilbake i arbeid før sykepengene tar slutt, kan du ha rett til annen økonomisk støtte. Ta kontakt med Nav for veiledning eller hjelp til å søke.",
   },
   [StandardtekstKey.INGEN_RETTIGHETER]: {
     label: "Ingen videre rettigheter",


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endrer tekst som blir med dialogmøte referat om man huker av for at man har opplyst

### Screenshots 📸✨

https://github.com/user-attachments/assets/e7654d29-fa00-4c6e-a70b-cdeea2bd3a99

