### PR TITLE
IS-2700: Hente kjønn og fødselsdato fra PDL

### DIFF
--- a/src/components/personkort/PersonkortHeader/KjonnIkon.tsx
+++ b/src/components/personkort/PersonkortHeader/KjonnIkon.tsx
@@ -2,23 +2,11 @@ import { KJOENN } from "@/konstanter";
 import { getKvinneImage, getMannImage } from "@/utils/festiveUtils";
 import React from "react";
 
-export function hentBrukersKjoennFraFnr(fnr: string) {
-  const kjonnSiffer = Number(fnr.substring(8, 9));
-  if (kjonnSiffer % 2 === 0) {
-    return KJOENN.KVINNE;
-  }
-  return KJOENN.MANN;
-}
-
-export function KjonnIkon({ personident }: { personident: string }) {
+export function KjonnIkon({ kjonn }: { kjonn: string | null }) {
   return (
     <img
       className="mr-4"
-      src={
-        hentBrukersKjoennFraFnr(personident) === KJOENN.KVINNE
-          ? getKvinneImage()
-          : getMannImage()
-      }
+      src={kjonn === KJOENN.KVINNE ? getKvinneImage() : getMannImage()}
       alt="person"
     />
   );

--- a/src/components/personkort/PersonkortHeader/KjonnIkon.tsx
+++ b/src/components/personkort/PersonkortHeader/KjonnIkon.tsx
@@ -1,12 +1,15 @@
-import { KJOENN } from "@/konstanter";
+import { KJOENN, Kjoenn } from "@/data/navbruker/types/BrukerinfoDTO";
 import { getKvinneImage, getMannImage } from "@/utils/festiveUtils";
 import React from "react";
 
-export function KjonnIkon({ kjonn }: { kjonn: string | null }) {
+export function KjonnIkon({ kjonn }: { kjonn: Kjoenn }) {
+  if (kjonn === Kjoenn.UKJENT) {
+    return null;
+  }
   return (
     <img
       className="mr-4"
-      src={kjonn === KJOENN.KVINNE ? getKvinneImage() : getMannImage()}
+      src={kjonn === Kjoenn.KVINNE ? getKvinneImage() : getMannImage()}
       alt="person"
     />
   );

--- a/src/components/personkort/PersonkortHeader/KjonnIkon.tsx
+++ b/src/components/personkort/PersonkortHeader/KjonnIkon.tsx
@@ -1,15 +1,15 @@
-import { KJOENN, Kjoenn } from "@/data/navbruker/types/BrukerinfoDTO";
+import { KJOENN } from "@/konstanter";
 import { getKvinneImage, getMannImage } from "@/utils/festiveUtils";
 import React from "react";
 
-export function KjonnIkon({ kjonn }: { kjonn: Kjoenn }) {
-  if (kjonn === Kjoenn.UKJENT) {
+export function KjonnIkon({ kjonn }: { kjonn: KJOENN }) {
+  if (kjonn === KJOENN.UKJENT) {
     return null;
   }
   return (
     <img
       className="mr-4"
-      src={kjonn === Kjoenn.KVINNE ? getKvinneImage() : getMannImage()}
+      src={kjonn === KJOENN.KVINNE ? getKvinneImage() : getMannImage()}
       alt="person"
     />
   );

--- a/src/components/personkort/PersonkortHeader/NavnHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/NavnHeader.tsx
@@ -15,7 +15,7 @@ export function NavnHeader({ navnSykmeldt, alder }: Props) {
     <div className="flex items-center">
       <Heading size="xsmall" level="3">
         {navnSykmeldt}
-        {alder != null && ` (${alder} år)`}
+        {alder !== null && ` (${alder} år)`}
       </Heading>
       {hasGjentakendeSykefravar && (
         <Tooltip content={"Gjentatt sykefravær"}>

--- a/src/components/personkort/PersonkortHeader/NavnHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/NavnHeader.tsx
@@ -8,7 +8,7 @@ interface Props {
   fodselsdato: string | null;
 }
 
-function hentBrukersAlderFraFodselsdato(fodselsdato: string | null) {
+function beregnBrukersAlderFraFodselsdato(fodselsdato: string | null) {
   if (!fodselsdato) return null;
   const dagensDato = new Date();
   const fodselsdatoDate = new Date(fodselsdato);
@@ -22,11 +22,13 @@ function hentBrukersAlderFraFodselsdato(fodselsdato: string | null) {
 
 export function NavnHeader({ navnSykmeldt, fodselsdato }: Props) {
   const { hasGjentakendeSykefravar } = useOppfolgingstilfellePersonQuery();
+  const alder = beregnBrukersAlderFraFodselsdato(fodselsdato);
 
   return (
     <div className="flex items-center">
       <Heading size="xsmall" level="3">
-        {`${navnSykmeldt} (${hentBrukersAlderFraFodselsdato(fodselsdato)} år)`}
+        {navnSykmeldt}
+        {alder !== null && ` (${alder} år)`}
       </Heading>
       {hasGjentakendeSykefravar && (
         <Tooltip content={"Gjentatt sykefravær"}>

--- a/src/components/personkort/PersonkortHeader/NavnHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/NavnHeader.tsx
@@ -5,30 +5,17 @@ import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/pe
 
 interface Props {
   navnSykmeldt: string;
-  fodselsdato: string | null;
+  alder: number | null;
 }
 
-function beregnBrukersAlderFraFodselsdato(fodselsdato: string | null) {
-  if (!fodselsdato) return null;
-  const dagensDato = new Date();
-  const fodselsdatoDate = new Date(fodselsdato);
-  const fodselsDatoIAr = new Date(fodselsdatoDate);
-  fodselsDatoIAr.setFullYear(dagensDato.getFullYear());
-  if (dagensDato.getTime() < fodselsDatoIAr.getTime()) {
-    return dagensDato.getFullYear() - fodselsdatoDate.getFullYear() - 1;
-  }
-  return dagensDato.getFullYear() - fodselsdatoDate.getFullYear();
-}
-
-export function NavnHeader({ navnSykmeldt, fodselsdato }: Props) {
+export function NavnHeader({ navnSykmeldt, alder }: Props) {
   const { hasGjentakendeSykefravar } = useOppfolgingstilfellePersonQuery();
-  const alder = beregnBrukersAlderFraFodselsdato(fodselsdato);
 
   return (
     <div className="flex items-center">
       <Heading size="xsmall" level="3">
         {navnSykmeldt}
-        {alder !== null && ` (${alder} år)`}
+        {alder != null && ` (${alder} år)`}
       </Heading>
       {hasGjentakendeSykefravar && (
         <Tooltip content={"Gjentatt sykefravær"}>

--- a/src/components/personkort/PersonkortHeader/NavnHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/NavnHeader.tsx
@@ -2,35 +2,31 @@ import { Heading, Tooltip } from "@navikt/ds-react";
 import { ArrowsCirclepathIcon } from "@navikt/aksel-icons";
 import React from "react";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
-import { hentBrukersFoedseldatoFraFnr } from "@/utils/fnrUtils";
 
 interface Props {
   navnSykmeldt: string;
-  personident: string;
+  fodselsdato: string | null;
 }
 
-export function hentBrukersAlderFraFnr(fnr: string) {
+function hentBrukersAlderFraFodselsdato(fodselsdato: string | null) {
+  if (!fodselsdato) return null;
   const dagensDato = new Date();
-  const fodselsdato = hentBrukersFoedseldatoFraFnr(fnr);
-
-  if (fodselsdato) {
-    const fodselsDatoIAr = new Date(fodselsdato);
-    fodselsDatoIAr.setFullYear(dagensDato.getFullYear());
-    if (fodselsdato && dagensDato.getTime() < fodselsDatoIAr.getTime()) {
-      return dagensDato.getFullYear() - fodselsdato.getFullYear() - 1;
-    }
-    return fodselsdato && dagensDato.getFullYear() - fodselsdato.getFullYear();
+  const fodselsdatoDate = new Date(fodselsdato);
+  const fodselsDatoIAr = new Date(fodselsdatoDate);
+  fodselsDatoIAr.setFullYear(dagensDato.getFullYear());
+  if (dagensDato.getTime() < fodselsDatoIAr.getTime()) {
+    return dagensDato.getFullYear() - fodselsdatoDate.getFullYear() - 1;
   }
-  return null;
+  return dagensDato.getFullYear() - fodselsdatoDate.getFullYear();
 }
 
-export function NavnHeader({ navnSykmeldt, personident }: Props) {
+export function NavnHeader({ navnSykmeldt, fodselsdato }: Props) {
   const { hasGjentakendeSykefravar } = useOppfolgingstilfellePersonQuery();
 
   return (
     <div className="flex items-center">
       <Heading size="xsmall" level="3">
-        {`${navnSykmeldt} (${hentBrukersAlderFraFnr(personident)} år)`}
+        {`${navnSykmeldt} (${hentBrukersAlderFraFodselsdato(fodselsdato)} år)`}
       </Heading>
       {hasGjentakendeSykefravar && (
         <Tooltip content={"Gjentatt sykefravær"}>

--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -13,7 +13,7 @@ import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 import { NavnHeader } from "@/components/personkort/PersonkortHeader/NavnHeader";
 import Utbetalingsinfo from "@/components/personkort/PersonkortHeader/Utbetalingsinfo";
 import { formaterFnr } from "@/utils/fnrUtils";
-import { mapKjoennFromDto, Kjoenn } from "@/data/navbruker/types/BrukerinfoDTO";
+import { mapKjoennFromDto } from "@/data/navbruker/types/BrukerinfoDTO";
 
 const texts = {
   copied: "Kopiert!",

--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -37,9 +37,12 @@ export function PersonkortHeader() {
   return (
     <>
       <div className="flex personkortHeader__info">
-        <KjonnIkon personident={personident} />
+        <KjonnIkon kjonn={navbruker.kjonn} />
         <div>
-          <NavnHeader navnSykmeldt={navbruker.navn} personident={personident} />
+          <NavnHeader
+            navnSykmeldt={navbruker.navn}
+            fodselsdato={navbruker.fodselsdato}
+          />
 
           <StyledFnr>
             {formaterFnr(personident)}

--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -40,10 +40,7 @@ export function PersonkortHeader() {
       <div className="flex personkortHeader__info">
         <KjonnIkon kjonn={mapKjoennFromDto(navbruker.kjonn)} />
         <div>
-          <NavnHeader
-            navnSykmeldt={navbruker.navn}
-            fodselsdato={navbruker.fodselsdato}
-          />
+          <NavnHeader navnSykmeldt={navbruker.navn} alder={navbruker.alder} />
 
           <StyledFnr>
             {formaterFnr(personident)}

--- a/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
+++ b/src/components/personkort/PersonkortHeader/PersonkortHeader.tsx
@@ -13,6 +13,7 @@ import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 import { NavnHeader } from "@/components/personkort/PersonkortHeader/NavnHeader";
 import Utbetalingsinfo from "@/components/personkort/PersonkortHeader/Utbetalingsinfo";
 import { formaterFnr } from "@/utils/fnrUtils";
+import { mapKjoennFromDto, Kjoenn } from "@/data/navbruker/types/BrukerinfoDTO";
 
 const texts = {
   copied: "Kopiert!",
@@ -37,7 +38,7 @@ export function PersonkortHeader() {
   return (
     <>
       <div className="flex personkortHeader__info">
-        <KjonnIkon kjonn={navbruker.kjonn} />
+        <KjonnIkon kjonn={mapKjoennFromDto(navbruker.kjonn)} />
         <div>
           <NavnHeader
             navnSykmeldt={navbruker.navn}

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -30,6 +30,8 @@ export const useBrukerinfoQuery = () => {
     aktivPersonident: "",
     arbeidssituasjon: "ARBEIDSTAKER",
     dodsdato: null,
+    kjonn: null,
+    fodselsdato: null,
     tilrettelagtKommunikasjon: {
       talesprakTolk: null,
       tegnsprakTolk: null,

--- a/src/data/navbruker/navbrukerQueryHooks.ts
+++ b/src/data/navbruker/navbrukerQueryHooks.ts
@@ -30,8 +30,9 @@ export const useBrukerinfoQuery = () => {
     aktivPersonident: "",
     arbeidssituasjon: "ARBEIDSTAKER",
     dodsdato: null,
-    kjonn: null,
+    kjonn: "UKJENT",
     fodselsdato: null,
+    alder: null,
     tilrettelagtKommunikasjon: {
       talesprakTolk: null,
       tegnsprakTolk: null,

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -12,6 +12,7 @@ export interface BrukerinfoDTO {
   arbeidssituasjon: string;
   kjonn: string | null;
   fodselsdato: string | null;
+  alder: number | null;
   dodsdato: string | null;
   tilrettelagtKommunikasjon: TilrettelagtKommunikasjon | null;
   sikkerhetstiltak: Sikkerhetstiltak[];

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -1,3 +1,5 @@
+import { KJOENN } from "@/konstanter";
+
 export interface KontaktinfoDTO {
   epost?: string;
   tlf?: string;
@@ -40,19 +42,13 @@ interface Sikkerhetstiltak {
   gyldigTom: Date;
 }
 
-export enum Kjoenn {
-  MANN = "MANN",
-  KVINNE = "KVINNE",
-  UKJENT = "UKJENT",
-}
-
-export function mapKjoennFromDto(kjonn: string | null): Kjoenn {
+export function mapKjoennFromDto(kjonn: string | null): KJOENN {
   switch (kjonn) {
-    case Kjoenn.MANN:
-      return Kjoenn.MANN;
-    case Kjoenn.KVINNE:
-      return Kjoenn.KVINNE;
+    case KJOENN.MANN:
+      return KJOENN.MANN;
+    case KJOENN.KVINNE:
+      return KJOENN.KVINNE;
     default:
-      return Kjoenn.UKJENT;
+      return KJOENN.UKJENT;
   }
 }

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -39,3 +39,20 @@ interface Sikkerhetstiltak {
   gyldigFom: Date;
   gyldigTom: Date;
 }
+
+export enum Kjoenn {
+  MANN = "MANN",
+  KVINNE = "KVINNE",
+  UKJENT = "UKJENT",
+}
+
+export function mapKjoennFromDto(kjonn: string | null): Kjoenn {
+  switch (kjonn) {
+    case Kjoenn.MANN:
+      return Kjoenn.MANN;
+    case Kjoenn.KVINNE:
+      return Kjoenn.KVINNE;
+    default:
+      return Kjoenn.UKJENT;
+  }
+}

--- a/src/data/navbruker/types/BrukerinfoDTO.ts
+++ b/src/data/navbruker/types/BrukerinfoDTO.ts
@@ -8,6 +8,8 @@ export interface BrukerinfoDTO {
   navn: string;
   aktivPersonident: string;
   arbeidssituasjon: string;
+  kjonn: string | null;
+  fodselsdato: string | null;
   dodsdato: string | null;
   tilrettelagtKommunikasjon: TilrettelagtKommunikasjon | null;
   sikkerhetstiltak: Sikkerhetstiltak[];

--- a/src/konstanter.ts
+++ b/src/konstanter.ts
@@ -6,7 +6,8 @@ export const PERSONKORTVISNING_TYPE = {
   SIKKERHETSTILTAK: "SIKKERHETSTILTAK",
 };
 
-export const KJOENN = {
-  KVINNE: "KVINNE",
-  MANN: "MANN",
-};
+export enum KJOENN {
+  KVINNE = "KVINNE",
+  MANN = "MANN",
+  UKJENT = "UKJENT",
+}

--- a/src/mocks/syfoperson/persondataMock.ts
+++ b/src/mocks/syfoperson/persondataMock.ts
@@ -16,6 +16,8 @@ export const brukerinfoMock: BrukerinfoDTO = {
   navn: ARBEIDSTAKER_DEFAULT_FULL_NAME,
   arbeidssituasjon: "ARBEIDSTAKER",
   dodsdato: null,
+  kjonn: "MANN",
+  fodselsdato: "1969-02-19",
   tilrettelagtKommunikasjon: null,
   sikkerhetstiltak: [],
 };

--- a/src/mocks/syfoperson/persondataMock.ts
+++ b/src/mocks/syfoperson/persondataMock.ts
@@ -18,6 +18,7 @@ export const brukerinfoMock: BrukerinfoDTO = {
   dodsdato: null,
   kjonn: "MANN",
   fodselsdato: "1969-02-19",
+  alder: 56,
   tilrettelagtKommunikasjon: null,
   sikkerhetstiltak: [],
 };

--- a/src/utils/fnrUtils.ts
+++ b/src/utils/fnrUtils.ts
@@ -1,32 +1,3 @@
 export const formaterFnr = (fnr: string) => {
   return fnr ? fnr.replace(/(......)(.....)/g, "$1 $2") : null;
 };
-
-export function hentBrukersFoedseldatoFraFnr(fnr: string) {
-  const individSifre = Number(fnr.substring(6, 9));
-
-  const dag = Number(fnr.substring(0, 2));
-  const foedselsDag = dag > 40 ? dag - 40 : dag;
-  const mnd = Number(fnr.substring(2, 4));
-  const fodselsMnd = mnd > 40 ? mnd - 40 : mnd;
-  const aar = Number(fnr.substring(4, 6));
-  let arhundre;
-  if (individSifre >= 0 && individSifre <= 499) {
-    arhundre = 19;
-  } else if (individSifre >= 500 && individSifre <= 749 && aar > 55) {
-    arhundre = 18;
-  } else if (individSifre >= 500 && individSifre <= 999 && aar <= 39) {
-    arhundre = 20;
-  } else if (individSifre >= 900 && individSifre <= 999 && aar >= 40) {
-    arhundre = 19;
-  } else {
-    return undefined;
-  }
-  const fodselsAr = arhundre * 100 + aar;
-  const fodselsdato = new Date();
-  fodselsdato.setUTCDate(foedselsDag);
-  fodselsdato.setUTCMonth(fodselsMnd - 1);
-  fodselsdato.setUTCFullYear(fodselsAr);
-  fodselsdato.setUTCHours(0, 0, 0, 0);
-  return fodselsdato;
-}

--- a/test/utils/fnrUtilsTest.js
+++ b/test/utils/fnrUtilsTest.js
@@ -2,87 +2,9 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { KJOENN } from "@/konstanter";
 import { hentBrukersKjoennFraFnr } from "@/components/personkort/PersonkortHeader/KjonnIkon";
 import { hentBrukersAlderFraFnr } from "@/components/personkort/PersonkortHeader/NavnHeader";
-import { formaterFnr, hentBrukersFoedseldatoFraFnr } from "@/utils/fnrUtils";
+import { formaterFnr } from "@/utils/fnrUtils";
 
 describe("fnrUtils", () => {
-  describe("hentBrukersFoedseldatoFraFnr", () => {
-    const assertLik = (verdi, resultat) => {
-      expect(hentBrukersFoedseldatoFraFnr(verdi).getTime()).to.equal(
-        resultat.getTime()
-      );
-    };
-    const assertUndefined = (verdi) => {
-      expect(hentBrukersFoedseldatoFraFnr(verdi)).to.equal(undefined);
-    };
-
-    it("Skal returnere undefined, med gyldig foedselsnummer, men ugyldig individsifre", () => {
-      assertUndefined("14018089988");
-    });
-
-    it("Skal returnere rett foedselsdato, med gyldig D-nummer", () => {
-      const foedselsdato = new Date("1980-01-14");
-      assertLik("54018010088", foedselsdato);
-    });
-
-    it("Skal returnere rett foedselsdato, med gyldig H-nummer", () => {
-      const foedselsdato = new Date("1980-01-14");
-      assertLik("14418010088", foedselsdato);
-    });
-
-    describe("Personer foedt [1900-1999], med individsifre:[000, 499]", () => {
-      const foedselsdato = new Date("1980-01-14");
-      it("Skal returnere rett foedselsdato, for individsifre 000", () => {
-        assertLik("14018000088", foedselsdato);
-      });
-
-      it("Skal returnere rett foedselsdato, for individsifre 499", () => {
-        assertLik("14018049988", foedselsdato);
-      });
-    });
-
-    describe("Personer foedt [1855-1899], med individsifre:[500, 749]", () => {
-      const foedselsdato = new Date("1880-01-14");
-      it("Skal returnere rett foedselsdato, for individsifre 500", () => {
-        assertLik("14018050088", foedselsdato);
-      });
-
-      it("Skal returnere rett foedselsdato, for individsifre 749", () => {
-        assertLik("14018074988", foedselsdato);
-      });
-    });
-
-    describe("Personer foedt [2000-2039], med individsifre:[500, 999]", () => {
-      const foedselsdato = new Date("2000-01-14");
-      it("Skal returnere rett foedselsdato, for individsifre 500", () => {
-        assertLik("14010050088", foedselsdato);
-      });
-
-      it("Skal returnere rett foedselsdato, for individsifre 749", () => {
-        assertLik("14010074988", foedselsdato);
-      });
-
-      it("Skal returnere rett foedselsdato, for individsifre 999", () => {
-        assertLik("14010099988", foedselsdato);
-      });
-
-      it("Skal returnere rett foedselsdato", () => {
-        const foedselsdato = new Date("2039-01-14");
-        assertLik("14013999988", foedselsdato);
-      });
-    });
-
-    describe("Personer foedt [1940-1999], med individsifre:[900, 999]", () => {
-      const foedselsdato = new Date("1940-01-14");
-      it("Skal returnere rett foedselsdato, for individsifre 900", () => {
-        assertLik("14014090088", foedselsdato);
-      });
-
-      it("Skal returnere rett foedselsdato, for individsifre 999", () => {
-        assertLik("14014099988", foedselsdato);
-      });
-    });
-  });
-
   describe("hentBrukersKjoennFraFnr", () => {
     it("Skal returnere kvinne, om 3. individsiffer er partall", () => {
       expect(hentBrukersKjoennFraFnr("01019900200")).to.equal(KJOENN.KVINNE);

--- a/test/utils/fnrUtilsTest.js
+++ b/test/utils/fnrUtilsTest.js
@@ -1,65 +1,7 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { KJOENN } from "@/konstanter";
-import { hentBrukersKjoennFraFnr } from "@/components/personkort/PersonkortHeader/KjonnIkon";
-import { hentBrukersAlderFraFnr } from "@/components/personkort/PersonkortHeader/NavnHeader";
+import { describe, expect, it } from "vitest";
 import { formaterFnr } from "@/utils/fnrUtils";
 
 describe("fnrUtils", () => {
-  describe("hentBrukersKjoennFraFnr", () => {
-    it("Skal returnere kvinne, om 3. individsiffer er partall", () => {
-      expect(hentBrukersKjoennFraFnr("01019900200")).to.equal(KJOENN.KVINNE);
-    });
-
-    it("Skal returnere mann, om 3. individsiffer er oddetall", () => {
-      expect(hentBrukersKjoennFraFnr("01019900100")).to.equal(KJOENN.MANN);
-    });
-  });
-
-  describe("hentBrukersAlderFraFnr", () => {
-    let dagensDato;
-
-    beforeEach(() => {
-      dagensDato = new Date();
-    });
-
-    const foedselsaar = 1958;
-    const hentFnrFraDato = (dato) => {
-      let dag = dato.getDate().toString();
-      dag = dag.length === 1 ? `0${dag}` : dag;
-      let mnd = (dato.getMonth() + 1).toString();
-      mnd = mnd.length === 1 ? `0${mnd}` : mnd;
-      const aar = dato.getFullYear().toString().substring(2, 4);
-      return `${dag + mnd + aar}33818`;
-    };
-
-    it("Skal returnere rett brukers alder, om bruker har hatt foedselsdag", () => {
-      const foedselsDatoPassert = new Date();
-      foedselsDatoPassert.setFullYear(foedselsaar);
-      const fnrFoedselsDatoPassert = hentFnrFraDato(foedselsDatoPassert);
-      const alder =
-        dagensDato.getFullYear() - foedselsDatoPassert.getFullYear();
-
-      expect(hentBrukersAlderFraFnr(fnrFoedselsDatoPassert)).to.equal(alder);
-    });
-
-    it("Skal returnere rett brukers alder, om bruker ikke har hatt foedselsdag", () => {
-      const foedselsdatoIkkePassert = new Date();
-      foedselsdatoIkkePassert.setFullYear(foedselsaar);
-      foedselsdatoIkkePassert.setTime(
-        foedselsdatoIkkePassert.getTime() + 24 * 60 * 60 * 1000
-      );
-      const fnrFoedselsDatoIkkePassert = hentFnrFraDato(
-        foedselsdatoIkkePassert
-      );
-      const alder =
-        dagensDato.getFullYear() - foedselsdatoIkkePassert.getFullYear() - 1;
-
-      expect(hentBrukersAlderFraFnr(fnrFoedselsDatoIkkePassert)).to.equal(
-        alder
-      );
-    });
-  });
-
   describe("formaterFnr", () => {
     it("Skal formatere fnr", () => {
       expect(formaterFnr("12121233333")).to.equal("121212 33333");


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Ingen synlig endring, men alder og kjønn skal nå vises basert på responsen fra PDL i stedet for å bli kalkulert fra personident'en.
