### PR TITLE
IS-4041: Add support for new skjemavariant in infoboks

### DIFF
--- a/src/mocks/meroppfolging-backend/kartleggingssporsmalMockData.ts
+++ b/src/mocks/meroppfolging-backend/kartleggingssporsmalMockData.ts
@@ -1,0 +1,283 @@
+import { ARBEIDSTAKER_DEFAULT } from "../common/mockConstants";
+import { KartleggingssporsmalSvarResponseDTO } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes";
+import { generateUUID } from "@/utils/utils";
+import {
+  KartleggingssporsmalFormSnapshotFieldOption,
+  KartleggingssporsmalFormSnapshotFieldType,
+  KartleggingssporsmalRadioGroupFieldSnapshot,
+  KartleggingssporsmalTextFieldSnapshot,
+} from "@/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes";
+import { daysFromToday } from "@/utils/datoUtils.ts";
+
+function createRadioOption(
+  id: string,
+  label: string,
+  isSelected = false
+): KartleggingssporsmalFormSnapshotFieldOption {
+  return {
+    optionId: id,
+    optionLabel: label,
+    wasSelected: isSelected,
+  };
+}
+
+/** Returns a default RADIO_GROUP field snapshot, useful as a base for spread overrides in tests. */
+export function defaultRadioGroupSporsmal(
+  fieldId: string
+): KartleggingssporsmalRadioGroupFieldSnapshot {
+  return {
+    fieldId: fieldId,
+    fieldType: KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP,
+    description: null,
+    label: "Label 1",
+    options: [
+      createRadioOption("1a", "Ja", true),
+      createRadioOption("1b", "Nei"),
+    ],
+    wasRequired: true,
+  };
+}
+
+// --- FLERVALG_V1 field snapshots ---
+
+const tilbakeTilJobbenHvorSannsynligHighRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("tilbakeTilJobbenHvorSannsynligFlervalg"),
+    label:
+      "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
+    options: [
+      createRadioOption("1a", "Jeg tror det er veldig sannsynlig"),
+      createRadioOption("1b", "Jeg tror det er lite sannsynlig"),
+      createRadioOption("1c", "Jeg er usikker", true),
+    ],
+  };
+
+const tilbakeTilJobbenHvorSannsynligLowRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("tilbakeTilJobbenHvorSannsynligFlervalg"),
+    label:
+      "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
+    options: [
+      createRadioOption("1a", "Jeg tror det er veldig sannsynlig", true),
+      createRadioOption("1b", "Jeg tror det er lite sannsynlig"),
+      createRadioOption("1c", "Jeg er usikker"),
+    ],
+  };
+
+const arbeidsgiverHvordanErSamarbeidHighRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("arbeidsgiverHvordanErSamarbeidFlervalg"),
+    label:
+      "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+    options: [
+      createRadioOption("2a", "Jeg opplever samarbeidet og relasjonen som god"),
+      createRadioOption(
+        "2b",
+        "Jeg opplever samarbeidet og relasjonen som dårlig",
+        true
+      ),
+    ],
+  };
+
+const arbeidsgiverHvordanErSamarbeidLowRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("arbeidsgiverHvordanErSamarbeidFlervalg"),
+    label:
+      "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
+    options: [
+      createRadioOption(
+        "2a",
+        "Jeg opplever samarbeidet og relasjonen som god",
+        true
+      ),
+      createRadioOption(
+        "2b",
+        "Jeg opplever samarbeidet og relasjonen som dårlig"
+      ),
+    ],
+  };
+
+const naarTilbakeTilJobben: KartleggingssporsmalRadioGroupFieldSnapshot = {
+  ...defaultRadioGroupSporsmal("naarTilbakeTilJobbenFlervalg"),
+  label: "Hvor lenge tror du at du kommer til å være sykmeldt?",
+  options: [
+    createRadioOption("3a", "Mindre enn seks måneder", true),
+    createRadioOption("3b", "Mer enn seks måneder"),
+  ],
+};
+
+/** FLERVALG_V1 answered with high-risk selections. */
+export const kartleggingssporsmalFlervalgV1Answered: KartleggingssporsmalSvarResponseDTO =
+  {
+    uuid: generateUUID(),
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    kandidatId: generateUUID(),
+    createdAt: daysFromToday(-2),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        tilbakeTilJobbenHvorSannsynligHighRisk,
+        arbeidsgiverHvordanErSamarbeidHighRisk,
+        naarTilbakeTilJobben,
+      ],
+    },
+  };
+
+/** FLERVALG_V1 answered with low-risk selections on all fields. */
+export const kartleggingssporsmalFlervalgV1LowRiskAnswered: KartleggingssporsmalSvarResponseDTO =
+  {
+    uuid: generateUUID(),
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    kandidatId: generateUUID(),
+    createdAt: daysFromToday(-2),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        tilbakeTilJobbenHvorSannsynligLowRisk,
+        arbeidsgiverHvordanErSamarbeidLowRisk,
+        naarTilbakeTilJobben,
+      ],
+    },
+  };
+
+// --- FLERVALG_FRITEKST_V3 field snapshots ---
+
+const mulighetForTilbakeTilJobbenHighRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("mulighetForTilbakeTilJobbenFlervalg"),
+    label:
+      "Hvordan ser du for deg muligheten for å komme tilbake til din nåværende jobb og stilling?",
+    description:
+      "Tenk over om du tror du kan komme helt eller delvis tilbake til din nåværende jobb og stilling, eller om du ser det som utfordrende.",
+    options: [
+      createRadioOption(
+        "kommer_tilbake",
+        "Jeg har tro på at jeg kommer tilbake til samme jobb og stilling"
+      ),
+      createRadioOption(
+        "utfordrende",
+        "Jeg ser på det som utfordrende å komme tilbake til samme jobb og stilling",
+        true
+      ),
+    ],
+  };
+
+const mulighetForTilbakeTilJobbenLowRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("mulighetForTilbakeTilJobbenFlervalg"),
+    label:
+      "Hvordan ser du for deg muligheten for å komme tilbake til din nåværende jobb og stilling?",
+    description:
+      "Tenk over om du tror du kan komme helt eller delvis tilbake til din nåværende jobb og stilling, eller om du ser det som utfordrende.",
+    options: [
+      createRadioOption(
+        "kommer_tilbake",
+        "Jeg har tro på at jeg kommer tilbake til samme jobb og stilling",
+        true
+      ),
+      createRadioOption(
+        "utfordrende",
+        "Jeg ser på det som utfordrende å komme tilbake til samme jobb og stilling"
+      ),
+    ],
+  };
+
+const mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse: KartleggingssporsmalTextFieldSnapshot =
+  {
+    fieldId: "mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse",
+    fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
+    description:
+      "Ikke skriv detaljerte opplysninger om helse, personlige opplysninger eller opplysninger om andre enn deg selv.",
+    label:
+      "Beskriv hva som er utfordrende, og hva du tror kan hjelpe deg videre",
+    value:
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
+      "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+    wasRequired: false,
+  };
+
+const arbeidsgiverFaarDuOppfolgingHighRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("arbeidsgiverFaarDuOppfolgingFlervalg"),
+    label: "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?",
+    description:
+      "Arbeidsgiveren din har hovedansvaret for å gjøre tilpasninger og følge deg opp på arbeidsplassen.",
+    options: [
+      createRadioOption(
+        "ja",
+        "Ja, jeg får oppfølging, og har snakket med arbeidsgiver om dette."
+      ),
+      createRadioOption(
+        "nei",
+        "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig.",
+        true
+      ),
+    ],
+  };
+
+const arbeidsgiverFaarDuOppfolgingLowRisk: KartleggingssporsmalRadioGroupFieldSnapshot =
+  {
+    ...defaultRadioGroupSporsmal("arbeidsgiverFaarDuOppfolgingFlervalg"),
+    label: "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?",
+    description:
+      "Arbeidsgiveren din har hovedansvaret for å gjøre tilpasninger og følge deg opp på arbeidsplassen.",
+    options: [
+      createRadioOption(
+        "ja",
+        "Ja, jeg får oppfølging, og har snakket med arbeidsgiver om dette.",
+        true
+      ),
+      createRadioOption(
+        "nei",
+        "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig."
+      ),
+    ],
+  };
+
+const arbeidsgiverFaarDuOppfolgingNeiBegrunnelse: KartleggingssporsmalTextFieldSnapshot =
+  {
+    fieldId: "arbeidsgiverFaarDuOppfolgingNeiBegrunnelse",
+    fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
+    description:
+      "Skriv kort om hva du har behov for og hva som er vanskelig. Svaret ditt er kun synlig for Nav, og blir ikke delt med din arbeidsgiver.",
+    label:
+      "Hva savner du i samarbeidet med arbeidsgiver for at du skal få bedre oppfølging?",
+    value: "   ",
+    wasRequired: false,
+  };
+
+/** FLERVALG_FRITEKST_V3 answered with high-risk selections and conditional fritekst fields included. */
+export const kartleggingssporsmalFlervalgFritekstV3Answered: KartleggingssporsmalSvarResponseDTO =
+  {
+    uuid: generateUUID(),
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    kandidatId: generateUUID(),
+    createdAt: daysFromToday(-2),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        mulighetForTilbakeTilJobbenHighRisk,
+        mulighetForTilbakeTilJobbenUtfordrendeBegrunnelse,
+        arbeidsgiverFaarDuOppfolgingHighRisk,
+        arbeidsgiverFaarDuOppfolgingNeiBegrunnelse,
+        naarTilbakeTilJobben,
+      ],
+    },
+  };
+
+/** FLERVALG_FRITEKST_V3 answered with low-risk selections. */
+export const kartleggingssporsmalFlervalgFritekstV3LowRiskAnswered: KartleggingssporsmalSvarResponseDTO =
+  {
+    uuid: generateUUID(),
+    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
+    kandidatId: generateUUID(),
+    createdAt: daysFromToday(-2),
+    formSnapshot: {
+      formSemanticVersion: "1.0.0",
+      fieldSnapshots: [
+        mulighetForTilbakeTilJobbenLowRisk,
+        arbeidsgiverFaarDuOppfolgingLowRisk,
+        naarTilbakeTilJobben,
+      ],
+    },
+  };

