### PR TITLE
IS-3828: Vis oppdatert status om behandler ifm dialogmøtereferat

### DIFF
--- a/src/mocks/isdialogmote/dialogmoterMock.ts
+++ b/src/mocks/isdialogmote/dialogmoterMock.ts
@@ -10,7 +10,6 @@ import {
   SvarType,
   VarselSvarDTO,
 } from "@/sider/dialogmoter/types/dialogmoteTypes";
-import { BehandlerType } from "@/data/behandler/BehandlerDTO";
 import {
   ANNEN_VEILEDER_IDENT,
   ARBEIDSTAKER_DEFAULT,
@@ -285,26 +284,6 @@ export const createReferat = (
   };
 };
 
-const behandler = (uuid: string): DialogmotedeltakerBehandlerDTO => {
-  return {
-    uuid: uuid + 4,
-    personIdent: "01038521470",
-    behandlerRef: uuid + 5,
-    behandlerNavn: "Lego Legesen",
-    behandlerKontor: "Fastlegekontoret",
-    behandlerType: BehandlerType.FASTLEGE,
-    type: "BEHANDLER",
-    varselList: [],
-    deltatt: true,
-    mottarReferat: true,
-  };
-};
-
-export const innkaltDialogmote = createDialogmote(
-  "5f1e2629-062b-442d-ae1f-3b08e9574cd3",
-  DialogmoteStatus.INNKALT,
-  dayjs().add(2, "days").toDate()
-);
 export const avlystDialogmote = createDialogmote(
   "2",
   DialogmoteStatus.AVLYST,
@@ -316,19 +295,7 @@ export const ferdigstiltDialogmote = createDialogmote(
   dayjs().subtract(2, "years").toDate()
 );
 
-export const innkaltDialogmoteMedBehandler = createDialogmote(
-  "4",
-  DialogmoteStatus.INNKALT,
-  dayjs().add(2, "days").toDate(),
-  behandler("4")
-);
-
-export const dialogmoterMock = [
-  innkaltDialogmote,
-  avlystDialogmote,
-  ferdigstiltDialogmote,
-  innkaltDialogmoteMedBehandler,
-];
+export const dialogmoterMock = [avlystDialogmote, ferdigstiltDialogmote];
 
 export const dialogmoteStatusEndringMock: DialogmoteStatusEndringDTO[] = [
   {

--- a/src/mocks/isdialogmote/mockIsdialogmote.ts
+++ b/src/mocks/isdialogmote/mockIsdialogmote.ts
@@ -7,6 +7,7 @@ import {
 import { ISDIALOGMOTE_ROOT } from "@/apiConstants";
 import {
   DialogmoteDTO,
+  DialogmoteInnkallingDTO,
   DialogmoteStatus,
 } from "@/sider/dialogmoter/types/dialogmoteTypes";
 import dayjs from "dayjs";
@@ -16,6 +17,7 @@ import {
   getMotebehovMock,
   setMotebehovMock,
 } from "@/mocks/syfomotebehov/motebehovMock";
+import { BehandlerType } from "@/data/behandler/BehandlerDTO.ts";
 
 let mockedDialogmoter = dialogmoterMock;
 
@@ -26,20 +28,38 @@ let avventMock: {
 }[] = [];
 
 export const mockIsdialogmote = [
-  http.post(`${ISDIALOGMOTE_ROOT}/dialogmote/personident`, () => {
-    mockedDialogmoter = [
-      ...mockedDialogmoter,
-      createDialogmote(
-        "0",
-        DialogmoteStatus.INNKALT,
-        dayjs().add(10, "days").toDate()
-      ),
-    ];
-    return new HttpResponse(null, { status: 200 });
-  }),
+  http.post(
+    `${ISDIALOGMOTE_ROOT}/dialogmote/personident`,
+    async ({ request }) => {
+      const body = (await request.json()) as DialogmoteInnkallingDTO;
+      mockedDialogmoter = [
+        ...mockedDialogmoter,
+        createDialogmote(
+          "0",
+          DialogmoteStatus.INNKALT,
+          dayjs().add(10, "days").toDate(),
+          body.behandler
+            ? {
+                uuid: "123",
+                personIdent: body.behandler?.personIdent,
+                behandlerRef: body.behandler?.behandlerRef,
+                behandlerNavn: body.behandler?.behandlerNavn,
+                behandlerKontor: body.behandler?.behandlerKontor,
+                behandlerType: BehandlerType.FASTLEGE,
+                type: "BEHANDLER",
+                varselList: [],
+                deltatt: true,
+                mottarReferat: true,
+              }
+            : undefined
+        ),
+      ];
+      return new HttpResponse(null, { status: 200 });
+    }
+  ),
 
   http.get(`${ISDIALOGMOTE_ROOT}/dialogmote/personident`, () => {
-    return HttpResponse.json([]);
+    return HttpResponse.json([...mockedDialogmoter]);
   }),
 
   http.get(

--- a/src/sider/dialogmoter/components/referat/Referat.tsx
+++ b/src/sider/dialogmoter/components/referat/Referat.tsx
@@ -31,6 +31,7 @@ import {
   Button,
   Checkbox,
   CheckboxGroup,
+  ErrorMessage,
   Heading,
   HStack,
   List,
@@ -157,6 +158,8 @@ export const texts = {
     behandlerMottaReferatLabel: "Behandleren skal motta referatet",
     behandlerReferatSamtykke:
       "Dersom behandleren ikke deltok i møtet, men likevel ønsker å motta referat, krever det et samtykke fra arbeidstakeren.",
+    behandlerMottarReferatError:
+      "Behandleren skal motta referat hvis de har deltatt i møtet",
   },
 };
 
@@ -345,10 +348,15 @@ const Referat = ({ dialogmote, mode }: ReferatProps): ReactElement => {
   }`;
   const behandlerDeltakerHeading = (
     behandler: DialogmotedeltakerBehandlerDTO,
-    deltatt: boolean | undefined
+    deltatt: boolean | undefined,
+    mottarReferat: boolean | undefined
   ): string =>
     `Behandler: ${behandler.behandlerNavn}${
-      deltatt === false ? ", deltok ikke" : ""
+      deltatt === false ? ", deltok ikke" : ", deltok"
+    }${
+      mottarReferat === false
+        ? " og skal ikke motta referat"
+        : " og skal motta referat"
     }`;
 
   return (
@@ -399,16 +407,19 @@ const Referat = ({ dialogmote, mode }: ReferatProps): ReactElement => {
               <ExpansionCardFormField
                 ariaLabel={behandlerDeltakerHeading(
                   dialogmote.behandler,
-                  watch("behandlerDeltatt")
+                  watch("behandlerDeltatt"),
+                  watch("behandlerMottarReferat")
                 )}
                 heading={
                   <DeltakerBehandlerHeading>
                     {behandlerDeltakerHeading(
                       dialogmote.behandler,
-                      watch("behandlerDeltatt")
+                      watch("behandlerDeltatt"),
+                      watch("behandlerMottarReferat")
                     )}
                   </DeltakerBehandlerHeading>
                 }
+                hasError={!!errors.behandlerMottarReferat}
               >
                 <VStack gap="space-16">
                   <BodyLong size="small">
@@ -419,10 +430,22 @@ const Referat = ({ dialogmote, mode }: ReferatProps): ReactElement => {
                   </Checkbox>
                   <Checkbox
                     size="small"
-                    {...register("behandlerMottarReferat")}
+                    {...register("behandlerMottarReferat", {
+                      validate: (value, formValues) => {
+                        if (formValues?.behandlerDeltatt && !value) {
+                          return texts.deltakere.behandlerMottarReferatError;
+                        }
+                        return true;
+                      },
+                    })}
                   >
                     {texts.deltakere.behandlerMottaReferatLabel}
                   </Checkbox>
+                  {errors.behandlerMottarReferat?.message && (
+                    <ErrorMessage size="small">
+                      {errors.behandlerMottarReferat.message}
+                    </ErrorMessage>
+                  )}
                   <BodyLong size="small">
                     {texts.deltakere.behandlerReferatSamtykke}
                   </BodyLong>

--- a/test/dialogmote/ReferatTest.tsx
+++ b/test/dialogmote/ReferatTest.tsx
@@ -112,12 +112,15 @@ describe("ReferatTest", () => {
   it("viser behandler som deltaker når behandler er med", () => {
     renderReferat(dialogmoteMedBehandler);
 
-    expect(screen.getByRole("heading", { name: behandlerDeltakerTekst })).to
-      .exist;
+    expect(
+      screen.getByRole("heading", {
+        name: `${behandlerDeltakerTekst}, deltok og skal motta referat`,
+      })
+    ).to.exist;
 
     expect(
       screen.getByRole("region", {
-        name: behandlerDeltakerTekst,
+        name: `${behandlerDeltakerTekst}, deltok og skal motta referat`,
       })
     ).to.exist;
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legge til status om behandler skal delta i møtet og motta referat eller ikke i tittelen
- Legge til front end sperre på at bruker må motta referat hvis vedkommende har deltatt (avklart med Stine)
- Endre mocken slik at det er mulig å kalle inn behandler og skrive referat lokalt

### Screenshots 📸✨
Før:
<img width="1124" height="260" alt="image" src="https://github.com/user-attachments/assets/3845e70b-8891-4d86-9a80-6e75c744921f" />

<details><summary>Etter:</summary>
<img width="1147" height="334" alt="Skjermbilde 2026-04-28 kl  12 02 48" src="https://github.com/user-attachments/assets/3d5bcdf0-47cb-4a64-9647-1630c7fe2682" />
</br>
<img width="1140" height="516" alt="Skjermbilde 2026-04-28 kl  12 03 10" src="https://github.com/user-attachments/assets/831f0572-4e0a-41b9-8835-202d82c186f3" />
</br>
<img width="1143" height="505" alt="Skjermbilde 2026-04-28 kl  12 03 28" src="https://github.com/user-attachments/assets/fa8ace9c-a24a-465a-8b63-8736ddb4324f" />
</br>
<img width="1142" height="544" alt="Skjermbilde 2026-04-28 kl  12 21 16" src="https://github.com/user-attachments/assets/a31e9dd8-8980-4d24-b92c-fc5602deb9c5" />
</details>