### PR TITLE
IS-4041: Update with new fieldIds for kartleggingsspørsmål

### DIFF
--- a/src/mocks/meroppfolging-backend/merOppfolgingMock.ts
+++ b/src/mocks/meroppfolging-backend/merOppfolgingMock.ts
@@ -82,7 +82,7 @@ export const defaultRadioGroupSporsmal = (
 
 const kartleggingssporsmal: KartleggingssporsmalRadioGroupFieldSnapshot[] = [
   {
-    ...defaultRadioGroupSporsmal("hvorSannsynligTilbakeTilJobben"),
+    ...defaultRadioGroupSporsmal("tilbakeTilJobbenHvorSannsynligFlervalg"),
     label:
       "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
     options: [
@@ -92,14 +92,16 @@ const kartleggingssporsmal: KartleggingssporsmalRadioGroupFieldSnapshot[] = [
     ],
   },
   {
-    ...defaultRadioGroupSporsmal("arbeidsgiverHvordanErSamarbeidFlervalg"),
-    label:
-      "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+    ...defaultRadioGroupSporsmal("arbeidsgiverFaarDuOppfolgingFlervalg"),
+    label: "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?",
     options: [
-      createRadioOption("2a", "Jeg opplever samarbeidet og relasjonen som god"),
       createRadioOption(
-        "2b",
-        "Jeg opplever samarbeidet og relasjonen som dårlig",
+        "ja",
+        "Ja, jeg får oppfølging, og har snakket med arbeidsgiver om dette."
+      ),
+      createRadioOption(
+        "nei",
+        "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig.",
         true
       ),
     ],
@@ -126,11 +128,12 @@ const hvorforUsikkerTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
   wasRequired: false,
 };
 
-const samarbeidTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
-  fieldId: "arbeidsgiverSamarbeidDarligBegrunnelse",
+const ikkeOppfolgingTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
+  fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",
   fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
   description: null,
-  label: "Hva gjør samarbeidet og relasjonen dårlig?",
+  label:
+    "Hva savner du i samarbeidet med arbeidsgiver for at du skal få bedre oppfølging?",
   value: "   ",
   wasRequired: false,
 };
@@ -147,7 +150,7 @@ export const kartleggingssporsmalAnswered: KartleggingssporsmalSvarResponseDTO =
         kartleggingssporsmal[0],
         hvorforUsikkerTextSporsmal,
         ...kartleggingssporsmal.slice(1, 2),
-        samarbeidTextSporsmal,
+        ikkeOppfolgingTextSporsmal,
         ...kartleggingssporsmal.slice(2),
       ],
     },
@@ -163,7 +166,9 @@ export const kartleggingssporsmalLowRiskAnswered: KartleggingssporsmalSvarRespon
       formSemanticVersion: "1.0.0",
       fieldSnapshots: [
         {
-          ...defaultRadioGroupSporsmal("hvorSannsynligTilbakeTilJobben"),
+          ...defaultRadioGroupSporsmal(
+            "tilbakeTilJobbenHvorSannsynligFlervalg"
+          ),
           label:
             "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
           options: [
@@ -173,20 +178,18 @@ export const kartleggingssporsmalLowRiskAnswered: KartleggingssporsmalSvarRespon
           ],
         },
         {
-          ...defaultRadioGroupSporsmal(
-            "arbeidsgiverHvordanErSamarbeidFlervalg"
-          ),
+          ...defaultRadioGroupSporsmal("arbeidsgiverFaarDuOppfolgingFlervalg"),
           label:
-            "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+            "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?",
           options: [
             createRadioOption(
-              "2a",
-              "Jeg opplever samarbeidet og relasjonen som god",
+              "ja",
+              "Ja, jeg får oppfølging, og har snakket med arbeidsgiver om dette.",
               true
             ),
             createRadioOption(
-              "2b",
-              "Jeg opplever samarbeidet og relasjonen som dårlig"
+              "nei",
+              "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig."
             ),
           ],
         },

--- a/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
+++ b/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
@@ -30,8 +30,16 @@ export const lowRiskAnswers = [
     optionId: "1a",
   },
   {
+    field: "tilbakeTilJobbenHvorSannsynligFlervalg",
+    optionId: "1a",
+  },
+  {
     field: "arbeidsgiverHvordanErSamarbeidFlervalg",
     optionId: "2a",
+  },
+  {
+    field: "arbeidsgiverFaarDuOppfolgingFlervalg",
+    optionId: "ja",
   },
   {
     field: "naarTilbakeTilJobbenFlervalg",

--- a/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
+++ b/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
@@ -17,9 +17,9 @@ export function hasRiskoForLangtidsfravar(
       if (!fieldSnapshot) return false;
 
       const option = fieldSnapshot.options?.find(
-        (option) => option.optionId !== answer.optionId
+        (option) => option.optionId === answer.optionId
       );
-      return option?.wasSelected;
+      return option !== undefined && !option.wasSelected;
     });
   }
 }

