### PR TITLE
IS-3976: use currentOppfolgingstilfelle for isAktivForesporsel

### DIFF
--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
@@ -90,9 +90,7 @@ export default function BeOmOppfolgingsplan({
   const narmesteLeder = watch("narmesteLeder");
   const lastForesporselCreatedAt = lastForesporsel?.createdAt;
   const isAktivForesporsel =
-    !!lastForesporselCreatedAt &&
-    !!currentOppfolgingstilfelle &&
-    !postOppfolgingsplanForesporsel.isSuccess
+    !!lastForesporselCreatedAt && !postOppfolgingsplanForesporsel.isSuccess
       ? isDateInOppfolgingstilfelle(
           lastForesporselCreatedAt,
           currentOppfolgingstilfelle

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
@@ -24,7 +24,6 @@ import {
   OppfolgingstilfelleDTO,
 } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { useOppfolgingsplanForesporselDocument } from "@/hooks/oppfolgingsplan/useOppfolgingsplanForesporselDocument";
-import { oppfolgingstilfelle } from "../../../../test/aktivitetskrav/vurdering/vurderingTestUtils";
 import LabelAndText from "@/components/LabelAndText";
 import { Controller, useForm } from "react-hook-form";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
@@ -96,7 +95,7 @@ export default function BeOmOppfolgingsplan({
     !postOppfolgingsplanForesporsel.isSuccess
       ? isDateInOppfolgingstilfelle(
           lastForesporselCreatedAt,
-          oppfolgingstilfelle
+          currentOppfolgingstilfelle
         )
       : false;
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Fikset bug i BeOmOppfolgingsplan.tsx der test-mockdata ble brukt i produksjonskoden:
1. Fjernet import { oppfolgingstilfelle } from "../../../../test/aktivitetskrav/vurdering/vurderingTestUtils"
2. Erstattet oppfolgingstilfelle med currentOppfolgingstilfelle (prop) i isAktivForesporsel-sjekken

Før: Warning-alertet "Obs! Det ble bedt om oppfølgingsplan fra..." ble aldri vist fordi datoen ble sjekket mot et test-oppfølgingstilfelle.

Etter: Sjekken bruker det faktiske oppfølgingstilfellet, så veiledere vil nå se varig status når forespørsel er sendt innenfor gjeldende tilfelle.

<img width="1656" height="850" alt="Skjermbilde 2026-05-22 kl  10 28 20" src="https://github.com/user-attachments/assets/2940cdc9-8e82-4540-8dd0-69b3f078a2e3" />

