### PR TITLE
Add non breaking space before percent sign

### DIFF
--- a/src/components/personkort/PersonkortHeader/Arbeidsforhold.tsx
+++ b/src/components/personkort/PersonkortHeader/Arbeidsforhold.tsx
@@ -24,7 +24,7 @@ function ArbeidsforholdText({ arbeidsforhold, isLast }: Props) {
   return (
     <>
       {arbeidsforhold.yrke} i {virksomhetsnavn} (
-      {arbeidsforhold.stillingsprosent}%)
+      {arbeidsforhold.stillingsprosent}&nbsp;%)
       {!isLast && ", "}
     </>
   );

--- a/test/components/personkort/PersonkortHeaderTest.tsx
+++ b/test/components/personkort/PersonkortHeaderTest.tsx
@@ -214,7 +214,7 @@ describe("PersonkortHeader", () => {
     renderPersonkortHeader();
 
     expect(screen.getByText("Arbeidsforhold:")).to.exist;
-    expect(screen.getByText(/Sykepleier i Sykehus AS \(80%\)/)).to.exist;
+    expect(screen.getByText(/Sykepleier i Sykehus AS \(80 %\)/)).to.exist;
     expect(screen.queryByText(",")).to.not.exist;
   });
 
@@ -265,8 +265,8 @@ describe("PersonkortHeader", () => {
     renderPersonkortHeader();
 
     expect(screen.getByText("Arbeidsforhold:")).to.exist;
-    expect(screen.getByText(/Sykepleier i Sykehus AS \(80%\),/)).to.exist;
-    expect(screen.getByText(/Brannmann i Brannvesenet \(40%\)/)).to.exist;
+    expect(screen.getByText(/Sykepleier i Sykehus AS \(80 %\),/)).to.exist;
+    expect(screen.getByText(/Brannmann i Brannvesenet \(40 %\)/)).to.exist;
   });
 
   it("viser 'mangler' når ingen aktive arbeidsforhold finnes", () => {


### PR DESCRIPTION
Det skal visst være mellomrom før prosenttegn. Legger til non breaking space før prosenttegnet.

<img width="813" height="337" alt="image" src="https://github.com/user-attachments/assets/158e8435-fe17-42a7-b51e-4de118c1a080" />

<img width="1159" height="173" alt="image" src="https://github.com/user-attachments/assets/0e48bf8f-29ab-4bde-8566-21780b8e7935" />

