### PR TITLE
IS-2132: Use virksomhetsnavn from leder query

### DIFF
--- a/src/data/virksomhet/virksomhetQueryHooks.ts
+++ b/src/data/virksomhet/virksomhetQueryHooks.ts
@@ -4,7 +4,7 @@ import {
   EregOrganisasjonResponseDTO,
   getVirksomhetsnavn,
 } from "@/data/virksomhet/types/EregOrganisasjonResponseDTO";
-import { useQueries, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/utils";
 
 export const virksomhetQueryKeys = {
@@ -15,14 +15,6 @@ const path = (virksomhetsnummer?: string) =>
   `${EREG_ROOT}/organisasjon/${virksomhetsnummer}`;
 const fetchVirksomhet = (path: string) =>
   get<EregOrganisasjonResponseDTO>(path);
-
-export interface VirksomhetQueryData {
-  virksomhetsnummer: string;
-  virksomhetsnavn?: string;
-  data?: EregOrganisasjonResponseDTO;
-}
-
-export type VirksomhetQueryDataRecord = Record<string, VirksomhetQueryData>;
 
 export function useVirksomhetQuery(virksomhetsnummer: string | undefined) {
   const query = useQuery({
@@ -35,37 +27,5 @@ export function useVirksomhetQuery(virksomhetsnummer: string | undefined) {
   return {
     data: query.data,
     virksomhetsnavn: query.data && getVirksomhetsnavn(query.data),
-  };
-}
-
-export function useVirksomheterQueries(virksomhetsnummer: string[] = []): {
-  data: VirksomhetQueryDataRecord;
-} {
-  const results = useQueries({
-    queries: virksomhetsnummer.map((nummer) => ({
-      queryKey: virksomhetQueryKeys.virksomhet(nummer),
-      queryFn: () => fetchVirksomhet(path(nummer)),
-      enabled: !!nummer,
-      staleTime: minutesToMillis(60 * 12),
-    })),
-  });
-
-  return {
-    data: results.reduce<VirksomhetQueryDataRecord>((acc, result, index) => {
-      const nummer = virksomhetsnummer[index];
-
-      if (!nummer) {
-        return acc;
-      }
-
-      return {
-        ...acc,
-        [nummer]: {
-          virksomhetsnummer: nummer,
-          virksomhetsnavn: result.data && getVirksomhetsnavn(result.data),
-          data: result.data,
-        },
-      };
-    }, {}),
   };
 }

--- a/src/sider/dialogmoter/components/svar/ArbeidsgiverSvar.tsx
+++ b/src/sider/dialogmoter/components/svar/ArbeidsgiverSvar.tsx
@@ -6,7 +6,6 @@ import { SvarDetaljer } from "@/sider/dialogmoter/components/svar/SvarDetaljer";
 import { useLedereQuery } from "@/data/leder/ledereQueryHooks";
 import { getHarAapnetTekst, getSvarTekst } from "@/utils/dialogmoteUtils";
 import { arbeidsgiverNavnMedVirksomhet } from "@/utils/motebehovUtils.ts";
-import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks.ts";
 
 const texts = {
   label: "Nærmeste leder:",
@@ -24,14 +23,11 @@ export const ArbeidsgiverSvar = ({
   defaultClosed = false,
 }: Props) => {
   const { getCurrentNarmesteLeder } = useLedereQuery();
-  const { virksomhetsnavn } = useVirksomhetQuery(virksomhetsnummer);
   const narmesteLeder = getCurrentNarmesteLeder(virksomhetsnummer);
   const arbeidsgiverInfo = narmesteLeder
     ? arbeidsgiverNavnMedVirksomhet(
         narmesteLeder.narmesteLederNavn,
-        virksomhetsnavn ||
-          narmesteLeder.virksomhetsnavn ||
-          narmesteLeder.virksomhetsnummer
+        narmesteLeder.virksomhetsnavn || narmesteLeder.virksomhetsnummer
       )
     : "";
 

--- a/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
+++ b/src/sider/dialogmoter/motebehov/MotebehovKvittering.tsx
@@ -23,10 +23,7 @@ import {
   OppfolgingstilfelleDTO,
 } from "@/data/oppfolgingstilfelle/person/types/OppfolgingstilfellePersonDTO";
 import { BodyShort } from "@navikt/ds-react";
-import {
-  useVirksomheterQueries,
-  useVirksomhetQuery,
-} from "@/data/virksomhet/virksomhetQueryHooks.ts";
+import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks.ts";
 
 export const arbeidsgiverNavnEllerTomStreng = (lederNavn: string | null) => {
   return lederNavn ? `${lederNavn}` : "";
@@ -272,20 +269,6 @@ function MotebehovArbeidsgiverInCurrentTilfelle({
     currentLedere,
     oppfolgingstilfelle
   );
-  const virksomheterByLedereInCurrentTilfelle = useVirksomheterQueries(
-    ledereInCurrentTilfelle.map((leder) => leder.virksomhetsnummer)
-  );
-  const ledereInCurrentTilfelleWithVirksomhetsnavn =
-    ledereInCurrentTilfelle.map((leder) => {
-      const virksomhetForLeder =
-        virksomheterByLedereInCurrentTilfelle.data[leder.virksomhetsnummer];
-
-      return {
-        ...leder,
-        virksomhetsnavn:
-          virksomhetForLeder?.virksomhetsnavn || leder.virksomhetsnavn,
-      };
-    });
 
   return motebehov ? (
     <MotebehovArbeidsgiverKvittering
@@ -295,7 +278,7 @@ function MotebehovArbeidsgiverInCurrentTilfelle({
     />
   ) : (
     <MotebehovKvitteringInnholdArbeidsgiverUtenMotebehov
-      ledereInCurrentTilfelle={ledereInCurrentTilfelleWithVirksomhetsnavn}
+      ledereInCurrentTilfelle={ledereInCurrentTilfelle}
       skjemaType={skjemaType}
     />
   );

--- a/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
+++ b/test/dialogmote/Motebehov/MotebehovKvitteringTest.tsx
@@ -29,11 +29,8 @@ import { ledereQueryKeys } from "@/data/leder/ledereQueryHooks";
 
 let queryClient: QueryClient;
 
-const virksomhetsnavnInText = "pontypandy Fire Service";
-const arbeidsgiverMedVirksomhet = `Are Arbeidsgiver (${virksomhetsnavnInText})`;
-const arbeidsgiverAltMedVirksomhet = `Are Arbeidsgiver (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
-const narmesteLederMedVirksomhet = `Tatten Tattover (${virksomhetsnavnInText})`;
-const narmesteLederAltMedVirksomhet = `Tatten Tattover (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
+const arbeidsgiverMedVirksomhet = `Are Arbeidsgiver (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
+const narmesteLederMedVirksomhet = `Tatten Tattover (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
 
 const renderMotebehovKvittering = () => {
   render(
@@ -187,7 +184,7 @@ describe("MotebehovKvittering", () => {
 
     expect(
       screen.getByAltText(
-        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Meldt behov.`
+        `Arbeidsgiver ${arbeidsgiverMedVirksomhet} Meldt behov.`
       )
     ).to.exist;
     expect(
@@ -211,7 +208,7 @@ describe("MotebehovKvittering", () => {
 
     expect(
       screen.getByAltText(
-        `Arbeidsgiver ${narmesteLederAltMedVirksomhet} Ikke meldt behov.`
+        `Arbeidsgiver ${narmesteLederMedVirksomhet} Ikke meldt behov.`
       )
     ).to.exist;
     expect(
@@ -221,12 +218,6 @@ describe("MotebehovKvittering", () => {
     ).to.exist;
   });
   it("viser virksomhetsnummer når nærmeste leder mangler virksomhetsnavn", () => {
-    queryClient.removeQueries({
-      queryKey: virksomhetQueryKeys.virksomhet(
-        VIRKSOMHET_PONTYPANDY.virksomhetsnummer
-      ),
-      exact: true,
-    });
     mockLedereUtenVirksomhetsnavn();
     mockMotebehov([motebehovArbeidstakerInTilfelleUbehandletMock]);
 
@@ -257,7 +248,7 @@ describe("MotebehovKvittering", () => {
 
     expect(
       screen.getByAltText(
-        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Meldt behov.`
+        `Arbeidsgiver ${arbeidsgiverMedVirksomhet} Meldt behov.`
       )
     ).to.exist;
     expect(
@@ -318,7 +309,7 @@ describe("MotebehovKvittering", () => {
 
     expect(
       screen.getByAltText(
-        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Meldt behov.`
+        `Arbeidsgiver ${arbeidsgiverMedVirksomhet} Meldt behov.`
       )
     ).to.exist;
     expect(
@@ -342,7 +333,7 @@ describe("MotebehovKvittering", () => {
 
     expect(
       screen.getByAltText(
-        `Arbeidsgiver ${narmesteLederAltMedVirksomhet} Ikke svart.`
+        `Arbeidsgiver ${narmesteLederMedVirksomhet} Ikke svart.`
       )
     ).to.exist;
     expect(
@@ -364,7 +355,7 @@ describe("MotebehovKvittering", () => {
 
     expect(
       screen.getByAltText(
-        `Arbeidsgiver ${arbeidsgiverAltMedVirksomhet} Svart nei.`
+        `Arbeidsgiver ${arbeidsgiverMedVirksomhet} Svart nei.`
       )
     ).to.exist;
     expect(


### PR DESCRIPTION
Nå som virksomhetsnavnet fra `isnarmesteleder` holdes oppdatert i APIet, så kan dette brukes i stedet for å sammenstille det med virksomhets-queriet. Fjerner dermed en workaround relatert til dette.

https://github.com/navikt/isnarmesteleder/pull/220

Testet i dev, fungerer som vanlig.