### PR TITLE
IS-3900: Add error message for write access

### DIFF
--- a/src/components/SkjemaInnsendingFeil.tsx
+++ b/src/components/SkjemaInnsendingFeil.tsx
@@ -1,24 +1,38 @@
-import { FlexRow, PaddingSize } from "@/components/Layout";
-import { ApiErrorException, defaultErrorTexts } from "@/api/errors";
+import { ApiErrorException, defaultErrorTexts, ErrorType } from "@/api/errors";
 import React from "react";
-import { Alert } from "@navikt/ds-react";
+import { Alert, HStack } from "@navikt/ds-react";
 
 interface Props {
   error: unknown;
-  bottomPadding?: PaddingSize | null;
+  defaultErrorMsgOverride?: string;
+}
+
+function resolveErrorMessage(
+  error: unknown,
+  defaultErrorMsgOverride: string
+): string {
+  if (
+    error instanceof ApiErrorException &&
+    error.error.type !== ErrorType.GENERAL_ERROR
+  ) {
+    return error.error.defaultErrorMsg;
+  }
+  return defaultErrorMsgOverride;
 }
 
 export function SkjemaInnsendingFeil({
   error,
-  bottomPadding = PaddingSize.MD,
+  defaultErrorMsgOverride,
 }: Props) {
+  const message = resolveErrorMessage(
+    error,
+    defaultErrorMsgOverride ?? defaultErrorTexts.generalError
+  );
   return (
-    <FlexRow bottomPadding={bottomPadding ? bottomPadding : undefined}>
+    <HStack className={"my-2"}>
       <Alert variant="error" size="small" contentMaxWidth={false}>
-        {error instanceof ApiErrorException
-          ? error.error.defaultErrorMsg
-          : defaultErrorTexts.generalError}
+        {message}
       </Alert>
-    </FlexRow>
+    </HStack>
   );
 }

--- a/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
+++ b/src/components/oppfolgingsoppgave/Oppfolgingsoppgave.tsx
@@ -8,6 +8,7 @@ import {
   Tag,
   Tooltip,
 } from "@navikt/ds-react";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import React, { useState } from "react";
 import OpenOppfolgingsoppgaveModalButton from "@/components/oppfolgingsoppgave/OpenOppfolgingsoppgaveModalButton";
 import { useAktivOppfolgingsoppgave } from "@/data/oppfolgingsoppgave/useAktivOppfolgingsoppgave";
