### PR TITLE
IS-3826: Remove old oppfølgingsplan view

### DIFF
--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanLink.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanLink.tsx
@@ -6,6 +6,7 @@ import {
   restdatoTilLesbarDato,
   tilLesbarPeriodeMedArstall,
 } from "@/utils/datoUtils";
+import { SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT } from "@/apiConstants";
 
 const texts = {
   duration: "Varighet",
@@ -32,7 +33,11 @@ interface Props {
 
 export default function OppfolgingsplanLink({ dialog }: Props) {
   return (
-    <LinkPanel href={`/sykefravaer/oppfoelgingsplaner/${dialog.id}`}>
+    <LinkPanel
+      href={`${SYFOOPPFOLGINGSPLANSERVICE_V2_ROOT}/dokument/${dialog.id}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       <LinkPanel.Title>
         <OppfolgingsplanVirksomhetTittel plan={dialog} />
       </LinkPanel.Title>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Skrive oss ut av gammel visning av oppfølgingsplan

- [x] Testet i dev

Refaktorering kommer i ny PR

### Screenshots 📸✨
Før:
<img width="3188" height="13772" alt="Oppf_lgingsplan - Sykefrav_r" src="https://github.com/user-attachments/assets/25e680bb-e7ba-4785-9fc0-38871a993a30" />

Nå:
<img width="1261" height="1420" alt="Skjermbilde 2026-05-29 kl  10 26 34" src="https://github.com/user-attachments/assets/feaf71cc-3966-43c1-84ab-e7bf2c57ab29" />