### PR TITLE
IS-3728: Add virksomhetsnavn to dialogmøtebehov

### DIFF
--- a/src/data/virksomhet/virksomhetQueryHooks.ts
+++ b/src/data/virksomhet/virksomhetQueryHooks.ts
@@ -4,19 +4,30 @@ import {
   EregOrganisasjonResponseDTO,
   getVirksomhetsnavn,
 } from "@/data/virksomhet/types/EregOrganisasjonResponseDTO";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/utils";
 
 export const virksomhetQueryKeys = {
   virksomhet: (virksomhetsnummer?: string) => ["virksomhet", virksomhetsnummer],
 };
 
+const path = (virksomhetsnummer?: string) =>
+  `${EREG_ROOT}/organisasjon/${virksomhetsnummer}`;
+const fetchVirksomhet = (path: string) =>
+  get<EregOrganisasjonResponseDTO>(path);
+
+export interface VirksomhetQueryData {
+  virksomhetsnummer: string;
+  virksomhetsnavn?: string;
+  data?: EregOrganisasjonResponseDTO;
+}
+
+export type VirksomhetQueryDataRecord = Record<string, VirksomhetQueryData>;
+
 export function useVirksomhetQuery(virksomhetsnummer: string | undefined) {
-  const path = `${EREG_ROOT}/organisasjon/${virksomhetsnummer}`;
-  const fetchVirksomhet = () => get<EregOrganisasjonResponseDTO>(path);
   const query = useQuery({
     queryKey: virksomhetQueryKeys.virksomhet(virksomhetsnummer),
-    queryFn: fetchVirksomhet,
+    queryFn: () => fetchVirksomhet(path(virksomhetsnummer)),
     enabled: !!virksomhetsnummer,
     staleTime: minutesToMillis(60 * 12),
   });
@@ -24,5 +35,37 @@ export function useVirksomhetQuery(virksomhetsnummer: string | undefined) {
   return {
     data: query.data,
     virksomhetsnavn: query.data && getVirksomhetsnavn(query.data),
+  };
+}
+
+export function useVirksomheterQueries(virksomhetsnummer: string[] = []): {
+  data: VirksomhetQueryDataRecord;
+} {
+  const results = useQueries({
+    queries: virksomhetsnummer.map((nummer) => ({
+      queryKey: virksomhetQueryKeys.virksomhet(nummer),
+      queryFn: () => fetchVirksomhet(path(nummer)),
+      enabled: !!nummer,
+      staleTime: minutesToMillis(60 * 12),
+    })),
+  });
+
+  return {
+    data: results.reduce<VirksomhetQueryDataRecord>((acc, result, index) => {
+      const nummer = virksomhetsnummer[index];
+
+      if (!nummer) {
+        return acc;
+      }
+
+      return {
+        ...acc,
+        [nummer]: {
+          virksomhetsnummer: nummer,
+          virksomhetsnavn: result.data && getVirksomhetsnavn(result.data),
+          data: result.data,
+        },
+      };
+    }, {}),
   };
 }

--- a/src/sider/dialogmoter/components/motehistorikk/MotebehovHistorikk.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MotebehovHistorikk.tsx
@@ -9,6 +9,7 @@ import {
   MotebehovArbeidsgiverKvittering,
   MotebehovKvitteringInnholdArbeidstaker,
 } from "@/sider/dialogmoter/motebehov/MotebehovKvittering";
+import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks.ts";
 
 const texts = {
   title: "Møtebehovhistorikk",
@@ -21,13 +22,16 @@ function MotebehovHistorikkEvent({
 }: {
   motebehov: MotebehovVeilederDTO;
 }) {
+  const { virksomhetsnavn } = useVirksomhetQuery(motebehov?.virksomhetsnummer);
   const [isOpen, setIsOpen] = useState(false);
+
   const isArbeidstaker = isArbeidstakerMotebehov(motebehov);
   const headerText = `Møtebehov fra ${
     isArbeidstaker ? "den sykmeldte" : "nærmeste leder"
   } ${tilLesbarDatoMedArstall(motebehov.opprettetDato)}`;
   const isBehandlet =
     motebehov.behandletTidspunkt && motebehov.behandletVeilederIdent;
+  const virksomhet = virksomhetsnavn || motebehov?.virksomhetsnummer;
 
   const handleAccordionClick = () => setIsOpen(!isOpen);
 
@@ -42,7 +46,10 @@ function MotebehovHistorikkEvent({
             arbeidstakersMotebehov={motebehov}
           />
         ) : (
-          <MotebehovArbeidsgiverKvittering motebehov={motebehov} />
+          <MotebehovArbeidsgiverKvittering
+            motebehov={motebehov}
+            virksomhet={virksomhet}
+          />
         )}
         {isBehandlet && (
           <BodyShort className="mt-2">{`Møtebehovet ble vurdert av ${

--- a/src/sider/dialogmoter/components/svar/ArbeidsgiverSvar.tsx
+++ b/src/sider/dialogmoter/components/svar/ArbeidsgiverSvar.tsx
@@ -2,10 +2,11 @@ import { DialogmotedeltakerArbeidsgiverVarselDTO } from "@/sider/dialogmoter/typ
 import React from "react";
 import { EkspanderbartSvarPanel } from "@/sider/dialogmoter/components/svar/EkspanderbartSvarPanel";
 import { SvarIcon } from "@/sider/dialogmoter/components/svar/SvarIcon";
-import { capitalizeAllWords } from "@/utils/stringUtils";
 import { SvarDetaljer } from "@/sider/dialogmoter/components/svar/SvarDetaljer";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { getHarAapnetTekst, getSvarTekst } from "@/utils/dialogmoteUtils";
+import { arbeidsgiverNavnMedVirksomhet } from "@/utils/motebehovUtils.ts";
+import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks.ts";
 
 const texts = {
   label: "Nærmeste leder:",
@@ -23,8 +24,16 @@ export const ArbeidsgiverSvar = ({
   defaultClosed = false,
 }: Props) => {
   const { getCurrentNarmesteLeder } = useLedereQuery();
-  const narmesteLederNavn =
-    getCurrentNarmesteLeder(virksomhetsnummer)?.narmesteLederNavn || "";
+  const { virksomhetsnavn } = useVirksomhetQuery(virksomhetsnummer);
+  const narmesteLeder = getCurrentNarmesteLeder(virksomhetsnummer);
+  const arbeidsgiverInfo = narmesteLeder
+    ? arbeidsgiverNavnMedVirksomhet(
+        narmesteLeder.narmesteLederNavn,
+        virksomhetsnavn ||
+          narmesteLeder.virksomhetsnavn ||
+          narmesteLeder.virksomhetsnummer
+      )
+    : "";
 
   const svar = varsel?.svar;
   const svarTittelTekst = !svar
@@ -36,7 +45,7 @@ export const ArbeidsgiverSvar = ({
       title={{
         icon: <SvarIcon svarType={svar?.svarType} />,
         label: texts.label,
-        body: `${capitalizeAllWords(narmesteLederNavn)}, ${svarTittelTekst}`,
+        body: `${arbeidsgiverInfo}, ${svarTittelTekst}`,
       }}
       defaultOpen={!defaultClosed && !!svar}
     >

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  arbeidsgiverNavnMedVirksomhet,
   getMotebehovInActiveTilfelle,
   isArbeidstakerMotebehov,
   motebehovUbehandlet,
@@ -22,6 +23,10 @@ import {
   OppfolgingstilfelleDTO,
 } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { BodyShort } from "@navikt/ds-react";
+import {
+  useVirksomheterQueries,
+  useVirksomhetQuery,
+} from "@/data/virksomhet/virksomhetQueryHooks.ts";
 
 export const arbeidsgiverNavnEllerTomStreng = (lederNavn: string | null) => {
   return lederNavn ? `${lederNavn}` : "";
@@ -127,7 +132,7 @@ export const MotebehovKvitteringInnholdArbeidstaker = ({
 };
 
 export const composeArbeidsgiverSvarText = (
-  lederNavn: string | null,
+  arbeidsgiverInfo: string | null,
   skjemaType: MotebehovSkjemaType | null,
   harMotebehov?: boolean,
   svarOpprettetDato?: Date
@@ -135,7 +140,7 @@ export const composeArbeidsgiverSvarText = (
   return composePersonSvarText(
     "Nærmeste leder: ",
     skjemaType,
-    arbeidsgiverNavnEllerTomStreng(capitalizeAllWords(lederNavn || "")),
+    arbeidsgiverInfo || "",
     harMotebehov,
     svarOpprettetDato
   );
@@ -144,15 +149,22 @@ export const composeArbeidsgiverSvarText = (
 export function MotebehovArbeidsgiverKvittering({
   motebehov,
   skjemaType,
+  virksomhet,
 }: {
   motebehov: MotebehovVeilederDTO;
   skjemaType?: MotebehovSkjemaType | null;
+  virksomhet?: string;
 }) {
   const arbeidsgiverOnskerMote = motebehov.formValues.harMotebehov;
   const skjemaTypeMotebehov = skjemaType ?? motebehov.skjemaType;
-  const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverNavnEllerTomStreng(
-    motebehov.opprettetAvNavn
-  )} ${ikonAlternativTekst(skjemaTypeMotebehov, arbeidsgiverOnskerMote)}`;
+  const arbeidsgiverInfo = arbeidsgiverNavnMedVirksomhet(
+    motebehov.opprettetAvNavn,
+    virksomhet
+  );
+  const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverInfo} ${ikonAlternativTekst(
+    skjemaTypeMotebehov,
+    arbeidsgiverOnskerMote
+  )}`;
 
   return (
     <MotebehovKvitteringInnhold
@@ -160,7 +172,7 @@ export function MotebehovArbeidsgiverKvittering({
       ikonAltTekst={ikonAltTekst}
       motebehov={motebehov}
       tekst={composeArbeidsgiverSvarText(
-        motebehov.opprettetAvNavn,
+        arbeidsgiverInfo,
         skjemaTypeMotebehov,
         arbeidsgiverOnskerMote,
         motebehov.opprettetDato
@@ -170,28 +182,29 @@ export function MotebehovArbeidsgiverKvittering({
 }
 
 interface MotebehovKvitteringInnholdArbeidsgiverUtenMotebehovProps {
-  ledereUtenInnsendtMotebehov: NarmesteLederRelasjonDTO[];
+  ledereInCurrentTilfelle: NarmesteLederRelasjonDTO[];
   skjemaType: MotebehovSkjemaType | null;
 }
 
 export const MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov = ({
-  ledereUtenInnsendtMotebehov,
+  ledereInCurrentTilfelle,
   skjemaType,
 }: MotebehovKvitteringInnholdArbeidsgiverUtenMotebehovProps) => (
   <>
-    {ledereUtenInnsendtMotebehov.map(
+    {ledereInCurrentTilfelle.map(
       (leder: NarmesteLederRelasjonDTO, index: number) => {
-        const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverNavnEllerTomStreng(
-          leder.narmesteLederNavn
-        )} ${ikonAlternativTekst(skjemaType)}`;
+        const arbeidsgiverInfo = arbeidsgiverNavnMedVirksomhet(
+          leder.narmesteLederNavn,
+          leder.virksomhetsnavn || leder.virksomhetsnummer
+        );
+        const ikonAltTekst = `Arbeidsgiver ${arbeidsgiverInfo} ${ikonAlternativTekst(
+          skjemaType
+        )}`;
         return (
           <MotebehovKvitteringInnhold
             key={index}
             ikonAltTekst={ikonAltTekst}
-            tekst={composeArbeidsgiverSvarText(
-              leder.narmesteLederNavn,
-              skjemaType
-            )}
+            tekst={composeArbeidsgiverSvarText(arbeidsgiverInfo, skjemaType)}
           />
         );
       }
@@ -251,20 +264,38 @@ function MotebehovArbeidsgiverInCurrentTilfelle({
   oppfolgingstilfelle: OppfolgingstilfelleDTO;
   skjemaType: MotebehovSkjemaType | null;
 }) {
+  const { virksomhetsnavn } = useVirksomhetQuery(motebehov?.virksomhetsnummer);
+  const virksomhet = virksomhetsnavn || motebehov?.virksomhetsnummer;
+
   const { currentLedere } = useLedereQuery();
   const ledereInCurrentTilfelle = aktiveNarmesteLedereForOppfolgingstilfelle(
     currentLedere,
     oppfolgingstilfelle
   );
+  const virksomheterByLedereInCurrentTilfelle = useVirksomheterQueries(
+    ledereInCurrentTilfelle.map((leder) => leder.virksomhetsnummer)
+  );
+  const ledereInCurrentTilfelleWithVirksomhetsnavn =
+    ledereInCurrentTilfelle.map((leder) => {
+      const virksomhetForLeder =
+        virksomheterByLedereInCurrentTilfelle.data[leder.virksomhetsnummer];
+
+      return {
+        ...leder,
+        virksomhetsnavn:
+          virksomhetForLeder?.virksomhetsnavn || leder.virksomhetsnavn,
+      };
+    });
 
   return motebehov ? (
     <MotebehovArbeidsgiverKvittering
       motebehov={motebehov}
       skjemaType={motebehov?.skjemaType ?? null}
+      virksomhet={virksomhet}
     />
   ) : (
     <MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov
-      ledereUtenInnsendtMotebehov={ledereInCurrentTilfelle}
+      ledereInCurrentTilfelle={ledereInCurrentTilfelleWithVirksomhetsnavn}
       skjemaType={skjemaType}
     />
   );
@@ -284,10 +315,16 @@ function UbehandledeMotebehovUtenforTilfelle({
   const ubehandletMotebehovArbeidsgiver = ubehandledeEldreMotebehov.find(
     (motebehov) => !isArbeidstakerMotebehov(motebehov)
   );
+  const { virksomhetsnavn } = useVirksomhetQuery(
+    ubehandletMotebehovArbeidsgiver?.virksomhetsnummer
+  );
 
   const harUbehandledeMotebehov = !!(
     ubehandletMotebehovArbeidstaker || ubehandletMotebehovArbeidsgiver
   );
+
+  const virksomhet =
+    virksomhetsnavn || ubehandletMotebehovArbeidsgiver?.virksomhetsnummer;
 
   return harUbehandledeMotebehov ? (
     <div className="flex flex-col gap-2">
@@ -304,6 +341,7 @@ function UbehandledeMotebehovUtenforTilfelle({
         <MotebehovArbeidsgiverKvittering
           motebehov={ubehandletMotebehovArbeidsgiver}
           skjemaType={ubehandletMotebehovArbeidsgiver?.skjemaType ?? null}
+          virksomhet={virksomhet}
         />
       )}
     </div>

--- a/src/utils/motebehovUtils.ts
+++ b/src/utils/motebehovUtils.ts
@@ -8,6 +8,7 @@ import {
 } from "@/data/motebehov/types/motebehovTypes";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { MotebehovTilbakemeldingDTO } from "@/data/motebehov/useVurderMotebehov";
+import { arbeidsgiverNavnEllerTomStreng } from "@/sider/dialogmoter/motebehov/MotebehovKvittering.tsx";
 
 export const sorterMotebehovDataEtterDatoDesc = (
   a: MotebehovVeilederDTO,
@@ -164,4 +165,13 @@ export function mapMotebehovToSvarMotebehovFormat(
         skjemaType: MotebehovSkjemaType.SVAR_BEHOV,
       };
     });
+}
+
+export function arbeidsgiverNavnMedVirksomhet(
+  lederNavn: string | null,
+  virksomhet?: string
+) {
+  const lederNavnString = arbeidsgiverNavnEllerTomStreng(lederNavn);
+
+  return virksomhet ? `${lederNavnString} (${virksomhet})` : lederNavnString;
 }

--- a/test/dialogmote/DeltakereSvarInfo/DeltakereSvarInfoArbeidsgiverTest.tsx
+++ b/test/dialogmote/DeltakereSvarInfo/DeltakereSvarInfoArbeidsgiverTest.tsx
@@ -14,10 +14,12 @@ import {
   SvarType,
 } from "@/sider/dialogmoter/types/dialogmoteTypes";
 import { queryClientWithMockData } from "../../testQueryClient";
+import { VIRKSOMHET_PONTYPANDY } from "@/mocks/common/mockConstants";
 
 let queryClient: any;
 
 const ingenDetaljerTekst = "Ingen detaljer er tilgjengelig.";
+const narmesteLederNavnMedVirksomhet = `${narmesteLederNavn} (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
 
 const renderDeltakereSvarInfo = (dialogmote: DialogmoteDTO) =>
   render(
@@ -43,7 +45,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder har åpnet innkalling med minus-sirkel-ikon og begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, åpnet innkallingen 01.12.2021 - Har ikke gitt svar`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, åpnet innkallingen 01.12.2021 - Har ikke gitt svar`;
       renderDeltakereSvarInfo(dialogmoteMedLestInnkalling);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -71,7 +73,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder 'kommer' med suksess-ikon og manglende begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, kommer - Svar mottatt 01.12.2021`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, kommer - Svar mottatt 01.12.2021`;
       renderDeltakereSvarInfo(dialogmoteMedLestInnkalling);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -99,7 +101,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder ønsker å endre tid/sted med advarsel-ikon og begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, ønsker å endre tidspunkt eller sted - Svar mottatt 01.12.2021`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, ønsker å endre tidspunkt eller sted - Svar mottatt 01.12.2021`;
       renderDeltakereSvarInfo(dialogmoteMedLestInnkalling);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -127,7 +129,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder ønsker å avlyse med feil-ikon og begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, ønsker å avlyse - Svar mottatt 01.12.2021`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, ønsker å avlyse - Svar mottatt 01.12.2021`;
       renderDeltakereSvarInfo(dialogmoteMedLestInnkalling);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -145,7 +147,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder har ikke åpnet innkalling med minus-sirkel-ikon og manglende begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, har ikke åpnet innkallingen`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, har ikke åpnet innkallingen`;
       renderDeltakereSvarInfo(dialogmoteMedUlestInnkalling);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -171,7 +173,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder har åpnet endring med minus-sirkel-ikon og manglende begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, åpnet endringen 03.12.2021 - Har ikke gitt svar`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, åpnet endringen 03.12.2021 - Har ikke gitt svar`;
       renderDeltakereSvarInfo(dialogmoteMedLestEndring);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -199,7 +201,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder 'kommer' med suksess-ikon og manglende begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, kommer - Svar mottatt 03.12.2021`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, kommer - Svar mottatt 03.12.2021`;
       renderDeltakereSvarInfo(dialogmoteMedLestEndring);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -227,7 +229,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder ønsker å endre tid/sted med advarsel-ikon og begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, ønsker å endre tidspunkt eller sted - Svar mottatt 03.12.2021`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, ønsker å endre tidspunkt eller sted - Svar mottatt 03.12.2021`;
       renderDeltakereSvarInfo(dialogmoteMedLestEndring);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -255,7 +257,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder ønsker å avlyse med feil-ikon og begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, ønsker å avlyse - Svar mottatt 03.12.2021`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, ønsker å avlyse - Svar mottatt 03.12.2021`;
       renderDeltakereSvarInfo(dialogmoteMedLestEndring);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;
@@ -273,7 +275,7 @@ describe("DeltakereSvarInfo for arbeidsgiver", () => {
     );
 
     it("viser nærmeste leder har ikke åpnet endring med minus-sirkel-ikon og manglende begrunnelse", () => {
-      const expectedText = `${narmesteLederNavn}, har ikke åpnet endringen`;
+      const expectedText = `${narmesteLederNavnMedVirksomhet}, har ikke åpnet endringen`;
       renderDeltakereSvarInfo(dialogmoteMedUlestEndring);
 
       expect(screen.getByText("Nærmeste leder:")).to.exist;

--- a/test/dialogmote/MoteSvarHistorikkTest.tsx
+++ b/test/dialogmote/MoteSvarHistorikkTest.tsx
@@ -26,6 +26,8 @@ import userEvent from "@testing-library/user-event";
 
 let queryClient: QueryClient;
 
+const narmesteLederNavnMedVirksomhet = `${NARMESTE_LEDER_DEFAULT.navn} (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
+
 type InnkallingSvar = Pick<VarselSvarDTO, "svarType" | "svarTekst">;
 const varselAT = (
   svar: InnkallingSvar,
@@ -212,10 +214,10 @@ describe("MoteSvarHistorikk", () => {
       2
     );
     assertExpandableWithHeader(
-      `${NARMESTE_LEDER_DEFAULT.navn}, kommer - Svar mottatt 26.05.2021`
+      `${narmesteLederNavnMedVirksomhet}, kommer - Svar mottatt 26.05.2021`
     );
     assertExpandableWithHeader(
-      `${NARMESTE_LEDER_DEFAULT.navn}, ønsker å endre tidspunkt eller sted - Svar mottatt 26.05.2021`
+      `${narmesteLederNavnMedVirksomhet}, ønsker å endre tidspunkt eller sted - Svar mottatt 26.05.2021`
     );
   });
   it("viser innkalling med svar for avlyst møte", async () => {
@@ -227,7 +229,7 @@ describe("MoteSvarHistorikk", () => {
     await userEvent.click(accordion);
 
     assertExpandableWithHeader(
-      `${NARMESTE_LEDER_DEFAULT.navn}, kommer - Svar mottatt 26.05.2021`
+      `${narmesteLederNavnMedVirksomhet}, kommer - Svar mottatt 26.05.2021`
     );
     assertExpandableWithHeader(
       `${ARBEIDSTAKER_DEFAULT_FULL_NAME}, ønsker å avlyse - Svar mottatt 26.05.2021`

--- a/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
+++ b/test/dialogmote/Motebehov/DialogmoteOnskePanelTest.tsx
@@ -7,6 +7,7 @@ import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
 import {
   ARBEIDSTAKER_DEFAULT,
   VEILEDER_IDENT_DEFAULT,
+  VIRKSOMHET_PONTYPANDY,
 } from "@/mocks/common/mockConstants";
 import {
   defaultFormValue,
@@ -21,8 +22,11 @@ import { UtropstegnImage } from "../../../img/ImageComponents";
 import MotebehovKvittering from "@/sider/dialogmoter/motebehov/MotebehovKvittering";
 import BehandleMotebehovKnapp from "@/components/motebehov/BehandleMotebehovKnapp";
 import DialogmotePanel from "@/sider/dialogmoter/components/DialogmotePanel";
+import { virksomhetQueryKeys } from "@/data/virksomhet/virksomhetQueryHooks";
 
 let queryClient: QueryClient;
+
+const arbeidsgiverMedVirksomhet = `Are Arbeidsgiver (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
 
 const renderDialogmoteOnskePanel = () => {
   render(
@@ -39,6 +43,17 @@ function mockMotebehov(motebehov: MotebehovVeilederDTO[]) {
   queryClient.setQueryData(
     motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
     () => motebehov
+  );
+}
+
+function mockVirksomhet() {
+  queryClient.setQueryData(
+    virksomhetQueryKeys.virksomhet(VIRKSOMHET_PONTYPANDY.virksomhetsnummer),
+    () => ({
+      navn: {
+        navnelinje1: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
+      },
+    })
   );
 }
 
@@ -85,6 +100,7 @@ const nyttOppfolgingstilfelle = {
 describe("DialogmoteOnskePanel", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
+    mockVirksomhet();
   });
 
   it("Tidligere behandlet møtebehov utenfor oppfølgingstilfelle", () => {
@@ -160,7 +176,7 @@ describe("DialogmoteOnskePanel", () => {
     ).to.exist;
     expect(
       screen.getByText(
-        `Are Arbeidsgiver, har svart NEI - ${toDatePrettyPrint(
+        `${arbeidsgiverMedVirksomhet}, har svart NEI - ${toDatePrettyPrint(
           datoInnenforOppfolgingstilfelle
         )}`
       )
@@ -193,7 +209,7 @@ describe("DialogmoteOnskePanel", () => {
     ).to.exist;
     expect(
       screen.getByText(
-        `Are Arbeidsgiver, har svart NEI - ${toDatePrettyPrint(
+        `${arbeidsgiverMedVirksomhet}, har svart NEI - ${toDatePrettyPrint(
           datoInnenforOppfolgingstilfelle
         )}`
       )

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -7,7 +7,9 @@ import MotebehovKvittering from "@/sider/dialogmoter/motebehov/MotebehovKvitteri
 import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
 import {
   ARBEIDSTAKER_DEFAULT,
+  LEDERE_DEFAULT,
   VEILEDER_IDENT_DEFAULT,
+  VIRKSOMHET_PONTYPANDY,
 } from "@/mocks/common/mockConstants";
 import {
   createFormValues,
@@ -22,8 +24,16 @@ import {
   MotebehovVeilederDTO,
 } from "@/data/motebehov/types/motebehovTypes";
 import { addDays, addWeeks } from "@/utils/datoUtils";
+import { virksomhetQueryKeys } from "@/data/virksomhet/virksomhetQueryHooks";
+import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
 
 let queryClient: QueryClient;
+
+const virksomhetsnavnInText = "pontypandy Fire Service";
+const arbeidsgiverMedVirksomhet = `Are Arbeidsgiver (${virksomhetsnavnInText})`;
+const arbeidsgiverAltMedVirksomhet = `Are Arbeidsgiver (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
+const narmesteLederMedVirksomhet = `Tatten Tattover (${virksomhetsnavnInText})`;
+const narmesteLederAltMedVirksomhet = `Tatten Tattover (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
 
 const renderMotebehovKvittering = () => {
   render(
@@ -37,6 +47,28 @@ function mockMotebehov(motebehov: MotebehovVeilederDTO[]) {
   queryClient.setQueryData(
     motebehovQueryKeys.motebehov(ARBEIDSTAKER_DEFAULT.personIdent),
     () => motebehov
+  );
+}
+
+function mockVirksomhet() {
+  queryClient.setQueryData(
+    virksomhetQueryKeys.virksomhet(VIRKSOMHET_PONTYPANDY.virksomhetsnummer),
+    () => ({
+      navn: {
+        navnelinje1: VIRKSOMHET_PONTYPANDY.virksomhetsnavn,
+      },
+    })
+  );
+}
+
+function mockLedereUtenVirksomhetsnavn() {
+  queryClient.setQueryData(
+    ledereQueryKeys.ledere(ARBEIDSTAKER_DEFAULT.personIdent),
+    () =>
+      LEDERE_DEFAULT.map((leder) => ({
+        ...leder,
+        virksomhetsnavn: "",
+      }))
   );
 }
 
@@ -129,6 +161,7 @@ function createMotebehovUtenforTilfelle(motebehov: MotebehovVeilederDTO) {
 describe("MotebehovKvittering", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
+    mockVirksomhet();
   });
   it("Ingen møtebehov", () => {
     mockMotebehov([]);
@@ -152,10 +185,13 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
     expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Meldt behov.")).to
-      .exist;
     expect(
-      screen.getByText("Are Arbeidsgiver, har meldt behov", {
+      screen.getByAltText(
+        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Meldt behov.`
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(`${arbeidsgiverMedVirksomhet}, har meldt behov`, {
         exact: false,
       })
     ).to.exist;
@@ -174,12 +210,38 @@ describe("MotebehovKvittering", () => {
     expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
 
     expect(
-      screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke meldt behov.")
+      screen.getByAltText(
+        `Arbeidsgiver ${narmesteLederAltMedVirksomhet} Ikke meldt behov.`
+      )
     ).to.exist;
     expect(
-      screen.getByText("Tatten Tattover, har ikke meldt behov", {
+      screen.getByText(`${narmesteLederMedVirksomhet}, har ikke meldt behov`, {
         exact: false,
       })
+    ).to.exist;
+  });
+  it("viser virksomhetsnummer når nærmeste leder mangler virksomhetsnavn", () => {
+    queryClient.removeQueries({
+      queryKey: virksomhetQueryKeys.virksomhet(
+        VIRKSOMHET_PONTYPANDY.virksomhetsnummer
+      ),
+      exact: true,
+    });
+    mockLedereUtenVirksomhetsnavn();
+    mockMotebehov([motebehovArbeidstakerInTilfelleUbehandletMock]);
+
+    renderMotebehovKvittering();
+
+    expect(
+      screen.getByAltText(
+        `Arbeidsgiver Tatten Tattover (${VIRKSOMHET_PONTYPANDY.virksomhetsnummer}) Ikke meldt behov.`
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(
+        `Tatten Tattover (${VIRKSOMHET_PONTYPANDY.virksomhetsnummer}), har ikke meldt behov`,
+        { exact: false }
+      )
     ).to.exist;
   });
   it("viser meldt møtebehov fra arbeidsgiver og sykmeldt når kun arbeidsgiver har meldt behov innenfor tilfelle", () => {
@@ -193,10 +255,13 @@ describe("MotebehovKvittering", () => {
       })
     ).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Meldt behov.")).to
-      .exist;
     expect(
-      screen.getByText("Are Arbeidsgiver, har meldt behov", {
+      screen.getByAltText(
+        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Meldt behov.`
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(`${arbeidsgiverMedVirksomhet}, har meldt behov`, {
         exact: false,
       })
     ).to.exist;
@@ -251,10 +316,13 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
     expect(screen.getByText("Jeg, arbeidstaker, har behov for møte.")).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Meldt behov.")).to
-      .exist;
     expect(
-      screen.getByText("Are Arbeidsgiver, har meldt behov", {
+      screen.getByAltText(
+        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Meldt behov.`
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(`${arbeidsgiverMedVirksomhet}, har meldt behov`, {
         exact: false,
       })
     ).to.exist;
@@ -272,10 +340,13 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
     expect(screen.getByText("Møter er bra!")).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Tatten Tattover Ikke svart.")).to
-      .exist;
     expect(
-      screen.getByText("Tatten Tattover, har ikke svart", {
+      screen.getByAltText(
+        `Arbeidsgiver ${narmesteLederAltMedVirksomhet} Ikke svart.`
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(`${narmesteLederMedVirksomhet}, har ikke svart`, {
         exact: false,
       })
     ).to.exist;
@@ -291,10 +362,13 @@ describe("MotebehovKvittering", () => {
       })
     ).to.exist;
 
-    expect(screen.getByAltText("Arbeidsgiver Are Arbeidsgiver Svart nei.")).to
-      .exist;
     expect(
-      screen.getByText("Are Arbeidsgiver, har svart NEI", {
+      screen.getByAltText(
+        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Svart nei.`
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(`${arbeidsgiverMedVirksomhet}, har svart NEI`, {
         exact: false,
       })
     ).to.exist;
@@ -358,9 +432,12 @@ describe("MotebehovKvittering", () => {
         expect(screen.getByText("Hva slags tolk har dere behov for?")).to.exist;
         expect(screen.getByText("Har behov for svensk tolk")).to.exist;
         expect(
-          screen.getByText("Tatten Tattover, har ikke meldt behov", {
-            exact: false,
-          })
+          screen.getByText(
+            `${narmesteLederMedVirksomhet}, har ikke meldt behov`,
+            {
+              exact: false,
+            }
+          )
         ).to.exist;
       });
     });
@@ -457,7 +534,7 @@ describe("MotebehovKvittering", () => {
         expect(screen.getByText("Har behov for svensk tolk")).to.exist;
 
         expect(
-          screen.getByText("Are Arbeidsgiver, har svart JA", {
+          screen.getByText(`${arbeidsgiverMedVirksomhet}, har svart JA`, {
             exact: false,
           })
         ).to.exist;
@@ -590,7 +667,7 @@ describe("MotebehovKvittering", () => {
         ).to.exist;
 
         expect(
-          screen.getByText("Are Arbeidsgiver, har svart JA", {
+          screen.getByText(`${arbeidsgiverMedVirksomhet}, har svart JA`, {
             exact: false,
           })
         ).to.exist;
@@ -705,7 +782,7 @@ describe("MotebehovKvittering", () => {
         ).to.exist;
 
         expect(
-          screen.getByText("Are Arbeidsgiver, har svart NEI", {
+          screen.getByText(`${arbeidsgiverMedVirksomhet}, har svart NEI`, {
             exact: false,
           })
         ).to.exist;


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger på virksomhetsnavn i parantes etter leder i forbindelse med møtebehov. For å gjøre det konsekvent, har jeg gjort dette alle steder hvor møtebehov fremkommer (historikk osv.). Jeg tar gjerne innspill på hvordan dette ser ut! Man kan ha teksten i bold, eller som en slags tag, eller noe på hover, eller noe helt annet.

Jeg har prøvd å gjøre dette så ryddig som mulig, men komponenter og funksjoner brukes veldig på kryss og tvers så det var ikke så veldig lett. Så gjerne gi innspill på struktur og sånt! F.eks. har konstantnavn for tekst som "Nærmeste Ledersen (Selskap AS)" blitt kalt typ `virksomhet` eller `virksomhetString` selv om det står flere ting inni der. Jeg tenkte det var det som nærmeste representerte hva teksten viser. 

### Screenshots 📸✨

<img width="1894" height="1081" alt="image" src="https://github.com/user-attachments/assets/7ff91717-1796-4067-882c-961870496742" />

<img width="1201" height="725" alt="image" src="https://github.com/user-attachments/assets/6c1d5eda-3f82-4982-82c3-776f66fad9a4" />

<img width="1265" height="761" alt="image" src="https://github.com/user-attachments/assets/275f0e15-a99e-474c-b229-76ba984f62c1" />

<img width="1270" height="426" alt="image" src="https://github.com/user-attachments/assets/90bdea41-b75a-4fc3-8139-b6ef6a1078d0" />

<img width="1201" height="467" alt="image" src="https://github.com/user-attachments/assets/732d7bf8-11f8-4162-a362-61aa4092e426" />
