### PR TITLE
Fix/IS-3988 aktive op global nav

### DIFF
--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -7,6 +7,7 @@ import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryH
 import {
   useGetLPSOppfolgingsplanerQuery,
   useGetOppfolgingsplanerQuery,
+  useGetOppfolgingsplanerV2Query,
 } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 import { toOppfolgingsplanLPSMedPersonoppgave } from "@/utils/oppfolgingsplanerUtils";
@@ -18,6 +19,7 @@ import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
 import { useManglendemedvirkningVurderingQuery } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { useKartleggingssporsmalKandidaterQuery } from "@/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks";
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 
 export enum Menypunkter {
   AKTIVITETSKRAV = "AKTIVITETSKRAV",
@@ -115,6 +117,7 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
   const personoppgaver = usePersonoppgaverQuery();
   const getOppfolgingsplanerQuery = useGetOppfolgingsplanerQuery();
   const getLPSOppfolgingsplaner = useGetLPSOppfolgingsplanerQuery();
+  const getOppfolgingsplanerV2Query = useGetOppfolgingsplanerV2Query();
   const motebehov = useMotebehovQuery();
   const aktivitetskrav = useAktivitetskravQuery();
   const arbeidsuforhetVurderinger = useGetArbeidsuforhetVurderingerQuery();
@@ -123,6 +126,7 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
   const manglendeMedvirkningVurdering = useManglendemedvirkningVurderingQuery();
   const kartleggingssporsmalKandidat = useKartleggingssporsmalKandidaterQuery();
   const featureToggles = useFeatureToggles();
+  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
 
   const isPending = featureToggles.isPending;
 
@@ -198,7 +202,9 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
           senOppfolgingKandidat.data,
           friskmeldingTilArbeidsformidlingVedtak.data,
           manglendeMedvirkningVurdering.sisteVurdering,
-          kartleggingssporsmalKandidat.data
+          kartleggingssporsmalKandidat.data,
+          getOppfolgingsplanerV2Query.data,
+          latestOppfolgingstilfelle
         );
 
         return (

--- a/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
@@ -1,12 +1,16 @@
 import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
 import { useHistorikkOppfolgingsplan } from "@/data/historikk/historikkQueryHooks";
-import { useGetLPSOppfolgingsplanerQuery } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
+import {
+  useGetLPSOppfolgingsplanerQuery,
+  useGetOppfolgingsplanerV2Query,
+} from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { OppfolgingsplanLPS } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanLPS";
 import { HistorikkEvents } from "@/hooks/historikk/useHistorikk";
 import {
   OppfolgingsplanForesporselResponse,
   useGetOppfolgingsplanForesporselQuery,
 } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanForesporselHooks";
+import { OppfolgingsplanV2DTO } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
 
 function lpsplanerToHistorikkEvents(
   oppfolgingsplanerLPS: OppfolgingsplanLPS[]
@@ -16,6 +20,18 @@ function lpsplanerToHistorikkEvents(
     tekst: `Oppfølgingsplanen ble delt med Nav av ${virksomhetsnummer}.`,
     tidspunkt: new Date(opprettet),
   }));
