### PR TITLE
IS-3934: Remove non-working close button

### DIFF
--- a/src/sider/frisktilarbeid/VedtakFattet.tsx
+++ b/src/sider/frisktilarbeid/VedtakFattet.tsx
@@ -75,7 +75,7 @@ export default function VedtakFattet({
         </Alert>
       )}
       {visInfotrygdAlert(vedtak.infotrygdStatus) && (
-        <Alert variant="warning" className="[&>*]:max-w-fit" closeButton>
+        <Alert variant="warning" className="[&>*]:max-w-fit">
           {texts.infotrygdAlert}
           <br />
           <i>{texts.infotrygdRutine}</i>


### PR DESCRIPTION
`closeButton` på advarselen hadde ingen assosiert `onClose`, så den gjorde ingenting. Jeg sjekket git-historikken, og det så egentlig litt ut til at den propen ble lagt til ved uhell. Snakket med Stine om det, og vi ble enige om at det ga mening å vise advarselen så lenge kvitteringen har feil og oppgaven ikke var fjernet fra oversikten. Dermed fjernes knappen.