--- a/src/mocks/meroppfolging-backend/merOppfolgingMock.ts
+++ b/src/mocks/meroppfolging-backend/merOppfolgingMock.ts
@@ -2,202 +2,21 @@ import {
   MEROPPFOLGING_BACKEND_V1_ROOT,
   MEROPPFOLGING_BACKEND_V2_ROOT,
 } from "@/apiConstants";
-import { SenOppfolgingFormResponseDTOV2 } from "@/data/senoppfolging/senOppfolgingTypes";
-import { ARBEIDSTAKER_DEFAULT } from "../common/mockConstants";
 import { http, HttpResponse } from "msw";
-import { KartleggingssporsmalSvarResponseDTO } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes";
-import { FormSnapshotFieldOption } from "@/data/skjemasvar/types/SkjemasvarTypes";
-import { generateUUID } from "@/utils/utils";
-import {
-  KartleggingssporsmalFormSnapshotFieldType,
-  KartleggingssporsmalRadioGroupFieldSnapshot,
-  KartleggingssporsmalTextFieldSnapshot,
-} from "@/data/kartleggingssporsmal/kartleggingssporsmalSkjemasvarTypes";
-import { daysFromToday } from "@/utils/datoUtils.ts";
+import { snartSluttPaSykepengeneMock } from "@/mocks/meroppfolging-backend/snartSluttPaSykepengeneMockData.ts";
+import { kartleggingssporsmalFlervalgFritekstV3Answered } from "@/mocks/meroppfolging-backend/kartleggingssporsmalMockData.ts";
 
 export const mockMerOppfolging = [
   http.get(
     `${MEROPPFOLGING_BACKEND_V2_ROOT}/senoppfolging/formresponse`,
     () => {
-      return HttpResponse.json(merOppfolgingMock);
+      return HttpResponse.json(snartSluttPaSykepengeneMock);
     }
   ),
   http.get(
     `${MEROPPFOLGING_BACKEND_V1_ROOT}/kartleggingssporsmal/kandidat/:kandidatUUID/svar`,
     () => {
-      return HttpResponse.json(kartleggingssporsmalAnswered);
+      return HttpResponse.json(kartleggingssporsmalFlervalgFritekstV3Answered);
     }
   ),
 ];
