### PR TITLE
Vis nye oppfølgingplaner på nøkkelinfo og aktivitetskrav sider

### DIFF
--- a/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
@@ -2,17 +2,26 @@ import React from "react";
 import styled from "styled-components";
 import { lpsPlanerWithActiveTilfelle } from "@/utils/oppfolgingsplanUtils";
 import {
+  restdatoTilLesbarDato,
   tilLesbarDatoMedArstall,
   tilLesbarPeriodeMedArstall,
 } from "@/utils/datoUtils";
 import { OppfolgingsplanLPS } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanLPS";
-import { LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT } from "@/apiConstants";
+import {
+  LPS_OPPFOLGINGSPLAN_MOTTAK_V1_ROOT,
+  SYFO_OPPFOLGINGSPLAN_BACKEND_ROOT,
+} from "@/apiConstants";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
 import {
   useGetLPSOppfolgingsplanerQuery,
   useGetOppfolgingsplanerQuery,
+  useGetOppfolgingsplanerV2Query,
 } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { OppfolgingsplanDTO } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanDTO";
+import {
+  OppfolgingsplanV2DTO,
+  partitionOppfolgingsplanerByActiveTilfelle,
+} from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { Alert, Heading, Link, Loader } from "@navikt/ds-react";
 
@@ -111,20 +120,64 @@ function LPSPlaner({ lpsPlaner }: LpsPlanerProps) {
   );
 }
 