--- a/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
+++ b/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
@@ -257,13 +257,13 @@ describe("Kartleggingssporsmal", () => {
     expect(
       screen.getAllByRole("radiogroup", {
         name: RegExp(
-          "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?"
+          "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?"
         ),
       })[0]
     ).to.exist;
     expect(
       screen.getByRole("radio", {
-        name: "Jeg opplever samarbeidet og relasjonen som dårlig",
+        name: "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig.",
         checked: true,
       })
     ).to.exist;

--- a/test/kartleggingssporsmal/vurdereBehovTest.ts
+++ b/test/kartleggingssporsmal/vurdereBehovTest.ts
@@ -72,10 +72,58 @@ describe("vurdereBehov", () => {
     expect(hasRisk).to.equal(false);
   });
 
-  it("returns true when one answer differs from low-risk option", () => {
+  it("returns true when hvorSannsynligTilbakeTilJobben is RISK_OPTION_1", () => {
+    const answeredQuestions = createAnsweredQuestions({
+      hvorSannsynligTilbakeTilJobben: "RISK_OPTION_1",
+      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
+      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+    });
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(true);
+  });
+
+  it("returns true when hvorSannsynligTilbakeTilJobben is RISK_OPTION_2", () => {
+    const answeredQuestions = createAnsweredQuestions({
+      hvorSannsynligTilbakeTilJobben: "RISK_OPTION_2",
+      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
+      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+    });
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(true);
+  });
+
+  it("returns true when arbeidsgiverHvordanErSamarbeid differs from low-risk option", () => {
+    const answeredQuestions = createAnsweredQuestions({
+      hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
+      arbeidsgiverHvordanErSamarbeidFlervalg: "RISK_OPTION_3",
+      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+    });
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(true);
+  });
+
+  it("returns true when naarTilbakeTilJobben differs from low-risk option", () => {
     const answeredQuestions = createAnsweredQuestions({
       hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
       arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
+      naarTilbakeTilJobbenFlervalg: "RISK_OPTION_4",
+    });
+
+    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+    expect(hasRisk).to.equal(true);
+  });
+
+  it("returns true when all answers differ from low-risk options", () => {
+    const answeredQuestions = createAnsweredQuestions({
+      hvorSannsynligTilbakeTilJobben: "RISK_OPTION_1",
+      arbeidsgiverHvordanErSamarbeidFlervalg: "RISK_OPTION_3",
       naarTilbakeTilJobbenFlervalg: "RISK_OPTION_4",
     });
 

--- a/test/kartleggingssporsmal/vurdereBehovTest.ts
+++ b/test/kartleggingssporsmal/vurdereBehovTest.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  hasRiskoForLangtidsfravar,
-  lowRiskAnswers,
-} from "@/sider/kartleggingssporsmal/info/vurdereBehov.ts";
+import { hasRiskoForLangtidsfravar } from "@/sider/kartleggingssporsmal/info/vurdereBehov.ts";
 import {
   KartleggingssporsmalFormSnapshotFieldType,
   KartleggingssporsmalRadioGroupFieldSnapshot,
@@ -28,7 +25,7 @@ function createRadioGroupFieldSnapshot(
   };
 }
 
-function createAnsweredQuestions(
+function createAnsweredQuestionsV1(
   selectedOptionsByField: Record<string, string>
 ): KartleggingssporsmalSvarResponseDTO {
   return {
@@ -42,17 +39,48 @@ function createAnsweredQuestions(
         createRadioGroupFieldSnapshot(
           "hvorSannsynligTilbakeTilJobben",
           selectedOptionsByField.hvorSannsynligTilbakeTilJobben,
-          [lowRiskAnswers[0].optionId, "RISK_OPTION_1", "RISK_OPTION_2"]
+          ["1a", "1b", "1c"]
         ),
         createRadioGroupFieldSnapshot(
           "arbeidsgiverHvordanErSamarbeidFlervalg",
           selectedOptionsByField.arbeidsgiverHvordanErSamarbeidFlervalg,
-          [lowRiskAnswers[1].optionId, "RISK_OPTION_3"]
+          ["2a", "2b"]
         ),
         createRadioGroupFieldSnapshot(
           "naarTilbakeTilJobbenFlervalg",
           selectedOptionsByField.naarTilbakeTilJobbenFlervalg,
-          [lowRiskAnswers[2].optionId, "RISK_OPTION_4"]
+          ["3a", "3b"]
+        ),
+      ],
+    },
+  };
+}
+
+function createAnsweredQuestionsV2(
+  selectedOptionsByField: Record<string, string>
+): KartleggingssporsmalSvarResponseDTO {
+  return {
+    uuid: "test-uuid",
+    fnr: "12345678910",
+    kandidatId: "kandidat-id",
+    createdAt: new Date("2026-01-01"),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        createRadioGroupFieldSnapshot(
+          "tilbakeTilJobbenHvorSannsynligFlervalg",
+          selectedOptionsByField.tilbakeTilJobbenHvorSannsynligFlervalg,
+          ["1a", "1b", "1c"]
+        ),
+        createRadioGroupFieldSnapshot(
+          "arbeidsgiverFaarDuOppfolgingFlervalg",
+          selectedOptionsByField.arbeidsgiverFaarDuOppfolgingFlervalg,
+          ["ja", "nei"]
+        ),
+        createRadioGroupFieldSnapshot(
+          "naarTilbakeTilJobbenFlervalg",
+          selectedOptionsByField.naarTilbakeTilJobbenFlervalg,
+          ["3a", "3b"]
         ),
       ],
     },
@@ -60,101 +88,177 @@ function createAnsweredQuestions(
 }
 
 describe("vurdereBehov", () => {
-  it("returns false when all selected options are low-risk answers", () => {
-    const answeredQuestions = createAnsweredQuestions({
-      hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
-      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
-      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+  describe("FLERVALG_V1", () => {
+    it("returns false when all selected options are low-risk answers", () => {
+      const answeredQuestions = createAnsweredQuestionsV1({
+        hvorSannsynligTilbakeTilJobben: "1a",
+        arbeidsgiverHvordanErSamarbeidFlervalg: "2a",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
+
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(false);
     });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+    it("returns true when hvorSannsynligTilbakeTilJobben is 1b", () => {
+      const answeredQuestions = createAnsweredQuestionsV1({
+        hvorSannsynligTilbakeTilJobben: "1b",
+        arbeidsgiverHvordanErSamarbeidFlervalg: "2a",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
 
-    expect(hasRisk).to.equal(false);
-  });
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
 
-  it("returns true when hvorSannsynligTilbakeTilJobben is RISK_OPTION_1", () => {
-    const answeredQuestions = createAnsweredQuestions({
-      hvorSannsynligTilbakeTilJobben: "RISK_OPTION_1",
-      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
-      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+      expect(hasRisk).to.equal(true);
     });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+    it("returns true when hvorSannsynligTilbakeTilJobben is 1c", () => {
+      const answeredQuestions = createAnsweredQuestionsV1({
+        hvorSannsynligTilbakeTilJobben: "1c",
+        arbeidsgiverHvordanErSamarbeidFlervalg: "2a",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
 
-    expect(hasRisk).to.equal(true);
-  });
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
 
-  it("returns true when hvorSannsynligTilbakeTilJobben is RISK_OPTION_2", () => {
-    const answeredQuestions = createAnsweredQuestions({
-      hvorSannsynligTilbakeTilJobben: "RISK_OPTION_2",
-      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
-      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+      expect(hasRisk).to.equal(true);
     });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+    it("returns true when arbeidsgiverHvordanErSamarbeid differs from low-risk option", () => {
+      const answeredQuestions = createAnsweredQuestionsV1({
+        hvorSannsynligTilbakeTilJobben: "1a",
+        arbeidsgiverHvordanErSamarbeidFlervalg: "2b",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
 
-    expect(hasRisk).to.equal(true);
-  });
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
 
-  it("returns true when arbeidsgiverHvordanErSamarbeid differs from low-risk option", () => {
-    const answeredQuestions = createAnsweredQuestions({
-      hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
-      arbeidsgiverHvordanErSamarbeidFlervalg: "RISK_OPTION_3",
-      naarTilbakeTilJobbenFlervalg: lowRiskAnswers[2].optionId,
+      expect(hasRisk).to.equal(true);
     });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+    it("returns true when naarTilbakeTilJobben differs from low-risk option", () => {
+      const answeredQuestions = createAnsweredQuestionsV1({
+        hvorSannsynligTilbakeTilJobben: "1a",
+        arbeidsgiverHvordanErSamarbeidFlervalg: "2a",
+        naarTilbakeTilJobbenFlervalg: "3b",
+      });
 
-    expect(hasRisk).to.equal(true);
-  });
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
 
-  it("returns true when naarTilbakeTilJobben differs from low-risk option", () => {
-    const answeredQuestions = createAnsweredQuestions({
-      hvorSannsynligTilbakeTilJobben: lowRiskAnswers[0].optionId,
-      arbeidsgiverHvordanErSamarbeidFlervalg: lowRiskAnswers[1].optionId,
-      naarTilbakeTilJobbenFlervalg: "RISK_OPTION_4",
+      expect(hasRisk).to.equal(true);
     });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+    it("returns true when all answers differ from low-risk options", () => {
+      const answeredQuestions = createAnsweredQuestionsV1({
+        hvorSannsynligTilbakeTilJobben: "1b",
+        arbeidsgiverHvordanErSamarbeidFlervalg: "2b",
+        naarTilbakeTilJobbenFlervalg: "3b",
+      });
 
-    expect(hasRisk).to.equal(true);
-  });
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
 
-  it("returns true when all answers differ from low-risk options", () => {
-    const answeredQuestions = createAnsweredQuestions({
-      hvorSannsynligTilbakeTilJobben: "RISK_OPTION_1",
-      arbeidsgiverHvordanErSamarbeidFlervalg: "RISK_OPTION_3",
-      naarTilbakeTilJobbenFlervalg: "RISK_OPTION_4",
+      expect(hasRisk).to.equal(true);
     });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+    it("returns false when there are no radio-group answers", () => {
+      const answeredQuestions: KartleggingssporsmalSvarResponseDTO = {
+        uuid: "test-uuid",
+        fnr: "12345678910",
+        kandidatId: "kandidat-id",
+        createdAt: new Date("2026-01-01"),
+        formSnapshot: {
+          formSemanticVersion: "1.0.0",
+          fieldSnapshots: [
+            {
+              fieldId: "tilleggsinformasjon",
+              fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
+              label: "Tilleggsinformasjon",
+              description: null,
+              value: "Tekst",
+              wasRequired: false,
+            },
+          ],
+        },
+      };
 
-    expect(hasRisk).to.equal(true);
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(false);
+    });
   });
 
-  it("returns false when there are no radio-group answers", () => {
-    const answeredQuestions: KartleggingssporsmalSvarResponseDTO = {
-      uuid: "test-uuid",
-      fnr: "12345678910",
-      kandidatId: "kandidat-id",
-      createdAt: new Date("2026-01-01"),
-      formSnapshot: {
-        formSemanticVersion: "1.0.0",
-        fieldSnapshots: [
-          {
-            fieldId: "tilleggsinformasjon",
-            fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
-            label: "Tilleggsinformasjon",
-            description: null,
-            value: "Tekst",
-            wasRequired: false,
-          },
-        ],
-      },
-    };
+  describe("FLERVALG_FRITEKST_V2", () => {
+    it("returns false when all selected options are low-risk answers", () => {
+      const answeredQuestions = createAnsweredQuestionsV2({
+        tilbakeTilJobbenHvorSannsynligFlervalg: "1a",
+        arbeidsgiverFaarDuOppfolgingFlervalg: "ja",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
 
-    const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
 
-    expect(hasRisk).to.equal(false);
+      expect(hasRisk).to.equal(false);
+    });
+
+    it("returns true when tilbakeTilJobbenHvorSannsynlig is 1b", () => {
+      const answeredQuestions = createAnsweredQuestionsV2({
+        tilbakeTilJobbenHvorSannsynligFlervalg: "1b",
+        arbeidsgiverFaarDuOppfolgingFlervalg: "ja",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
+
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(true);
+    });
+
+    it("returns true when tilbakeTilJobbenHvorSannsynlig is 1c", () => {
+      const answeredQuestions = createAnsweredQuestionsV2({
+        tilbakeTilJobbenHvorSannsynligFlervalg: "1c",
+        arbeidsgiverFaarDuOppfolgingFlervalg: "ja",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
+
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(true);
+    });
+
+    it("returns true when arbeidsgiverFaarDuOppfolging is nei", () => {
+      const answeredQuestions = createAnsweredQuestionsV2({
+        tilbakeTilJobbenHvorSannsynligFlervalg: "1a",
+        arbeidsgiverFaarDuOppfolgingFlervalg: "nei",
+        naarTilbakeTilJobbenFlervalg: "3a",
+      });
+
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(true);
+    });
+
+    it("returns true when naarTilbakeTilJobben differs from low-risk option", () => {
+      const answeredQuestions = createAnsweredQuestionsV2({
+        tilbakeTilJobbenHvorSannsynligFlervalg: "1a",
+        arbeidsgiverFaarDuOppfolgingFlervalg: "ja",
+        naarTilbakeTilJobbenFlervalg: "3b",
+      });
+
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(true);
+    });
+
+    it("returns true when all answers differ from low-risk options", () => {
+      const answeredQuestions = createAnsweredQuestionsV2({
+        tilbakeTilJobbenHvorSannsynligFlervalg: "1b",
+        arbeidsgiverFaarDuOppfolgingFlervalg: "nei",
+        naarTilbakeTilJobbenFlervalg: "3b",
+      });
+
+      const hasRisk = hasRiskoForLangtidsfravar(answeredQuestions);
+
+      expect(hasRisk).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Vi endret `fieldId` for spørsmål 1 i [denne commiten](https://github.com/navikt/bro-frontend/commit/56f0e6dbc25c382209dc7150369f6fd28ed46369#diff-730f9cd9b90d40b591690010fd4d2d177d865468c1a935dc44e3db83e4ec64e7) av det jeg ser, men ikke oppdatert det siden. Det har vært en mangel der som vi ikke har vært klar over. I tillegg oppdaterer jeg med fritekst-spørsmålene ettersom vi nå rullet det ut til alle.

Nå som vi gjør utregninger basert på svar-fieldIds så har vi fått en sterk kobling mellom endringer på spørsmålene i bro-frontend og infoboksen her, så det må vi være klar over fremover 🤔

### Screenshots 📸✨

<img width="687" height="788" alt="image" src="https://github.com/user-attachments/assets/b5865630-6a6e-42e6-8925-108df91313b2" />