-
-export const merOppfolgingMock: SenOppfolgingFormResponseDTOV2 = {
-  uuid: "123",
-  personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
-  createdAt: new Date(),
-  formType: "V2",
-  questionResponses: [
-    {
-      questionType: "FREMTIDIG_SITUASJON",
-      questionText:
-        "I hvilken situasjon ser du for deg at du står når sykepengene tar slutt?",
-      answerType: "TILBAKE_HOS_ARBEIDSGIVER",
-      answerText: "Jeg er frisk og tilbake hos arbeidsgiver",
-    },
-    {
-      questionType: "BEHOV_FOR_OPPFOLGING",
-      questionText: "Har du behov for hjelp fra oss i Nav?",
-      answerType: "JA",
-      answerText: "Ja, jeg vil snakke med en veileder i Nav",
-    },
-  ],
-};
-
-const createRadioOption = (
-  id: string,
-  label: string,
-  isSelected = false
-): FormSnapshotFieldOption => {
-  return {
-    optionId: id,
-    optionLabel: label,
-    wasSelected: isSelected,
-  };
-};
-
-export const defaultRadioGroupSporsmal = (
-  fieldId: string
-): KartleggingssporsmalRadioGroupFieldSnapshot => {
-  return {
-    fieldId: fieldId,
-    fieldType: KartleggingssporsmalFormSnapshotFieldType.RADIO_GROUP,
-    description: null,
-    label: "Label 1",
-    options: [
-      createRadioOption("1a", "Ja", true),
-      createRadioOption("1b", "Nei"),
-    ],
-    wasRequired: true,
-  };
-};
-
-const kartleggingssporsmal: KartleggingssporsmalRadioGroupFieldSnapshot[] = [
-  {
-    ...defaultRadioGroupSporsmal("hvorSannsynligTilbakeTilJobben"),
-    label:
-      "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
-    options: [
-      createRadioOption("1a", "Jeg tror det er veldig sannsynlig"),
-      createRadioOption("1b", "Jeg tror det er lite sannsynlig"),
-      createRadioOption("1c", "Jeg er usikker", true),
-    ],
-  },
-  {
-    ...defaultRadioGroupSporsmal("arbeidsgiverHvordanErSamarbeidFlervalg"),
-    label:
-      "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
-    options: [
-      createRadioOption("2a", "Jeg opplever samarbeidet og relasjonen som god"),
-      createRadioOption(
-        "2b",
-        "Jeg opplever samarbeidet og relasjonen som dårlig",
-        true
-      ),
-    ],
-  },
-  {
-    ...defaultRadioGroupSporsmal("naarTilbakeTilJobbenFlervalg"),
-    label: "Hvor lenge tror du at du kommer til å være sykmeldt?",
-    options: [
-      createRadioOption("3a", "Mindre enn seks måneder", true),
-      createRadioOption("3b", "Mer enn seks måneder"),
-    ],
-  },
-];
-
-const hvorforUsikkerTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
-  fieldId: "tilbakeTilJobbenLiteSannsynligBegrunnelse",
-  fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
-  description:
-    "Skriv kortfattet hvorfor du er usikker på om du kommer tilbake i jobben du ble sykmeldt fra",
-  label: "Hva gjør deg usikker?",
-  value:
-    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. " +
-    "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-  wasRequired: false,
-};
-
-const samarbeidTextSporsmal: KartleggingssporsmalTextFieldSnapshot = {
-  fieldId: "arbeidsgiverSamarbeidDarligBegrunnelse",
-  fieldType: KartleggingssporsmalFormSnapshotFieldType.TEXT,
-  description: null,
-  label: "Hva gjør samarbeidet og relasjonen dårlig?",
-  value: "   ",
-  wasRequired: false,
-};
-
-export const kartleggingssporsmalAnswered: KartleggingssporsmalSvarResponseDTO =
-  {
-    uuid: generateUUID(),
-    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
-    kandidatId: generateUUID(),
-    createdAt: daysFromToday(-2),
-    formSnapshot: {
-      formSemanticVersion: "1.0.0",
-      fieldSnapshots: [
-        kartleggingssporsmal[0],
-        hvorforUsikkerTextSporsmal,
-        ...kartleggingssporsmal.slice(1, 2),
-        samarbeidTextSporsmal,
-        ...kartleggingssporsmal.slice(2),
-      ],
-    },
-  };
-
-export const kartleggingssporsmalLowRiskAnswered: KartleggingssporsmalSvarResponseDTO =
-  {
-    uuid: generateUUID(),
-    fnr: ARBEIDSTAKER_DEFAULT.personIdent,
-    kandidatId: generateUUID(),
-    createdAt: daysFromToday(-2),
-    formSnapshot: {
-      formSemanticVersion: "1.0.0",
-      fieldSnapshots: [
-        {
-          ...defaultRadioGroupSporsmal("hvorSannsynligTilbakeTilJobben"),
-          label:
-            "Hvor sannsynlig er det at du kommer tilbake i jobben du ble sykmeldt fra?",
-          options: [
-            createRadioOption("1a", "Jeg tror det er veldig sannsynlig", true),
-            createRadioOption("1b", "Jeg tror det er lite sannsynlig"),
-            createRadioOption("1c", "Jeg er usikker"),
-          ],
-        },
-        {
-          ...defaultRadioGroupSporsmal(
-            "arbeidsgiverHvordanErSamarbeidFlervalg"
-          ),
-          label:
-            "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?",
-          options: [
-            createRadioOption(
-              "2a",
-              "Jeg opplever samarbeidet og relasjonen som god",
-              true
-            ),
-            createRadioOption(
-              "2b",
-              "Jeg opplever samarbeidet og relasjonen som dårlig"
-            ),
-          ],
-        },
-        {
-          ...defaultRadioGroupSporsmal("naarTilbakeTilJobbenFlervalg"),
-          label: "Hvor lenge tror du at du kommer til å være sykmeldt?",
-          options: [
-            createRadioOption("3a", "Mindre enn seks måneder", true),
-            createRadioOption("3b", "Mer enn seks måneder"),
-          ],
-        },
-      ],
-    },
-  };