+interface AktivPlanV2LenkeProps {
+  aktivPlan: OppfolgingsplanV2DTO;
+}
+
+function AktivPlanV2Lenke({ aktivPlan }: AktivPlanV2LenkeProps) {
+  const { virksomhetsnavn } = useVirksomhetQuery(aktivPlan.virksomhetsnummer);
+  const deltMedNav = restdatoTilLesbarDato(aktivPlan.deltMedNavTidspunkt);
+  return (
+    <AktivPlan>
+      <a
+        className="lenke"
+        href={`${SYFO_OPPFOLGINGSPLAN_BACKEND_ROOT}/oppfolgingsplaner/${aktivPlan.uuid}`}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {virksomhetsnavn && virksomhetsnavn.length > 0
+          ? virksomhetsnavn.toLowerCase()
+          : aktivPlan.virksomhetsnummer}
+      </a>
+      <span className="ml-8">{`delt med Nav ${deltMedNav}`}</span>
+    </AktivPlan>
+  );
+}
+
+interface AktivePlanerV2Props {
+  aktivePlaner: OppfolgingsplanV2DTO[];
+}
+
+function AktivePlanerV2({ aktivePlaner }: AktivePlanerV2Props) {
+  return (
+    <>
+      {aktivePlaner.map((plan, index) => (
+        <AktivPlanV2Lenke key={index} aktivPlan={plan} />
+      ))}
+    </>
+  );
+}
+
 interface OppfolgingsplanerProps {
   aktivePlaner: OppfolgingsplanDTO[];
+  aktivePlanerV2: OppfolgingsplanV2DTO[];
   lpsPlaner: OppfolgingsplanLPS[];
 }
 
 function Oppfolgingsplaner({
   aktivePlaner,
+  aktivePlanerV2,
   lpsPlaner,
 }: OppfolgingsplanerProps) {
-  const anyActivePlaner = aktivePlaner.length > 0 || lpsPlaner.length > 0;
+  const anyActivePlaner =
+    aktivePlaner.length > 0 ||
+    aktivePlanerV2.length > 0 ||
+    lpsPlaner.length > 0;
 
   return anyActivePlaner ? (
     <div>
       <AktivePlaner aktivePlaner={aktivePlaner} />
+      <AktivePlanerV2 aktivePlaner={aktivePlanerV2} />
       <LPSPlaner lpsPlaner={lpsPlaner} />
     </div>
   ) : (
@@ -141,16 +194,27 @@ export default function UtdragOppfolgingsplaner({
 }: Props) {
   const getOppfolgingsplanerQuery = useGetOppfolgingsplanerQuery();
   const getLPSOppfolgingsplanerQuery = useGetLPSOppfolgingsplanerQuery();
+  const getOppfolgingsplanerV2Query = useGetOppfolgingsplanerV2Query();
 
   const activeLpsPlaner = lpsPlanerWithActiveTilfelle(
     getLPSOppfolgingsplanerQuery.data,
     selectedOppfolgingstilfelle
   );
+  const [aktiveOppfolgingsplanerV2] = selectedOppfolgingstilfelle
+    ? partitionOppfolgingsplanerByActiveTilfelle(
+        getOppfolgingsplanerV2Query.data,
+        selectedOppfolgingstilfelle
+      )
+    : [[]];
+
   const showLoader =
     getOppfolgingsplanerQuery.isPending &&
-    getLPSOppfolgingsplanerQuery.isPending;
+    getLPSOppfolgingsplanerQuery.isPending &&
+    getOppfolgingsplanerV2Query.isPending;
   const showError =
-    getOppfolgingsplanerQuery.isError && getLPSOppfolgingsplanerQuery.isError;
+    getOppfolgingsplanerQuery.isError &&
+    getLPSOppfolgingsplanerQuery.isError &&
+    getOppfolgingsplanerV2Query.isError;
 
   return (
     <div>
@@ -166,6 +230,7 @@ export default function UtdragOppfolgingsplaner({
       ) : (
         <Oppfolgingsplaner
           aktivePlaner={getOppfolgingsplanerQuery.data}
+          aktivePlanerV2={aktiveOppfolgingsplanerV2}
           lpsPlaner={activeLpsPlaner}
         />
       )}

--- a/test/components/UtdragFraSykefravaeretTest.tsx
+++ b/test/components/UtdragFraSykefravaeretTest.tsx
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   ARBEIDSTAKER_DEFAULT,
   VIRKSOMHET_BRANNOGBIL,
+  VIRKSOMHET_PONTYPANDY,
 } from "@/mocks/common/mockConstants";
 import { queryClientWithMockData } from "../testQueryClient";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
@@ -20,6 +21,7 @@ import {
   setSykmeldingDataFromOppfolgingstilfelle,
 } from "../utils/oppfolgingstilfelleUtils";
 import { sykmeldingerMock } from "@/mocks/syfosmregister/sykmeldingerMock";
+import { OppfolgingsplanV2DTO } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
 
 let queryClient: QueryClient;
 
@@ -177,6 +179,68 @@ describe("UtdragFraSykefravaeret", () => {
           dayjs(oppfolgingsplanCreatedAt).subtract(1, "days").toDate()
         )} (LPS)`
       )
+    ).to.not.exist;
+  });
+
+  it("Viser oppfolgingsplan V2 innenfor oppfolgingstilfelle", () => {
+    const oppfolgingstilfeller = createOppfolgingstilfelleFromSykmelding([
+      sykmeldingNow,
+    ]);
+    const tilfelle = oppfolgingstilfeller[0];
+    const planInnenforTilfelle: OppfolgingsplanV2DTO = {
+      uuid: "test-uuid-v2",
+      fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+      virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+      opprettet: new Date().toISOString(),
+      deltMedNavTidspunkt: new Date().toISOString(),
+      sistEndret: new Date().toISOString(),
+      evalueringsdato: addDays(new Date(), 7).toString(),
+    };
+    queryClient.setQueryData(
+      oppfolgingsplanQueryKeys.oppfolgingsplanerV2(
+        ARBEIDSTAKER_DEFAULT.personIdent
+      ),
+      () => [planInnenforTilfelle]
+    );
+
+    renderUtdragFraSykefravaeret(tilfelle);
+
+    expect(
+      screen.getByRole("link", {
+        name: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+      })
+    ).to.exist;
+    expect(screen.queryByText("Ingen planer er delt med Nav")).to.not.exist;
+  });
+
+  it("Viser ikke oppfolgingsplan V2 når den er utenfor oppfolgingstilfellet", () => {
+    const oppfolgingstilfeller = createOppfolgingstilfelleFromSykmelding([
+      sykmeldingNow,
+    ]);
+    const tilfelle = oppfolgingstilfeller[0];
+    const planUtenforTilfelle: OppfolgingsplanV2DTO = {
+      uuid: "test-uuid-v2-old",
+      fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+      virksomhetsnummer: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+      opprettet: addWeeks(new Date(), -4).toISOString(),
+      deltMedNavTidspunkt: addWeeks(new Date(), -4).toISOString(),
+      sistEndret: addWeeks(new Date(), -4).toISOString(),
+      evalueringsdato: addWeeks(new Date(), -2).toString(),
+    };
+    queryClient.setQueryData(
+      oppfolgingsplanQueryKeys.oppfolgingsplanerV2(
+        ARBEIDSTAKER_DEFAULT.personIdent
+      ),
+      () => [planUtenforTilfelle]
+    );
+
+    renderUtdragFraSykefravaeret(tilfelle);
+
+    expect(screen.getByText("Ingen planer er delt med Nav")).to.exist;
+    expect(
+      screen.queryByRole("link", {
+        name: VIRKSOMHET_PONTYPANDY.virksomhetsnummer,
+      })
     ).to.not.exist;
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
   - Henter nå V2-planer via useGetOppfolgingsplanerV2Query()
   - Filtrerer V2-planer til aktivt oppfølgingstilfelle med partitionOppfolgingsplanerByActiveTilfelle
   - Ny AktivPlanV2Lenke-komponent rendrer virksomhetsnavn + "delt med Nav [dato]" + PDF-lenke
   - "Ingen planer er delt med Nav" vises nå kun når alle tre kildene er tomme
   - Loading/error-states inkluderer V2-queryen (AND-logikk: kun vis loader/feil om alle tre feiler)

test/components/UtdragFraSykefravaeretTest.tsx
   - To nye tester: V2-plan innenfor tilfelle vises ✓, V2-plan utenfor tilfelle skjules ✓

### Screenshots 📸✨
<img width="1702" height="1307" alt="Skjermbilde 2026-05-21 kl  13 54 16" src="https://github.com/user-attachments/assets/9d6dc606-183d-4256-9a65-03bde0e8f6ac" />


<img width="1699" height="1228" alt="Skjermbilde 2026-05-21 kl  13 55 11" src="https://github.com/user-attachments/assets/bf8fa906-b1d1-4b43-9b76-13c4e4635158" />
