### PR TITLE
IS: add mellomrom mellom ikke gjentakende fravaer tekst i infoboks

### DIFF
--- a/src/sider/kartleggingssporsmal/info/KartleggingInfo.tsx
+++ b/src/sider/kartleggingssporsmal/info/KartleggingInfo.tsx
@@ -44,9 +44,11 @@ export function KartleggingInfo({ answeredQuestions }: Props) {
         <List.Item>
           <div className="flex flex-col">
             <div className="flex items-center">
-              {hasGjentakendeSykefravar
-                ? texts.list.hasGjentakendeSykefravar
-                : boldRegex(texts.list.noGjentakendeSykefravar, "ikke")}
+              <span>
+                {hasGjentakendeSykefravar
+                  ? texts.list.hasGjentakendeSykefravar
+                  : boldRegex(texts.list.noGjentakendeSykefravar, "ikke")}
+              </span>
               <ArrowsCirclepathIcon className="ml-2" />
             </div>
             <ReadMore header="Hva er gjentakende sykefravær?" size="small">


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Lagt til et mellomrom rundt ordet `ikke`

### Screenshots 📸✨
Før:
<img width="653" height="182" alt="Skjermbilde 2026-06-15 kl  09 29 37" src="https://github.com/user-attachments/assets/0c3d1219-037f-4241-8d87-2fbc941432a0" />

Etter:
<img width="658" height="190" alt="Skjermbilde 2026-06-15 kl  09 23 48" src="https://github.com/user-attachments/assets/fa643306-fbd0-471a-be80-fec3703016b0" />

