### PR TITLE
IS-3934: Add infobox for veiledervurdering

### DIFF
--- a/src/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes.ts
+++ b/src/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes.ts
@@ -1,7 +1,11 @@
 export interface KartleggingssporsmalFormSnapshot {
   formSemanticVersion: string;
-  fieldSnapshots: KartleggingssporsmalFieldSnapshot[];
+  fieldSnapshots: KartleggingssporsmalFieldSnapshotUnion[];
 }
+
+export type KartleggingssporsmalFieldSnapshotUnion =
+  | KartleggingssporsmalRadioGroupFieldSnapshot
+  | KartleggingssporsmalTextFieldSnapshot;
 
 export interface KartleggingssporsmalFieldSnapshot {
   fieldId: string;
@@ -17,12 +21,14 @@ export enum KartleggingssporsmalFormSnapshotFieldType {
 
 export interface KartleggingssporsmalRadioGroupFieldSnapshot
   extends KartleggingssporsmalFieldSnapshot {
+  fieldType: KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP;
   options: KartleggingssporsmalFormSnapshotFieldOption[];
   wasRequired: boolean | null;
 }
 
 export interface KartleggingssporsmalTextFieldSnapshot
   extends KartleggingssporsmalFieldSnapshot {
+  fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT;
   value: string;
   wasRequired: boolean | null;
 }

--- a/src/mocks/meroppfolging-backend/merOppfolgingMock.ts
+++ b/src/mocks/meroppfolging-backend/merOppfolgingMock.ts
@@ -53,61 +53,69 @@ export const merOppfolgingMock: SenOppfolgingFormResponseDTOV2 = {
 };
 
 const createRadioOption = (
+  id: string,
   label: string,
   isSelected = false
 ): FormSnapshotFieldOption => {
   return {
-    optionId: label,
+    optionId: id,
     optionLabel: label,
     wasSelected: isSelected,
   };
 };
 
-export const defaultRadioGroupSporsmal: KartleggingssporsmalRadioGroupFieldSnapshot =
-  {
-    fieldId: "hvorSannsynligTilbakeTilJobben",
+export const defaultRadioGroupSporsmal = (
+  fieldId: string
+): KartleggingssporsmalRadioGroupFieldSnapshot => {
+  return {
+    fieldId: fieldId,
     fieldType: KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP,
     description: null,
     label: "Label 1",
-    options: [createRadioOption("Ja", true), createRadioOption("Nei")],
+    options: [
+      createRadioOption("1a", "Ja", true),
+      createRadioOption("1b", "Nei"),
+    ],
     wasRequired: true,
   };
+};
 
 const kartleggingssporsmal: KartleggingssporsmalRadioGroupFieldSnapshot[] = [
   {
-    ...defaultRadioGroupSporsmal,
+    ...defaultRadioGroupSporsmal("hvorSannsynligTilbakeTilJobben"),
     label:
       "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
     options: [
-      createRadioOption("Jeg tror det er veldig sannsynlig"),
-      createRadioOption("Jeg tror det er lite sannsynlig"),
-      createRadioOption("Jeg er usikker", true),
+      createRadioOption("1a", "Jeg tror det er veldig sannsynlig"),
+      createRadioOption("1b", "Jeg tror det er lite sannsynlig"),
+      createRadioOption("1c", "Jeg er usikker", true),
     ],
   },
   {
-    ...defaultRadioGroupSporsmal,
+    ...defaultRadioGroupSporsmal("arbeidsgiverHvordanErSamarbeidFlervalg"),
     label:
       "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
     options: [
-      createRadioOption("Jeg opplever samarbeidet og relasjonen som god"),
+      createRadioOption("2a", "Jeg opplever samarbeidet og relasjonen som god"),
       createRadioOption(
+        "2b",
         "Jeg opplever samarbeidet og relasjonen som dårlig",
         true
       ),
     ],
   },
   {
-    ...defaultRadioGroupSporsmal,
+    ...defaultRadioGroupSporsmal("naarTilbakeTilJobbenFlervalg"),
     label: "Hvor lenge tror du at du kommer til å være sykmeldt?",
     options: [
-      createRadioOption("Mindre enn seks måneder", true),
-      createRadioOption("Mer enn seks måneder"),
+      createRadioOption("3a", "Mindre enn seks måneder", true),
+      createRadioOption("3b", "Mer enn seks måneder"),
     ],
   },
 ];
 
 const hvorforUsikkerTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
-  fieldId: "tilbakemelding",
+  fieldId: "tilbakeTilJobbenLiteSannsynligBegrunnelse",
   fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
   description:
     "Skriv kortfattet hvorfor du er usikker på om du kommer tilbake i jobben du ble sykmeldt fra",
@@ -119,7 +127,7 @@ const hvorforUsikkerTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
 };
 
 const samarbeidTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
-  fieldId: "tilbakemelding",
+  fieldId: "arbeidsgiverSamarbeidDarligBegrunnelse",
   fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
   description: null,
   label: "Hva gjør samarbeidet og relasjonen dårlig?",
@@ -141,6 +149,55 @@ export const kartleggingssporsmalAnswered: KartleggingssporsmalSvarResponseDTO =
         ...kartleggingssporsmal.slice(1, 2),
         samarbeidTextSporsmal,
         ...kartleggingssporsmal.slice(2),
+      ],
+    },
+  };
+
+export const kartleggingssporsmalLowRiskAnswered: KartleggingssporsmalSvarResponseDTO =
+  {
+    uuid: generateUUID(),
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    kandidatId: generateUUID(),
+    createdAt: daysFromToday(-2),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        {
+          ...defaultRadioGroupSporsmal("hvorSannsynligTilbakeTilJobben"),
+          label:
+            "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
+          options: [
+            createRadioOption("1a", "Jeg tror det er veldig sannsynlig", true),
+            createRadioOption("1b", "Jeg tror det er lite sannsynlig"),
+            createRadioOption("1c", "Jeg er usikker"),
+          ],
+        },
+        {
+          ...defaultRadioGroupSporsmal(
+            "arbeidsgiverHvordanErSamarbeidFlervalg"
+          ),
+          label:
+            "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+          options: [
+            createRadioOption(
+              "2a",
+              "Jeg opplever samarbeidet og relasjonen som god",
+              true
+            ),
+            createRadioOption(
+              "2b",
+              "Jeg opplever samarbeidet og relasjonen som dårlig"
+            ),
+          ],
+        },
+        {
+          ...defaultRadioGroupSporsmal("naarTilbakeTilJobbenFlervalg"),
+          label: "Hvor lenge tror du at du kommer til å være sykmeldt?",
+          options: [
+            createRadioOption("3a", "Mindre enn seks måneder", true),
+            createRadioOption("3b", "Mer enn seks måneder"),
+          ],
+        },
       ],
     },
   };

