### PR TITLE
Parse body in proxy on POST, PUT, and PATCH

### DIFF
--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -109,7 +109,7 @@ const proxyOnBehalfOf = (
       return proxyExternalHost(
         externalAppConfig,
         accessToken,
-        req.method === "POST",
+        ["POST", "PUT", "PATCH"].includes(req.method),
         rewritePath
       )(req, res, next);
     })


### PR DESCRIPTION
Fikk et problem (i dev) hvor backenden ikke oppførte seg som det skulle, selv om alle testene tilsa at ting skulle være greit. Viste seg at `proxy.ts` ikke parset bodyen på requests som ikke var av typen `POST`. Dette bør fikse problemet.