### PR TITLE
IS-3797: Move panels according to relevance

### DIFF
--- a/src/data/motebehov/types/motebehovTypes.ts
+++ b/src/data/motebehov/types/motebehovTypes.ts
@@ -1,6 +1,6 @@
 import { FormSnapshot } from "@/data/skjemasvar/types/SkjemasvarTypes";
 
-export interface MotebehovVeilederDTO {
+export interface Motebehov {
   id: string;
   opprettetDato: Date;
   opprettetAvNavn: string | null;
@@ -8,10 +8,23 @@ export interface MotebehovVeilederDTO {
   virksomhetsnummer: string;
   behandletTidspunkt: Date | null;
   behandletVeilederIdent: string | null;
-  innmelderType: MotebehovInnmelder;
-  skjemaType: MotebehovSkjemaType;
+  skjemaType: MotebehovSkjemaType.MELD_BEHOV | MotebehovSkjemaType.SVAR_BEHOV;
   formValues: MotebehovFormValuesOutputDTO;
 }
+
+export type MotebehovVeilederDTO = Motebehov & {
+  innmelderType: MotebehovInnmelder;
+};
+
+export type MeldtMotebehov = Motebehov & {
+  innmelder: MotebehovInnmelder;
+  skjemaType: MotebehovSkjemaType.MELD_BEHOV;
+};
+
+export type SvarMotebehov = Motebehov & {
+  innmelder: MotebehovInnmelder;
+  skjemaType: MotebehovSkjemaType.SVAR_BEHOV;
+};
 
 export type Virksomhetsnummer = string;
 export type InnsenderKey = [Virksomhetsnummer, MotebehovInnmelder];
@@ -29,32 +42,6 @@ export interface MotebehovFormValuesOutputDTO {
 export enum MotebehovSkjemaType {
   MELD_BEHOV = "MELD_BEHOV",
   SVAR_BEHOV = "SVAR_BEHOV",
-}
-
-export interface MeldtMotebehov {
-  id: string;
-  opprettetDato: Date;
-  opprettetAvNavn: string | null;
-  innmelder: MotebehovInnmelder;
-  arbeidstakerFnr: string;
-  virksomhetsnummer: string;
-  behandletTidspunkt: Date | null;
-  behandletVeilederIdent: string | null;
-  skjemaType: MotebehovSkjemaType.MELD_BEHOV;
-  formValues: MotebehovFormValuesOutputDTO;
-}
-
-export interface SvarMotebehov {
-  id: string;
-  opprettetDato: Date;
-  opprettetAvNavn: string | null;
-  innmelder: MotebehovInnmelder;
-  arbeidstakerFnr: string;
-  virksomhetsnummer: string;
-  behandletTidspunkt: Date | null;
-  behandletVeilederIdent: string | null;
-  skjemaType: MotebehovSkjemaType.SVAR_BEHOV;
-  formValues: MotebehovFormValuesOutputDTO;
 }
 
 export enum MotebehovInnmelder {

--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -1,12 +1,8 @@
 import React from "react";
 import Sidetopp from "../../components/side/Sidetopp";
-import UtdragFraSykefravaeretPanel from "../../components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
-import InnkallingDialogmotePanel from "./components/innkalling/InnkallingDialogmotePanel";
 import SideLaster from "../../components/side/SideLaster";
 import { useDialogmoterQuery } from "@/sider/dialogmoter/hooks/dialogmoteQueryHooks";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
-import { DialogmoteFerdigstilteReferatPanel } from "@/sider/dialogmoter/components/DialogmoteFerdigstilteReferatPanel";
-import { DialogmoteStatus } from "@/sider/dialogmoter/types/dialogmoteTypes";
 import { useGetDialogmoteunntakQuery } from "@/data/dialogmotekandidat/useGetDialogmoteunntakQuery";
 import * as Tredelt from "@/components/side/TredeltSide";
 import Side from "@/components/side/Side";
@@ -14,17 +10,14 @@ import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import MotehistorikkPanel from "@/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel";
 import MoteSvarHistorikk from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk";
 import MotebehovHistorikk from "@/sider/dialogmoter/components/motehistorikk/MotebehovHistorikk";
-import { InfoOmTolk } from "@/sider/dialogmoter/motebehov/InfoOmTolk";
-import { UtropstegnImage } from "../../../img/ImageComponents";
-import MotebehovKvittering from "@/sider/dialogmoter/motebehov/MotebehovKvittering";
-import BehandleMotebehovKnapp from "@/components/motebehov/BehandleMotebehovKnapp";
-import DialogmotePanel from "@/sider/dialogmoter/components/DialogmotePanel";
 import { useGetDialogmoteIkkeAktuell } from "@/sider/dialogmoter/hooks/useGetDialogmoteIkkeAktuell";
+import { MotelandingssidePanels } from "@/sider/dialogmoter/utils/MotelandingssidePanels";
+import { harUbehandletMotebehov } from "@/utils/motebehovUtils";
+import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 
 const texts = {
   pageTitle: "Møtelandingsside",
   dialogmoter: "Dialogmøter",
-  behovForDialogmote: "Behov for dialogmøte",
 };
 
 export default function Motelandingsside() {
@@ -32,6 +25,7 @@ export default function Motelandingsside() {
     isLoading: henterDialogmoter,
     isError: henterDialogmoterFeilet,
     aktivtDialogmote,
+    ferdigstilteDialogmoter,
     historiskeDialogmoter,
   } = useDialogmoterQuery();
   const {
@@ -42,6 +36,7 @@ export default function Motelandingsside() {
   const getDialogmoteIkkeAktuell = useGetDialogmoteIkkeAktuell();
   const { isLoading: henterLedere, isError: henterLedereFeilet } =
     useLedereQuery();
+  const motebehov = useMotebehovQuery();
 
   const henter =
     henterDialogmoter ||
@@ -54,6 +49,8 @@ export default function Motelandingsside() {
     henterDialogmoteunntakFeilet ||
     getDialogmoteIkkeAktuell.isError;
 
+  const hasUbehandletMotebehov = harUbehandletMotebehov(motebehov.data);
+
   return (
     <Side tittel={texts.pageTitle} aktivtMenypunkt={Menypunkter.DIALOGMOTE}>
       <SideLaster isLoading={henter} isError={hentingFeilet}>
@@ -61,21 +58,11 @@ export default function Motelandingsside() {
 
         <Tredelt.Container>
           <Tredelt.FirstColumn>
-            <DialogmotePanel
-              icon={UtropstegnImage}
-              header={texts.behovForDialogmote}
-            >
-              <MotebehovKvittering />
-              <BehandleMotebehovKnapp />
-            </DialogmotePanel>
-            <InfoOmTolk />
-            <InnkallingDialogmotePanel aktivtDialogmote={aktivtDialogmote} />
-            <DialogmoteFerdigstilteReferatPanel
-              ferdigstilteMoter={historiskeDialogmoter.filter(
-                (mote) => mote.status === DialogmoteStatus.FERDIGSTILT
-              )}
+            <MotelandingssidePanels
+              hasUbehandletMotebehov={hasUbehandletMotebehov}
+              ferdigstilteDialogmoter={ferdigstilteDialogmoter}
+              aktivtDialogmote={aktivtDialogmote}
             />
-            <UtdragFraSykefravaeretPanel />
           </Tredelt.FirstColumn>
 
           <Tredelt.SecondColumn className="flex flex-col gap-4">

--- a/src/sider/dialogmoter/components/innkalling/InnkallingDialogmotePanel.tsx
+++ b/src/sider/dialogmoter/components/innkalling/InnkallingDialogmotePanel.tsx
@@ -9,9 +9,9 @@ import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import { Alert, BodyShort, Button } from "@navikt/ds-react";
 import {
+  dialogmoteIkkeAktuellRoutePath,
   dialogmoteRoutePath,
   dialogmoteUnntakRoutePath,
-  dialogmoteIkkeAktuellRoutePath,
 } from "@/AppRouter";
 import { Link } from "react-router-dom";
 import DialogmoteFrist from "@/sider/dialogmoter/components/DialogmoteFrist";

--- a/src/sider/dialogmoter/motebehov/MotebehovPanel.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovPanel.tsx
@@ -1,0 +1,22 @@
+import { UtropstegnImage } from "../../../../img/ImageComponents";
+import MotebehovKvittering from "@/sider/dialogmoter/motebehov/MotebehovKvittering";
+import BehandleMotebehovKnapp from "@/components/motebehov/BehandleMotebehovKnapp";
+import DialogmotePanel from "@/sider/dialogmoter/components/DialogmotePanel";
+import React from "react";
+import { InfoOmTolk } from "@/sider/dialogmoter/motebehov/InfoOmTolk";
+
+const texts = {
+  behovForDialogmote: "Behov for dialogmøte",
+};
+
+export const MotebehovPanel = () => {
+  return (
+    <>
+      <DialogmotePanel icon={UtropstegnImage} header={texts.behovForDialogmote}>
+        <MotebehovKvittering />
+        <BehandleMotebehovKnapp />
+      </DialogmotePanel>
+      <InfoOmTolk />
+    </>
+  );
+};

--- a/src/sider/dialogmoter/utils/MotelandingssidePanels.tsx
+++ b/src/sider/dialogmoter/utils/MotelandingssidePanels.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import UtdragFraSykefravaeretPanel from "../../../components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
+import { DialogmoteDTO } from "@/sider/dialogmoter/types/dialogmoteTypes";
+import { MotebehovPanel } from "@/sider/dialogmoter/motebehov/MotebehovPanel";
+import InnkallingDialogmotePanel from "@/sider/dialogmoter/components/innkalling/InnkallingDialogmotePanel";
+import { DialogmoteFerdigstilteReferatPanel } from "@/sider/dialogmoter/components/DialogmoteFerdigstilteReferatPanel";
+
+interface Panel {
+  key: string;
+  priority: number;
+  element: React.ReactElement;
+}
+
+interface MotelandingssidePanelsProps {
+  hasUbehandletMotebehov: boolean;
+  aktivtDialogmote: DialogmoteDTO | undefined;
+  ferdigstilteDialogmoter: DialogmoteDTO[];
+}
+
+export const MotelandingssidePanels = ({
+  hasUbehandletMotebehov,
+  aktivtDialogmote,
+  ferdigstilteDialogmoter,
+}: MotelandingssidePanelsProps) => {
+  const panels: Panel[] = [
+    {
+      key: "motebehov",
+      priority: hasUbehandletMotebehov ? 0 : 1,
+      element: <MotebehovPanel />,
+    },
+    {
+      key: "innkalling",
+      priority: hasUbehandletMotebehov ? 1 : 0,
+      element: (
+        <InnkallingDialogmotePanel aktivtDialogmote={aktivtDialogmote} />
+      ),
+    },
+    {
+      key: "ferdigstilte-referat",
+      priority: 2,
+      element: (
+        <DialogmoteFerdigstilteReferatPanel
+          ferdigstilteMoter={ferdigstilteDialogmoter}
+        />
+      ),
+    },
+    {
+      key: "utdrag-fra-sykefravaeret",
+      priority: 3,
+      element: <UtdragFraSykefravaeretPanel />,
+    },
+  ];
+  const sortedPanels = panels.sort((a, b) => a.priority - b.priority);
+
+  return (
+    <>
+      {sortedPanels.map((panel) => (
+        <React.Fragment key={panel.key}>{panel.element}</React.Fragment>
+      ))}
+    </>
+  );
+};


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Legger til enkel relevansrangering av panelene på dialogmøtesiden. Hvis bruker har ubehandlet møtebehov, vil dette ligge øverst for å oppfordre veiler til å behandle før innkalling. Hvis møtebehovet er behandlet, eller bruker ikke ha sendt inn møtebehov, vil man se knappen for å kalle inn øverst.

Man kan utvide dette konseptet videre hvis man vil (f.eks. referat?), men tenker dette er en god start og løser litt av det underliggende problemet på en enkel måte. Kristin har sett på dette og approvet :smile: Tar gjerne imot andre innspill også! 

### Screenshots 📸✨
<img width="1895" height="932" alt="image" src="https://github.com/user-attachments/assets/50353762-1711-493e-93b1-e6dee154a46e" />
<img width="1895" height="1341" alt="image" src="https://github.com/user-attachments/assets/2b296de1-f78b-44d4-8349-3d5c4d1aed72" />
<img width="1895" height="1341" alt="image" src="https://github.com/user-attachments/assets/0ff5ab14-8a0b-4a0e-9ee2-0f8ea7383017" />

