### PR TITLE
IS-4038: Remove support/toggles for deprecated assessment feature

### DIFF
--- a/server/unleash.ts
+++ b/server/unleash.ts
@@ -58,9 +58,5 @@ export function getToggles(veilederId, enhetId) {
       "isNyTilgangskontrollEnabled",
       context
     ),
-    isVurderingssideKartleggingEnabled: unleash.isEnabled(
-      "isVurderingssideKartleggingEnabled",
-      context
-    ),
   };
 }

--- a/src/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks.ts
+++ b/src/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks.ts
@@ -7,13 +7,13 @@ import { get, put } from "@/api/axios";
 import {
   hasAnsweredKartleggingssporsmal,
   KartleggingssporsmalKandidatResponseDTO,
+  KartleggingssporsmalKandidatVurderingRequestDTO,
   KartleggingssporsmalSvarResponseDTO,
 } from "@/data/kartleggingssporsmal/kartleggingssporsmalTypes";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { minutesToMillis } from "@/utils/utils";
 import { ApiErrorException } from "@/api/errors";
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
-import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
 
 export const kartleggingssporsmalQueryKeys = {
   kartleggingssporsmalKandidat: (fnr: string) => [
@@ -70,17 +70,14 @@ export const useKartleggingssporsmalSvarQuery = (
 export const useKartleggingssporsmalVurderSvar = () => {
   const fnr = useValgtPersonident();
   const queryClient = useQueryClient();
-  const postVurderSvar = ({
+  const putVurderSvar = ({
     kandidatUuid,
     vurderingAlternativ,
-  }: {
-    kandidatUuid: string;
-    vurderingAlternativ?: VurderingAlternativ;
-  }) => {
+  }: KartleggingssporsmalKandidatVurderingRequestDTO) => {
     const path = `${ISMEROPPFOLGING_ROOT}/kartleggingssporsmal/kandidater/${kandidatUuid}`;
     return put<KartleggingssporsmalKandidatResponseDTO>(
       path,
-      vurderingAlternativ ? { vurderingAlternativ: vurderingAlternativ } : {},
+      { vurderingAlternativ: vurderingAlternativ },
       fnr
     );
   };
@@ -88,7 +85,7 @@ export const useKartleggingssporsmalVurderSvar = () => {
     kartleggingssporsmalQueryKeys.kartleggingssporsmalKandidat(fnr);
 
   return useMutation({
-    mutationFn: postVurderSvar,
+    mutationFn: putVurderSvar,
     onSuccess: (data: KartleggingssporsmalKandidatResponseDTO) => {
       return queryClient.setQueryData(
         kartleggingssporsmalKandidatQueryKey,

--- a/src/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts
+++ b/src/data/kartleggingssporsmal/kartleggingssporsmalTypes.ts
@@ -18,6 +18,11 @@ export interface KartleggingssporsmalKandidatVurderingResponseDTO {
   vurderingAlternativ?: VurderingAlternativ;
 }
 
+export interface KartleggingssporsmalKandidatVurderingRequestDTO {
+  kandidatUuid: string;
+  vurderingAlternativ: VurderingAlternativ;
+}
+
 export enum KandidatStatus {
   KANDIDAT = "KANDIDAT",
   SVAR_MOTTATT = "SVAR_MOTTATT",

--- a/src/data/unleash/unleash_types.ts
+++ b/src/data/unleash/unleash_types.ts
@@ -10,7 +10,6 @@ export enum ToggleNames {
   isFlexjarKartleggingssporsmalEnabled = "isFlexjarKartleggingssporsmalEnabled", // Benytter Lumi, ikke Flexjar
   isForsokForsterketOppfolgingMerkingEnabled = "isForsokForsterketOppfolgingMerkingEnabled",
   isNyTilgangskontrollEnabled = "isNyTilgangskontrollEnabled",
-  isVurderingssideKartleggingEnabled = "isVurderingssideKartleggingEnabled",
 }
 
 export const defaultToggles: Toggles = {
@@ -20,5 +19,4 @@ export const defaultToggles: Toggles = {
   isFlexjarKartleggingssporsmalEnabled: false,
   isForsokForsterketOppfolgingMerkingEnabled: false,
   isNyTilgangskontrollEnabled: false,
-  isVurderingssideKartleggingEnabled: false,
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -65,7 +65,7 @@ const handlers = [
   ...mockIsdialogmotekandidat,
   ...mockIsfrisktilarbeid,
   ...mockIsmanglendemedvirkning,
-  ...mockIsmeroppfolging(true),
+  ...mockIsmeroppfolging,
   mockIsnarmesteleder,
   ...mockisoppfolgingsplanForesporsel,
   mockIsoppfolgingstilfelle,

--- a/src/mocks/ismeroppfolging/mockIsmeroppfolging.ts
+++ b/src/mocks/ismeroppfolging/mockIsmeroppfolging.ts
@@ -71,20 +71,6 @@ export const kartleggingIsKandidatAndAnsweredQuestions: KartleggingssporsmalKand
     vurdering: null,
   };
 
-export const kartleggingssporsmalFerdigbehandlet: KartleggingssporsmalKandidatResponseDTO =
-  {
-    ...kartleggingIsKandidatAndReceivedQuestions,
-    status: KandidatStatus.FERDIGBEHANDLET,
-    vurdering: {
-      vurdertAt: daysFromToday(-14),
-      vurdertBy: VEILEDER_DEFAULT.ident,
-    },
-    createdAt: daysFromToday(-20),
-    statusAt: daysFromToday(-20),
-    svarAt: daysFromToday(-15),
-    varsletAt: daysFromToday(-20),
-  };
-
 export const kartleggingssporsmalVurderingFerdigbehandlet: KartleggingssporsmalKandidatResponseDTO =
   {
     ...kartleggingIsKandidatAndReceivedQuestions,
@@ -103,9 +89,7 @@ export const kartleggingssporsmalVurderingFerdigbehandlet: KartleggingssporsmalK
 let kartleggingssporsmalMock: KartleggingssporsmalKandidatResponseDTO =
   kartleggingIsKandidatAndAnsweredQuestions;
 
-export const mockIsmeroppfolging = (
-  isVurderingssideKartleggingEnabled?: boolean
-) => [
+export const mockIsmeroppfolging = [
   http.get(`${ISMEROPPFOLGING_ROOT}/senoppfolging/kandidater`, () => {
     return HttpResponse.json([
       senOppfolgingKandidatMock,
@@ -137,22 +121,15 @@ export const mockIsmeroppfolging = (
   http.get(`${ISMEROPPFOLGING_ROOT}/kartleggingssporsmal/kandidater`, () => {
     return HttpResponse.json([
       kartleggingssporsmalMock,
-      isVurderingssideKartleggingEnabled
-        ? kartleggingssporsmalVurderingFerdigbehandlet
-        : kartleggingssporsmalFerdigbehandlet,
+      kartleggingssporsmalVurderingFerdigbehandlet,
     ]);
   }),
   http.put(
     `${ISMEROPPFOLGING_ROOT}/kartleggingssporsmal/kandidater/:kandidatUUID`,
     () => {
-      kartleggingssporsmalMock = isVurderingssideKartleggingEnabled
-        ? kartleggingssporsmalVurderingFerdigbehandlet
-        : kartleggingssporsmalFerdigbehandlet;
-      return HttpResponse.json(
-        isVurderingssideKartleggingEnabled
-          ? kartleggingssporsmalVurderingFerdigbehandlet
-          : kartleggingssporsmalFerdigbehandlet
-      );
+      kartleggingssporsmalMock = kartleggingssporsmalVurderingFerdigbehandlet;
+
+      return HttpResponse.json(kartleggingssporsmalVurderingFerdigbehandlet);
     }
   ),
 ];

--- a/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
+++ b/src/sider/kartleggingssporsmal/KartleggingssporsmalSide.tsx
@@ -8,7 +8,6 @@ import {
   BodyLong,
   BodyShort,
   Box,
-  Button,
   Heading,
   List,
 } from "@navikt/ds-react";
@@ -21,12 +20,10 @@ import {
 import {
   useKartleggingssporsmalKandidaterQuery,
   useKartleggingssporsmalSvarQuery,
-  useKartleggingssporsmalVurderSvar,
 } from "@/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks";
 import { tilLesbarDatoMedArstall } from "@/utils/datoUtils";
 import { EksternLenke } from "@/components/EksternLenke";
 import UtdragFraSykefravaeret from "@/components/utdragFraSykefravaeret/UtdragFraSykefravaeret";
-import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
 import { Events, trackEvent } from "@/utils/umami";
 import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
 import { KartleggingssporsmalSkjemasvar } from "@/sider/kartleggingssporsmal/skjemasvar/KartleggingssporsmalSkjemasvar";
@@ -39,7 +36,6 @@ import { kartleggingssporsmalSurvey } from "@/components/lumi/kartleggingssporsm
 
 const texts = {
   title: "Kartleggingsspørsmål",
-  vurdereOppgaveText: "Svarene er vurdert, fjern oppgaven",
   kandidat: "Spørsmålene ble sendt",
   svart: "Den sykmeldte svarte",
   ikkeSvart: "Den sykmeldte har ikke svart",
@@ -149,13 +145,12 @@ export default function KartleggingssporsmalSide(): ReactElement {
     useKartleggingssporsmalSvarQuery(nyesteKandidat);
   const answeredQuestions = getKartleggingssporsmalSvar.data;
 
-  const vurderSvar = useKartleggingssporsmalVurderSvar();
   const kontaktinformasjon = useKontaktinfoQuery();
 
   const isSurveyVisible =
     toggles.isFlexjarKartleggingssporsmalEnabled &&
     answeredQuestions &&
-    vurderSvar.isSuccess;
+    nyesteKandidat?.status === KandidatStatus.FERDIGBEHANDLET;
 
   const lumiSurvey = isSurveyVisible ? (
     <LumiSurvey
@@ -181,10 +176,8 @@ export default function KartleggingssporsmalSide(): ReactElement {
     kontaktinformasjon.isError;
 
   const behandletWithoutVurdering =
-    nyesteKandidat?.status === "FERDIGBEHANDLET" &&
+    nyesteKandidat?.status === KandidatStatus.FERDIGBEHANDLET &&
     !nyesteKandidat?.vurdering?.vurderingAlternativ;
-  const showKartleggingVurdering =
-    toggles.isVurderingssideKartleggingEnabled && !behandletWithoutVurdering;
 
   return (
     <Side
@@ -217,33 +210,8 @@ export default function KartleggingssporsmalSide(): ReactElement {
                       formSnapshot={answeredQuestions.formSnapshot}
                     />
 
-                    {!showKartleggingVurdering && (
-                      <>
-                        {nyesteKandidat.status ===
-                          KandidatStatus.SVAR_MOTTATT && (
-                          <>
-                            <Button
-                              variant="primary"
-                              size="medium"
-                              onClick={() =>
-                                vurderSvar.mutate({
-                                  kandidatUuid: nyesteKandidat.kandidatUuid,
-                                })
-                              }
-                              loading={vurderSvar.isPending}
-                            >
-                              {texts.vurdereOppgaveText}
-                            </Button>
-                            {vurderSvar.isError && (
-                              <SkjemaInnsendingFeil error={vurderSvar.error} />
-                            )}
-                          </>
-                        )}
-                        {nyesteKandidat.status ===
-                          KandidatStatus.FERDIGBEHANDLET && (
-                          <SuccessAlert nyesteKandidat={nyesteKandidat} />
-                        )}
-                      </>
+                    {behandletWithoutVurdering && (
+                      <SuccessAlert nyesteKandidat={nyesteKandidat} />
                     )}
                   </>
                 ) : (
@@ -282,13 +250,12 @@ export default function KartleggingssporsmalSide(): ReactElement {
                   </>
                 )}
               </Box>
-              {showKartleggingVurdering &&
+              {!behandletWithoutVurdering &&
                 answeredQuestions &&
                 nyesteKandidat.status !== KandidatStatus.KANDIDAT && (
                   <KartleggingVurdering
                     nyesteKandidat={nyesteKandidat}
                     answeredQuestions={answeredQuestions}
-                    vurderSvarMutation={vurderSvar}
                   />
                 )}
               <KartleggingssporsmalHistorikk

--- a/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
+++ b/src/sider/kartleggingssporsmal/vurdering/KartleggingVurdering.tsx
@@ -15,11 +15,11 @@ import { VurderingAlternativ } from "@/sider/kartleggingssporsmal/types.ts";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil.tsx";
 import React, { useState } from "react";
 import { SuccessAlert } from "@/sider/kartleggingssporsmal/successAlert/SuccessAlert.tsx";
-import { UseMutationResult } from "@tanstack/react-query";
 import { finnNaisUrlIntern } from "@/utils/miljoUtil.ts";
 import { EksternLenke } from "@/components/EksternLenke.tsx";
 import { Events, trackEvent } from "@/utils/umami.ts";
 import { KartleggingInfo } from "@/sider/kartleggingssporsmal/info/KartleggingInfo.tsx";
+import { useKartleggingssporsmalVurderSvar } from "@/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks.ts";
 
 const texts = {
   heading: "Vurdering",
@@ -50,24 +50,14 @@ function logEvent() {
 interface Props {
   nyesteKandidat: KartleggingssporsmalKandidatResponseDTO;
   answeredQuestions: KartleggingssporsmalSvarResponseDTO;
-  // Vi må ta inn vurderSvarMutation fordi visning av tilbakemeldingsboksen er knyttet til mutation i KartleggingssporsmalSide.tsx
-  // Kan unngå dette når man har én vurderingsside, ikke to ulike måter å vurdere på
-  vurderSvarMutation: UseMutationResult<
-    KartleggingssporsmalKandidatResponseDTO,
-    Error,
-    {
-      kandidatUuid: string;
-      vurderingAlternativ?: VurderingAlternativ;
-    },
-    unknown
-  >;
 }
 
 export function KartleggingVurdering({
   nyesteKandidat,
   answeredQuestions,
-  vurderSvarMutation,
 }: Props) {
+  const vurderSvar = useKartleggingssporsmalVurderSvar();
+
   const [chosenAlternative, setChosenAlternative] =
     useState<VurderingAlternativ | null>(
       nyesteKandidat.vurdering?.vurderingAlternativ ?? null
@@ -102,7 +92,7 @@ export function KartleggingVurdering({
           size="medium"
           onClick={() => {
             if (chosenAlternative) {
-              vurderSvarMutation.mutate({
+              vurderSvar.mutate({
                 kandidatUuid: nyesteKandidat.kandidatUuid,
                 vurderingAlternativ: chosenAlternative,
               });
@@ -110,14 +100,12 @@ export function KartleggingVurdering({
               setChosenAlternativeError(texts.error);
             }
           }}
-          loading={vurderSvarMutation.isPending}
+          loading={vurderSvar.isPending}
         >
           {texts.button}
         </Button>
       )}
-      {vurderSvarMutation.isError && (
-        <SkjemaInnsendingFeil error={vurderSvarMutation.error} />
-      )}
+      {vurderSvar.isError && <SkjemaInnsendingFeil error={vurderSvar.error} />}
       {nyesteKandidat.status === KandidatStatus.FERDIGBEHANDLET && (
         <SuccessAlert nyesteKandidat={nyesteKandidat} />
       )}

--- a/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
+++ b/test/kartleggingssporsmal/KartleggingssporsmalTest.tsx
@@ -12,7 +12,6 @@ import { queryClientWithMockData } from "../testQueryClient";
 import {
   kartleggingIsKandidatAndAnsweredQuestions,
   kartleggingIsKandidatAndReceivedQuestions,
-  kartleggingssporsmalFerdigbehandlet,
   kartleggingssporsmalVurderingFerdigbehandlet,
 } from "@/mocks/ismeroppfolging/mockIsmeroppfolging";
 
@@ -168,7 +167,7 @@ describe("Kartleggingssporsmal", () => {
       })
     ).to.exist;
 
-    expect(queryButton("Svarene er vurdert, fjern oppgaven")).to.not.exist;
+    expect(queryButton("Lagre vurdering, fjern oppgaven")).to.not.exist;
   });
 
   it("Sykmeldt is kandidat, but was not varslet (kandidat pre-pilot)", () => {
@@ -219,7 +218,7 @@ describe("Kartleggingssporsmal", () => {
     expect(screen.getByText("Brukeren er reservert fra digital kommunikasjon"))
       .to.exist;
 
-    expect(queryButton("Svarene er vurdert, fjern oppgaven")).to.not.exist;
+    expect(queryButton("Lagre vurdering, fjern oppgaven")).to.not.exist;
   });
 
   it("Sykmeldt is kandidat and has answered questions", () => {
@@ -240,7 +239,7 @@ describe("Kartleggingssporsmal", () => {
       .exist;
     expect(screen.queryByText("Slik ser spørsmålene ut for den sykmeldte")).to
       .exist;
-    expect(screen.getAllByRole("radiogroup").length).toBe(3);
+    expect(screen.getAllByRole("radiogroup").length).toBeGreaterThan(0);
 
     expect(
       screen.getAllByRole("radiogroup", {
@@ -289,7 +288,7 @@ describe("Kartleggingssporsmal", () => {
     ).to.exist;
     expect(screen.queryByText("Utdrag fra sykefraværet")).to.exist;
 
-    expect(getButton("Svarene er vurdert, fjern oppgaven")).to.exist;
+    expect(getButton("Lagre vurdering, fjern oppgaven")).to.exist;
   });
 
   it("Sykmeldt is kandidat and has answered FLERVALG_FRITEKST_V3 questions", () => {
@@ -344,36 +343,7 @@ describe("Kartleggingssporsmal", () => {
     ).to.not.exist;
   });
 
-  it("Sykmeldt is ferdigbehandlet", () => {
-    mockKartleggingssporsmalKandidat(
-      kartleggingssporsmalFerdigbehandlet,
-      ARBEIDSTAKER_DEFAULT.personIdent
-    );
-    mockKartleggingssporsmalSvar(
-      kartleggingssporsmalFlervalgV1Answered,
-      kartleggingssporsmalFerdigbehandlet.kandidatUuid
-    );
-
-    renderKartleggingssporsmal();
-
-    expect(screen.queryByText("Den sykmeldte svarte", { exact: false })).to
-      .exist;
-    expect(screen.queryByText("Spørsmålene ble sendt", { exact: false })).to
-      .exist;
-    expect(screen.queryByText("Slik ser spørsmålene ut for den sykmeldte")).to
-      .exist;
-
-    expect(
-      screen.queryByText(`Oppgaven er behandlet av ${VEILEDER_DEFAULT.ident}`)
-    ).to.exist;
-
-    expect(screen.queryByText(`Velg alternativet som passer vurderingen`)).to
-      .not.exist;
-  });
-
   it("Sykmeldt is ferdigbehandlet with vurdering", () => {
-    mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
     mockKartleggingssporsmalKandidat(
       kartleggingssporsmalVurderingFerdigbehandlet,
       ARBEIDSTAKER_DEFAULT.personIdent
@@ -403,51 +373,8 @@ describe("Kartleggingssporsmal", () => {
     ).to.exist;
   });
 
-  describe("Evaluate answers to kartleggingsspørsmål", () => {
-    it("API returning Ok will show success message", async () => {
-      mockKartleggingssporsmalKandidat(
-        kartleggingIsKandidatAndAnsweredQuestions,
-        ARBEIDSTAKER_DEFAULT.personIdent
-      );
-      mockKartleggingssporsmalSvar(
-        kartleggingssporsmalFlervalgV1Answered,
-        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
-      );
-      stubDefaultIsmeroppfolging(false);
-
-      renderKartleggingssporsmal();
-
-      await clickButton("Svarene er vurdert, fjern oppgaven");
-      expect(await screen.findByText("Oppgaven er behandlet av Z990000")).to
-        .exist;
-    });
-
-    it("API returning error will show error message", async () => {
-      mockKartleggingssporsmalKandidat(
-        kartleggingIsKandidatAndAnsweredQuestions,
-        ARBEIDSTAKER_DEFAULT.personIdent
-      );
-      mockKartleggingssporsmalSvar(
-        kartleggingssporsmalFlervalgV1Answered,
-        kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
-      );
-      stubVurderSvarError();
-
-      renderKartleggingssporsmal();
-
-      await clickButton("Svarene er vurdert, fjern oppgaven");
-      expect(
-        await screen.findByText(
-          "Det skjedde en uventet feil. Vennligst prøv igjen senere."
-        )
-      ).to.exist;
-    });
-  });
-
   describe("Evaluate answers to kartleggingsspørsmål with vurdering", () => {
     it("Submitting without choosing an option shows error message", async () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
         ARBEIDSTAKER_DEFAULT.personIdent
@@ -465,8 +392,6 @@ describe("Kartleggingssporsmal", () => {
     });
 
     it("API returning Ok will show success message", async () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
         ARBEIDSTAKER_DEFAULT.personIdent
@@ -475,7 +400,7 @@ describe("Kartleggingssporsmal", () => {
         kartleggingssporsmalFlervalgV1Answered,
         kartleggingIsKandidatAndAnsweredQuestions.kandidatUuid
       );
-      stubDefaultIsmeroppfolging(true);
+      stubDefaultIsmeroppfolging();
 
       renderKartleggingssporsmal();
 
@@ -490,8 +415,6 @@ describe("Kartleggingssporsmal", () => {
     });
 
     it("API returning error will show error message", async () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
         ARBEIDSTAKER_DEFAULT.personIdent
@@ -527,8 +450,6 @@ describe("Kartleggingssporsmal", () => {
       "Svarene indikerer ikke behov for videre vurdering av oppfølging – se veiledning";
 
     it("Shows hasRiskoForLangtidsfravarText when svar indicate risk for langtidsfravar", () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
         ARBEIDSTAKER_DEFAULT.personIdent
@@ -545,8 +466,6 @@ describe("Kartleggingssporsmal", () => {
     });
 
     it("Does not show hasRiskoForLangtidsfravarText when all selected radio options are low-risk", () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
         ARBEIDSTAKER_DEFAULT.personIdent
@@ -567,8 +486,6 @@ describe("Kartleggingssporsmal", () => {
     });
 
     it("Shows hasGjentakendeSykefravarText when hasGjentakendeSykefravar is true", () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockGjentakendeFravar(true);
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
@@ -586,8 +503,6 @@ describe("Kartleggingssporsmal", () => {
     });
 
     it("Shows readmore for gjentakende sykefravær definition", () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
         ARBEIDSTAKER_DEFAULT.personIdent
@@ -610,8 +525,6 @@ describe("Kartleggingssporsmal", () => {
     });
 
     it("Does not show hasGjentakendeSykefravarText when hasGjentakendeSykefravar is true", () => {
-      mockEnabledToggles([ToggleNames.isVurderingssideKartleggingEnabled]);
-
       mockGjentakendeFravar(false);
       mockKartleggingssporsmalKandidat(
         kartleggingIsKandidatAndAnsweredQuestions,
@@ -635,7 +548,7 @@ describe("Kartleggingssporsmal", () => {
 
   describe("KartleggingssporsmalHistorikk", () => {
     const tidligereKandidatMedSvar: KartleggingssporsmalKandidatResponseDTO = {
-      ...kartleggingssporsmalFerdigbehandlet,
+      ...kartleggingssporsmalVurderingFerdigbehandlet,
       kandidatUuid: generateUUID(),
       svarAt: daysFromToday(-30),
       vurdering: {

--- a/test/stubs/stubIsmeroppfolging.ts
+++ b/test/stubs/stubIsmeroppfolging.ts
@@ -3,9 +3,8 @@ import { ISMEROPPFOLGING_ROOT } from "@/apiConstants";
 import { mockIsmeroppfolging } from "@/mocks/ismeroppfolging/mockIsmeroppfolging";
 import { mockServer } from "../setup";
 
-export const stubDefaultIsmeroppfolging = (
-  isVurderingssideKartleggingEnabled: boolean
-) => mockServer.use(...mockIsmeroppfolging(isVurderingssideKartleggingEnabled));
+export const stubDefaultIsmeroppfolging = () =>
+  mockServer.use(...mockIsmeroppfolging);
 
 export const stubVurderSvarError = () =>
   mockServer.use(


### PR DESCRIPTION
Fjerner feature toggle for å kunne sende inn med/uten vurdering. Nå er det uansett påkrevd (foreløpig ikke i APIet, dette må også fikses). Med dette fjerner jeg også kode relatert til ferdigstillinger uten vurdering, men vi må fremdeles kunne _vise_ gamle ferdigstillinger. Koden er uansett forenklet :brain: 

Rydder også opp i mocks og tester