--- a/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
+++ b/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
@@ -275,9 +275,11 @@ export default function KartleggingssporsmalSide(): ReactElement {
                 )}
               </Box>
               {showKartleggingVurdering &&
+                answeredQuestions &&
                 nyesteKandidat.status !== KandidatStatus.KANDIDAT && (
                   <KartleggingVurdering
                     nyesteKandidat={nyesteKandidat}
+                    answeredQuestions={answeredQuestions}
                     vurderSvarMutation={vurderSvar}
                   />
                 )}

--- a/src/sider/kartleggingssporsmal/info/KartleggingInfo.tsx
+++ b/src/sider/kartleggingssporsmal/info/KartleggingInfo.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { Box, Heading, List } from "@navikt/ds-react";
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts";
+import { KartleggingssporsmalSvarResponseDTO } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts";
+import { hasRiskoForLangtidsfravar } from "@/sider/kartleggingssporsmal/info/vurdereBehov.ts";
+
+const texts = {
+  heading: "Oppsummering av den sykmeldtes situasjon",
+  list: {
+    hasGjentakendeSykefravar: "Den sykmeldte har gjentagende fravær",
+    noGjentakendeSykefravar: "Den sykmeldte har ikke gjentagende fravær",
+    hasRiskoForLangtidsfravar:
+      "Svarene indikerer behov for vurdering av oppfølging – se veiledning",
+    noRiskoForLangtidsfravar:
+      "Svarene indikerer ikke behov for videre vurdering av oppfølging – se veiledning",
+  },
+};
+
+interface Props {
+  answeredQuestions: KartleggingssporsmalSvarResponseDTO;
+}
+
+export function KartleggingInfo({ answeredQuestions }: Props) {
+  const { hasGjentakendeSykefravar } = useOppfolgingstilfellePersonQuery();
+
+  return (
+    <Box
+      background="accent-soft"
+      borderColor="brand-blue"
+      borderWidth="1"
+      className="flex flex-col rounded p-4 mt-2 gap-4"
+    >
+      <Heading size="small">{texts.heading}</Heading>
+      <List as="ul" size="small">
+        <List.Item>
+          {hasGjentakendeSykefravar
+            ? texts.list.hasGjentakendeSykefravar
+            : boldRegex(texts.list.noGjentakendeSykefravar, "ikke")}
+        </List.Item>
+
+        <List.Item>
+          {hasRiskoForLangtidsfravar(answeredQuestions)
+            ? texts.list.hasRiskoForLangtidsfravar
+            : boldRegex(texts.list.noRiskoForLangtidsfravar, "ikke")}
+        </List.Item>
+      </List>
+    </Box>
+  );
+}
+
+function boldRegex(text: string, searchTerm: string) {
+  const regex = new RegExp(`(${searchTerm})`, "gi");
+  const parts = text.split(regex);
+
+  return (
+    <>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <strong key={i}>{part}</strong>
+        ) : (
+          <span key={i}>{part}</span>
+        )
+      )}
+    </>
+  );
+}

