### PR TITLE
IS-3353: Forbedre kvitteringsside etter fattet 8-5 vedtak

### DIFF
--- a/src/sider/frisktilarbeid/FriskmeldingTilArbeidsformidling.tsx
+++ b/src/sider/frisktilarbeid/FriskmeldingTilArbeidsformidling.tsx
@@ -3,9 +3,9 @@ import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
 import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 import FattVedtakSkjema from "@/sider/frisktilarbeid/FattVedtakSkjema";
 import NyttVedtak from "@/sider/frisktilarbeid/NyttVedtak";
-import { VedtakFattet } from "@/sider/frisktilarbeid/VedtakFattet";
+import VedtakFattet from "@/sider/frisktilarbeid/VedtakFattet";
 
-export function FriskmeldingTilArbeidsformidling() {
+export default function FriskmeldingTilArbeidsformidling() {
   const { data } = useVedtakQuery();
   const [isNyVurderingStarted, setIsNyVurderingStarted] = useState(false);
 

--- a/src/sider/frisktilarbeid/FriskmeldingTilArbeidsformidlingSide.tsx
+++ b/src/sider/frisktilarbeid/FriskmeldingTilArbeidsformidlingSide.tsx
@@ -5,7 +5,7 @@ import SideLaster from "@/components/side/SideLaster";
 import * as Tredelt from "@/components/side/TredeltSide";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
-import { FriskmeldingTilArbeidsformidling } from "@/sider/frisktilarbeid/FriskmeldingTilArbeidsformidling";
+import FriskmeldingTilArbeidsformidling from "@/sider/frisktilarbeid/FriskmeldingTilArbeidsformidling";
 import VeiledningBox from "@/sider/frisktilarbeid/VeiledningBox";
 import { NotificationProvider } from "@/context/notification/NotificationContext";
 import NyttigeLenkerBox from "@/sider/frisktilarbeid/NyttigeLenkerBox";

--- a/src/sider/frisktilarbeid/NyttVedtak.tsx
+++ b/src/sider/frisktilarbeid/NyttVedtak.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from "react";
+import React, { useState } from "react";
 import {
   Alert,
   BodyShort,
@@ -8,7 +8,6 @@ import {
   Loader,
 } from "@navikt/ds-react";
 import dayjs from "dayjs";
-import { tilDatoMedManedNavn } from "@/utils/datoUtils";
 import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
 import { useNotification } from "@/context/notification/NotificationContext";
 import {
@@ -16,77 +15,19 @@ import {
   useVilkarForVedtakQuery,
 } from "@/data/frisktilarbeid/vedtakQuery";
 import KanIkkeFatteNyttVedtakAlert from "@/sider/frisktilarbeid/KanIkkeFatteNyttVedtakAlert";
+import VedtakInfoPanel from "@/sider/frisktilarbeid/VedtakInfoPanel";
 
 const texts = {
-  heading: {
-    startNytt: "Start nytt vedtak",
-    aktivtVedtak: "Aktivt vedtak",
-  },
+  startNyttVedtak: "Start nytt vedtak",
   nyttVedtak:
     "Her kan du fatte et nytt vedtak for § 8-5 friskmelding til arbeidsformidling. Husk å sjekke at alle nødvendige forutsetninger er oppfylt før ordningen starter.",
-  forrigeVedtakInfo: (
-    vedtakFattetDato: string,
-    vedtakStartText: string,
-    vedtakEndText: string
-  ) => {
-    return `Forrige vedtak på denne personen ble fattet ${vedtakFattetDato}. Perioden for friskmelding til arbeidsformidling ${vedtakStartText} og ${vedtakEndText}.`;
-  },
-  vedtakFattet: "Vedtak fattet:",
-  vedtakStartet: "Startet:",
-  vedtakAvsluttes: "Avsluttes:",
   nyttVedtakKnapp: "Nytt vedtak",
 };
-
-function ForrigeVedtakText({
-  vedtak,
-}: {
-  vedtak: VedtakResponseDTO;
-}): ReactElement {
-  const hasVedtakStarted = dayjs(vedtak.fom).isBefore(dayjs());
-  const hasVedtakEnded = dayjs(vedtak.tom).isBefore(dayjs());
-  const vedtakStartDato = tilDatoMedManedNavn(vedtak.fom);
-  const vedtakAvsluttetDato = tilDatoMedManedNavn(vedtak.tom);
-  const vedtakFattetDato = tilDatoMedManedNavn(vedtak.createdAt);
-  const vedtakStartText = hasVedtakStarted
-    ? `ble startet: ${vedtakStartDato}`
-    : `starter: ${vedtakStartDato}`;
-  const vedtakEndText = hasVedtakEnded
-    ? `ble avsluttet: ${vedtakAvsluttetDato}`
-    : `avsluttes: ${vedtakAvsluttetDato}`;
-
-  return (
-    <BodyShort>
-      {texts.forrigeVedtakInfo(
-        vedtakFattetDato,
-        vedtakStartText,
-        vedtakEndText
-      )}
-    </BodyShort>
-  );
-}
 
 function isActiveExistingVedtak(vedtak: VedtakResponseDTO): boolean {
   const vedtakTomDate = dayjs(vedtak.tom);
   const today = dayjs();
   return today.isBefore(vedtakTomDate) || today.isSame(vedtakTomDate, "date");
-}
-
-function AktivtVedtakInfo({ vedtak }: { vedtak: VedtakResponseDTO }) {
-  return (
-    <div>
-      <BodyShort>
-        {`${texts.vedtakFattet} ${tilDatoMedManedNavn(vedtak.createdAt)}`}
-      </BodyShort>
-      <div className="flex flex-row gap-4">
-        <BodyShort>
-          {`${texts.vedtakStartet} ${tilDatoMedManedNavn(vedtak.fom)}`}
-        </BodyShort>
-        <BodyShort>
-          {`${texts.vedtakAvsluttes} ${tilDatoMedManedNavn(vedtak.tom)}`}
-        </BodyShort>
-      </div>
-    </div>
-  );
 }
 
 interface Props {
@@ -95,6 +36,7 @@ interface Props {
 
 export default function NyttVedtak({ setIsNyVurderingStarted }: Props) {
   const { notification } = useNotification();
+  const [isNotificationVisible, setIsNotificationVisible] = useState(true);
   const { data } = useVedtakQuery();
   const { isRegisteredArbeidssoker, isPending } = useVilkarForVedtakQuery();
   const vedtak: VedtakResponseDTO | undefined = data[0];
@@ -104,52 +46,46 @@ export default function NyttVedtak({ setIsNyVurderingStarted }: Props) {
 
   return (
     <>
-      {notification && (
-        <Alert variant={"success"} className="mb-4">
+      {notification && isNotificationVisible && (
+        <Alert
+          variant={"success"}
+          className="mb-4"
+          closeButton
+          onClose={() => setIsNotificationVisible(false)}
+        >
           {notification.message}
         </Alert>
       )}
-      <div className="flex flex-col gap-4">
-        <Box
-          background="surface-default"
-          padding="6"
-          className="flex flex-col gap-4"
-        >
-          <Heading level="2" size="medium">
-            {isActiveVedtak
-              ? texts.heading.aktivtVedtak
-              : texts.heading.startNytt}
-          </Heading>
-          {isExistingVedtak ? (
-            isActiveVedtak ? (
-              <AktivtVedtakInfo vedtak={vedtak} />
-            ) : (
-              <ForrigeVedtakText vedtak={vedtak} />
-            )
-          ) : (
-            <BodyShort>{texts.nyttVedtak}</BodyShort>
-          )}
-          {isPending ? (
-            <Loader size="xlarge" title="Laster inn vilkår for vedtak" />
-          ) : (
-            <>
-              {!kanFatteNyttVedtak && (
-                <KanIkkeFatteNyttVedtakAlert
-                  isActiveVedtak={isActiveVedtak}
-                  isRegisteredArbeidssoker={!!isRegisteredArbeidssoker}
-                />
-              )}
-              <Button
-                className="w-fit"
-                onClick={() => setIsNyVurderingStarted(true)}
-                disabled={!kanFatteNyttVedtak}
-              >
-                {texts.nyttVedtakKnapp}
-              </Button>
-            </>
-          )}
-        </Box>
-      </div>
+      {isExistingVedtak && <VedtakInfoPanel vedtak={vedtak} className="mb-2" />}
+      <Box
+        background="surface-default"
+        padding="6"
+        className="flex flex-col gap-4"
+      >
+        <Heading level="3" size="medium">
+          {texts.startNyttVedtak}
+        </Heading>
+        {!isActiveVedtak && <BodyShort>{texts.nyttVedtak}</BodyShort>}
+        {isPending ? (
+          <Loader size="xlarge" title="Laster inn vilkår for vedtak" />
+        ) : (
+          <>
+            {!kanFatteNyttVedtak && (
+              <KanIkkeFatteNyttVedtakAlert
+                isActiveVedtak={isActiveVedtak}
+                isRegisteredArbeidssoker={!!isRegisteredArbeidssoker}
+              />
+            )}
+            <Button
+              className="w-fit"
+              onClick={() => setIsNyVurderingStarted(true)}
+              disabled={!kanFatteNyttVedtak}
+            >
+              {texts.nyttVedtakKnapp}
+            </Button>
+          </>
+        )}
+      </Box>
     </>
   );
 }

--- a/src/sider/frisktilarbeid/VedtakInfoPanel.tsx
+++ b/src/sider/frisktilarbeid/VedtakInfoPanel.tsx
@@ -1,0 +1,72 @@
+import { BodyShort, Box, Heading } from "@navikt/ds-react";
+import { CheckmarkCircleIcon } from "@navikt/aksel-icons";
+import React from "react";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils";
+import { VedtakResponseDTO } from "@/data/frisktilarbeid/frisktilarbeidTypes";
+import dayjs from "dayjs";
+
+const texts = {
+  aktivtVedtak: "Aktivt vedtak",
+  tidligereVedtak: "Tidligere vedtak",
+  gosysOppgaveSendt: "Gosys oppgaven er automatisk sendt til NAY.",
+  vedtakJournalfort: "Vedtaket er journalført i Gosys.",
+};
+
+function isActiveExistingVedtak(vedtak: VedtakResponseDTO): boolean {
+  const vedtakTomDate = dayjs(vedtak.tom);
+  const today = dayjs();
+  return today.isBefore(vedtakTomDate) || today.isSame(vedtakTomDate, "date");
+}
+
+interface Props {
+  vedtak: VedtakResponseDTO;
+  className?: string;
+}
+
+export default function VedtakInfoPanel({ vedtak, className }: Props) {
+  const vedtakFattetDate = tilLesbarDatoMedArUtenManedNavn(vedtak.createdAt);
+  const vedtakStartDateText = tilLesbarDatoMedArUtenManedNavn(vedtak.fom);
+  const vedtakEndDateText = tilLesbarDatoMedArUtenManedNavn(vedtak.tom);
+
+  return (
+    <Box
+      background="surface-default"
+      className={`flex flex-col p-4 gap-2 ${className}`}
+    >
+      <Heading level="3" size="medium">
+        {isActiveExistingVedtak(vedtak)
+          ? texts.aktivtVedtak
+          : texts.tidligereVedtak}
+      </Heading>
+      <div>
+        <div className="flex flex-row gap-4">
+          <BodyShort>
+            Start: <b>{vedtakStartDateText}</b>
+          </BodyShort>
+          <BodyShort>
+            Slutt: <b>{vedtakEndDateText}</b>
+          </BodyShort>
+        </div>
+        <BodyShort>
+          Vedtaket ble fattet: <b>{vedtakFattetDate}</b>
+        </BodyShort>
+      </div>
+      <div className="flex flex-row gap-2">
+        <CheckmarkCircleIcon
+          color="green"
+          title="a11y-title"
+          fontSize="1.5rem"
+        />
+        <BodyShort>{texts.gosysOppgaveSendt}</BodyShort>
+      </div>
+      <div className="flex flex-row gap-2">
+        <CheckmarkCircleIcon
+          color="green"
+          title="a11y-title"
+          fontSize="1.5rem"
+        />
+        <BodyShort>{texts.vedtakJournalfort}</BodyShort>
+      </div>
+    </Box>
+  );
+}

--- a/test/frisktilarbeid/FriskmeldingTilArbeidsformidlingTest.tsx
+++ b/test/frisktilarbeid/FriskmeldingTilArbeidsformidlingTest.tsx
@@ -4,7 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { navEnhet } from "../dialogmote/testData";
 import React from "react";
-import { FriskmeldingTilArbeidsformidling } from "@/sider/frisktilarbeid/FriskmeldingTilArbeidsformidling";
+import FriskmeldingTilArbeidsformidling from "@/sider/frisktilarbeid/FriskmeldingTilArbeidsformidling";
 import { beforeEach, describe, expect, it } from "vitest";
 import { clickButton, getButton } from "../testUtils";
 import {
@@ -65,11 +65,7 @@ describe("FriskmeldingTilArbeidsformidling", () => {
     renderFriskmeldingTilArbeidsformidling();
 
     expect(screen.getByText("Start nytt vedtak")).to.exist;
-    expect(
-      screen.getByText("Forrige vedtak på denne personen ble fattet", {
-        exact: false,
-      })
-    ).to.exist;
+    expect(screen.getByText("Tidligere vedtak")).to.exist;
   });
 
   it("viser aktivt vedtak når det finnes", () => {

--- a/test/frisktilarbeid/VedtakFattetTest.tsx
+++ b/test/frisktilarbeid/VedtakFattetTest.tsx
@@ -4,7 +4,7 @@ import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { navEnhet } from "../dialogmote/testData";
 import { NotificationProvider } from "@/context/notification/NotificationContext";
 import React from "react";
-import { VedtakFattet } from "@/sider/frisktilarbeid/VedtakFattet";
+import VedtakFattet from "@/sider/frisktilarbeid/VedtakFattet";
 import {
   InfotrygdStatus,
   VedtakResponseDTO,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Forbedre kvitteringsside for 8-5 etter man har fattet vedtak
- Legger til visningspanel for vedtak som brukes både på kvitteringsside, og når veileder har lukket oppgaven.
- Legger på at notification alerts kan lukkes.

### Screenshots 📸✨

Før
Aktivt vedtak

https://github.com/user-attachments/assets/4e359bdd-f7e9-47e7-8ae5-85ac766114f2


Utgått vedtak


https://github.com/user-attachments/assets/871237f6-e2ec-4e92-883f-8e7bab5c9e43



Etter
Aktivt vedtak

https://github.com/user-attachments/assets/44cc469a-ab53-4cea-a19b-19bcfa4e186c


Ikke lenger aktivt vedtak

https://github.com/user-attachments/assets/599040ec-cc2c-458b-8489-d1f8bbb8728c



