### PR TITLE
Fix/redis error handling

### DIFF
--- a/server/valkey.ts
+++ b/server/valkey.ts
@@ -13,10 +13,10 @@ export async function getValkeyClient(): Promise<RedisClientType> {
 
   if (valkeyClient) {
     valkeyClient.removeAllListeners();
-    valkeyClient = undefined;
+    valkeyClient.destroy();
   }
 
-  const client = createClient({
+  valkeyClient = createClient({
     url: Config.valkey.uri,
     username: Config.valkey.username,
     password: Config.valkey.password,
@@ -30,16 +30,10 @@ export async function getValkeyClient(): Promise<RedisClientType> {
     },
   }) as RedisClientType;
 
-  client.on("error", (err) => {
+  valkeyClient.on("error", (err) => {
     logger.error({ err }, "Valkey client error");
   });
 
-  client.on("end", () => {
-    logger.warn("Valkey client disconnected");
-    valkeyClient = undefined;
-  });
-
-  await client.connect();
-  valkeyClient = client;
+  await valkeyClient.connect();
   return valkeyClient;
 }

--- a/server/valkey.ts
+++ b/server/valkey.ts
@@ -1,20 +1,45 @@
 import { createClient, RedisClientType } from "redis";
 import Config from "./config.js";
+import { logger } from "@navikt/pino-logger";
 
 let valkeyClient: RedisClientType | undefined;
 
+const MAX_RECONNECT_DELAY_MS = 5000;
+
 export async function getValkeyClient(): Promise<RedisClientType> {
-  if (valkeyClient) {
+  if (valkeyClient?.isReady) {
     return valkeyClient;
   }
 
-  valkeyClient = createClient({
+  if (valkeyClient) {
+    valkeyClient.removeAllListeners();
+    valkeyClient = undefined;
+  }
+
+  const client = createClient({
     url: Config.valkey.uri,
     username: Config.valkey.username,
     password: Config.valkey.password,
     database: Config.valkey.database,
+    socket: {
+      reconnectStrategy: (retries: number) => {
+        const delay = Math.min(retries * 100, MAX_RECONNECT_DELAY_MS);
+        logger.warn(`Valkey reconnect attempt ${retries}, next in ${delay}ms`);
+        return delay;
+      },
+    },
   }) as RedisClientType;
 
-  await valkeyClient.connect();
+  client.on("error", (err) => {
+    logger.error({ err }, "Valkey client error");
+  });
+
+  client.on("end", () => {
+    logger.warn("Valkey client disconnected");
+    valkeyClient = undefined;
+  });
+
+  await client.connect();
+  valkeyClient = client;
   return valkeyClient;
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

La til error event listener for redis client. Se https://github.com/redis/node-redis#events.
> ⚠️ You MUST listen to error events. If a client doesn't have at least one error listener registered and an error occurs, that error will be thrown and the Node.js process will exit. 

Så det var en del restart av podder igjen pga dette. Det betyr kanskje at vi kan bumpe opp versjonen igjen 🤞 
