### PR TITLE
IS-3294: Don't show utbetaltTom if from old oppfolgingstilfelle

### DIFF
--- a/src/components/personkort/PersonkortHeader/MaksdatoSummary.tsx
+++ b/src/components/personkort/PersonkortHeader/MaksdatoSummary.tsx
@@ -11,12 +11,17 @@ const texts = {
 
 interface MaksdatoSummaryProps {
   maxDate: Maksdato;
+  startDate?: Date;
 }
 
-export function MaksdatoSummary({ maxDate }: MaksdatoSummaryProps) {
-  const utbetaltTom = maxDate.utbetalt_tom
-    ? tilLesbarDatoMedArUtenManedNavn(maxDate.utbetalt_tom)
-    : "Mangler";
+export function MaksdatoSummary({ maxDate, startDate }: MaksdatoSummaryProps) {
+  const isUtbetaltTomBeforeStart =
+    !!startDate && !!maxDate.utbetalt_tom && maxDate.utbetalt_tom < startDate;
+  const utbetaltTom =
+    !maxDate.utbetalt_tom || isUtbetaltTomBeforeStart
+      ? "Mangler"
+      : tilLesbarDatoMedArUtenManedNavn(maxDate.utbetalt_tom);
+
   return (
     <div className={"flex flex-row gap-3 items-center"}>
       <SyketilfelleSummaryElement

--- a/src/components/personkort/PersonkortHeader/Utbetalingsinfo.tsx
+++ b/src/components/personkort/PersonkortHeader/Utbetalingsinfo.tsx
@@ -26,7 +26,7 @@ export default function Utbetalingsinfo({ maksdato }: Props) {
 
   return maksdato ? (
     <>
-      <MaksdatoSummary maxDate={maksdato} />
+      <MaksdatoSummary maxDate={maksdato} startDate={startDate} />
       {isUtbetalingsinfoFromBeforeOppfolgingstilfelleStart(
         maksdato,
         startDate

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -210,6 +210,87 @@ describe("PersonkortHeader", () => {
     expect(screen.getByText("Mangler")).to.exist;
   });
 
+  it("viser 'Mangler' for utbetalt tom når utbetalt_tom er før oppfølgingstilfellets start", () => {
+    const startDate = new Date("2025-01-10");
+    const endDate = new Date("2025-02-10");
+
+    const oppfolgingstilfelle = {
+      ...oppfolgingstilfellePersonMock,
+      oppfolgingstilfelleList: [
+        oppfolgingstilfellePersonMock.oppfolgingstilfelleList[0],
+        oppfolgingstilfellePersonMock.oppfolgingstilfelleList[1],
+        {
+          ...oppfolgingstilfellePersonMock.oppfolgingstilfelleList[2],
+          start: startDate,
+          end: endDate,
+        },
+      ],
+    };
+
+    queryClient.setQueryData(
+      oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(
+        ARBEIDSTAKER_DEFAULT.personIdent
+      ),
+      () => oppfolgingstilfelle
+    );
+
+    queryClient.setQueryData(
+      maksdatoQueryKeys.maksdato(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => ({
+        maxDate: {
+          ...maksdatoMock.maxDate,
+          utbetalt_tom: new Date("2025-01-05"), // before start
+        },
+      })
+    );
+
+    renderPersonkortHeader();
+
+    expect(screen.getByText("Utbetalt tom:")).to.exist;
+    expect(screen.getByText("Mangler")).to.exist;
+  });
+
+  it("viser dato for utbetalt tom når utbetalt_tom er etter oppfølgingstilfellets start", () => {
+    const startDate = new Date("2025-01-10");
+    const endDate = new Date("2025-02-10");
+    const utbetaltTomDate = new Date("2025-01-15");
+
+    const oppfolgingstilfelle = {
+      ...oppfolgingstilfellePersonMock,
+      oppfolgingstilfelleList: [
+        oppfolgingstilfellePersonMock.oppfolgingstilfelleList[0],
+        oppfolgingstilfellePersonMock.oppfolgingstilfelleList[1],
+        {
+          ...oppfolgingstilfellePersonMock.oppfolgingstilfelleList[2],
+          start: startDate,
+          end: endDate,
+        },
+      ],
+    };
+
+    queryClient.setQueryData(
+      oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(
+        ARBEIDSTAKER_DEFAULT.personIdent
+      ),
+      () => oppfolgingstilfelle
+    );
+
+    queryClient.setQueryData(
+      maksdatoQueryKeys.maksdato(ARBEIDSTAKER_DEFAULT.personIdent),
+      () => ({
+        maxDate: {
+          ...maksdatoMock.maxDate,
+          utbetalt_tom: utbetaltTomDate, // after start
+        },
+      })
+    );
+
+    renderPersonkortHeader();
+
+    const expected = tilLesbarDatoMedArUtenManedNavn(utbetaltTomDate);
+    expect(screen.getByText(expected)).to.exist;
+  });
+
   describe("Utbetalingsinfo warning", () => {
     const startDate = addDays(new Date(), -10);
     const endDate = addDays(new Date(), 10);


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Ser at `sykepengedager-informasjon` i en del tilfeller plukker opp `utbetalt_tom` fra gamle sykepengesøknader (som antakelig har blitt revurdert på en eller annen måte), så jeg tenker at det er bedre å vise åpenbart gamle datoer (dvs fra før oppfølgingstilfellets start) som "Mangler". 

Dette vil bedre seg etter hvert som vi får mer oppdaterte data i `sykepengedager-informasjon`. Det er bare de siste 2-3 ukene utbetalt_tom har blitt lagret for søknader fra Spleis. 

