### PR TITLE
IS-3801: Legge til feature toggled vurderingspanel

### DIFF
--- a/server/unleash.ts
+++ b/server/unleash.ts
@@ -58,5 +58,9 @@ export function getToggles(veilederId, enhetId) {
       "isNyTilgangskontrollEnabled",
       context
     ),
+    isVurderingssideKartleggingEnabled: unleash.isEnabled(
+      "isVurderingssideKartleggingEnabled",
+      context
+    ),
   };
 }

--- a/src/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks.ts
+++ b/src/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks.ts
@@ -13,6 +13,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/utils";
 import { ApiErrorException } from "@/api/errors";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
+import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
 
 export const kartleggingssporsmalQueryKeys = {
   kartleggingssporsmalKandidat: (fnr: string) => [
@@ -69,9 +70,19 @@ export const useKartleggingssporsmalSvarQuery = (
 export const useKartleggingssporsmalVurderSvar = () => {
   const fnr = useValgtPersonident();
   const queryClient = useQueryClient();
-  const postVurderSvar = (kandidatUuid: string) => {
+  const postVurderSvar = ({
+    kandidatUuid,
+    vurderingAlternativ,
+  }: {
+    kandidatUuid: string;
+    vurderingAlternativ?: VurderingAlternativ;
+  }) => {
     const path = `${ISMEROPPFOLGING_ROOT}/kartleggingssporsmal/kandidater/${kandidatUuid}`;
-    return put<KartleggingssporsmalKandidatResponseDTO>(path, {}, fnr);
+    return put<KartleggingssporsmalKandidatResponseDTO>(
+      path,
+      vurderingAlternativ ? { vurderingAlternativ: vurderingAlternativ } : {},
+      fnr
+    );
   };
   const kartleggingssporsmalKandidatQueryKey =
     kartleggingssporsmalQueryKeys.kartleggingssporsmalKandidat(fnr);

--- a/src/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts
+++ b/src/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts
@@ -1,4 +1,5 @@
 import { KartleggingssporsmalFormSnapshot } from "@/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes";
+import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
 
 export interface KartleggingssporsmalKandidatResponseDTO {
   kandidatUuid: string;
@@ -14,6 +15,7 @@ export interface KartleggingssporsmalKandidatResponseDTO {
 export interface KartleggingssporsmalKandidatVurderingResponseDTO {
   vurdertAt: Date;
   vurdertBy: string;
+  vurderingAlternativ?: VurderingAlternativ;
 }
 
 export enum KandidatStatus {

--- a/src/data/unleash/unleash_types.ts
+++ b/src/data/unleash/unleash_types.ts
@@ -10,6 +10,7 @@ export enum ToggleNames {
   isFlexjarKartleggingssporsmalEnabled = "isFlexjarKartleggingssporsmalEnabled",
   isForsokForsterketOppfolgingMerkingEnabled = "isForsokForsterketOppfolgingMerkingEnabled",
   isNyTilgangskontrollEnabled = "isNyTilgangskontrollEnabled",
+  isVurderingssideKartleggingEnabled = "isVurderingssideKartleggingEnabled",
 }
 
 export const defaultToggles: Toggles = {
@@ -19,4 +20,5 @@ export const defaultToggles: Toggles = {
   isFlexjarKartleggingssporsmalEnabled: false,
   isForsokForsterketOppfolgingMerkingEnabled: false,
   isNyTilgangskontrollEnabled: false,
+  isVurderingssideKartleggingEnabled: false,
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -67,7 +67,7 @@ const handlers = [
   ...mockIsdialogmotekandidat,
   ...mockIsfrisktilarbeid,
   ...mockIsmanglendemedvirkning,
-  ...mockIsmeroppfolging,
+  ...mockIsmeroppfolging(true),
   mockIsnarmesteleder,
   ...mockisoppfolgingsplanForesporsel,
   mockIsoppfolgingstilfelle,

--- a/src/mocks/ismeroppfolging/mockIsmeroppfolging.ts
+++ b/src/mocks/ismeroppfolging/mockIsmeroppfolging.ts
@@ -86,10 +86,27 @@ export const kartleggingssporsmalFerdigbehandlet: KartleggingssporsmalKandidatRe
     varsletAt: daysFromToday(-20),
   };
 
+export const kartleggingssporsmalVurderingFerdigbehandlet: KartleggingssporsmalKandidatResponseDTO =
+  {
+    ...kartleggingIsKandidatAndReceivedQuestions,
+    status: KandidatStatus.FERDIGBEHANDLET,
+    vurdering: {
+      vurdertAt: daysFromToday(-14),
+      vurdertBy: VEILEDER_DEFAULT.ident,
+      vurderingAlternativ: "IKKE_RISIKO_FOR_LANGTIDSFRAVAR",
+    },
+    createdAt: daysFromToday(-20),
+    statusAt: daysFromToday(-20),
+    svarAt: daysFromToday(-15),
+    varsletAt: daysFromToday(-20),
+  };
+
 let kartleggingssporsmalMock: KartleggingssporsmalKandidatResponseDTO =
   kartleggingIsKandidatAndAnsweredQuestions;
 
-export const mockIsmeroppfolging = [
+export const mockIsmeroppfolging = (
+  isVurderingssideKartleggingEnabled?: boolean
+) => [
   http.get(`${ISMEROPPFOLGING_ROOT}/senoppfolging/kandidater`, () => {
     return HttpResponse.json([
       senOppfolgingKandidatMock,
@@ -121,14 +138,22 @@ export const mockIsmeroppfolging = [
   http.get(`${ISMEROPPFOLGING_ROOT}/kartleggingssporsmal/kandidater`, () => {
     return HttpResponse.json([
       kartleggingssporsmalMock,
-      kartleggingssporsmalFerdigbehandlet,
+      isVurderingssideKartleggingEnabled
+        ? kartleggingssporsmalVurderingFerdigbehandlet
+        : kartleggingssporsmalFerdigbehandlet,
     ]);
   }),
   http.put(
     `${ISMEROPPFOLGING_ROOT}/kartleggingssporsmal/kandidater/:kandidatUUID`,
     () => {
-      kartleggingssporsmalMock = kartleggingssporsmalFerdigbehandlet;
-      return HttpResponse.json(kartleggingssporsmalFerdigbehandlet);
+      kartleggingssporsmalMock = isVurderingssideKartleggingEnabled
+        ? kartleggingssporsmalVurderingFerdigbehandlet
+        : kartleggingssporsmalFerdigbehandlet;
+      return HttpResponse.json(
+        isVurderingssideKartleggingEnabled
+          ? kartleggingssporsmalVurderingFerdigbehandlet
+          : kartleggingssporsmalFerdigbehandlet
+      );
     }
   ),
 ];

--- a/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
+++ b/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
@@ -35,6 +35,8 @@ import KartleggingssporsmalFlexjar from "@/sider/kartleggingssporsmal/Kartleggin
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { StoreKey, useLocalStorageState } from "@/hooks/useLocalStorageState";
 import { KartleggingssporsmalHistorikk } from "@/sider/kartleggingssporsmal/historikk/KartleggingssporsmalHistorikk";
+import { KartleggingVurdering } from "@/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx";
+import { SuccessAlert } from "@/sider/kartleggingssporsmal/successAlert/SuccessAlert.tsx";
 
 const texts = {
   title: "Kartleggingsspørsmål",
@@ -42,8 +44,6 @@ const texts = {
   kandidat: "Spørsmålene ble sendt",
   svart: "Den sykmeldte svarte",
   ikkeSvart: "Den sykmeldte har ikke svart",
-  svarVurdert: "Svarene er vurdert",
-  svarVurdertAv: "Oppgaven er behandlet av",
   extraInfo:
     "Ved manglende svar vil vi automatisk sende et nytt varsel på SMS etter syv dager, du trenger ikke å purre manuelt. Den sykmeldte er ikke pålagt å svare. Det skal derfor ikke sendes forhåndsvarsel for brudd på folketrygdloven § 8-8 dersom det ikke kommer inn et svar.",
   extraInfoReservert:
@@ -84,6 +84,16 @@ const texts = {
       "Sykmeldte som svarer at de tror de blir sykmeldt mer enn seks måneder, har dårlig relasjon til arbeidsgiver eller som er usikre på om de kommer tilbake til nåværende jobb, gir en indikasjon på behov for nærmere vurdering av oppfølgingsbehov. Dette vil ofte innebære at Nav bør ta kontakt med den sykmeldte og arbeidsgiver.",
     link: 'Bruk også "Bli kjent og forstå behov"',
     url: "https://navno.sharepoint.com/:u:/r/sites/fag-og-ytelser-veileder-for-arbeidsrettet-brukeroppfolging/SitePages/Start.aspx?csf=1&web=1&e=qc76DU#bli-kjent-og-forst%C3%A5-behov",
+  },
+  vurderingBox: {
+    heading: "Vurdering",
+    legend: "Velg alternativet som passer vurderingen",
+    RISIKO_FOR_LANGTIDSFRAVAR:
+      "Jeg vurderer at den sykmeldte har risiko for et langtidsfravær",
+    IKKE_RISIKO_FOR_LANGTIDSFRAVAR:
+      "Jeg vurderer at den sykmeldte ikke har risiko for et langtidsfravær",
+    button: "Lagre vurdering, fjern oppgaven",
+    error: "Du må velge et alternativ",
   },
 };
 
@@ -140,15 +150,19 @@ function trackAccordionApnet(isOpen: boolean, accordionTekst: string): void {
 }
 
 export default function KartleggingssporsmalSide(): ReactElement {
+  const { toggles } = useFeatureToggles();
+
   const getKandidater = useKartleggingssporsmalKandidaterQuery();
   const kandidater = getKandidater.data || [];
   const nyesteKandidat = kandidater[0];
+
   const getKartleggingssporsmalSvar =
     useKartleggingssporsmalSvarQuery(nyesteKandidat);
   const answeredQuestions = getKartleggingssporsmalSvar.data;
+
   const vurderSvar = useKartleggingssporsmalVurderSvar();
   const kontaktinformasjon = useKontaktinfoQuery();
-  const { toggles } = useFeatureToggles();
+
   const [feedbackDate] = useLocalStorageState<Date | null>(
     StoreKey.FLEXJAR_KARTLEGGGINSSPORSMAL_FEEDBACK_DATE
   );
@@ -165,6 +179,12 @@ export default function KartleggingssporsmalSide(): ReactElement {
     getKandidater.isError ||
     getKartleggingssporsmalSvar.isError ||
     kontaktinformasjon.isError;
+
+  const behandletWithoutVurdering =
+    nyesteKandidat?.status === "FERDIGBEHANDLET" &&
+    !nyesteKandidat?.vurdering?.vurderingAlternativ;
+  const showKartleggingVurdering =
+    toggles.isVurderingssideKartleggingEnabled && !behandletWithoutVurdering;
 
   return (
     <Side
@@ -195,42 +215,37 @@ export default function KartleggingssporsmalSide(): ReactElement {
                     <KartleggingssporsmalSkjemasvar
                       formSnapshot={answeredQuestions.formSnapshot}
                     />
-                    {nyesteKandidat.status === KandidatStatus.SVAR_MOTTATT && (
+
+                    {!showKartleggingVurdering && (
                       <>
-                        <Button
-                          variant="primary"
-                          size="medium"
-                          onClick={() =>
-                            vurderSvar.mutate(nyesteKandidat.kandidatUuid)
-                          }
-                          loading={vurderSvar.isPending}
-                        >
-                          {texts.vurdereOppgaveText}
-                        </Button>
-                        {vurderSvar.isError && (
-                          <SkjemaInnsendingFeil
-                            bottomPadding={PaddingSize.NONE}
-                            error={vurderSvar.error}
-                          />
+                        {nyesteKandidat.status ===
+                          KandidatStatus.SVAR_MOTTATT && (
+                          <>
+                            <Button
+                              variant="primary"
+                              size="medium"
+                              onClick={() =>
+                                vurderSvar.mutate({
+                                  kandidatUuid: nyesteKandidat.kandidatUuid,
+                                })
+                              }
+                              loading={vurderSvar.isPending}
+                            >
+                              {texts.vurdereOppgaveText}
+                            </Button>
+                            {vurderSvar.isError && (
+                              <SkjemaInnsendingFeil
+                                bottomPadding={PaddingSize.NONE}
+                                error={vurderSvar.error}
+                              />
+                            )}
+                          </>
+                        )}
+                        {nyesteKandidat.status ===
+                          KandidatStatus.FERDIGBEHANDLET && (
+                          <SuccessAlert nyesteKandidat={nyesteKandidat} />
                         )}
                       </>
-                    )}
-                    {nyesteKandidat.status ===
-                      KandidatStatus.FERDIGBEHANDLET && (
-                      <Alert size="medium" variant="success">
-                        <BodyShort
-                          size="small"
-                          weight="semibold"
-                          className="mb-2"
-                        >
-                          {`${texts.svarVurdert} ${tilLesbarDatoMedArstall(
-                            nyesteKandidat.vurdering?.vurdertAt
-                          )}`}
-                        </BodyShort>
-                        <BodyShort size="small">
-                          {`${texts.svarVurdertAv} ${nyesteKandidat.vurdering?.vurdertBy}`}
-                        </BodyShort>
-                      </Alert>
                     )}
                   </>
                 ) : (
@@ -269,6 +284,10 @@ export default function KartleggingssporsmalSide(): ReactElement {
                   </>
                 )}
               </Box>
+              {showKartleggingVurdering &&
+                nyesteKandidat.status !== KandidatStatus.KANDIDAT && (
+                  <KartleggingVurdering nyesteKandidat={nyesteKandidat} />
+                )}
               <KartleggingssporsmalHistorikk
                 tidligereKandidater={kandidater.slice(1)}
               />

--- a/src/sider/kartleggingssporsmal/successAlert/SuccessAlert.tsx
+++ b/src/sider/kartleggingssporsmal/successAlert/SuccessAlert.tsx
@@ -1,0 +1,26 @@
+import { Alert, BodyShort } from "@navikt/ds-react";
+import { tilLesbarDatoMedArstall } from "@/utils/datoUtils.ts";
+import React from "react";
+import { KartleggingssporsmalKandidatResponseDTO } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts";
+
+const texts = {
+  svarVurdert: "Svarene er vurdert",
+  svarVurdertAv: "Oppgaven er behandlet av",
+};
+
+interface SuccessAlertProps {
+  nyesteKandidat: KartleggingssporsmalKandidatResponseDTO;
+}
+
+export const SuccessAlert = ({ nyesteKandidat }: SuccessAlertProps) => (
+  <Alert size="medium" variant="success">
+    <BodyShort size="small" weight="semibold" className="mb-2">
+      {`${texts.svarVurdert} ${tilLesbarDatoMedArstall(
+        nyesteKandidat.vurdering?.vurdertAt
+      )}`}
+    </BodyShort>
+    <BodyShort size="small">
+      {`${texts.svarVurdertAv} ${nyesteKandidat.vurdering?.vurdertBy}`}
+    </BodyShort>
+  </Alert>
+);

--- a/src/sider/kartleggingssporsmal/types.ts
+++ b/src/sider/kartleggingssporsmal/types.ts
@@ -1,0 +1,3 @@
+export type VurderingAlternativ =
+  | "RISIKO_FOR_LANGTIDSFRAVAR"
+  | "IKKE_RISIKO_FOR_LANGTIDSFRAVAR";

--- a/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
+++ b/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
@@ -1,0 +1,90 @@
+import { Box, Button, Heading, Radio, RadioGroup } from "@navikt/ds-react";
+import {
+  KandidatStatus,
+  KartleggingssporsmalKandidatResponseDTO,
+} from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts";
+import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil.tsx";
+import { PaddingSize } from "@/components/Layout.tsx";
+import React, { useState } from "react";
+import { useKartleggingssporsmalVurderSvar } from "@/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks.ts";
+import { SuccessAlert } from "@/sider/kartleggingssporsmal/successAlert/SuccessAlert.tsx";
+
+const texts = {
+  heading: "Vurdering",
+  legend: "Velg alternativet som passer vurderingen",
+  RISIKO_FOR_LANGTIDSFRAVAR:
+    "Jeg vurderer at den sykmeldte har risiko for et langtidsfravær",
+  IKKE_RISIKO_FOR_LANGTIDSFRAVAR:
+    "Jeg vurderer at den sykmeldte ikke har risiko for et langtidsfravær",
+  button: "Lagre vurdering, fjern oppgaven",
+  error: "Du må velge et alternativ",
+};
+
+interface KartleggingVurderingProps {
+  nyesteKandidat: KartleggingssporsmalKandidatResponseDTO;
+}
+
+export const KartleggingVurdering = ({
+  nyesteKandidat,
+}: KartleggingVurderingProps) => {
+  const vurderSvar = useKartleggingssporsmalVurderSvar();
+
+  const [chosenAlternative, setChosenAlternative] =
+    useState<VurderingAlternativ | null>(
+      nyesteKandidat.vurdering?.vurderingAlternativ ?? null
+    );
+  const [chosenAlternativeError, setChosenAlternativeError] = useState<
+    string | null
+  >(null);
+
+  return (
+    <Box background="default" className="p-6 gap-6 [&>*]:mb-4 mb-4">
+      <Heading size={"medium"}>{texts.heading}</Heading>
+      <RadioGroup
+        legend={texts.legend}
+        size="small"
+        value={chosenAlternative}
+        readOnly={nyesteKandidat.status === KandidatStatus.FERDIGBEHANDLET}
+        error={chosenAlternativeError}
+        onChange={(e: VurderingAlternativ) => setChosenAlternative(e)}
+      >
+        <Radio value="RISIKO_FOR_LANGTIDSFRAVAR">
+          {texts.RISIKO_FOR_LANGTIDSFRAVAR}
+        </Radio>
+        <Radio value="IKKE_RISIKO_FOR_LANGTIDSFRAVAR">
+          {texts.IKKE_RISIKO_FOR_LANGTIDSFRAVAR}
+        </Radio>
+      </RadioGroup>
+
+      {nyesteKandidat.status === KandidatStatus.SVAR_MOTTATT && (
+        <Button
+          variant="primary"
+          size="medium"
+          onClick={() => {
+            if (chosenAlternative) {
+              vurderSvar.mutate({
+                kandidatUuid: nyesteKandidat.kandidatUuid,
+                vurderingAlternativ: chosenAlternative,
+              });
+            } else {
+              setChosenAlternativeError(texts.error);
+            }
+          }}
+          loading={vurderSvar.isPending}
+        >
+          {texts.button}
+        </Button>
+      )}
+      {vurderSvar.isError && (
+        <SkjemaInnsendingFeil
+          bottomPadding={PaddingSize.NONE}
+          error={vurderSvar.error}
+        />
+      )}
+      {nyesteKandidat.status === KandidatStatus.FERDIGBEHANDLET && (
+        <SuccessAlert nyesteKandidat={nyesteKandidat} />
+      )}
+    </Box>
+  );
+};

--- a/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
+++ b/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
@@ -13,13 +13,16 @@ import {
   kartleggingIsKandidatAndAnsweredQuestions,
   kartleggingIsKandidatAndReceivedQuestions,
   kartleggingssporsmalFerdigbehandlet,
+  kartleggingssporsmalVurderingFerdigbehandlet,
 } from "@/mocks/ismeroppfolging/mockIsmeroppfolging";
 import { kartleggingssporsmalAnswered } from "@/mocks/meroppfolging-backend/merOppfolgingMock";
 import {
   ARBEIDSTAKER_DEFAULT,
+  BEHANDLENDE_ENHET_DEFAULT,
   VEILEDER_DEFAULT,
+  VEILEDER_IDENT_DEFAULT,
 } from "@/mocks/common/mockConstants";
-import { ValgtEnhetProvider } from "@/context/ValgtEnhetContext";
+import { ValgtEnhetContext } from "@/context/ValgtEnhetContext";
 import { renderWithRouter } from "../testRouterUtils";
 import { appRoutePath } from "@/AppRouter";
 import { screen } from "@testing-library/react";
@@ -36,6 +39,9 @@ import {
 import { brukerQueryKeys } from "@/data/navbruker/navbrukerQueryHooks";
 import { kontaktinformasjonMock } from "@/mocks/syfoperson/persondataMock";
 import { generateUUID } from "@/utils/utils";
+import { mockUnleashTogglesOffResponse } from "@/mocks/unleashMocks.ts";
+import { unleashQueryKeys } from "@/data/unleash/unleashQueryHooks.ts";
+import { ToggleNames } from "@/data/unleash/unleash_types.ts";
 
 let queryClient: QueryClient;
 
@@ -69,13 +75,32 @@ const mockKartleggingssporsmalSvar = (
   );
 };
 
+const mockEnabledToggles = (enabledToggles: ToggleNames[]) =>
+  queryClient.setQueryData(
+    unleashQueryKeys.toggles(
+      BEHANDLENDE_ENHET_DEFAULT.enhetId,
+      VEILEDER_IDENT_DEFAULT
+    ),
+    () => ({
+      ...mockUnleashTogglesOffResponse,
+      ...enabledToggles.reduce((accumulator, toggleName) => {
+        return { ...accumulator, [toggleName]: true };
+      }, {}),
+    })
+  );
+
 const renderKartleggingssporsmal = () => {
   renderWithRouter(
-    <ValgtEnhetProvider>
-      <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <ValgtEnhetContext.Provider
+        value={{
+          valgtEnhet: BEHANDLENDE_ENHET_DEFAULT.enhetId,
+          setValgtEnhet: () => void 0,
+        }}
+      >
         <KartleggingssporsmalSide />
-      </QueryClientProvider>
-    </ValgtEnhetProvider>,
+      </ValgtEnhetContext.Provider>
+    </QueryClientProvider>,
     `${appRoutePath}/kartleggingssporsmal`,
     [`${appRoutePath}/kartleggingssporsmal`]
   );
@@ -88,6 +113,7 @@ describe("Kartleggingssporsmal", () => {
       brukerQueryKeys.kontaktinfo(ARBEIDSTAKER_DEFAULT.personIdent),
       () => kontaktinformasjonMock
     );
+    mockEnabledToggles([]);
   });
 
   it("Sykmeldt is not kandidat", () => {
@@ -272,6 +298,41 @@ describe("Kartleggingssporsmal", () => {
     expect(
       screen.queryByText(`Oppgaven er behandlet av ${VEILEDER_DEFAULT.ident}`)
     ).to.exist;
+
+    expect(screen.queryByText(`Velg alternativet som passer vurderingen`)).to
+      .not.exist;
+  });
+
+  it("Sykmeldt is ferdigbehandlet with vurdering", () => {
+    mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+    mockKartleggingssporsmalKandidat(
+      kartleggingssporsmalVurderingFerdigbehandlet,
+      ARBEIDSTAKER_DEFAULT.personIdent
+    );
+    mockKartleggingssporsmalSvar(
+      kartleggingssporsmalAnswered,
+      kartleggingssporsmalVurderingFerdigbehandlet.kandidatUuid
+    );
+
+    renderKartleggingssporsmal();
+
+    expect(screen.queryByText("Den sykmeldte svarte", { exact: false })).to
+      .exist;
+    expect(screen.queryByText("Spørsmålene ble sendt", { exact: false })).to
+      .exist;
+    expect(screen.queryByText("Slik ser spørsmålene ut for den sykmeldte")).to
+      .exist;
+
+    expect(
+      screen.queryByText(`Oppgaven er behandlet av ${VEILEDER_DEFAULT.ident}`)
+    ).to.exist;
+
+    expect(
+      screen.queryByText(
+        `Jeg vurderer at den sykmeldte ikke har risiko for et langtidsfravær`
+      )
+    ).to.exist;
   });
 
   describe("Evaluate answers to kartleggingsspørsmål", () => {
@@ -284,7 +345,7 @@ describe("Kartleggingssporsmal", () => {
         kartleggingssporsmalAnswered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
-      stubDefaultIsmeroppfolging();
+      stubDefaultIsmeroppfolging(false);
 
       renderKartleggingssporsmal();
 
@@ -307,6 +368,80 @@ describe("Kartleggingssporsmal", () => {
       renderKartleggingssporsmal();
 
       await clickButton("Svarene er vurdert, fjern oppgaven");
+      expect(
+        await screen.findByText(
+          "Det skjedde en uventet feil. Vennligst prøv igjen senere."
+        )
+      ).to.exist;
+    });
+  });
+
+  describe("Evaluate answers to kartleggingsspørsmål with vurdering", () => {
+    it("Submitting without choosing an option shows error message", async () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+      stubVurderSvarError();
+
+      renderKartleggingssporsmal();
+
+      await clickButton("Lagre vurdering, fjern oppgaven");
+      expect(await screen.findByText("Du må velge et alternativ")).to.exist;
+    });
+
+    it("API returning Ok will show success message", async () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+      stubDefaultIsmeroppfolging(true);
+
+      renderKartleggingssporsmal();
+
+      await screen
+        .getByLabelText(
+          "Jeg vurderer at den sykmeldte har risiko for et langtidsfravær"
+        )
+        .click();
+      await clickButton("Lagre vurdering, fjern oppgaven");
+      expect(await screen.findByText("Oppgaven er behandlet av Z990000")).to
+        .exist;
+    });
+
+    it("API returning error will show error message", async () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+      stubVurderSvarError();
+
+      renderKartleggingssporsmal();
+
+      await screen
+        .getByLabelText(
+          "Jeg vurderer at den sykmeldte har risiko for et langtidsfravær"
+        )
+        .click();
+      await clickButton("Lagre vurdering, fjern oppgaven");
       expect(
         await screen.findByText(
           "Det skjedde en uventet feil. Vennligst prøv igjen senere."
@@ -346,7 +481,8 @@ describe("Kartleggingssporsmal", () => {
 
       renderKartleggingssporsmal();
 
-      expect(screen.queryByText("Historikk")).to.not.exist;
+      expect(screen.queryByRole("heading", { level: 2, name: "Historikk" })).to
+        .not.exist;
     });
 
     it("renders nothing when previous kandidater have not answered", () => {
@@ -361,7 +497,8 @@ describe("Kartleggingssporsmal", () => {
 
       renderKartleggingssporsmal();
 
-      expect(screen.queryByText("Historikk")).to.not.exist;
+      expect(screen.queryByRole("heading", { level: 2, name: "Historikk" })).to
+        .not.exist;
     });
 
     it("renders historikk header when there are previous kandidater with svar", () => {
@@ -380,7 +517,8 @@ describe("Kartleggingssporsmal", () => {
 
       renderKartleggingssporsmal();
 
-      expect(screen.getByText("Historikk")).to.exist;
+      expect(screen.queryByRole("heading", { level: 2, name: "Historikk" })).to
+        .exist;
       expect(screen.getByText("Tidligere svar på kartleggingsspørsmål")).to
         .exist;
     });

--- a/test/stubs/stubIsmeroppfolging.ts
+++ b/test/stubs/stubIsmeroppfolging.ts
@@ -3,8 +3,9 @@ import { ISMEROPPFOLGING_ROOT } from "@/apiConstants";
 import { mockIsmeroppfolging } from "@/mocks/ismeroppfolging/mockIsmeroppfolging";
 import { mockServer } from "../setup";
 
-export const stubDefaultIsmeroppfolging = () =>
-  mockServer.use(...mockIsmeroppfolging);
+export const stubDefaultIsmeroppfolging = (
+  isVurderingssideKartleggingEnabled: boolean
+) => mockServer.use(...mockIsmeroppfolging(isVurderingssideKartleggingEnabled));
 
 export const stubVurderSvarError = () =>
   mockServer.use(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Legger til et nytt vurderingspanel som kun vises når Unleash er skrudd på (og så lenge kandidat ikke allerede er ferdigbehandlet uten en vurdering). Størsteparten av endringene i PRen ble faktsik relatert til testoppsettet, da jeg måtte fasilitere for mocking av Unleash. Dette påvirket litt andre greier, så jeg måtte pynte litt på enkelte gamle tester for å gjøre dem mer spesifikke.

### Screenshots 📸✨

Svar innsendt, kandidat er ikke ferdigbehandlet
<img width="1152" height="1199" alt="image" src="https://github.com/user-attachments/assets/a088c65f-e0ab-42b0-859b-8a15def7f29f" />

Svar innsendt, PEBCAK
<img width="1152" height="1199" alt="image" src="https://github.com/user-attachments/assets/6eecb7bc-8638-40bb-9376-8160addbf252" />

Svar innsendt, kandidat er ferdigbehandlet
<img width="1152" height="1199" alt="image" src="https://github.com/user-attachments/assets/7b356318-4bc4-46f7-b009-72fad3b28ab7" />

Legacy - enhet skal benytte vurderingsside, men kandidat ble ferdigbehandlet før prodsetting
<img width="1152" height="1199" alt="image" src="https://github.com/user-attachments/assets/56980f6d-05cb-472b-9e1a-1a95394c1749" />
