### PR TITLE
Add FNR sync to decorator

### DIFF
--- a/src/decorator/Decorator.tsx
+++ b/src/decorator/Decorator.tsx
@@ -46,6 +46,9 @@ const Decorator = () => {
     <internarbeidsflate-decorator
       ref={decoratorRef}
       app-name={decoratorConfig.appName}
+      fetch-active-user-on-mount={String(
+        decoratorConfig.fetchActiveUserOnMount
+      )}
       fetch-active-enhet-on-mount={String(
         decoratorConfig.fetchActiveEnhetOnMount
       )}

--- a/src/decorator/decoratorConfig.ts
+++ b/src/decorator/decoratorConfig.ts
@@ -21,6 +21,7 @@ const getUrlFormat = (): UrlFormat => {
 
 export const decoratorConfig: DecoratorProps = {
   appName: "Sykefraværsoppfølging",
+  fetchActiveUserOnMount: true,
   fetchActiveEnhetOnMount: true,
   showEnheter: true,
   showSearchArea: true,
@@ -29,5 +30,4 @@ export const decoratorConfig: DecoratorProps = {
   environment: getEnvironment(),
   urlFormat: getUrlFormat(),
   proxy: "/modiacontextholder",
-  fnrSyncMode: "writeOnly",
 };


### PR DESCRIPTION
Legger til at man henter FNR hvis det er eksternt endret. Årsaken til at det ble en feil her er at de andre appene _ikke_ bruker denne funksjonaliteten, trolig fordi den er mer "i veien" enn det er verdt. Veldig viktig å få denne på plass.