--- a/src/mocks/meroppfolging-backend/snartSluttPaSykepengeneMockData.ts
+++ b/src/mocks/meroppfolging-backend/snartSluttPaSykepengeneMockData.ts
@@ -1,0 +1,24 @@
+import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants.ts";
+import { SenOppfolgingFormResponseDTOV2 } from "@/data/senoppfolging/senOppfolgingTypes.ts";
+
+export const snartSluttPaSykepengeneMock: SenOppfolgingFormResponseDTOV2 = {
+  uuid: "123",
+  personIdent: ARBEIDSTAKER_DEFAULT.personIdent,
+  createdAt: new Date(),
+  formType: "V2",
+  questionResponses: [
+    {
+      questionType: "FREMTIDIG_SITUASJON",
+      questionText:
+        "I hvilken situasjon ser du for deg at du står når sykepengene tar slutt?",
+      answerType: "TILBAKE_HOS_ARBEIDSGIVER",
+      answerText: "Jeg er frisk og tilbake hos arbeidsgiver",
+    },
+    {
+      questionType: "BEHOV_FOR_OPPFOLGING",
+      questionText: "Har du behov for hjelp fra oss i Nav?",
+      answerType: "JA",
+      answerText: "Ja, jeg vil snakke med en veileder i Nav",
+    },
+  ],
+};

