### PR TITLE
Oppdater bannertekst om nye tilganger

### DIFF
--- a/src/components/LegacyTilgangBanner.tsx
+++ b/src/components/LegacyTilgangBanner.tsx
@@ -1,11 +1,10 @@
-import { GlobalAlert } from "@navikt/ds-react";
+import { GlobalAlert, Link } from "@navikt/ds-react";
 import React from "react";
 
 const texts = {
-  title:
-    "Grunnet nye tilgangsordninger i Modia/Syfo vil tilgangen din snart stenges.",
+  title: "Du har en gammel tilgang til Modia Sykefraværsoppfølging",
   description:
-    "For å beholde tilgangen må du be din leder om å gi deg en av tilgangene MODIA-SYFO-VEILEDER eller MODIA-SYFO-LESETILGANG i Mine Tilganger.",
+    "Det er opprettet nye tilganger for Modia SYFO. Hvis du er SYFO-veileder må du få tildelt den nye tilgangen innen 1. juni 2026. Etter det vil brukere med gammel tilgang kun ha tilgang til Finn fastlege.",
 };
 
 export default function LegacyTilgangBanner() {
@@ -16,7 +15,17 @@ export default function LegacyTilgangBanner() {
           {texts.title}
         </GlobalAlert.Title>
       </GlobalAlert.Header>
-      <GlobalAlert.Content>{texts.description}</GlobalAlert.Content>
+      <GlobalAlert.Content>
+        {texts.description}{" "}
+        <Link
+          href="https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-sykefravarsoppfolging-og-sykepenger/SitePages/Nye-tilganger-til-Modia-sykefrav%C3%A6rsoppf%C3%B8lging.aspx"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Les mer på Navet
+        </Link>
+        .
+      </GlobalAlert.Content>
     </GlobalAlert>
   );
 }

--- a/test/components/LegacyTilgangBannerTest.tsx
+++ b/test/components/LegacyTilgangBannerTest.tsx
@@ -19,8 +19,7 @@ import { ToggleNames } from "@/data/unleash/unleash_types";
 import { tilgangQueryKeys } from "@/data/tilgang/tilgangQueryHooks";
 import { tilgangBrukerMock } from "@/mocks/istilgangskontroll/tilgangtilbrukerMock";
 
-const bannerTitle =
-  "Grunnet nye tilgangsordninger i Modia/Syfo vil tilgangen din snart stenges.";
+const bannerTitle = "Du har en gammel tilgang til Modia Sykefraværsoppfølging";
 
 describe("LegacyTilgangBanner", () => {
   it("viser advarsel om legacy tilgang", () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Oppdaterer teksten i global alert banner om nye tilganger i forkant av å skru på feature flag som viser banneret til brukere med gammel tilgang. En lenke til mer informasjon på Navet er også lagt til.

### Screenshots 📸✨

<img width="1697" height="483" alt="image" src="https://github.com/user-attachments/assets/ce0e5cb4-e9d8-498f-a10b-f88f93cad1a6" />


