### PR TITLE
IS-3895: Use explicit NPM registries

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,4 +1,16 @@
 version: 2
+
+registries:
+  npmjs:
+    type: npm-registry
+    url: https://registry.npmjs.org
+
+  github-packages:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{ secrets.NPM_AUTH_TOKEN }}
+    replaces-base: false
+
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -9,11 +21,14 @@ updates:
 
   - package-ecosystem: npm
     directory: "/"
+    registries:
+      - npmjs
+      - github-packages
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
     ignore:
-      - dependency-name: 'nav-frontend*'
+      - dependency-name: "nav-frontend*"
     groups:
       minor-and-patch:
         patterns:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 ignore-scripts=true
+registry=https://registry.npmjs.org/
 @navikt:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
Dependabot har sluttet å virke, og dette håper jeg bøte på problemet. Det virker som at vår `.npmrc` har gjort at vi alltid går mot `https://npm.pkg.github.com/` mens Dependabot kjører. Dette registryet har ikke vært helt i sync med vår egen `package.json`, så når Dependabot har prøvd å installere (for eksempel) `"@types/react-document-title": "2.0.10"` så har den ikke funnet noen pakke nyere enn `2.0.5`. Forsøket her er å gjøre registries mer eksplisitt, da spesielt i `dependabot.yaml`, slik at den går til NPM for alle pakker utenom dem prefikset med `@navikt`.

At dette fungerer er ren gjetning, forresten :blush: Må bare teste