### PR TITLE
remove description from KartleggingssporsmalTextSvar

### DIFF
--- a/src/sider/kartleggingssporsmal/skjemasvar/KartleggingssporsmalTextSvar.tsx
+++ b/src/sider/kartleggingssporsmal/skjemasvar/KartleggingssporsmalTextSvar.tsx
@@ -12,7 +12,6 @@ export function KartleggingssporsmalTextSvar({ textSvar }: Props) {
   return (
     <Textarea
       label={textSvar.label}
-      description={textSvar.description}
       value={isEmpty ? "Ingen tekst" : textSvar.value}
       size={"small"}
       readOnly={true}


### PR DESCRIPTION
Vi pratet litt i sonen om at det egentlig ikke er nødvendig for veiledere å se denne teksten.

### Screenshots 📸✨
<img width="1650" height="1045" alt="Skjermbilde 2026-05-21 kl  15 26 14" src="https://github.com/user-attachments/assets/b6aaa30d-b118-4c64-b30e-ca09ec7f4c05" />
