### PR TITLE
Remove custom Dependabot registry, npmjs.org

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,10 +1,6 @@
 version: 2
 
 registries:
-  npmjs:
-    type: npm-registry
-    url: https://registry.npmjs.org
-
   github-packages:
     type: npm-registry
     url: https://npm.pkg.github.com
@@ -22,7 +18,6 @@ updates:
   - package-ecosystem: npm
     directory: "/"
     registries:
-      - npmjs
       - github-packages
     schedule:
       interval: weekly


### PR DESCRIPTION
Dependabot har en configfeil etter fiksen min:

<img width="911" height="278" alt="image" src="https://github.com/user-attachments/assets/61be43ae-0d0b-419b-9759-2fa9b579992c" />

Det gir ikke særlig mye mening at den skal forekomme, iom. at `registry.npmjs.org` ikke krever autentisering og at vi fikk inn en PR i går. [Var litt diskusjon rundt det her](https://github.com/dependabot/dependabot-core/issues/10258). Men jeg tenker jeg prøver å fjerne den, så ser vi om ting blir bedre. Hvis Dependabot-PRer fungerer etter det, så innfører jeg samme endring til de andre repoene våre.