### PR TITLE
IS-3419: Sende med personident for mulige oppfolgingsenheter

### DIFF
--- a/src/data/oppfolgingsenhet/useGetMuligeOppfolgingsenheter.tsx
+++ b/src/data/oppfolgingsenhet/useGetMuligeOppfolgingsenheter.tsx
@@ -2,26 +2,32 @@ import { SYFOBEHANDLENDEENHET_ROOT } from "@/apiConstants";
 import { useQuery } from "@tanstack/react-query";
 import { get } from "@/api/axios";
 import { useBehandlendeEnhetQuery } from "@/data/behandlendeenhet/behandlendeEnhetQueryHooks";
+import { useValgtPersonident } from "@/hooks/useValgtBruker";
 
 export const muligeOppfolgingsenhetQueryKeys = {
-  muligeOppfolgingsenheter: (enhetId?: string) => [
+  muligeOppfolgingsenheter: (enhetId?: string, personident?: string) => [
     "muligeOppfolgingsenheter",
     enhetId,
+    personident,
   ],
 };
 
 export function useGetMuligeOppfolgingsenheter() {
   const { data: behandlendeenhet } = useBehandlendeEnhetQuery();
+  const personident = useValgtPersonident();
   const enhetId =
     behandlendeenhet?.oppfolgingsenhetDTO?.enhet.enhetId ??
     behandlendeenhet?.geografiskEnhet?.enhetId;
   const path = `${SYFOBEHANDLENDEENHET_ROOT}/tilordningsenheter/${enhetId}`;
-  const getVeilederBrukerKnytning = () => get<Enhet[]>(path);
+  const fetchMuligeOppfolgingsenheter = () => get<Enhet[]>(path, personident);
 
   return useQuery({
-    queryKey: muligeOppfolgingsenhetQueryKeys.muligeOppfolgingsenheter(enhetId),
-    queryFn: getVeilederBrukerKnytning,
-    enabled: !!enhetId,
+    queryKey: muligeOppfolgingsenhetQueryKeys.muligeOppfolgingsenheter(
+      enhetId,
+      personident
+    ),
+    queryFn: fetchMuligeOppfolgingsenheter,
+    enabled: !!personident && !!enhetId,
   });
 }
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Sender med personident slik at backend kan finne geografisk enhet og legge den til i lista over mulige oppfølgingsenheter (dette er relevant når noen skal sendes tilbake både fra Nav utland og fra ROE).

Ref https://github.com/navikt/syfobehandlendeenhet/pull/226

### Screenshots 📸✨


<img width="875" height="395" alt="enhet" src="https://github.com/user-attachments/assets/f1da00a7-d24e-4189-8373-f01d5ee9e7e8" />
