### PR TITLE
IS-3454: endre start ny vurdering 8.4 tekst

### DIFF
--- a/src/sider/arbeidsuforhet/NyVurdering.tsx
+++ b/src/sider/arbeidsuforhet/NyVurdering.tsx
@@ -21,7 +21,7 @@ const texts = {
 const lastVurderingText = (vurderinger: VurderingResponseDTO[]) => {
   const lastVurdering = vurderinger[0];
   if (!lastVurdering) {
-    return "Ingen vurderinger har blitt gjort, trykk på 'Start ny vurdering' for å sende forhåndsvarsel";
+    return "Ingen vurderinger har blitt gjort.";
   }
 
   if (lastVurdering.type === VurderingType.FORHANDSVARSEL) {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Endret teksten for å kunne starte ny 8.4 vurdering slik at den passer både for pilotkontor og resten av kontorene. 

### Screenshots 📸✨
Før:
<img width="1072" height="571" alt="image" src="https://github.com/user-attachments/assets/124f95d1-0a46-40f2-be2f-62ed1100972d" />

Nå:
<img width="681" height="255" alt="Skjermbilde 2025-10-07 kl  09 56 10" src="https://github.com/user-attachments/assets/d36ea590-56ce-4f17-b4ea-40449bd2a6b9" />

