### PR TITLE
Op query refactor

### DIFF
--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -4,11 +4,6 @@ import UnfinishedTasks from "./UnfinishedTasks";
 import { Link } from "react-router-dom";
 import { numberOfTasks } from "@/utils/globalNavigasjonUtils";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
-import {
-  useGetLPSOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerV2Query,
-} from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
 import { toOppfolgingsplanLPSMedPersonoppgave } from "@/utils/oppfolgingsplanerUtils";
 import { useAktivitetskravQuery } from "@/data/aktivitetskrav/aktivitetskravQueryHooks";
@@ -19,7 +14,7 @@ import { useVedtakQuery } from "@/data/frisktilarbeid/vedtakQuery";
 import { useManglendemedvirkningVurderingQuery } from "@/data/manglendemedvirkning/manglendeMedvirkningQueryHooks";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { useKartleggingssporsmalKandidaterQuery } from "@/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks";
-import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
 
 export enum Menypunkter {
   AKTIVITETSKRAV = "AKTIVITETSKRAV",
@@ -115,9 +110,7 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
   const refs = useRef<HTMLAnchorElement[]>([]);
 
   const personoppgaver = usePersonoppgaverQuery();
-  const getOppfolgingsplanerQuery = useGetOppfolgingsplanerQuery();
-  const getLPSOppfolgingsplaner = useGetLPSOppfolgingsplanerQuery();
-  const getOppfolgingsplanerV2Query = useGetOppfolgingsplanerV2Query();
+  const { aktivePlaner, aktivePlanerV2, lpsPlaner } = useOppfolgingsplaner();
   const motebehov = useMotebehovQuery();
   const aktivitetskrav = useAktivitetskravQuery();
   const arbeidsuforhetVurderinger = useGetArbeidsuforhetVurderingerQuery();
@@ -126,11 +119,10 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
   const manglendeMedvirkningVurdering = useManglendemedvirkningVurderingQuery();
   const kartleggingssporsmalKandidat = useKartleggingssporsmalKandidaterQuery();
   const featureToggles = useFeatureToggles();
-  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
 
   const isPending = featureToggles.isPending;
 
-  const oppfolgingsplanerLPSMedPersonOppgave = getLPSOppfolgingsplaner.data.map(
+  const oppfolgingsplanerLPSMedPersonOppgave = lpsPlaner.map(
     (oppfolgingsplanLPS) =>
       toOppfolgingsplanLPSMedPersonoppgave(
         oppfolgingsplanLPS,
@@ -194,7 +186,7 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
         const tasks = numberOfTasks(
           menypunkt,
           motebehov.data,
-          getOppfolgingsplanerQuery.data,
+          aktivePlaner,
           personoppgaver.data,
           oppfolgingsplanerLPSMedPersonOppgave,
           aktivitetskrav.data,
@@ -203,8 +195,7 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
           friskmeldingTilArbeidsformidlingVedtak.data,
           manglendeMedvirkningVurdering.sisteVurdering,
           kartleggingssporsmalKandidat.data,
-          getOppfolgingsplanerV2Query.data,
-          latestOppfolgingstilfelle
+          aktivePlanerV2.length
         );
 
         return (

--- a/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
+++ b/src/components/utdragFraSykefravaeret/UtdragOppfolgingsplaner.tsx
@@ -11,11 +11,6 @@ import {
   SYFO_OPPFOLGINGSPLAN_BACKEND_ROOT,
 } from "@/apiConstants";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
-import {
-  useGetLPSOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerV2Query,
-} from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { OppfolgingsplanDTO } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanDTO";
 import {
   OppfolgingsplanV2DTO,
@@ -23,6 +18,7 @@ import {
 } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
 import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { Alert, Heading, Link, Loader } from "@navikt/ds-react";
+import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
 
 const texts = {
   header: "Oppfølgingsplan",
@@ -186,44 +182,34 @@ interface Props {
 export default function UtdragOppfolgingsplaner({
   selectedOppfolgingstilfelle,
 }: Props) {
-  const getOppfolgingsplanerQuery = useGetOppfolgingsplanerQuery();
-  const getLPSOppfolgingsplanerQuery = useGetLPSOppfolgingsplanerQuery();
-  const getOppfolgingsplanerV2Query = useGetOppfolgingsplanerV2Query();
+  const { aktivePlaner, allePlanerV2, lpsPlaner, isLoading, isError } =
+    useOppfolgingsplaner();
 
   const activeLpsPlaner = lpsPlanerWithActiveTilfelle(
-    getLPSOppfolgingsplanerQuery.data,
+    lpsPlaner,
     selectedOppfolgingstilfelle
   );
   const [aktiveOppfolgingsplanerV2] = selectedOppfolgingstilfelle
     ? partitionOppfolgingsplanerByActiveTilfelle(
-        getOppfolgingsplanerV2Query.data,
+        allePlanerV2,
         selectedOppfolgingstilfelle
       )
     : [[]];
-
-  const showLoader =
-    getOppfolgingsplanerQuery.isPending &&
-    getLPSOppfolgingsplanerQuery.isPending &&
-    getOppfolgingsplanerV2Query.isPending;
-  const showError =
-    getOppfolgingsplanerQuery.isError &&
-    getLPSOppfolgingsplanerQuery.isError &&
-    getOppfolgingsplanerV2Query.isError;
 
   return (
     <div>
       <Heading size="small" level="3">
         {texts.header}
       </Heading>
-      {showLoader ? (
+      {isLoading ? (
         <Loader size="large" title={texts.pending} />
-      ) : showError ? (
+      ) : isError ? (
         <Alert size="small" inline variant="error">
           {texts.error}
         </Alert>
       ) : (
         <Oppfolgingsplaner
-          aktivePlaner={getOppfolgingsplanerQuery.data}
+          aktivePlaner={aktivePlaner}
           aktivePlanerV2={aktiveOppfolgingsplanerV2}
           lpsPlaner={activeLpsPlaner}
         />

--- a/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
+++ b/src/hooks/historikk/useOppfolgingsplanHistorikk.ts
@@ -1,9 +1,5 @@
 import { HistorikkEvent } from "@/data/historikk/types/historikkTypes";
 import { useHistorikkOppfolgingsplan } from "@/data/historikk/historikkQueryHooks";
-import {
-  useGetLPSOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerV2Query,
-} from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
 import { OppfolgingsplanLPS } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanLPS";
 import { HistorikkEvents } from "@/hooks/historikk/useHistorikk";
 import {
@@ -11,6 +7,7 @@ import {
   useGetOppfolgingsplanForesporselQuery,
 } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanForesporselHooks";
 import { OppfolgingsplanV2DTO } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
+import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
 
 function lpsplanerToHistorikkEvents(
   oppfolgingsplanerLPS: OppfolgingsplanLPS[]
@@ -53,20 +50,16 @@ export function useOppfolgingsplanHistorikk(): HistorikkEvents {
     isError: isOppfolgingsplanError,
   } = useHistorikkOppfolgingsplan();
   const {
-    data: oppfolgingsplanerLPS,
-    isLoading: isOppfolgingsplanerLPSLoading,
-    isError: isOppfolgingsplanerLPSError,
-  } = useGetLPSOppfolgingsplanerQuery();
+    lpsPlaner: oppfolgingsplanerLPS,
+    allePlanerV2: oppfolgingsplanerV2,
+    isLoading: isOppfolgingsplanerLoading,
+    isError: isOppfolgingsplanerError,
+  } = useOppfolgingsplaner();
   const {
     data: oppfolgingsplanForesporsler,
     isLoading: isOppfolgingsplanForesporslerLoading,
     isError: isOppfolgingsplanForesporslerError,
   } = useGetOppfolgingsplanForesporselQuery();
-  const {
-    data: oppfolgingsplanerV2,
-    isLoading: isOppfolgingsplanerV2Loading,
-    isError: isOppfolgingsplanerV2Error,
-  } = useGetOppfolgingsplanerV2Query();
 
   const oppfolgingsplanHistorikkEvents = oppfolgingsplanHistorikk
     .concat(lpsplanerToHistorikkEvents(oppfolgingsplanerLPS))
@@ -76,14 +69,12 @@ export function useOppfolgingsplanHistorikk(): HistorikkEvents {
   return {
     isLoading:
       isOppfolgingsplanLoading ||
-      isOppfolgingsplanerLPSLoading ||
-      isOppfolgingsplanForesporslerLoading ||
-      isOppfolgingsplanerV2Loading,
+      isOppfolgingsplanerLoading ||
+      isOppfolgingsplanForesporslerLoading,
     isError:
       isOppfolgingsplanError ||
-      isOppfolgingsplanerLPSError ||
-      isOppfolgingsplanForesporslerError ||
-      isOppfolgingsplanerV2Error,
+      isOppfolgingsplanerError ||
+      isOppfolgingsplanForesporslerError,
     events: oppfolgingsplanHistorikkEvents,
   };
 }

--- a/src/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO.ts
+++ b/src/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO.ts
@@ -29,27 +29,43 @@ function isOppfolgingsplanWithinActiveTilfelle(
 
 /**
  * Partisjonerer en liste av oppfølgingsplaner i aktive og inaktive basert på om oppfølgingsplanen er opprettet innenfor det siste oppfølgingstilfellet.
+ * Kun den siste planen (nyeste `opprettet`) per virksomhet innenfor det aktive tilfellet regnes som aktiv.
  * @param planer Liste over alle historiske oppfølgingsplaner som skal partisjoneres.
  * @param latestOppfolgingstilfelle Det siste oppfølgingstilfellet.
- * @returns En tuple \`[aktivePlaner, inaktivePlaner]\` der første element inneholder planer innenfor perioden,
+ * @returns En tuple \`[aktivePlaner, inaktivePlaner]\` der første element inneholder den siste planen per virksomhet innenfor perioden,
  *          og andre element inneholder alle andre planer.
  */
 export function partitionOppfolgingsplanerByActiveTilfelle(
   planer: OppfolgingsplanV2DTO[],
   latestOppfolgingstilfelle: OppfolgingstilfelleDTO
 ): [OppfolgingsplanV2DTO[], OppfolgingsplanV2DTO[]] {
-  const [aktivePlaner, inaktivePlaner] = planer.reduce(
-    (acc, plan) => {
-      if (
-        isOppfolgingsplanWithinActiveTilfelle(plan, latestOppfolgingstilfelle)
-      ) {
-        acc[0].push(plan);
-      } else {
-        acc[1].push(plan);
-      }
-      return acc;
-    },
-    [[], []] as [OppfolgingsplanV2DTO[], OppfolgingsplanV2DTO[]]
-  );
+  const planerInnenforTilfelle: OppfolgingsplanV2DTO[] = [];
+  const planerUtenforTilfelle: OppfolgingsplanV2DTO[] = [];
+
+  for (const plan of planer) {
+    if (
+      isOppfolgingsplanWithinActiveTilfelle(plan, latestOppfolgingstilfelle)
+    ) {
+      planerInnenforTilfelle.push(plan);
+    } else {
+      planerUtenforTilfelle.push(plan);
+    }
+  }
+
+  const sistePerVirksomhet = new Map<string, OppfolgingsplanV2DTO>();
+  for (const plan of planerInnenforTilfelle) {
+    const existing = sistePerVirksomhet.get(plan.virksomhetsnummer);
+    if (!existing || new Date(plan.opprettet) > new Date(existing.opprettet)) {
+      sistePerVirksomhet.set(plan.virksomhetsnummer, plan);
+    }
+  }
+
+  const aktivePlaner = [...sistePerVirksomhet.values()];
+  const aktiveUuids = new Set(aktivePlaner.map((p) => p.uuid));
+  const inaktivePlaner = [
+    ...planerInnenforTilfelle.filter((p) => !aktiveUuids.has(p.uuid)),
+    ...planerUtenforTilfelle,
+  ];
+
   return [aktivePlaner, inaktivePlaner];
 }

--- a/src/sider/oppfolgingsplan/hooks/useOppfolgingsplaner.ts
+++ b/src/sider/oppfolgingsplan/hooks/useOppfolgingsplaner.ts
@@ -13,7 +13,6 @@ import {
   partitionOppfolgingsplanerByActiveTilfelle,
 } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
-import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 
 export interface OppfolgingsplanerResult {
   aktivePlaner: OppfolgingsplanDTO[];
@@ -24,8 +23,6 @@ export interface OppfolgingsplanerResult {
   lpsPlaner: OppfolgingsplanLPS[];
   isLoading: boolean;
   isError: boolean;
-  latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined;
-  hasActiveOppfolgingstilfelle: boolean;
 }
 
 /**
@@ -37,8 +34,7 @@ export function useOppfolgingsplaner(): OppfolgingsplanerResult {
   const getOppfolgingsplanerQuery = useGetOppfolgingsplanerQuery();
   const getLPSOppfolgingsplanerQuery = useGetLPSOppfolgingsplanerQuery();
   const getOppfolgingsplanerV2Query = useGetOppfolgingsplanerV2Query();
-  const { latestOppfolgingstilfelle, hasActiveOppfolgingstilfelle } =
-    useOppfolgingstilfellePersonQuery();
+  const { latestOppfolgingstilfelle } = useOppfolgingstilfellePersonQuery();
 
   const [aktivePlaner, inaktivePlaner] = partitionOppfolgingsplanerByAktivPlan(
     getOppfolgingsplanerQuery.data
@@ -66,7 +62,5 @@ export function useOppfolgingsplaner(): OppfolgingsplanerResult {
       getOppfolgingsplanerQuery.isError ||
       getLPSOppfolgingsplanerQuery.isError ||
       getOppfolgingsplanerV2Query.isError,
-    latestOppfolgingstilfelle,
-    hasActiveOppfolgingstilfelle,
   };
 }

--- a/src/sider/oppfolgingsplan/hooks/useOppfolgingsplaner.ts
+++ b/src/sider/oppfolgingsplan/hooks/useOppfolgingsplaner.ts
@@ -1,0 +1,72 @@
+import {
+  useGetLPSOppfolgingsplanerQuery,
+  useGetOppfolgingsplanerQuery,
+  useGetOppfolgingsplanerV2Query,
+} from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
+import { OppfolgingsplanLPS } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanLPS";
+import {
+  OppfolgingsplanDTO,
+  partitionOppfolgingsplanerByAktivPlan,
+} from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanDTO";
+import {
+  OppfolgingsplanV2DTO,
+  partitionOppfolgingsplanerByActiveTilfelle,
+} from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
+import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+
+export interface OppfolgingsplanerResult {
+  aktivePlaner: OppfolgingsplanDTO[];
+  inaktivePlaner: OppfolgingsplanDTO[];
+  aktivePlanerV2: OppfolgingsplanV2DTO[];
+  inaktivePlanerV2: OppfolgingsplanV2DTO[];
+  allePlanerV2: OppfolgingsplanV2DTO[];
+  lpsPlaner: OppfolgingsplanLPS[];
+  isLoading: boolean;
+  isError: boolean;
+  latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined;
+  hasActiveOppfolgingstilfelle: boolean;
+}
+
+/**
+ * Samle-hook for alle oppfølgingsplaner (V1, V2 og LPS).
+ * Partisjonerer V1- og V2-planer i aktive og inaktive basert på gjeldende oppfølgingstilfelle.
+ * LPS-planer returneres urørt — konsumenten kobler personoppgaver selv ved behov.
+ */
+export function useOppfolgingsplaner(): OppfolgingsplanerResult {
+  const getOppfolgingsplanerQuery = useGetOppfolgingsplanerQuery();
+  const getLPSOppfolgingsplanerQuery = useGetLPSOppfolgingsplanerQuery();
+  const getOppfolgingsplanerV2Query = useGetOppfolgingsplanerV2Query();
+  const { latestOppfolgingstilfelle, hasActiveOppfolgingstilfelle } =
+    useOppfolgingstilfellePersonQuery();
+
+  const [aktivePlaner, inaktivePlaner] = partitionOppfolgingsplanerByAktivPlan(
+    getOppfolgingsplanerQuery.data
+  );
+
+  const [aktivePlanerV2, inaktivePlanerV2] = latestOppfolgingstilfelle
+    ? partitionOppfolgingsplanerByActiveTilfelle(
+        getOppfolgingsplanerV2Query.data,
+        latestOppfolgingstilfelle
+      )
+    : [[], []];
+
+  return {
+    aktivePlaner,
+    inaktivePlaner,
+    aktivePlanerV2,
+    inaktivePlanerV2,
+    allePlanerV2: getOppfolgingsplanerV2Query.data,
+    lpsPlaner: getLPSOppfolgingsplanerQuery.data,
+    isLoading:
+      getOppfolgingsplanerQuery.isLoading ||
+      getLPSOppfolgingsplanerQuery.isLoading ||
+      getOppfolgingsplanerV2Query.isLoading,
+    isError:
+      getOppfolgingsplanerQuery.isError ||
+      getLPSOppfolgingsplanerQuery.isError ||
+      getOppfolgingsplanerV2Query.isError,
+    latestOppfolgingstilfelle,
+    hasActiveOppfolgingstilfelle,
+  };
+}

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
@@ -7,24 +7,17 @@ import { toOppfolgingsplanLPSMedPersonoppgave } from "@/utils/oppfolgingsplanerU
 import { BodyShort, Box, Heading } from "@navikt/ds-react";
 import OppfolgingsplanLink from "@/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanLink";
 import * as Tredelt from "@/components/side/TredeltSide";
-import {
-  useGetLPSOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerQuery,
-  useGetOppfolgingsplanerV2Query,
-} from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanQueryHooks";
-import { partitionOppfolgingsplanerByActiveTilfelle } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
-import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks";
 import OppfolgingsplanV2Item from "@/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanV2Item";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import SideLaster from "@/components/side/SideLaster";
 import Side from "@/components/side/Side";
-import { partitionOppfolgingsplanerByAktivPlan } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanDTO";
 import BeOmOppfolgingsplan from "@/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import AktiveOppfolgingsplaner from "@/sider/oppfolgingsplan/oppfolgingsplaner/AktiveOppfolgingsplaner";
 import { aktiveNarmesteLedereForOppfolgingstilfelle } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import LumiSurvey from "@/components/lumi/LumiSurvey";
 import { oppfolgingsplanSurvey } from "@/components/lumi/oppfolgingsplanSurvey";
+import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
 
 const texts = {
   pageTitle: "Oppfølgingsplaner",
@@ -39,32 +32,24 @@ const texts = {
 };
 
 export default function OppfolgingsplanerOversikt() {
-  const getOppfolgingsplanerV2 = useGetOppfolgingsplanerV2Query();
-  const getOppfolgingsplaner = useGetOppfolgingsplanerQuery();
-  const getLPSOppfolgingsplaner = useGetLPSOppfolgingsplanerQuery();
-  const { latestOppfolgingstilfelle, hasActiveOppfolgingstilfelle } =
-    useOppfolgingstilfellePersonQuery();
+  const {
+    aktivePlaner,
+    inaktivePlaner,
+    aktivePlanerV2: aktiveOppfolgingsplanerV2,
+    inaktivePlanerV2: inaktiveOppfolgingsplanerV2,
+    lpsPlaner,
+    isLoading,
+    isError,
+    latestOppfolgingstilfelle,
+    hasActiveOppfolgingstilfelle,
+  } = useOppfolgingsplaner();
   const currentOppfolgingstilfelle = hasActiveOppfolgingstilfelle
     ? latestOppfolgingstilfelle
     : undefined;
   const { currentLedere } = useLedereQuery();
 
-  const isLoading =
-    getOppfolgingsplaner.isLoading ||
-    getLPSOppfolgingsplaner.isLoading ||
-    getOppfolgingsplanerV2.isLoading;
-
-  const isError =
-    getOppfolgingsplaner.isError ||
-    getLPSOppfolgingsplaner.isError ||
-    getOppfolgingsplanerV2.isError;
-
-  const [aktivePlaner, inaktivePlaner] = partitionOppfolgingsplanerByAktivPlan(
-    getOppfolgingsplaner.data
-  );
-
   const getPersonOppgaverQuery = usePersonoppgaverQuery();
-  const oppfolgingsplanerLPSMedPersonOppgave = getLPSOppfolgingsplaner.data.map(
+  const oppfolgingsplanerLPSMedPersonOppgave = lpsPlaner.map(
     (oppfolgingsplanLPS) =>
       toOppfolgingsplanLPSMedPersonoppgave(
         oppfolgingsplanLPS,
@@ -83,14 +68,6 @@ export default function OppfolgingsplanerOversikt() {
     .sort((a, b) => {
       return new Date(b.opprettet).getTime() - new Date(a.opprettet).getTime();
     });
-
-  const [aktiveOppfolgingsplanerV2, inaktiveOppfolgingsplanerV2] =
-    !!latestOppfolgingstilfelle && getOppfolgingsplanerV2.isSuccess
-      ? partitionOppfolgingsplanerByActiveTilfelle(
-          getOppfolgingsplanerV2.data,
-          latestOppfolgingstilfelle
-        )
-      : [[], []];
 
   const hasTidligereOppfolgingsplaner =
     inaktivePlaner.length !== 0 ||

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
@@ -18,6 +18,7 @@ import { aktiveNarmesteLedereForOppfolgingstilfelle } from "@/data/oppfolgingsti
 import LumiSurvey from "@/components/lumi/LumiSurvey";
 import { oppfolgingsplanSurvey } from "@/components/lumi/oppfolgingsplanSurvey";
 import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
+import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts";
 
 const texts = {
   pageTitle: "Oppfølgingsplaner",
@@ -32,6 +33,8 @@ const texts = {
 };
 
 export default function OppfolgingsplanerOversikt() {
+  const { latestOppfolgingstilfelle, hasActiveOppfolgingstilfelle } =
+    useOppfolgingstilfellePersonQuery();
   const {
     aktivePlaner,
     inaktivePlaner,
@@ -40,8 +43,6 @@ export default function OppfolgingsplanerOversikt() {
     lpsPlaner,
     isLoading,
     isError,
-    latestOppfolgingstilfelle,
-    hasActiveOppfolgingstilfelle,
   } = useOppfolgingsplaner();
   const currentOppfolgingstilfelle = hasActiveOppfolgingstilfelle
     ? latestOppfolgingstilfelle

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -9,11 +9,6 @@ import {
   aktiveOppfolgingsplaner,
   OppfolgingsplanDTO,
 } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanDTO";
-import {
-  OppfolgingsplanV2DTO,
-  partitionOppfolgingsplanerByActiveTilfelle,
-} from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
-import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { MotebehovVeilederDTO } from "@/data/motebehov/types/motebehovTypes";
 import {
   getAllUbehandledePersonOppgaver,
@@ -188,19 +183,12 @@ export function numberOfTasks(
     | KartleggingssporsmalKandidatResponseDTO[]
     | undefined
     | null,
-  oppfolgingsplanerV2: OppfolgingsplanV2DTO[],
-  latestOppfolgingstilfelle: OppfolgingstilfelleDTO | undefined
+  antallAktiveV2Planer: number
 ): number {
   switch (menypunkt) {
     case Menypunkter.DIALOGMOTE:
       return getNumberOfMoteOppgaver(motebehov, personOppgaver);
     case Menypunkter.OPPFOELGINGSPLANER: {
-      const aktiveV2Planer = latestOppfolgingstilfelle
-        ? partitionOppfolgingsplanerByActiveTilfelle(
-            oppfolgingsplanerV2,
-            latestOppfolgingstilfelle
-          )[0].length
-        : 0;
       return (
         aktiveOppfolgingsplaner(oppfolgingsplaner).length +
         numberOfActiveLPSOppfolgingsplaner(oppfolgingsplanerlps) +
@@ -208,7 +196,7 @@ export function numberOfTasks(
           personOppgaver,
           PersonOppgaveType.OPPFOLGINGSPLANLPS
         ) +
-        aktiveV2Planer
+        antallAktiveV2Planer
       );
     }
     case Menypunkter.AKTIVITETSKRAV:

--- a/test/oppfolgingsplan/OppfolgingsplanV2DTOTest.ts
+++ b/test/oppfolgingsplan/OppfolgingsplanV2DTOTest.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { partitionOppfolgingsplanerByActiveTilfelle } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanV2DTO";
+import { OppfolgingstilfelleDTO } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
+
+function lagPlan(uuid: string, virksomhetsnummer: string, opprettet: string) {
+  return {
+    uuid,
+    fnr: "12345678910",
+    deltMedNavTidspunkt: opprettet,
+    virksomhetsnummer,
+    opprettet,
+    sistEndret: opprettet,
+    evalueringsdato: "2026-06-01",
+  };
+}
+
+const aktivtTilfelle: OppfolgingstilfelleDTO = {
+  start: new Date("2026-01-01"),
+  end: new Date("2026-12-31"),
+  antallSykedager: 100,
+  varighetUker: 14,
+  virksomhetsnummerList: ["111111111", "222222222"],
+  arbeidstakerAtTilfelleEnd: true,
+};
+
+describe("partitionOppfolgingsplanerByActiveTilfelle", () => {
+  it("returnerer tom liste når det ikke finnes planer", () => {
+    const [aktive, inaktive] = partitionOppfolgingsplanerByActiveTilfelle(
+      [],
+      aktivtTilfelle
+    );
+
+    expect(aktive).toEqual([]);
+    expect(inaktive).toEqual([]);
+  });
+
+  it("kun siste plan per virksomhet innenfor tilfellet er aktiv", () => {
+    const gammelPlan = lagPlan("1", "111111111", "2026-02-01");
+    const nyPlan = lagPlan("2", "111111111", "2026-03-01");
+
+    const [aktive, inaktive] = partitionOppfolgingsplanerByActiveTilfelle(
+      [gammelPlan, nyPlan],
+      aktivtTilfelle
+    );
+
+    expect(aktive).toHaveLength(1);
+    expect(aktive[0].uuid).toBe("2");
+    expect(inaktive).toHaveLength(1);
+    expect(inaktive[0].uuid).toBe("1");
+  });
+
+  it("siste plan per virksomhet er aktiv når det er flere virksomheter", () => {
+    const plan1V1 = lagPlan("1", "111111111", "2026-02-01");
+    const plan2V1 = lagPlan("2", "111111111", "2026-04-01");
+    const plan1V2 = lagPlan("3", "222222222", "2026-03-01");
+
+    const [aktive, inaktive] = partitionOppfolgingsplanerByActiveTilfelle(
+      [plan1V1, plan2V1, plan1V2],
+      aktivtTilfelle
+    );
+
+    expect(aktive).toHaveLength(2);
+    const aktiveUuids = aktive.map((p) => p.uuid).sort();
+    expect(aktiveUuids).toEqual(["2", "3"]);
+    expect(inaktive).toHaveLength(1);
+    expect(inaktive[0].uuid).toBe("1");
+  });
+
+  it("planer utenfor tilfellet er alltid inaktive", () => {
+    const planForTilfelle = lagPlan("1", "111111111", "2025-06-01");
+    const planInnenforTilfelle = lagPlan("2", "111111111", "2026-05-01");
+
+    const [aktive, inaktive] = partitionOppfolgingsplanerByActiveTilfelle(
+      [planForTilfelle, planInnenforTilfelle],
+      aktivtTilfelle
+    );
+
+    expect(aktive).toHaveLength(1);
+    expect(aktive[0].uuid).toBe("2");
+    expect(inaktive).toHaveLength(1);
+    expect(inaktive[0].uuid).toBe("1");
+  });
+
+  it("eneste plan innenfor tilfellet for en virksomhet er aktiv", () => {
+    const plan = lagPlan("1", "111111111", "2026-05-01");
+
+    const [aktive, inaktive] = partitionOppfolgingsplanerByActiveTilfelle(
+      [plan],
+      aktivtTilfelle
+    );
+
+    expect(aktive).toHaveLength(1);
+    expect(aktive[0].uuid).toBe("1");
+    expect(inaktive).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

 1. Created shared hook useOppfolgingsplaner() (src/sider/oppfolgingsplan/hooks/useOppfolgingsplaner.ts)

   - Combines all 3 queries (V1, V2, LPS) + oppfølgingstilfelle
   - Returns aktivePlaner, inaktivePlaner, aktivePlanerV2, inaktivePlanerV2, allePlanerV2, lpsPlaner, isLoading, isError, latestOppfolgingstilfelle, hasActiveOppfolgingstilfelle

  2. Refactored all consumers to use the shared hook:

   - GlobalNavigasjon.tsx
   - OppfolgingsplanerOversikt.tsx
   - UtdragOppfolgingsplaner.tsx
   - useOppfolgingsplanHistorikk.ts

  3. Fixed V2 "active" definition (OppfolgingsplanV2DTO.ts)

   - Only the latest plan per virksomhet (by opprettet) within the active tilfelle is considered active
   - Older plans from the same virksomhet are now correctly placed in the inactive list

  4. Added tests:

   - test/oppfolgingsplan/OppfolgingsplanV2DTOTest.ts — 5 unit tests for partition logic

