### PR TITLE
IS-3378-2: Gjor oppfylt arbeidsuforhet vurdering tilgjengelig for alle

### DIFF
--- a/src/sider/arbeidsuforhet/VelgVurdering.tsx
+++ b/src/sider/arbeidsuforhet/VelgVurdering.tsx
@@ -45,15 +45,13 @@ export default function VelgVurdering() {
             {texts.innstillingUtenForhandsvarselButton}
           </Button>
         )}
-        {toggles.isInnstillingUtenForhandsvarselArbeidsuforhetEnabled && (
-          <Button
-            as="a"
-            variant="secondary"
-            onClick={() => navigate(`${arbeidsuforhetPath}/oppfylt`)}
-          >
-            {texts.oppfyltButton}
-          </Button>
-        )}
+        <Button
+          as="a"
+          variant="secondary"
+          onClick={() => navigate(`${arbeidsuforhetPath}/oppfylt`)}
+        >
+          {texts.oppfyltButton}
+        </Button>
       </div>
     </Box>
   );


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Gjør funksjonalitet for å vurdere oppfylt uten å sende forhåndsvarsel på arbeidsuførhet 8-4 vurdering tilgjengelig for alle.

### Screenshots 📸✨
Slik vil det vises for alle som ikke har tilgang til "Avslag uten forhåndsvarsel" -funksjonalitet
<img width="1303" height="558" alt="Screenshot 2025-08-19 at 10 05 37" src="https://github.com/user-attachments/assets/fc2e4e22-7904-458a-b406-0d33be3130fc" />
