### PR TITLE
IS-3330: Stotte for å vise fordeling til ufordelt på historikk

### DIFF
--- a/src/components/side/tildeltveileder/TildeltVeileder.tsx
+++ b/src/components/side/tildeltveileder/TildeltVeileder.tsx
@@ -3,6 +3,7 @@ import { Button, Tag } from "@navikt/ds-react";
 import { useGetVeilederBrukerKnytning } from "@/data/veilederbrukerknytning/useGetVeilederBrukerKnytning";
 import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import EndreTildeltVeilederModal from "@/components/side/tildeltveileder/EndreTildeltVeilederModal";
+import { VeilederIdent } from "@/data/veilederbrukerknytning/useTildelVeileder";
 
 const texts = {
   tildeltVeileder: "Tildelt veileder: ",
@@ -11,7 +12,7 @@ const texts = {
 };
 
 interface VeilederNavnProps {
-  tildeltVeilederident: string;
+  tildeltVeilederident: VeilederIdent;
 }
 
 function VeilederNavn({ tildeltVeilederident }: VeilederNavnProps) {
@@ -25,7 +26,9 @@ function VeilederNavn({ tildeltVeilederident }: VeilederNavnProps) {
         : tildeltVeilederident}
     </span>
   ) : (
-    <span></span>
+    <Tag variant="info" size="small">
+      {texts.ufordelt}
+    </Tag>
   );
 }
 

--- a/src/data/veilederbrukerknytning/useGetVeilederBrukerKnytning.tsx
+++ b/src/data/veilederbrukerknytning/useGetVeilederBrukerKnytning.tsx
@@ -2,6 +2,10 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { get } from "@/api/axios";
 import { useQuery } from "@tanstack/react-query";
 import { SYFOOVERSIKTSRV_PERSONTILDELING_ROOT } from "@/apiConstants";
+import {
+  IkkeTildeltVeileder,
+  VeilederIdent,
+} from "@/data/veilederbrukerknytning/useTildelVeileder";
 
 export const veilederBrukerKnytningQueryKeys = {
   veilederBrukerKnytning: (personident: string) => [
@@ -43,13 +47,13 @@ export const useVeilederTildelingHistorikkData = () => {
 
 export interface VeilederBrukerKnytningDTO {
   personident: string;
-  tildeltVeilederident?: string;
+  tildeltVeilederident: VeilederIdent | IkkeTildeltVeileder;
   tildeltEnhet?: string;
 }
 
 export interface VeilederTildelingHistorikkDTO {
   tildeltDato: Date;
-  tildeltVeileder: string;
+  tildeltVeileder: VeilederIdent | IkkeTildeltVeileder;
   tildeltEnhet: string;
   tildeltAv: string;
 }

--- a/src/data/veilederinfo/veilederinfoQueryHooks.ts
+++ b/src/data/veilederinfo/veilederinfoQueryHooks.ts
@@ -3,6 +3,7 @@ import { get } from "@/api/axios";
 import { Veileder } from "@/data/veilederinfo/types/Veileder";
 import { useQuery } from "@tanstack/react-query";
 import { useValgtEnhet } from "@/context/ValgtEnhetContext";
+import { VeilederIdent } from "@/data/veilederbrukerknytning/useTildelVeileder";
 
 export const veilederinfoQueryKeys = {
   veilederinfo: ["veilederinfo"],
@@ -34,7 +35,7 @@ export const useAktivVeilederinfoQuery = () => {
   });
 };
 
-export const useVeilederInfoQuery = (ident: string) => {
+export const useVeilederInfoQuery = (ident: VeilederIdent) => {
   const fetchVeilederinfoByIdent = () =>
     get<Veileder>(`${SYFOVEILEDER_ROOT}/veiledere/${ident}`);
   return useQuery({

--- a/src/hooks/historikk/useVeilederTildelingHistorikk.ts
+++ b/src/hooks/historikk/useVeilederTildelingHistorikk.ts
@@ -22,6 +22,8 @@ function getHistorikkTekst(value: VeilederTildelingHistorikkDTO): string {
     value.tildeltAv == value.tildeltVeileder
   ) {
     return `${value.tildeltVeileder} på enhet ${value.tildeltEnhet} ble satt som veileder`;
+  } else if (value.tildeltVeileder === null) {
+    return `${value.tildeltAv} satt sykmeldt som ufordelt`;
   } else {
     return `${value.tildeltAv} satt ${value.tildeltVeileder} på enhet ${value.tildeltEnhet} som veileder`;
   }

--- a/src/mocks/syfooversiktsrv/mockSyfooversiktsrv.ts
+++ b/src/mocks/syfooversiktsrv/mockSyfooversiktsrv.ts
@@ -29,6 +29,12 @@ export const mockSyfooversiktsrv = [
         tildeltEnhet: "0315",
       },
       {
+        tildeltDato: "2024-06-21",
+        tildeltAv: "A123456",
+        tildeltVeileder: null,
+        tildeltEnhet: "0315",
+      },
+      {
         tildeltDato: "2024-02-21",
         tildeltAv: "X000000",
         tildeltVeileder: "A123456",

--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -113,7 +113,7 @@ export default function Historikk({
     historikkEvents
   );
 
-  function filteredEvents() {
+  function filteredEvents(): HistorikkEvent[] {
     if (selectedTilfelleIndex === 0) {
       return historikkEvents;
     } else if (selectedTilfelleIndex === -1) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til støtte for å vise historikk på når sykmeldt har blitt satt som ufordelt.


### Screenshots 📸✨
Før
<img width="1635" height="917" alt="Screenshot 2025-07-10 at 13 57 35" src="https://github.com/user-attachments/assets/b3597b5c-0bf9-49e2-9713-1e258eb095b9" />

Etter
<img width="1713" height="65" alt="Screenshot 2025-07-10 at 13 57 07" src="https://github.com/user-attachments/assets/0bd52c1c-67c0-4a36-b4a7-8c8882a585b3" />

