### PR TITLE
IS-4011: Fix tilfelle selection in dropdown + texts

### DIFF
--- a/src/sider/historikk/Historikk.tsx
+++ b/src/sider/historikk/Historikk.tsx
@@ -1,8 +1,5 @@
 import React, { ReactElement, useState } from "react";
-import {
-  tilLesbarDatoMedArstall,
-  tilLesbarPeriodeMedArstall,
-} from "@/utils/datoUtils";
+import { tilLesbarDatoMedArstall } from "@/utils/datoUtils";
 import {
   HistorikkEvent,
   HistorikkEventType,
@@ -133,6 +130,8 @@ function tagFromKilde(kilde: HistorikkEventType): ReactElement {
   }
 }
 
+const TILFELLE_OPTION_OFFSET = 1;
+
 interface Props {
   historikkEvents: HistorikkEvent[];
   tilfeller: OppfolgingstilfelleDTO[];
@@ -157,7 +156,7 @@ export default function Historikk({
       return historikkEvents.filter((event) =>
         isDateInOppfolgingstilfelle(
           event.tidspunkt,
-          tilfeller[selectedTilfelleIndex]
+          tilfeller[selectedTilfelleIndex - TILFELLE_OPTION_OFFSET]
         )
       );
     }
@@ -181,8 +180,13 @@ export default function Historikk({
         >
           <option value={0}>{texts.velgTilfelleDefaultValg}</option>
           {tilfeller.map((tilfelle, index) => (
-            <option key={index + 1} value={index + 1}>
-              {tilLesbarPeriodeMedArstall(tilfelle.start, tilfelle.end)}
+            <option
+              key={index + TILFELLE_OPTION_OFFSET}
+              value={index + TILFELLE_OPTION_OFFSET}
+            >
+              {`${tilLesbarDatoMedArstall(
+                new Date(tilfelle.start)
+              )} - ${tilLesbarDatoMedArstall(new Date(tilfelle.end))}`}
             </option>
           ))}
           {eventUtenforTilfelleList.length > 0 && (

--- a/test/historikk/HistorikkTest.tsx
+++ b/test/historikk/HistorikkTest.tsx
@@ -57,12 +57,7 @@ import {
   historikkOppfolgingsoppgaveFjernetMock,
 } from "@/mocks/oppfolgingsoppgave/historikkOppfolgingsoppgaveMock";
 import { AktivitetskravStatus } from "@/data/aktivitetskrav/aktivitetskravTypes";
-import {
-  addDays,
-  addWeeks,
-  tilLesbarDatoMedArstall,
-  tilLesbarPeriodeMedArstall,
-} from "@/utils/datoUtils";
+import { addDays, addWeeks, tilLesbarDatoMedArstall } from "@/utils/datoUtils";
 import { motebehovQueryKeys } from "@/data/motebehov/motebehovQueryHooks";
 import { motebehovMock } from "@/mocks/syfomotebehov/motebehovMock";
 import { oppfolgingsplanForesporselQueryKeys } from "@/sider/oppfolgingsplan/hooks/oppfolgingsplanForesporselHooks";
@@ -226,18 +221,11 @@ describe("Historikk", () => {
     );
     renderHistorikk();
 
-    const lastOppfolgingstilfelle =
-      oppfolgingstilfellePersonMock.oppfolgingstilfelleList[
-        oppfolgingstilfellePersonMock.oppfolgingstilfelleList.length - 1
-      ];
-    const dropdownOptionText = tilLesbarPeriodeMedArstall(
-      lastOppfolgingstilfelle.start,
-      lastOppfolgingstilfelle.end
-    );
-
     expect(await screen.findAllByText("Historikk")).to.exist;
     expect(screen.getByLabelText("Velg sykefraværstilfelle")).to.exist;
-    expect(screen.getByRole("option", { name: dropdownOptionText })).to.exist;
+    expect(
+      screen.getByRole("option", { name: "6. juni 2019 - 21. januar 2020" })
+    ).to.exist;
     expect(
       screen.queryByRole("option", { name: "Utenfor sykefraværstilfelle" })
     ).to.not.exist;
@@ -261,17 +249,10 @@ describe("Historikk", () => {
     );
     renderHistorikk();
 
-    const lastOppfolgingstilfelle =
-      oppfolgingstilfellePersonMock.oppfolgingstilfelleList[
-        oppfolgingstilfellePersonMock.oppfolgingstilfelleList.length - 1
-      ];
-    const dropdownOptionText = tilLesbarPeriodeMedArstall(
-      lastOppfolgingstilfelle.start,
-      lastOppfolgingstilfelle.end
-    );
-
     expect(await screen.findAllByText("Historikk")).to.exist;
-    expect(screen.getByRole("option", { name: dropdownOptionText })).to.exist;
+    expect(
+      screen.getByRole("option", { name: "6. juni 2019 - 21. januar 2020" })
+    ).to.exist;
     expect(screen.getByRole("option", { name: "Utenfor sykefraværstilfelle" }))
       .to.exist;
   });


### PR DESCRIPTION
Denne dropdownen har systematisk valgt feil tilfelle, siden `value` per valg var satt til `index + 1` samtidig som `tilfeller[selectedTilfelleIndex]` ikke tok hensyn til denne offseten. Dette førte også til at om man valgte det nederste tilfellet, så kræsjet hele siden. Det har [dukket opp noen slike feil i prod](https://grafana.nav.cloud.nais.io/d/b24c6d83-63dc-43bc-90ed-b4a78d092080/stack-trace-drilldown?orgId=1&var-app=syfomodiaperson&var-env=PD969E40991D5C4A8&var-errmsg=Cannot%20read%20properties%20of%20undefined%20%28reading%20%27start%27%29&from=now-90d&to=now&timezone=browser), men ikke kjempemange.

I tillegg oppdaget jeg at datoformateringen så litt rar ut. Synes det var merkelig å fjerne årstallet fra visningen i dropdownlisten, så jeg bare fjernet den logikken :shrug: Enig?
```
[
  "28. august 2025 – 22. oktober 2026",
  "21. februar – 10. desember 2020",
  "6. – 21. januar 2019"
]
```
til
```
[
  "28. august 2025 – 22. oktober 2026",
  "21. februar 2020 – 10. desember 2020",
  "6. juni 2019 – 21. januar 2020"
]
```