### PR TITLE
IS-3016: Add motesvar historikk for endring and avlysning sider

### DIFF
--- a/src/mocks/isdialogmote/dialogmoterMock.ts
+++ b/src/mocks/isdialogmote/dialogmoterMock.ts
@@ -29,7 +29,10 @@ import { addDays } from "@/utils/datoUtils";
 import { DialogmoteStatusEndringDTO } from "@/sider/dialogmoter/types/dialogmoteStatusEndringTypes";
 
 type VarselOpts = {
-  varselType: MotedeltakerVarselType.INNKALT | MotedeltakerVarselType.AVLYST;
+  varselType:
+    | MotedeltakerVarselType.INNKALT
+    | MotedeltakerVarselType.AVLYST
+    | MotedeltakerVarselType.NYTT_TID_STED;
   uuid: string;
   svar?: VarselSvarDTO;
 };
@@ -43,9 +46,9 @@ const createVarsel = ({
     case MotedeltakerVarselType.INNKALT: {
       return {
         uuid: uuid + 2,
-        createdAt: "2021-05-26T12:56:26.271381",
+        createdAt: dayjs().subtract(10, "days").toISOString(),
         varselType: varselType,
-        lestDato: "2021-05-26T12:56:26.271381",
+        lestDato: dayjs().subtract(9, "days").toISOString(),
         fritekst: "Ipsum lorum",
         ...(svar ? { svar } : {}),
         document: [
@@ -77,9 +80,9 @@ const createVarsel = ({
     case MotedeltakerVarselType.AVLYST: {
       return {
         uuid: uuid + 4,
-        createdAt: "2021-05-26T12:56:26.271381",
+        createdAt: dayjs().subtract(1, "days").toISOString(),
         varselType: varselType,
-        lestDato: "2021-05-26T12:56:26.271381",
+        lestDato: dayjs().subtract(1, "days").toISOString(),
         fritekst: "Ipsum lorum",
         ...(svar ? { svar } : {}),
         document: [
@@ -108,6 +111,23 @@ const createVarsel = ({
         ],
       };
     }
+    case MotedeltakerVarselType.NYTT_TID_STED: {
+      return {
+        uuid: uuid + 5,
+        createdAt: dayjs().subtract(5, "days").toISOString(),
+        varselType: varselType,
+        lestDato: dayjs().subtract(5, "days").toISOString(),
+        fritekst: "Ipsum lorum",
+        ...(svar ? { svar } : {}),
+        document: [
+          {
+            type: DocumentComponentType.PARAGRAPH,
+            title: "Endring",
+            texts: [],
+          },
+        ],
+      };
+    }
   }
 };
 
@@ -121,7 +141,7 @@ export const createDialogmote = (
     {
       ...createVarsel({
         svar: {
-          svarTidspunkt: addDays(moteTid, -3).toJSON(),
+          svarTidspunkt: addDays(moteTid, 1).toISOString(),
           svarType: SvarType.KOMMER,
         },
         uuid,
@@ -129,17 +149,61 @@ export const createDialogmote = (
       }),
       digitalt: true,
     },
+    {
+      ...createVarsel({
+        svar: {
+          svarTidspunkt: addDays(moteTid, 3).toISOString(),
+          svarTekst: "Nei nå har jeg lagt planer gitt!",
+          svarType: SvarType.KOMMER_IKKE,
+        },
+        uuid,
+        varselType: MotedeltakerVarselType.NYTT_TID_STED,
+      }),
+      digitalt: false,
+    },
+    {
+      ...createVarsel({
+        svar: undefined,
+        uuid,
+        varselType: MotedeltakerVarselType.NYTT_TID_STED,
+      }),
+      digitalt: false,
+    },
   ];
   const arbeidsgiverVarselList: DialogmotedeltakerArbeidsgiverVarselDTO[] = [
     {
       ...createVarsel({
         svar: {
-          svarTidspunkt: addDays(moteTid, -3).toJSON(),
+          svarTidspunkt: addDays(moteTid, -3).toISOString(),
           svarTekst: "Passer ikke denne dagen.",
           svarType: SvarType.NYTT_TID_STED,
         },
         uuid,
         varselType: MotedeltakerVarselType.INNKALT,
+      }),
+      status: "",
+    },
+    {
+      ...createVarsel({
+        svar: {
+          svarTidspunkt: addDays(moteTid, 1).toISOString(),
+          svarTekst: "Hva med fredag?",
+          svarType: SvarType.NYTT_TID_STED,
+        },
+        uuid,
+        varselType: MotedeltakerVarselType.NYTT_TID_STED,
+      }),
+      status: "",
+    },
+    {
+      ...createVarsel({
+        svar: {
+          svarTidspunkt: addDays(moteTid, 3).toISOString(),
+          svarTekst: "Jo det passer visst likevel yey!",
+          svarType: SvarType.KOMMER,
+        },
+        uuid,
+        varselType: MotedeltakerVarselType.NYTT_TID_STED,
       }),
       status: "",
     },
@@ -191,7 +255,7 @@ export const createDialogmote = (
     });
     behandlerVarselList.push({
       uuid: uuid + 5,
-      createdAt: addDays(moteTid, -4).toJSON(),
+      createdAt: addDays(moteTid, -4).toISOString(),
       varselType: MotedeltakerVarselType.AVLYST,
       fritekst: "Ipsum lorum behandler",
       document: [],
@@ -201,8 +265,8 @@ export const createDialogmote = (
 
   const dialogMote: DialogmoteDTO = {
     uuid: uuid,
-    createdAt: addDays(moteTid, -4).toJSON(),
-    updatedAt: addDays(moteTid, -4).toJSON(),
+    createdAt: addDays(moteTid, -4).toISOString(),
+    updatedAt: addDays(moteTid, -4).toISOString(),
     status: moteStatus,
     opprettetAv: VEILEDER_IDENT_DEFAULT,
     tildeltVeilederIdent: VEILEDER_IDENT_DEFAULT,
@@ -226,7 +290,7 @@ export const createDialogmote = (
         }
       : {}),
     sted: "This is a very lang text that has a lot of characters and describes where the meeting will take place.",
-    tid: moteTid.toJSON(),
+    tid: moteTid.toISOString(),
     videoLink: "https://video.nav.no/xyz",
     referatList: [],
   };
@@ -294,8 +358,17 @@ export const ferdigstiltDialogmote = createDialogmote(
   DialogmoteStatus.FERDIGSTILT,
   dayjs().subtract(2, "years").toDate()
 );
+export const innkaltDialogmote = createDialogmote(
+  "5f1e2629-062b-442d-ae1f-3b08e9574cd3",
+  DialogmoteStatus.INNKALT,
+  dayjs().add(2, "days").toDate()
+);
 
-export const dialogmoterMock = [avlystDialogmote, ferdigstiltDialogmote];
+export const dialogmoterMock = [
+  innkaltDialogmote,
+  avlystDialogmote,
+  ferdigstiltDialogmote,
+];
 
 export const dialogmoteStatusEndringMock: DialogmoteStatusEndringDTO[] = [
   {

--- a/src/sider/dialogmoter/Motelandingsside.tsx
+++ b/src/sider/dialogmoter/Motelandingsside.tsx
@@ -8,12 +8,12 @@ import * as Tredelt from "@/components/side/TredeltSide";
 import Side from "@/components/side/Side";
 import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
 import MotehistorikkPanel from "@/sider/dialogmoter/components/motehistorikk/MotehistorikkPanel";
-import MoteSvarHistorikk from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk";
 import MotebehovHistorikk from "@/sider/dialogmoter/components/motehistorikk/MotebehovHistorikk";
 import { useGetDialogmoteIkkeAktuell } from "@/sider/dialogmoter/hooks/useGetDialogmoteIkkeAktuell";
 import { MotelandingssidePanels } from "@/sider/dialogmoter/utils/MotelandingssidePanels";
 import { harUbehandletMotebehov } from "@/utils/motebehovUtils";
 import { useMotebehovQuery } from "@/data/motebehov/motebehovQueryHooks";
+import { MoteSvarHistorikkGroupedByMote } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkGroupedByMote.tsx";
 
 const texts = {
   pageTitle: "Møtelandingsside",
@@ -71,7 +71,9 @@ export default function Motelandingsside() {
               dialogmoteunntak={dialogmoteunntak}
               dialogmoteikkeaktuell={getDialogmoteIkkeAktuell.data}
             />
-            <MoteSvarHistorikk historiskeMoter={historiskeDialogmoter} />
+            <MoteSvarHistorikkGroupedByMote
+              historiskeMoter={historiskeDialogmoter}
+            />
             <MotebehovHistorikk />
           </Tredelt.SecondColumn>
         </Tredelt.Container>

--- a/src/sider/dialogmoter/components/DialogmoteSideContainer.tsx
+++ b/src/sider/dialogmoter/components/DialogmoteSideContainer.tsx
@@ -9,11 +9,14 @@ import Side from "@/components/side/Side";
 import SideLaster from "@/components/side/SideLaster";
 import Sidetopp from "@/components/side/Sidetopp";
 import Feilmelding from "@/components/Feilmelding";
+import * as Tredelt from "@/components/side/TredeltSide.tsx";
+import { MoteSvarHistorikkSingle } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkSingle.tsx";
 
 interface DialogmoteSideProps {
   title: string;
   header: string;
   children: (dialogmote: DialogmoteDTO) => ReactElement;
+  showMoteSvarHistorikk?: boolean;
 }
 
 const texts = {
@@ -24,6 +27,7 @@ export default function DialogmoteSideContainer({
   title,
   header,
   children,
+  showMoteSvarHistorikk = false,
 }: DialogmoteSideProps): ReactElement {
   const { dialogmoteUuid } = useParams<{
     dialogmoteUuid: string;
@@ -39,11 +43,29 @@ export default function DialogmoteSideContainer({
     <Side tittel={title} aktivtMenypunkt={Menypunkter.DIALOGMOTE}>
       <SideLaster isLoading={isLoading} isError={isError}>
         <Sidetopp tittel={header} />
-        {brukerKanIkkeVarslesDigitalt && (
-          <BrukerKanIkkeVarslesPapirpostAdvarsel />
-        )}
         {dialogmote ? (
-          children(dialogmote)
+          <div>
+            {showMoteSvarHistorikk ? (
+              <Tredelt.Container>
+                <Tredelt.FirstColumn>
+                  {brukerKanIkkeVarslesDigitalt && (
+                    <BrukerKanIkkeVarslesPapirpostAdvarsel />
+                  )}
+                  {children(dialogmote)}
+                </Tredelt.FirstColumn>
+                <Tredelt.SecondColumn>
+                  <MoteSvarHistorikkSingle dialogmote={dialogmote} />
+                </Tredelt.SecondColumn>
+              </Tredelt.Container>
+            ) : (
+              <>
+                {brukerKanIkkeVarslesDigitalt && (
+                  <BrukerKanIkkeVarslesPapirpostAdvarsel />
+                )}
+                {children(dialogmote)}
+              </>
+            )}
+          </div>
         ) : (
           <Feilmelding tittel={texts.moteNotFound} />
         )}

--- a/src/sider/dialogmoter/components/avlys/AvlysDialogmoteContainer.tsx
+++ b/src/sider/dialogmoter/components/avlys/AvlysDialogmoteContainer.tsx
@@ -12,6 +12,7 @@ export default function AvlysDialogmoteContainer(): ReactElement {
     <DialogmoteSideContainer
       title={texts.avlysDialogmote}
       header={texts.avlysDialogmote}
+      showMoteSvarHistorikk={true}
     >
       {(dialogmote) => (
         <MalformProvider>

--- a/src/sider/dialogmoter/components/endre/EndreDialogmoteContainer.tsx
+++ b/src/sider/dialogmoter/components/endre/EndreDialogmoteContainer.tsx
@@ -10,17 +10,13 @@ import Sidetopp from "@/components/side/Sidetopp";
 import { BrukerKanIkkeVarslesPapirpostAdvarsel } from "@/sider/dialogmoter/components/BrukerKanIkkeVarslesPapirpostAdvarsel";
 import Feilmelding from "@/components/Feilmelding";
 import * as Tredelt from "@/components/side/TredeltSide";
-import DeltakereSvarInfo from "@/sider/dialogmoter/components/DeltakereSvarInfo";
-import { BodyLong, Box, Heading } from "@navikt/ds-react";
-import { MoteIkonBlaaImage } from "../../../../../img/ImageComponents";
 import { MalformProvider } from "@/context/malform/MalformContext";
+import { MoteSvarHistorikkSingle } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkSingle.tsx";
 
 const texts = {
   pageTitle: "Endre dialogmøte",
   pageHeader: "Endre dialogmøte",
   moteNotFound: "Fant ikke dialogmøte",
-  motesvarHeading: "Møtesvar",
-  motesvarSubheading: "Viser svar på siste innkalling/endring",
 };
 
 export default function EndreDialogmoteContainer() {
@@ -49,18 +45,7 @@ export default function EndreDialogmoteContainer() {
               </MalformProvider>
             </Tredelt.FirstColumn>
             <Tredelt.SecondColumn>
-              <Box background="default" className="flex flex-col gap-4 p-6">
-                <div className="flex gap-4">
-                  <img src={MoteIkonBlaaImage} alt="moteikon" />
-                  <div>
-                    <Heading level="2" size="medium">
-                      {texts.motesvarHeading}
-                    </Heading>
-                    <BodyLong size="small">{texts.motesvarSubheading}</BodyLong>
-                  </div>
-                </div>
-                <DeltakereSvarInfo dialogmote={dialogmote} />
-              </Box>
+              <MoteSvarHistorikkSingle dialogmote={dialogmote} />
             </Tredelt.SecondColumn>
           </Tredelt.Container>
         ) : (

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkGroupedByMote.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkGroupedByMote.tsx
@@ -14,7 +14,7 @@ interface Props {
   historiskeMoter: DialogmoteDTO[];
 }
 
-export default function MoteSvarHistorikk({ historiskeMoter }: Props) {
+export function MoteSvarHistorikkGroupedByMote({ historiskeMoter }: Props) {
   const hasMoteHistorikk = historiskeMoter.length > 0;
 
   return (
@@ -25,8 +25,8 @@ export default function MoteSvarHistorikk({ historiskeMoter }: Props) {
       />
       {hasMoteHistorikk ? (
         <Accordion>
-          {historiskeMoter.map((mote, index) => (
-            <MoteSvarHistorikkEvent dialogmote={mote} key={index} />
+          {historiskeMoter.map((mote) => (
+            <MoteSvarHistorikkEvent dialogmote={mote} key={mote.uuid} />
           ))}
         </Accordion>
       ) : (

--- a/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkSingle.tsx
+++ b/src/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkSingle.tsx
@@ -1,0 +1,28 @@
+import { DialogmoteDTO } from "@/sider/dialogmoter/types/dialogmoteTypes";
+import { Box } from "@navikt/ds-react";
+import React from "react";
+import { MoteSvarHistorikkInnkalling } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkInnkalling.tsx";
+import { MoteSvarHistorikkEndringer } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkEndringer.tsx";
+import DialogmoteHistorikkHeader from "@/sider/dialogmoter/components/motehistorikk/DialogmoteHistorikkHeader.tsx";
+
+const texts = {
+  motesvarHeading: "Møtesvar",
+  motesvarSubheading: "Viser alle svar for det aktuelle møtet",
+};
+
+interface Props {
+  dialogmote: DialogmoteDTO;
+}
+
+export function MoteSvarHistorikkSingle({ dialogmote }: Props) {
+  return (
+    <Box background="default" className="flex flex-col gap-4 p-6">
+      <DialogmoteHistorikkHeader
+        title={texts.motesvarHeading}
+        subtitle={texts.motesvarSubheading}
+      />
+      <MoteSvarHistorikkInnkalling dialogmote={dialogmote} />
+      <MoteSvarHistorikkEndringer dialogmote={dialogmote} />
+    </Box>
+  );
+}

--- a/src/sider/dialogmoter/components/referat/DialogmoteEndreReferatContainer.tsx
+++ b/src/sider/dialogmoter/components/referat/DialogmoteEndreReferatContainer.tsx
@@ -10,7 +10,11 @@ const texts = {
 
 export default function DialogmoteEndreReferatContainer(): ReactElement {
   return (
-    <DialogmoteSideContainer title={texts.pageTitle} header={texts.pageHeader}>
+    <DialogmoteSideContainer
+      title={texts.pageTitle}
+      header={texts.pageHeader}
+      showMoteSvarHistorikk={true}
+    >
       {(dialogmote) => (
         <MalformProvider>
           <Referat dialogmote={dialogmote} mode={ReferatMode.ENDRET} />

--- a/test/dialogmote/MoteSvarHistorikkGroupedByMoteTest.tsx
+++ b/test/dialogmote/MoteSvarHistorikkGroupedByMoteTest.tsx
@@ -19,11 +19,10 @@ import {
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
-import MoteSvarHistorikk from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikk";
 import { queryClientWithMockData } from "../testQueryClient";
 import { expect, describe, it, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
-
+import { MoteSvarHistorikkGroupedByMote } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkGroupedByMote.tsx";
 let queryClient: QueryClient;
 
 const narmesteLederNavnMedVirksomhet = `${NARMESTE_LEDER_DEFAULT.navn} (${VIRKSOMHET_PONTYPANDY.virksomhetsnavn})`;
@@ -165,20 +164,22 @@ const avlystMote: DialogmoteDTO = {
   referatList: [],
 };
 
-const renderMoteSvarHistorikk = (historiskeMoter: DialogmoteDTO[]) => {
+const renderMoteSvarHistorikkGroupedByMote = (
+  historiskeMoter: DialogmoteDTO[]
+) => {
   render(
     <QueryClientProvider client={queryClient}>
-      <MoteSvarHistorikk historiskeMoter={historiskeMoter} />
+      <MoteSvarHistorikkGroupedByMote historiskeMoter={historiskeMoter} />
     </QueryClientProvider>
   );
 };
 
-describe("MoteSvarHistorikk", () => {
+describe("MoteSvarHistorikkGroupedByMote", () => {
   beforeEach(() => {
     queryClient = queryClientWithMockData();
   });
   it("viser accordion for hvert møte", () => {
-    renderMoteSvarHistorikk([ferdigstiltMote, avlystMote]);
+    renderMoteSvarHistorikkGroupedByMote([ferdigstiltMote, avlystMote]);
 
     const accordions = getAccordionButtons();
     expect(accordions.length).to.equal(2);
@@ -186,7 +187,7 @@ describe("MoteSvarHistorikk", () => {
     expect(accordions[1].textContent).to.contain("Avlyst møte 22. mars 2020");
   });
   it("viser sted og veileder for møte", async () => {
-    renderMoteSvarHistorikk([ferdigstiltMote]);
+    renderMoteSvarHistorikkGroupedByMote([ferdigstiltMote]);
 
     const accordion = screen.getByRole("button", {
       name: "Møte 15. januar 2021",
@@ -198,7 +199,7 @@ describe("MoteSvarHistorikk", () => {
       .exist;
   });
   it("viser innkalling og endring med svar for ferdigstilt møte", async () => {
-    renderMoteSvarHistorikk([ferdigstiltMote]);
+    renderMoteSvarHistorikkGroupedByMote([ferdigstiltMote]);
 
     const accordion = screen.getByRole("button", {
       name: "Møte 15. januar 2021",
@@ -221,7 +222,7 @@ describe("MoteSvarHistorikk", () => {
     );
   });
   it("viser innkalling med svar for avlyst møte", async () => {
-    renderMoteSvarHistorikk([avlystMote]);
+    renderMoteSvarHistorikkGroupedByMote([avlystMote]);
 
     const accordion = screen.getByRole("button", {
       name: "Avlyst møte 22. mars 2020",

--- a/test/dialogmote/MoteSvarHistorikkSingleTest.tsx
+++ b/test/dialogmote/MoteSvarHistorikkSingleTest.tsx
@@ -1,0 +1,82 @@
+import {
+  DialogmoteDTO,
+  DialogmoteStatus,
+  MotedeltakerVarselType,
+} from "@/sider/dialogmoter/types/dialogmoteTypes";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+import { queryClientWithMockData } from "../testQueryClient";
+import { expect, describe, it, beforeEach } from "vitest";
+import { MoteSvarHistorikkSingle } from "@/sider/dialogmoter/components/motehistorikk/MoteSvarHistorikkSingle.tsx";
+import { createDialogmote } from "@/mocks/isdialogmote/dialogmoterMock";
+import dayjs from "dayjs";
+
+let queryClient: QueryClient;
+
+const moteKunInnkalling: DialogmoteDTO = (() => {
+  const base = createDialogmote(
+    "test-1",
+    DialogmoteStatus.INNKALT,
+    dayjs().add(2, "days").toDate()
+  );
+  return {
+    ...base,
+    arbeidstaker: {
+      ...base.arbeidstaker,
+      varselList: base.arbeidstaker.varselList.filter(
+        (v) => v.varselType === MotedeltakerVarselType.INNKALT
+      ),
+    },
+    arbeidsgiver: {
+      ...base.arbeidsgiver,
+      varselList: base.arbeidsgiver.varselList.filter(
+        (v) => v.varselType === MotedeltakerVarselType.INNKALT
+      ),
+    },
+  };
+})();
+
+const moteInnkallingOgToEndringer: DialogmoteDTO = createDialogmote(
+  "test-2",
+  DialogmoteStatus.INNKALT,
+  dayjs().add(2, "days").toDate()
+);
+
+const renderMoteSvarHistorikkSingle = (dialogmote: DialogmoteDTO) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MoteSvarHistorikkSingle dialogmote={dialogmote} />
+    </QueryClientProvider>
+  );
+
+describe("MoteSvarHistorikkSingle", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  describe("møte med kun innkalling", () => {
+    it("viser én seksjon for innkalling, ingen endringer", () => {
+      renderMoteSvarHistorikkSingle(moteKunInnkalling);
+
+      expect(screen.getAllByText(/Innkalling sendt .* - svar:/)).to.have.length(
+        1
+      );
+      expect(screen.queryByText(/Endret tid\/sted sendt .* - svar:/)).to.not
+        .exist;
+    });
+  });
+
+  describe("møte med innkalling og to endringer", () => {
+    it("viser tre seksjoner: innkalling og to endringer", () => {
+      renderMoteSvarHistorikkSingle(moteInnkallingOgToEndringer);
+
+      expect(screen.getAllByText(/Innkalling sendt .* - svar:/)).to.have.length(
+        1
+      );
+      expect(
+        screen.getAllByText(/Endret tid\/sted sendt .* - svar:/)
+      ).to.have.length(2);
+    });
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

- Lagt til møtesvar-historikk på sidene for å endre og avlyse dialogmøte
- Vi hadde allerede en MoteSvarHistorikk som tok inn en liste med møter, denne ble døpt om til AlleMoteSvarHistorikk for å skille fra den nye som kun tar inn ett møte.
  - Derfor også litt store diffs på test-filene
- Tar i bruk `DialogmoteHistorikkHeader`, da forsvinner det blå ikonet, men det er konsistent med historikk i tredjekolonne på andre dialogmøtesider.

Det er kanskje ikke så pent, men gjenbruker komponenter vi allerede har, og det viser i alle fall hele historikken.
Det vises lignende historikk **gruppert på møte** ute i dialogmøtesiden også.

- [x] Teste i dev

### Screenshots 📸✨
Før:
<img width="1216" height="766" alt="image" src="https://github.com/user-attachments/assets/d4eeb820-6a2c-4e1e-9c13-1d3bca3963e3" />

Etter:
<img width="1158" height="909" alt="image" src="https://github.com/user-attachments/assets/d623c4db-60f1-4e9f-a355-e97e5491afb7" />