### PR TITLE
Fix/econnreset errors with keep alive

### DIFF
--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import http from "http";
+import https from "https";
 import proxy from "express-http-proxy";
 import url from "url";
 
@@ -9,15 +10,21 @@ import Config from "./config.js";
 import { logger } from "@navikt/pino-logger";
 
 /**
- * Custom HTTP agent with keepAlive disabled.
+ * Custom HTTP/HTTPS agents with keepAlive disabled.
  *
  * express-http-proxy hardcodes `Connection: close` on all outgoing requests.
  * Node.js 22+ defaults the global http.Agent to keepAlive: true, which causes
  * the agent to pool sockets that upstream servers have already closed — resulting
- * in ECONNRESET errors on the next reuse attempt. Using a dedicated agent with
+ * in ECONNRESET errors on the next reuse attempt. Using dedicated agents with
  * keepAlive: false matches the library's Connection: close behavior.
+ * Two agents are needed since http.Agent cannot be used for https:// targets.
  */
-const proxyAgent = new http.Agent({ keepAlive: false });
+const httpProxyAgent = new http.Agent({ keepAlive: false });
+const httpsProxyAgent = new https.Agent({ keepAlive: false });
+
+function getProxyAgent(host: string) {
+  return host.startsWith("https://") ? httpsProxyAgent : httpProxyAgent;
+}
 
 const transientErrorCodes = [
   "ECONNRESET",
@@ -31,7 +38,7 @@ const proxyExternalHostWithoutAuthentication = (host: any) =>
   proxy(host, {
     https: false,
     proxyReqOptDecorator: (options) => {
-      options.agent = proxyAgent;
+      options.agent = getProxyAgent(host);
       return options;
     },
     proxyReqPathResolver: (req) => {
@@ -70,7 +77,7 @@ const proxyExternalHost = (
     parseReqBody: parseReqBody,
     timeout: 30000,
     proxyReqOptDecorator: async (options) => {
-      options.agent = proxyAgent;
+      options.agent = getProxyAgent(host);
       if (!accessToken) {
         return options;
       }

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -1,6 +1,4 @@
 import express from "express";
-import http from "http";
-import https from "https";
 import proxy from "express-http-proxy";
 import url from "url";
 
@@ -8,23 +6,6 @@ import { getOnBehalfOfToken } from "./authUtils.js";
 import type { ExternalAppConfig } from "./config.js";
 import Config from "./config.js";
 import { logger } from "@navikt/pino-logger";
-
-/**
- * Custom HTTP/HTTPS agents with keepAlive disabled.
- *
- * express-http-proxy hardcodes `Connection: close` on all outgoing requests.
- * Node.js 22+ defaults the global http.Agent to keepAlive: true, which causes
- * the agent to pool sockets that upstream servers have already closed — resulting
- * in ECONNRESET errors on the next reuse attempt. Using dedicated agents with
- * keepAlive: false matches the library's Connection: close behavior.
- * Two agents are needed since http.Agent cannot be used for https:// targets.
- */
-const httpProxyAgent = new http.Agent({ keepAlive: false });
-const httpsProxyAgent = new https.Agent({ keepAlive: false });
-
-function getProxyAgent(host: string) {
-  return host.startsWith("https://") ? httpsProxyAgent : httpProxyAgent;
-}
 
 const transientErrorCodes = [
   "ECONNRESET",
@@ -38,7 +19,10 @@ const proxyExternalHostWithoutAuthentication = (host: any) =>
   proxy(host, {
     https: false,
     proxyReqOptDecorator: (options) => {
-      options.agent = getProxyAgent(host);
+      options.headers = {
+        ...options.headers,
+        connection: "keep-alive",
+      };
       return options;
     },
     proxyReqPathResolver: (req) => {
@@ -77,12 +61,12 @@ const proxyExternalHost = (
     parseReqBody: parseReqBody,
     timeout: 30000,
     proxyReqOptDecorator: async (options) => {
-      options.agent = getProxyAgent(host);
+      options.headers = {
+        ...options.headers,
+        connection: "keep-alive",
+      };
       if (!accessToken) {
         return options;
-      }
-      if (!options.headers) {
-        options.headers = {};
       }
       (options.headers as Record<string, string>)[
         "Authorization"

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import http from "http";
 import proxy from "express-http-proxy";
 import url from "url";
 
@@ -7,9 +8,32 @@ import type { ExternalAppConfig } from "./config.js";
 import Config from "./config.js";
 import { logger } from "@navikt/pino-logger";
 
+/**
+ * Custom HTTP agent with keepAlive disabled.
+ *
+ * express-http-proxy hardcodes `Connection: close` on all outgoing requests.
+ * Node.js 22+ defaults the global http.Agent to keepAlive: true, which causes
+ * the agent to pool sockets that upstream servers have already closed — resulting
+ * in ECONNRESET errors on the next reuse attempt. Using a dedicated agent with
+ * keepAlive: false matches the library's Connection: close behavior.
+ */
+const proxyAgent = new http.Agent({ keepAlive: false });
+
+const transientErrorCodes = [
+  "ECONNRESET",
+  "EPIPE",
+  "ECONNABORTED",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+];
+
 const proxyExternalHostWithoutAuthentication = (host: any) =>
   proxy(host, {
     https: false,
+    proxyReqOptDecorator: (options) => {
+      options.agent = proxyAgent;
+      return options;
+    },
     proxyReqPathResolver: (req) => {
       const urlFromApi = url.parse(host);
       const pathFromApi =
@@ -28,9 +52,8 @@ const proxyExternalHostWithoutAuthentication = (host: any) =>
     },
     proxyErrorHandler: (err, res, next) => {
       logger.error(`Error in proxy for ${host} ${err.message}, ${err.code}`);
-      if (err && err.code === "ECONNREFUSED") {
-        logger.error("proxyErrorHandler: Got ECONNREFUSED");
-        return res.status(503).send({ message: `Could not contact ${host}` });
+      if (err && transientErrorCodes.includes(err.code)) {
+        return res.status(502).send({ message: `Could not contact ${host}` });
       }
       next(err);
     },
@@ -47,6 +70,7 @@ const proxyExternalHost = (
     parseReqBody: parseReqBody,
     timeout: 30000,
     proxyReqOptDecorator: async (options) => {
+      options.agent = proxyAgent;
       if (!accessToken) {
         return options;
       }
@@ -85,9 +109,8 @@ const proxyExternalHost = (
     },
     proxyErrorHandler: (err, res, next) => {
       logger.error(`Error in proxy for ${host} ${err.message}, ${err.code}`);
-      if (err && err.code === "ECONNREFUSED") {
-        logger.error("proxyErrorHandler: Got ECONNREFUSED");
-        return res.status(503).send({ message: `Could not contact ${host}` });
+      if (err && transientErrorCodes.includes(err.code)) {
+        return res.status(502).send({ message: `Could not contact ${host}` });
       }
       next(err);
     },


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Det er en del feilmedinger på ECONNRESET i prod. Det skjer i alle bff'ene, men mest i syfomodiaperson (kanskje fordi den har mest trafikk?). 
Ser ut til å fikse det i dev, men ikke så lett å fremprovosere alltid. Hvis feilmeldingene forsvinner i prod, burde vi gjøre tilsvarende endringer i de andre bff'ene også.

express-http-proxy defaulter `Connection` headeren til `close`. Node 19+ forventer at det skal være `keep-alive` og forsøker derfor å bruke connections som har blitt lukket.