+}
+
+function oppfolgingsplanerV2ToHistorikkEvents(
+  oppfolgingsplanerV2: OppfolgingsplanV2DTO[]
+): HistorikkEvent[] {
+  return oppfolgingsplanerV2.map(
+    ({ deltMedNavTidspunkt, virksomhetsnummer }) => ({
+      kilde: "OPPFOLGINGSPLAN",
+      tekst: `Oppfølgingsplanen ble delt med Nav av ${virksomhetsnummer}.`,
+      tidspunkt: new Date(deltMedNavTidspunkt),
+    })
+  );
 }
 
 function foresporslerToHistorikkEvents(
@@ -46,20 +62,28 @@ export function useOppfolgingsplanHistorikk(): HistorikkEvents {
     isLoading: isOppfolgingsplanForesporslerLoading,
     isError: isOppfolgingsplanForesporslerError,
   } = useGetOppfolgingsplanForesporselQuery();
+  const {
+    data: oppfolgingsplanerV2,
+    isLoading: isOppfolgingsplanerV2Loading,
+    isError: isOppfolgingsplanerV2Error,
+  } = useGetOppfolgingsplanerV2Query();
 
   const oppfolgingsplanHistorikkEvents = oppfolgingsplanHistorikk
     .concat(lpsplanerToHistorikkEvents(oppfolgingsplanerLPS))
-    .concat(foresporslerToHistorikkEvents(oppfolgingsplanForesporsler || []));
+    .concat(foresporslerToHistorikkEvents(oppfolgingsplanForesporsler || []))
+    .concat(oppfolgingsplanerV2ToHistorikkEvents(oppfolgingsplanerV2));
 
   return {
     isLoading:
       isOppfolgingsplanLoading ||
       isOppfolgingsplanerLPSLoading ||
-      isOppfolgingsplanForesporslerLoading,
+      isOppfolgingsplanForesporslerLoading ||
+      isOppfolgingsplanerV2Loading,
     isError:
       isOppfolgingsplanError ||
       isOppfolgingsplanerLPSError ||
-      isOppfolgingsplanForesporslerError,
+      isOppfolgingsplanForesporslerError ||
+      isOppfolgingsplanerV2Error,
     events: oppfolgingsplanHistorikkEvents,
   };
 }

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -9,6 +9,11 @@ import {
   aktiveOppfolgingsplaner,
   OppfolgingsplanDTO,
 } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanDTO";