--- a/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
+++ b/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
@@ -1,0 +1,40 @@
+import { KartleggingssporsmalSvarResponseDTO } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts";
+import { KartleggingssporsmalFormSnapshotFieldType } from "@/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes.ts";
+
+export function hasRiskoForLangtidsfravar(
+  answeredQuestions: KartleggingssporsmalSvarResponseDTO
+) {
+  if (answeredQuestions.formSnapshot.fieldSnapshots) {
+    const optionAnswers = answeredQuestions.formSnapshot.fieldSnapshots.filter(
+      (field) =>
+        field?.fieldType ===
+        KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP
+    );
+    return lowRiskAnswers.some((answer) => {
+      const fieldSnapshot = optionAnswers.find(
+        (field) => field.fieldId === answer.field
+      );
+      if (!fieldSnapshot) return false;
+
+      const option = fieldSnapshot.options?.find(
+        (option) => option.optionId !== answer.optionId
+      );
+      return option?.wasSelected;
+    });
+  }
+}
+
+export const lowRiskAnswers = [
+  {
+    field: "hvorSannsynligTilbakeTilJobben",
+    optionId: "1a",
+  },
+  {
+    field: "arbeidsgiverHvordanErSamarbeidFlervalg",
+    optionId: "2a",
+  },
+  {
+    field: "naarTilbakeTilJobbenFlervalg",
+    optionId: "3a",
+  },
+] as const;

--- a/src/sider/kartleggingssporsmal/skjemasvar/KartleggingssporsmalSkjemasvar.tsx
+++ b/src/sider/kartleggingssporsmal/skjemasvar/KartleggingssporsmalSkjemasvar.tsx
@@ -4,8 +4,6 @@ import { KartleggingssporsmalTextSvar } from "@/sider/kartleggingssporsmal/skjem
 import {
   KartleggingssporsmalFormSnapshot,
   KartleggingssporsmalFormSnapshotFieldType,
-  KartleggingssporsmalRadioGroupFieldSnapshot,
-  KartleggingssporsmalTextFieldSnapshot,
 } from "@/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes";
 import { Alert } from "@navikt/ds-react";
 