@@ -99,6 +100,9 @@ export default function Oppfolgingsoppgave() {
           {texts.remove}
         </Button>
       </Tooltip>
+      {removeOppfolgingsoppgave.isError && (
+        <SkjemaInnsendingFeil error={removeOppfolgingsoppgave.error} />
+      )}
       <div className="mt-2">
         <Detail textColor="subtle" className="text-xs">
           {`Opprettet: ${tilLesbarDatoMedArUtenManedNavn(

--- a/src/sider/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
+++ b/src/sider/aktivitetskrav/vurdering/SendForhandsvarselSkjema.tsx
@@ -8,7 +8,7 @@ import { Button, HelpText, Label, Select, Textarea } from "@navikt/ds-react";
 import { useSendForhandsvarsel } from "@/data/aktivitetskrav/useSendForhandsvarsel";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { VurderAktivitetskravSkjemaProps } from "@/sider/aktivitetskrav/vurdering/vurderAktivitetskravSkjemaTypes";
-import { useForm, useController } from "react-hook-form";
+import { useController, useForm } from "react-hook-form";
 import { SkjemaHeading } from "@/sider/aktivitetskrav/vurdering/SkjemaHeading";
 import { ForhandsvisningModal } from "@/components/ForhandsvisningModal";
 import { Brevmal } from "@/data/aktivitetskrav/forhandsvarselTexts";

--- a/src/sider/arbeidsuforhet/innstillingutenforhandsvarsel/InnstillingUtenForhandsvarsel.tsx
+++ b/src/sider/arbeidsuforhet/innstillingutenforhandsvarsel/InnstillingUtenForhandsvarsel.tsx
@@ -16,9 +16,9 @@ import { Link, useNavigate } from "react-router-dom";
 import { arbeidsuforhetPath } from "@/AppRouter";
 import { FormProvider, useForm } from "react-hook-form";
 import {
+  AvslagUtenForhandsvarsel,
   VurderingInitiertAv,
   VurderingType,
-  AvslagUtenForhandsvarsel,
 } from "@/sider/arbeidsuforhet/data/arbeidsuforhetTypes";
 import { useSaveVurderingArbeidsuforhet } from "@/sider/arbeidsuforhet/hooks/useSaveVurderingArbeidsuforhet";
 import { useArbeidsuforhetVurderingDocument } from "@/sider/arbeidsuforhet/hooks/useArbeidsuforhetVurderingDocument";

--- a/src/sider/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
+++ b/src/sider/behandlerdialog/meldinger/BehandleBehandlerdialogSvarOppgaveKnapp.tsx
@@ -12,7 +12,8 @@ import {
   getAllBehandledePersonOppgaver,
   hasUbehandletPersonoppgave,
 } from "@/utils/personOppgaveUtils";
-import { FlexRow } from "@/components/Layout";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { HStack } from "@navikt/ds-react";
 
 const texts = {
   fjernOppgave:
@@ -54,18 +55,23 @@ export default function BehandleBehandlerdialogSvarOppgaveKnapp() {
     getSisteBehandledeBehandlerdialogSvarOppgave(personOppgaver);
 
   return (
-    <FlexRow>
-      {hasBehandlerDialogSvarOppgaver && (
-        <BehandlePersonOppgaveKnapp
-          personOppgave={sisteBehandledeOppgave}
-          isBehandlet={isBehandlet}
-          handleBehandleOppgave={() =>
-            behandleAllPersonoppgaver.mutate(behandlePersonOppgaveRequestDTO)
-          }
-          isBehandleOppgaveLoading={behandleAllPersonoppgaver.isPending}
-          behandleOppgaveText={texts.fjernOppgave}
-        />
+    <>
+      <HStack>
+        {hasBehandlerDialogSvarOppgaver && (
+          <BehandlePersonOppgaveKnapp
+            personOppgave={sisteBehandledeOppgave}
+            isBehandlet={isBehandlet}
+            handleBehandleOppgave={() =>
+              behandleAllPersonoppgaver.mutate(behandlePersonOppgaveRequestDTO)
+            }
+            isBehandleOppgaveLoading={behandleAllPersonoppgaver.isPending}
+            behandleOppgaveText={texts.fjernOppgave}
+          />
+        )}
+      </HStack>
+      {behandleAllPersonoppgaver.isError && (
+        <SkjemaInnsendingFeil error={behandleAllPersonoppgaver.error} />
       )}
-    </FlexRow>
+    </>
   );
 }

--- a/src/sider/frisktilarbeid/FattVedtakSkjema.tsx
+++ b/src/sider/frisktilarbeid/FattVedtakSkjema.tsx
@@ -21,6 +21,7 @@ import dayjs from "dayjs";
 import { useFriskmeldingTilArbeidsformidlingDocument } from "@/hooks/frisktilarbeid/useFriskmeldingTilArbeidsformidlingDocument";
 import { useMaksdatoQuery } from "@/data/maksdato/useMaksdatoQuery";
 import { useNotification } from "@/context/notification/NotificationContext";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 
 const begrunnelseMaxLength = 5000;
 
@@ -226,9 +227,10 @@ export default function FattVedtakSkjema() {
             {texts.gosysAlertBody}
           </Alert>
           {fattVedtak.isError && (
-            <Alert variant="error" size="small" contentMaxWidth={false}>
-              {texts.fattVedtakErrorMessage}
-            </Alert>
+            <SkjemaInnsendingFeil
+              error={fattVedtak.error}
+              defaultErrorMsgOverride={texts.fattVedtakErrorMessage}
+            />
           )}
           <div className="flex gap-4">
             <Button

--- a/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
+++ b/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
@@ -27,7 +27,6 @@ import { getWeeksBetween, tilLesbarDatoMedArstall } from "@/utils/datoUtils";
 import { EksternLenke } from "@/components/EksternLenke";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
-import { PaddingSize } from "@/components/Layout";
 import { Events, trackEvent } from "@/utils/umami";
 import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { KartleggingssporsmalSkjemasvar } from "@/sider/kartleggingssporsmal/skjemasvar/KartleggingssporsmalSkjemasvar";
@@ -224,10 +223,7 @@ export default function KartleggingssporsmalSide(): ReactElement {
                               {texts.vurdereOppgaveText}
                             </Button>
                             {vurderSvar.isError && (
-                              <SkjemaInnsendingFeil
-                                bottomPadding={PaddingSize.NONE}
-                                error={vurderSvar.error}
-                              />
+                              <SkjemaInnsendingFeil error={vurderSvar.error} />
                             )}
                           </>
                         )}

--- a/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
+++ b/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts";
 import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil.tsx";
-import { PaddingSize } from "@/components/Layout.tsx";
 import React, { useState } from "react";
 import { SuccessAlert } from "@/sider/kartleggingssporsmal/successAlert/SuccessAlert.tsx";
 import { UseMutationResult } from "@tanstack/react-query";
@@ -117,10 +116,7 @@ export function KartleggingVurdering({
         </Button>
       )}
       {vurderSvarMutation.isError && (
-        <SkjemaInnsendingFeil
-          bottomPadding={PaddingSize.NONE}
-          error={vurderSvarMutation.error}
-        />
+        <SkjemaInnsendingFeil error={vurderSvarMutation.error} />
       )}
       {nyesteKandidat.status === KandidatStatus.FERDIGBEHANDLET && (
         <SuccessAlert nyesteKandidat={nyesteKandidat} />

--- a/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSkjema.tsx
+++ b/src/sider/manglendemedvirkning/forhandsvarsel/ForhandsvarselSkjema.tsx
@@ -3,10 +3,10 @@ import {
   Box,
   Button,
   Heading,
-  List,
-  Textarea,
   HelpText,
   Label,
+  List,
+  Textarea,
 } from "@navikt/ds-react";
 import { useController, useForm } from "react-hook-form";
 import { Forhandsvisning } from "@/components/Forhandsvisning";

--- a/src/sider/oppfolgingsplan/lps/BehandleOppfolgingsplanLPS.tsx
+++ b/src/sider/oppfolgingsplan/lps/BehandleOppfolgingsplanLPS.tsx
@@ -5,6 +5,7 @@ import { toDatePrettyPrint } from "@/utils/datoUtils";
 import { usePersonoppgaverQuery } from "@/data/personoppgave/personoppgaveQueryHooks";
 import { OppfolgingsplanLPS } from "@/sider/oppfolgingsplan/hooks/types/OppfolgingsplanLPS";
 import { BodyShort, Button } from "@navikt/ds-react";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 
 const texts = {
   marker: "Marker som behandlet",
@@ -26,14 +27,19 @@ export default function BehandleOppfolgingsplanLPS({
   return (
     <>
       {personoppgave && !personoppgave.behandletTidspunkt && (
-        <Button
-          variant="secondary"
-          size="small"
-          onClick={() => behandlePersonoppgave.mutate(personoppgave.uuid)}
-          loading={behandlePersonoppgave.isPending}
-        >
-          {texts.marker}
-        </Button>
+        <>
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={() => behandlePersonoppgave.mutate(personoppgave.uuid)}
+            loading={behandlePersonoppgave.isPending}
+          >
+            {texts.marker}
+          </Button>
+          {behandlePersonoppgave.isError && (
+            <SkjemaInnsendingFeil error={behandlePersonoppgave.error} />
+          )}
+        </>
       )}
       {personoppgave && personoppgave.behandletTidspunkt && (
         <BodyShort size="small" className="flex gap-1 items-center">

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
@@ -27,6 +27,7 @@ import { useOppfolgingsplanForesporselDocument } from "@/hooks/oppfolgingsplan/u
 import LabelAndText from "@/components/LabelAndText";
 import { Controller, useForm } from "react-hook-form";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 
 const texts = {
   aktivForesporsel: "Obs! Det ble bedt om oppfølgingsplan fra",
@@ -42,7 +43,6 @@ const texts = {
   narmesteLeder: "Nærmeste leder:",
   button: "Send forespørsel",
   foresporselSendt: "Forespørsel om oppfølgingsplan sendt",
-  foresporselFeilet: "Det skjedde en uventet feil. Vennligst prøv igjen senere",
   readMoreText: "Dette får nærmeste leder tilsendt i e-posten fra Nav",
 };
 
@@ -193,9 +193,7 @@ export default function BeOmOppfolgingsplan({
           </Button>
         )}
         {postOppfolgingsplanForesporsel.isError && (
-          <Alert inline variant="error">
-            {texts.foresporselFeilet}
-          </Alert>
+          <SkjemaInnsendingFeil error={postOppfolgingsplanForesporsel.error} />
         )}
       </Box>
     </form>

--- a/src/sider/sykmeldinger/VurderBistandsbehov.tsx
+++ b/src/sider/sykmeldinger/VurderBistandsbehov.tsx
@@ -13,6 +13,7 @@ import { PersonOppgave } from "@/data/personoppgave/types/PersonOppgave";
 import { useBehandlePersonoppgaveWithoutRefetch } from "@/data/personoppgave/useBehandlePersonoppgave";
 import { StatusKanImage } from "../../../img/ImageComponents";
 import { Link as RouterLink } from "react-router-dom";
+import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 
 const texts = {
   header: "Vurder bistandsbehovet eller forslag til tiltak fra behandler:",
@@ -116,6 +117,9 @@ export default function VurderBistandsbehov({ oppgave }: Props) {
             </div>
           )}
         </div>
+        {behandleOppgave.isError && (
+          <SkjemaInnsendingFeil error={behandleOppgave.error} />
+        )}
       </Box>
     )
   );

--- a/test/sider/oppfolgingsplaner/BeOmOppfolgingsplanTest.tsx
+++ b/test/sider/oppfolgingsplaner/BeOmOppfolgingsplanTest.tsx
@@ -122,7 +122,7 @@ describe("BeOmOppfolgingsplan", () => {
     await userEvent.click(beOmOppfolgingsplanButton);
     expect(
       await screen.findByText(
-        "Det skjedde en uventet feil. Vennligst prøv igjen senere"
+        "Det skjedde en uventet feil. Vennligst prøv igjen senere."
       )
     ).to.exist;
   });


### PR DESCRIPTION
Tok en gjennomgang av mutasjonene våre og la til feilmelding der det manglet eller bare sto noe generisk. Jeg har tenkt svært lite på design for å holde oppgaven så liten som mulig. Jeg tuklet bare litt på luften til den standardkomponenten vi har, eller blir alt bare lagt inn et sted. Det viktigste er at veilederne faktisk får en feilmelding.

Jeg startet også med å fikse tilsvarende melding på feilmeldinger for utkast, men droppet dette til slutt. Man får egentlig ikke tilgangsfeil på dette uansett siden lagring av utkast er scopet til veilederen som skriver.

Jeg tar ikke bilder av alt. Sjekk Jira-oppgaven om du er usikker på hvilke steder som har fått endring. Eksempler:

<img width="1143" height="972" alt="image" src="https://github.com/user-attachments/assets/b4590e70-f691-41d1-93ca-84a28b6b6b72" />
<img width="1143" height="258" alt="image" src="https://github.com/user-attachments/assets/e2e0ea18-b154-42dc-93b2-a80b91036a81" />