+import {
+  OppfolgingsplanV2DTO,
+  partitionOppfolgingsplanerByActiveTilfelle,
+} from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
+import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import {
   getAllUbehandledePersonOppgaver,
@@ -182,20 +187,30 @@ export function numberOfTasks(
   kartleggingVurderinger:
     | KartleggingssporsmalKandidatResponseDTO[]
     | undefined
-    | null
+    | null,
+  oppfolgingsplanerV2: OppfolgingsplanV2DTO[],
+  latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
 ): number {
   switch (menypunkt) {
     case Menypunkter.DIALOGMOTE:
       return getNumberOfMoteOppgaver(motebehov, personOppgaver);
-    case Menypunkter.OPPFOELGINGSPLANER:
+    case Menypunkter.OPPFOELGINGSPLANER: {
+      const aktiveV2Planer = latestOppfolgingstilfelle
+        ? partitionOppfolgingsplanerByActiveTilfelle(
+            oppfolgingsplanerV2,
+            latestOppfolgingstilfelle
+          )[0].length
+        : 0;
       return (
         aktiveOppfolgingsplaner(oppfolgingsplaner).length +
         numberOfActiveLPSOppfolgingsplaner(oppfolgingsplanerlps) +
         numberOfUbehandledePersonOppgaver(
           personOppgaver,
           PersonOppgaveType.OPPFOLGINGSPLANLPS
-        )
+        ) +
+        aktiveV2Planer
       );
+    }
     case Menypunkter.AKTIVITETSKRAV:
       return getNumberOfAktivitetskravOppgaver(aktivitetskrav);
     case Menypunkter.BEHANDLERDIALOG:

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -20,6 +20,10 @@ import {
   personOppgaveUbehandletBehandlerdialogSvar,
   personOppgaveUbehandletBehandlerdialogUbesvartMelding,
 } from "@/mocks/ispersonoppgave/personoppgaveMock";
+import { oppfolgingsplanV2Mock } from "@/mocks/syfooppfolgingsplanbackend/oppfolgingsplanV2Mock";
+import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { oppfolgingstilfellePersonMock } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock";
+import { oppfolgingsplanQueryKeys } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { arbeidsuforhetQueryKeys } from "@/sider/arbeidsuforhet/hooks/arbeidsuforhetQueryHooks";
 import {
   createForhandsvarsel,
@@ -434,5 +438,20 @@ describe("GlobalNavigasjon", () => {
 
     expect(screen.getByRole("link", { name: "§ 8-8 Manglende medvirkning" })).to
       .exist;
+  });
+
+  it("viser rød prikk for menypunkt Oppfølgingsplaner når det finnes aktive V2-planer", () => {
+    queryClient.setQueryData(
+      oppfolgingsplanQueryKeys.oppfolgingsplanerV2(fnr),
+      () => oppfolgingsplanV2Mock
+    );
+    queryClient.setQueryData(
+      oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(fnr),
+      () => oppfolgingstilfellePersonMock
+    );
+    renderGlobalNavigasjon();
+
+    expect(screen.getByRole("link", { name: /Oppfølgingsplaner \(\d+ aktiv/ }))
+      .to.exist;
   });
 });

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -440,7 +440,7 @@ describe("GlobalNavigasjon", () => {
       .exist;
   });
 
-  it("viser rød prikk for menypunkt Oppfølgingsplaner når det finnes aktive V2-planer", () => {
+  it("viser aktive planer for menypunkt Oppfølgingsplaner når det finnes aktive V2-planer", () => {
     queryClient.setQueryData(
       oppfolgingsplanQueryKeys.oppfolgingsplanerV2(fnr),
       () => oppfolgingsplanV2Mock

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -49,6 +49,7 @@ import { dialogmoteStatusEndringMock } from "@/mocks/isdialogmote/dialogmoterMoc
 import { dialogmoterQueryKeys } from "@/sider/dialogmoter/hooks/dialogmoteQueryHooks";
 import { oppfolgingsplanQueryKeys } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { getDefaultOppfolgingsplanLPS } from "@/mocks/lps-oppfolgingsplan-mottak/oppfolgingsplanLPSMock";
+import { oppfolgingsplanV2Mock } from "@/mocks/syfooppfolgingsplanbackend/oppfolgingsplanV2Mock";
 import { oppfolgingsoppgaverQueryKeys } from "@/data/oppfolgingsoppgave/useOppfolgingsoppgaver";
 import {
   DATO_INNENFOR_OPPFOLGINGSTILFELLE,
@@ -106,6 +107,12 @@ function setupTestdataHistorikk() {
   );
   queryClient.setQueryData(
     oppfolgingsplanQueryKeys.oppfolgingsplanerLPS(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
+    () => []
+  );
+  queryClient.setQueryData(
+    oppfolgingsplanQueryKeys.oppfolgingsplanerV2(
       ARBEIDSTAKER_DEFAULT.personIdent
     ),
     () => []
@@ -746,6 +753,23 @@ describe("Historikk", () => {
       ).to.exist;
       expect(screen.getByText("Oppfølgingsplan")).to.exist;
       expect(screen.getByText("Oppfølgingsplan LPS")).to.exist;
+    });
+
+    it("viser historikk for V2-oppfølgingsplaner delt med Nav", () => {
+      const oppfolgingsplanV2 = oppfolgingsplanV2Mock[0];
+      queryClient.setQueryData(
+        oppfolgingsplanQueryKeys.oppfolgingsplanerV2(
+          ARBEIDSTAKER_DEFAULT.personIdent
+        ),
+        () => [oppfolgingsplanV2]
+      );
+      renderHistorikk();
+
+      expect(
+        screen.getByText(
+          `Oppfølgingsplanen ble delt med Nav av ${oppfolgingsplanV2.virksomhetsnummer}.`
+        )
+      ).to.exist;
     });
   });
 

--- a/test/testQueryClient.ts
+++ b/test/testQueryClient.ts
@@ -203,6 +203,12 @@ export const queryClientWithMockData = (): QueryClient => {
 
 export function setEmptyQueryData(existingClient: QueryClient): void {
   existingClient.setQueryData(
+    oppfolgingsplanQueryKeys.oppfolgingsplanerV2(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
+    () => []
+  );
+  existingClient.setQueryData(
     oppfolgingsplanQueryKeys.oppfolgingsplaner(
       ARBEIDSTAKER_DEFAULT.personIdent
     ),
@@ -255,5 +261,15 @@ export function setEmptyQueryData(existingClient: QueryClient): void {
       ARBEIDSTAKER_DEFAULT.personIdent
     ),
     () => null
+  );
+  existingClient.setQueryData(
+    oppfolgingstilfellePersonQueryKeys.oppfolgingstilfelleperson(
+      ARBEIDSTAKER_DEFAULT.personIdent
+    ),
+    () => ({
+      oppfolgingstilfelleList: [],
+      personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
+      hasGjentakendeSykefravar: false,
+    })
   );
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Inkluderer den nye oppfølgingplanen i opptellingen av aktive planer.
Kan testes med Normal Harpe i dev.

### Screenshots 📸✨
<img width="1707" height="935" alt="Skjermbilde 2026-05-27 kl  15 02 04" src="https://github.com/user-attachments/assets/0f43e3b1-4695-4e58-abb8-550c93cf2211" />

