### PR TITLE
IS-4070: Fix overflow with long texts

### DIFF
--- a/src/components/side/TredeltSide.tsx
+++ b/src/components/side/TredeltSide.tsx
@@ -22,7 +22,7 @@ interface Props {
 export function Container({ children, className = "" }: Props) {
   return (
     <div
-      className={`${className} flex flex-row -xl:flex-col -xl:overflow-y-scroll`}
+      className={`${className} flex flex-row -xl:flex-col -xl:overflow-y-auto`}
     >
       {children}
     </div>
@@ -32,9 +32,7 @@ export function Container({ children, className = "" }: Props) {
 export function FirstColumn({ children, className }: Props) {
   return (
     <div
-      className={
-        "xl:flex-grow-[3] xl:flex-shrink-1 xl:basis-0 xl:mr-2 " + className
-      }
+      className={`${className} xl:grow-3 xl:shrink xl:basis-0 xl:mr-2 min-w-0 `}
     >
       {children}
     </div>
@@ -44,10 +42,7 @@ export function FirstColumn({ children, className }: Props) {
 export function SecondColumn({ children, className }: Props) {
   return (
     <div
-      className={
-        "xl:flex-grow-[2] xl:flex-shrink-1 xl:basis-0 xl:h-screen xl:sticky xl:top-2 xl:overflow-y-scroll -xl:mt-2 " +
-        className
-      }
+      className={`${className} xl:grow-2 xl:shrink xl:basis-0 xl:h-screen xl:sticky xl:top-2 xl:overflow-y-auto -xl:mt-2 min-w-0 `}
     >
       {children}
     </div>

--- a/src/sider/behandlerdialog/meldinger/samtale/MeldingInnholdPanel.tsx
+++ b/src/sider/behandlerdialog/meldinger/samtale/MeldingInnholdPanel.tsx
@@ -3,7 +3,7 @@ import {
   MeldingDTO,
   MeldingType,
 } from "@/data/behandlerdialog/behandlerdialogTypes";
-import { BodyLong, Detail, Panel } from "@navikt/ds-react";
+import { Box, Detail } from "@navikt/ds-react";
 import { PaperclipIcon } from "@navikt/aksel-icons";
 import styled from "styled-components";
 import { tilDatoMedManedNavnOgKlokkeslett } from "@/utils/datoUtils";
@@ -15,10 +15,6 @@ import { getHeaderText } from "@/utils/documentComponentUtils";
 import { useVeilederInfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
 import { meldingTypeTexts } from "@/data/behandlerdialog/behandlerdialogTexts";
 import { ReturLegeerklaringWarningIcon } from "@/sider/behandlerdialog/legeerklaring/ReturLegeerklaringWarningIcon";
-
-const MeldingTekstWrapper = styled(BodyLong)`
-  white-space: pre-wrap;
-`;
 
 const MeldingDetails = styled.div`
   display: flex;
@@ -74,14 +70,14 @@ const MeldingTekst = ({ melding }: MeldingTekstProps): ReactElement => {
     const headerText = getHeaderText(document, DocumentComponentType.HEADER_H1);
     return (
       <>
-        <MeldingTekstWrapper>{headerText}</MeldingTekstWrapper>
+        <div className={"whitespace-pre-wrap wrap-anywhere"}>{headerText}</div>
         <PaminnelseWarningIcon />
       </>
     );
   } else {
     return (
       <>
-        <MeldingTekstWrapper>{tekst}</MeldingTekstWrapper>
+        <div className={"whitespace-pre-wrap wrap-anywhere"}>{tekst}</div>
         {isReturLegeerklaring && <ReturLegeerklaringWarningIcon />}
       </>
     );
@@ -101,7 +97,7 @@ export default function MeldingInnholdPanel({ melding }: Props) {
     : veilederInfo?.fulltNavn() || "";
 
   return (
-    <Panel border>
+    <Box className={"p-4 border rounded-lg bg-surface-default"}>
       <MeldingTekstContainer>
         <MeldingTekst melding={melding} />
       </MeldingTekstContainer>
@@ -125,6 +121,6 @@ export default function MeldingInnholdPanel({ melding }: Props) {
         {avsender && <Detail>{`Skrevet av ${avsender}`}</Detail>}
         {!melding.innkommende && <VisMelding melding={melding} />}
       </MeldingDetails>
-    </Panel>
+    </Box>
   );
 }


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Prøver å fikse et problem hvor "Meldinger" vokser seg stor og dytter vekk "Dialogmelding til behandler" ut av skjermen til høyre. Jeg måtte grave veldig for å klare å gjenskape problemet, men det virker som det kan være et ord i en tekst som ikke brekker skikkelig. Da vokste accordions i bredden, selv når den var minimert.

### Screenshots 📸✨
Før:
<img width="3434" height="1267" alt="image" src="https://github.com/user-attachments/assets/e5fc68bf-9f1e-4210-94ca-3d8be97e28ec" />
<img width="3434" height="1267" alt="image" src="https://github.com/user-attachments/assets/6c43e73b-47e2-4bee-9899-e0fc59573f50" />

Etter:
<img width="3434" height="1267" alt="image" src="https://github.com/user-attachments/assets/01c390a5-2fba-4377-a159-ae05a098fadb" />