@@ -23,28 +21,25 @@ export function KartleggingssporsmalSkjemasvar({ formSnapshot }: Props) {
   return (
     <div className="flex flex-col gap-7">
       {formSnapshot?.fieldSnapshots.map((field, index) => {
+        const fieldType: string = field.fieldType;
+
         switch (field.fieldType) {
           case KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP:
             return (
               <KartleggingssporsmalRadioGroupSvar
                 key={index}
-                radioGroupSvar={
-                  field as KartleggingssporsmalRadioGroupFieldSnapshot
-                }
+                radioGroupSvar={field}
               />
             );
           case KartleggingssporsmalFormSnapshotFieldType.TEXT:
             return (
-              <KartleggingssporsmalTextSvar
-                key={index}
-                textSvar={field as KartleggingssporsmalTextFieldSnapshot}
-              />
+              <KartleggingssporsmalTextSvar key={index} textSvar={field} />
             );
           default:
             return (
               <Alert className="w-1/2" variant={"error"}>
-                Mottok spørsmål av typen: {field.fieldType} som fremvisningen
-                ikke støtter. Send en sak i Porten der du melder ifra om dette.
+                Mottok spørsmål av typen: {fieldType} som fremvisningen ikke
+                støtter. Send en sak i Porten der du melder ifra om dette.
               </Alert>
             );
         }

--- a/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
+++ b/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
@@ -9,6 +9,7 @@ import {
 import {
   KandidatStatus,
   KartleggingssporsmalKandidatResponseDTO,
+  KartleggingssporsmalSvarResponseDTO,
 } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts";
 import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil.tsx";
@@ -19,6 +20,7 @@ import { UseMutationResult } from "@tanstack/react-query";
 import { finnNaisUrlIntern } from "@/utils/miljoUtil.ts";
 import { EksternLenke } from "@/components/EksternLenke.tsx";
 import { Events, trackEvent } from "@/utils/umami.ts";
+import { KartleggingInfo } from "@/sider/kartleggingssporsmal/info/KartleggingInfo.tsx";
 
 const texts = {
   heading: "Vurdering",
@@ -48,6 +50,7 @@ function logEvent() {
 
 interface Props {
   nyesteKandidat: KartleggingssporsmalKandidatResponseDTO;
+  answeredQuestions: KartleggingssporsmalSvarResponseDTO;
   // Vi må ta inn denne fordi visning av flexjar-boksen er knyttet til mutation i Kartleggingssporsmal.tsx
   // Kan unngå dette når man har én vurderingsside, ikke to ulike måter å vurdere på
   vurderSvarMutation: UseMutationResult<
@@ -63,6 +66,7 @@ interface Props {
 
 export function KartleggingVurdering({
   nyesteKandidat,
+  answeredQuestions,
   vurderSvarMutation,
 }: Props) {
   const [chosenAlternative, setChosenAlternative] =
@@ -75,6 +79,8 @@ export function KartleggingVurdering({
 
   return (
     <Box background="default" className="p-6 gap-6 [&>*]:mb-4 mb-4">
+      <KartleggingInfo answeredQuestions={answeredQuestions} />
+
       <Heading size={"medium"}>{texts.heading}</Heading>
       <RadioGroup
         legend={texts.legend}

--- a/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
+++ b/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
@@ -15,7 +15,10 @@ import {
   kartleggingssporsmalFerdigbehandlet,
   kartleggingssporsmalVurderingFerdigbehandlet,
 } from "@/mocks/ismeroppfolging/mockIsmeroppfolging";
-import { kartleggingssporsmalAnswered } from "@/mocks/meroppfolging-backend/merOppfolgingMock";
+import {
+  kartleggingssporsmalAnswered,
+  kartleggingssporsmalLowRiskAnswered,
+} from "@/mocks/meroppfolging-backend/merOppfolgingMock";
 import {
   ARBEIDSTAKER_DEFAULT,
   BEHANDLENDE_ENHET_DEFAULT,
@@ -42,6 +45,8 @@ import { generateUUID } from "@/utils/utils";
 import { mockUnleashTogglesOffResponse } from "@/mocks/unleashMocks.ts";
 import { unleashQueryKeys } from "@/data/unleash/unleashQueryHooks.ts";
 import { ToggleNames } from "@/data/unleash/unleash_types.ts";
+import { oppfolgingstilfellePersonMock } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock.ts";
+import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts";
 
 let queryClient: QueryClient;
 
@@ -74,6 +79,19 @@ const mockKartleggingssporsmalSvar = (
     () => kartleggingssporsmalSvarResponseDTO
   );
 };
+
+const mockGjentagendeFravar = (hasGjentakendeSykefravar: boolean) =>
+  queryClient.setQueryData(
+    oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
+    () => {
+      return {
+        ...oppfolgingstilfellePersonMock,
+        hasGjentakendeSykefravar: hasGjentakendeSykefravar,
+      };
+    }
+  );
 
 const mockEnabledToggles = (enabledToggles: ToggleNames[]) =>
   queryClient.setQueryData(
@@ -447,6 +465,101 @@ describe("Kartleggingssporsmal", () => {
           "Det skjedde en uventet feil. Vennligst prøv igjen senere."
         )
       ).to.exist;
+    });
+  });
+
+  describe("Display information box above vurdering", () => {
+    const hasGjentakendeSykefravar = "Den sykmeldte har gjentagende fravær";
+    const noGjentakendeSykefravar = "Den sykmeldte har ikke gjentagende fravær";
+    const hasRiskoForLangtidsfravar =
+      "Svarene indikerer behov for vurdering av oppfølging – se veiledning";
+    const noRiskoForLangtidsfravar =
+      "Svarene indikerer ikke behov for videre vurdering av oppfølging – se veiledning";
+
+    it("Shows hasRiskoForLangtidsfravarText when svar indicate risk for langtidsfravar", () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+
+      renderKartleggingssporsmal();
+
+      expect(screen.queryByText(hasRiskoForLangtidsfravar)).to.exist;
+      expect(screen.queryByText(noRiskoForLangtidsfravar)).to.not.exist;
+    });
+
+    it("Does not show hasRiskoForLangtidsfravarText when all selected radio options are low-risk", () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalLowRiskAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+
+      renderKartleggingssporsmal();
+
+      expect(
+        screen.getByRole("listitem", {
+          name: (_, element) => {
+            return element?.textContent === noRiskoForLangtidsfravar;
+          },
+        })
+      ).to.exist;
+      expect(screen.queryByText(hasRiskoForLangtidsfravar)).to.not.exist;
+    });
+
+    it("Shows hasGjentakendeSykefravarText when hasGjentakendeSykefravar is true", () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockGjentagendeFravar(true);
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+
+      renderKartleggingssporsmal();
+
+      expect(screen.queryByText(hasGjentakendeSykefravar)).to.exist;
+      expect(screen.queryByText(noGjentakendeSykefravar)).to.not.exist;
+    });
+
+    it("Does not show hasGjentakendeSykefravarText when hasGjentakendeSykefravar is true", () => {
+      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
+
+      mockGjentagendeFravar(false);
+      mockKartleggingssporsmalKandidat(
+        kartleggingIsKandidatAndAnsweredQuestions,
+        ARBEIDSTAKER_DEFAULT.personIdent
+      );
+      mockKartleggingssporsmalSvar(
+        kartleggingssporsmalAnswered,
+        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+      );
+
+      renderKartleggingssporsmal();
+
+      expect(
+        screen.getByRole("listitem", {
+          name: (_, element) => {
+            return element?.textContent === noGjentakendeSykefravar;
+          },
+        })
+      ).to.exist;
+      expect(screen.queryByText(hasGjentakendeSykefravar)).to.not.exist;
     });
   });
 

--- a/test/kartleggingssporsmal/vurdereBehovTest.ts
+++ b/test/kartleggingssporsmal/vurdereBehovTest.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasRiskoForLangtidsfravar,
+  lowRiskAnswers,
+} from "@/sider/kartleggingssporsmal/info/vurdereBehov.ts";
+import {
+  KartleggingssporsmalFormSnapshotFieldType,
+  KartleggingssporsmalRadioGroupFieldSnapshot,
+} from "@/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes";
+import { KartleggingssporsmalSvarResponseDTO } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes";
+
+function createRadioGroupFieldSnapshot(
+  fieldId: string,
+  selectedOptionId: string,
+  optionIds: readonly string[]
+): KartleggingssporsmalRadioGroupFieldSnapshot {
+  return {
+    fieldId,
+    fieldType: KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP,
+    label: fieldId,
+    description: null,
+    wasRequired: true,
+    options: optionIds.map((optionId) => ({
+      optionId,
+      optionLabel: optionId,
+      wasSelected: optionId === selectedOptionId,
+    })),
+  };
+}
+
+function createAnsweredQuestions(
+  selectedOptionsByField: Record<string, string>
+): KartleggingssporsmalSvarResponseDTO {
+  return {
+    uuid: "test-uuid",
+    fnr: "12345678910",
+    kandidatId: "kandidat-id",
+    createdAt: new Date("2026-01-01"),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        createRadioGroupFieldSnapshot(
+          "hvorSannsynligTilbakeTilJobben",
+          selectedOptionsByField.hvorSannsynligTilbakeTilJobben,
+          [lowRiskAnswers[0].optionId, "RISK_OPTION_1", "RISK_OPTION_2"]
+        ),
+        createRadioGroupFieldSnapshot(
+          "arbeidsgiverHvordanErSamarbeidFlervalg",
+          selectedOptionsByField.arbeidsgiverHvordanErSamarbeidFlervalg,
+          [lowRiskAnswers[1].optionId, "RISK_OPTION_3"]
+        ),
+        createRadioGroupFieldSnapshot(
+          "naarTilbakeTilJobbenFlervalg",
+          selectedOptionsByField.naarTilbakeTilJobbenFlervalg,
+          [lowRiskAnswers[2].optionId, "RISK_OPTION_4"]
+        ),
+      ],
+    },
+  };
+}
+
+describe("vurdereBehov", () => {
+  it("returns false when all selected options are low-risk answers", () => {
+    const answeredQuestions = createAnsweredQuestions({
+      hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
+      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
+      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+    });
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(false);
+  });
+
+  it("returns true when one answer differs from low-risk option", () => {
+    const answeredQuestions = createAnsweredQuestions({
+      hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
+      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
+      naarTilbakeTilJobbenFlervalg: "RISK_OPTION_4",
+    });
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(true);
+  });
+
+  it("returns false when there are no radio-group answers", () => {
+    const answeredQuestions: KartleggingssporsmalSvarResponseDTO = {
+      uuid: "test-uuid",
+      fnr: "12345678910",
+      kandidatId: "kandidat-id",
+      createdAt: new Date("2026-01-01"),
+      formSnapshot: {
+        formSemanticVersion: "1.0.0",
+        fieldSnapshots: [
+          {
+            fieldId: "tilleggsinformasjon",
+            fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
+            label: "Tilleggsinformasjon",
+            description: null,
+            value: "Tekst",
+            wasRequired: false,
+          },
+        ],
+      },
+    };
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(false);
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Legger til infoboks over vurdering av kartleggingsspørsmål. Her er det bare å komme med innspill på tekst/presentasjon, enten på PRen eller i [Slack-tråden](https://nav-it.slack.com/archives/G012X72TL12/p1779109259640669).

Jeg har også pyntet litt på [kartleggingssporsmalSkjemasvarTypes.ts](https://github.com/navikt/syfomodiaperson/compare/IS-3934-infobox?expand=1#diff-63d9eea85dbeb5754b574f3ab88e113d516c5ba30efb2426edbdfaad3295ad04) for å få bedre typeinferens, så slipper man `as` her og `as` der. Jeg fikset også på noen ID-er på mocken, da disse var duplisert og ikke matchet devmiljøet.

### Screenshots 📸✨

<img width="1160" height="1295" alt="image" src="https://github.com/user-attachments/assets/8bdea94b-86e5-47e0-a8fc-d1336678d447" />
<img width="1160" height="1305" alt="image" src="https://github.com/user-attachments/assets/175de277-25f4-4faa-ac47-ddbe058ce4f8" />