--- a/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
+++ b/src/sider/kartleggingssporsmal/info/vurdereBehov.ts
@@ -36,6 +36,7 @@ export function hasRisikoForLangtidsfravar(
 export const lowRiskOptionIdByRadioFieldId = {
   hvorSannsynligTilbakeTilJobben: "1a",
   tilbakeTilJobbenHvorSannsynligFlervalg: "1a",
+  mulighetForTilbakeTilJobbenFlervalg: "kommer_tilbake",
   arbeidsgiverHvordanErSamarbeidFlervalg: "2a",
   arbeidsgiverFaarDuOppfolgingFlervalg: "ja",
   naarTilbakeTilJobbenFlervalg: "3a",

--- a/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
+++ b/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
@@ -15,10 +15,7 @@ import {
   kartleggingssporsmalFerdigbehandlet,
   kartleggingssporsmalVurderingFerdigbehandlet,
 } from "@/mocks/ismeroppfolging/mockIsmeroppfolging";
-import {
-  kartleggingssporsmalAnswered,
-  kartleggingssporsmalLowRiskAnswered,
-} from "@/mocks/meroppfolging-backend/merOppfolgingMock";
+
 import {
   ARBEIDSTAKER_DEFAULT,
   BEHANDLENDE_ENHET_DEFAULT,
@@ -43,6 +40,11 @@ import { ToggleNames } from "@/data/unleash/unleash_types.ts";
 import { oppfolgingstilfellePersonMock } from "@/mocks/isoppfolgingstilfelle/oppfolgingstilfellePersonMock.ts";
 import { oppfolgingstilfellePersonQueryKeys } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts";
 import { daysFromToday } from "@/utils/datoUtils.ts";
+import {
+  kartleggingssporsmalFlervalgFritekstV3Answered,
+  kartleggingssporsmalFlervalgV1Answered,
+  kartleggingssporsmalFlervalgV1LowRiskAnswered,
+} from "@/mocks/meroppfolging-backend/kartleggingssporsmalMockData.ts";
 
 let queryClient: QueryClient;
 
@@ -226,7 +228,7 @@ describe("Kartleggingssporsmal", () => {
       ARBEIDSTAKER_DEFAULT.personIdent
     );
     mockKartleggingssporsmalSvar(
-      kartleggingssporsmalAnswered,
+      kartleggingssporsmalFlervalgV1Answered,
       kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
     );
 
@@ -290,13 +292,65 @@ describe("Kartleggingssporsmal", () => {
     expect(getButton("Svarene er vurdert, fjern oppgaven")).to.exist;
   });
 
+  it("Sykmeldt is kandidat and has answered FLERVALG_FRITEKST_V3 questions", () => {
+    mockKartleggingssporsmalKandidat(
+      kartleggingIsKandidatAndAnsweredQuestions,
+      ARBEIDSTAKER_DEFAULT.personIdent
+    );
+    mockKartleggingssporsmalSvar(
+      kartleggingssporsmalFlervalgFritekstV3Answered,
+      kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
+    );
+
+    renderKartleggingssporsmal();
+
+    expect(
+      screen.getByText(
+        "Hvordan ser du for deg muligheten for å komme tilbake til din nåværende jobb og stilling?"
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(
+        "Jeg ser på det som utfordrende å komme tilbake til samme jobb og stilling"
+      )
+    ).to.exist;
+
+    expect(
+      screen.getByText(
+        "Beskriv hva som er utfordrende, og hva du tror kan hjelpe deg videre"
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(
+        "Får du oppfølging av arbeidsgiveren din nå når du er sykmeldt?"
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(
+        "Nei, jeg opplever manglende oppfølging og at tilpasninger er vanskelig."
+      )
+    ).to.exist;
+    expect(
+      screen.getByText(
+        "Hva savner du i samarbeidet med arbeidsgiver for at du skal få bedre oppfølging?"
+      )
+    ).to.exist;
+    expect(screen.getByDisplayValue("Ingen tekst")).to.exist;
+
+    expect(
+      screen.queryByText(
+        "Hvordan vil du beskrive samarbeidet og relasjonen mellom deg og arbeidsgiveren din?"
+      )
+    ).to.not.exist;
+  });
+
   it("Sykmeldt is ferdigbehandlet", () => {
     mockKartleggingssporsmalKandidat(
       kartleggingssporsmalFerdigbehandlet,
       ARBEIDSTAKER_DEFAULT.personIdent
     );
     mockKartleggingssporsmalSvar(
-      kartleggingssporsmalAnswered,
+      kartleggingssporsmalFlervalgV1Answered,
       kartleggingssporsmalFerdigbehandlet.kandidatUuid
     );
 
@@ -325,7 +379,7 @@ describe("Kartleggingssporsmal", () => {
       ARBEIDSTAKER_DEFAULT.personIdent
     );
     mockKartleggingssporsmalSvar(
-      kartleggingssporsmalAnswered,
+      kartleggingssporsmalFlervalgV1Answered,
       kartleggingssporsmalVurderingFerdigbehandlet.kandidatUuid
     );
 
@@ -356,7 +410,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       stubDefaultIsmeroppfolging(false);
@@ -374,7 +428,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       stubVurderSvarError();
@@ -399,7 +453,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       stubVurderSvarError();
@@ -418,7 +472,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       stubDefaultIsmeroppfolging(true);
@@ -443,7 +497,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       stubVurderSvarError();
@@ -480,7 +534,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -498,7 +552,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalLowRiskAnswered,
+        kartleggingssporsmalFlervalgV1LowRiskAnswered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -521,7 +575,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -539,7 +593,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -564,7 +618,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -604,7 +658,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -620,7 +674,7 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
 
@@ -636,11 +690,11 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         tidligereKandidatMedSvar.kandidatUuid
       );
 
@@ -658,11 +712,11 @@ describe("Kartleggingssporsmal", () => {
         ARBEIDSTAKER_DEFAULT.personIdent
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
       mockKartleggingssporsmalSvar(
-        kartleggingssporsmalAnswered,
+        kartleggingssporsmalFlervalgV1Answered,
         tidligereKandidatMedSvar.kandidatUuid
       );
 

--- a/test/senoppfolging/SenOppfolgingTest.tsx
+++ b/test/senoppfolging/SenOppfolgingTest.tsx
@@ -11,7 +11,6 @@ import {
   VEILEDER_DEFAULT,
 } from "@/mocks/common/mockConstants";
 import { senOppfolgingSvarQueryKeys } from "@/data/senoppfolging/useSenOppfolgingSvarQuery";
-import { merOppfolgingMock } from "@/mocks/meroppfolging-backend/merOppfolgingMock";
 import { senOppfolgingKandidatQueryKeys } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
 import {
   ferdigbehandletKandidatMock,
@@ -30,6 +29,7 @@ import {
 import { changeTextInput, clickButton, getTextInput } from "../testUtils";
 import { renderWithRouter } from "../testRouterUtils";
 import { senOppfolgingPath } from "@/AppRouter";
+import { snartSluttPaSykepengeneMock } from "@/mocks/meroppfolging-backend/snartSluttPaSykepengeneMockData.ts";
 
 let queryClient: QueryClient;
 
@@ -53,7 +53,7 @@ const mockSenOppfolgingSvar = () => {
     senOppfolgingSvarQueryKeys.senOppfolgingSvar(
       ARBEIDSTAKER_DEFAULT.personIdent
     ),
-    () => merOppfolgingMock
+    () => snartSluttPaSykepengeneMock
   );
 };
 const mockSenOppfolgingKandidat = (
@@ -81,7 +81,7 @@ describe("Sen oppfolging", () => {
         "Den sykmeldte har ikke mottatt varsel om at det snart er slutt på sykepengene enda."
       )
     ).to.exist;
-    merOppfolgingMock.questionResponses.map((questionResponse) => {
+    snartSluttPaSykepengeneMock.questionResponses.map((questionResponse) => {
       expect(screen.queryByText(questionResponse.questionText)).to.not.exist;
       expect(screen.queryByText(questionResponse.answerText)).to.not.exist;
     });
@@ -118,7 +118,7 @@ describe("Sen oppfolging", () => {
     mockSenOppfolgingKandidat([senOppfolgingKandidatMock]);
     renderSenOppfolging();
 
-    merOppfolgingMock.questionResponses.map((questionResponse) => {
+    snartSluttPaSykepengeneMock.questionResponses.map((questionResponse) => {
       expect(screen.getByText(questionResponse.questionText)).to.exist;
       expect(screen.getByText(questionResponse.answerText)).to.exist;
     });


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

- Legger til det nyeste feltet inn i lista over lowrisk-svar som vi viser i infoboksen
- Gjør en del oppsett slik at mocking av dette skal bli enklere:
  - Mocker for FLERVALG_V1 med både low-risk og high-risk svar
  - Mocker for FLERVALG_FRITEKST_V3 med både low-risk og high-risk svar
- Skiller på mockdata mellom `kartleggingsspørsmål` og `snart slutt på sykepengene` fra `meroppfolging-backend`

### Screenshots 📸✨

<img width="1372" height="1572" alt="image" src="https://github.com/user-attachments/assets/1dac9147-f05d-4de4-9fcc-e56d3b81c114" />
