### PR TITLE
IS-4086: Add empty page for Utenlandsopphold

### DIFF
--- a/server/unleash.ts
+++ b/server/unleash.ts
@@ -58,5 +58,9 @@ export function getToggles(veilederId, enhetId) {
       "isNyTilgangskontrollEnabled",
       context,
     ),
+    isUtenlandsoppholdEnabled: unleash.isEnabled(
+      "isUtenlandsoppholdEnabled",
+      context,
+    ),
   };
 }

--- a/src/AppRouter.tsx
+++ b/src/AppRouter.tsx
@@ -42,6 +42,7 @@ import KartleggingssporsmalSide from "@/sider/kartleggingssporsmal/Kartleggingss
 import * as Umami from "@/utils/umami";
 import OppfolgingsplanerOversikt from "@/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt";
 import { useAktivVeilederinfoQuery } from "@/data/veilederinfo/veilederinfoQueryHooks";
+import { UtenlandsoppholdSide } from "@/sider/utenlandsopphold/UtenlandsoppholdSide.tsx";
 
 export const appRoutePath = "/sykefravaer";
 
@@ -55,6 +56,7 @@ export const arbeidsuforhetAvslagPath = `${appRoutePath}/arbeidsuforhet/avslag`;
 export const arbeidsuforhetIkkeAktuellPath = `${appRoutePath}/arbeidsuforhet/ikkeaktuell`;
 export const arbeidsuforhetPath = `${appRoutePath}/arbeidsuforhet`;
 export const frisktilarbeidPath = `${appRoutePath}/frisktilarbeid`;
+export const utenlandsoppholdPath = `${appRoutePath}/utenlandsopphold`;
 export const senOppfolgingPath = `${appRoutePath}/senoppfolging`;
 export const manglendeMedvirkningPath = `${appRoutePath}/manglendemedvirkning`;
 export const historikkPath = `${appRoutePath}/historikk`;
@@ -174,6 +176,11 @@ function AktivBrukerRouter(): ReactElement {
           <Route
             path={frisktilarbeidPath}
             element={<FriskmeldingTilArbeidsformidlingSide />}
+          />
+
+          <Route
+            path={utenlandsoppholdPath}
+            element={<UtenlandsoppholdSide />}
           />
 
           <Route path={senOppfolgingPath} element={<SenOppfolging />} />

--- a/src/components/globalnavigasjon/GlobalNavigasjon.tsx
+++ b/src/components/globalnavigasjon/GlobalNavigasjon.tsx
@@ -15,6 +15,7 @@ import { useManglendemedvirkningVurderingQuery } from "@/data/manglendemedvirkni
 import { useFeatureToggles } from "@/data/unleash/unleashQueryHooks";
 import { useKartleggingssporsmalKandidaterQuery } from "@/data/kartleggingssporsmal/kartleggingssporsmalQueryHooks";
 import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
+import { ToggleNames } from "@/data/unleash/unleash_types.ts";
 
 export enum Menypunkter {
   AKTIVITETSKRAV = "AKTIVITETSKRAV",
@@ -27,6 +28,7 @@ export enum Menypunkter {
   HISTORIKK = "HISTORIKK",
   ARBEIDSUFORHET = "ARBEIDSUFORHET",
   FRISKTILARBEID = "FRISKTILARBEID",
+  UTENLANDSOPPHOLD = "UTENLANDSOPPHOLD",
   SENOPPFOLGING = "SENOPPFOLGING",
   MANGLENDE_MEDVIRKNING = "MANGLENDE_MEDVIRKNING",
   KARTLEGGINGSSPORSMAL = "KARTLEGGINGSSPORSMAL",
@@ -81,6 +83,10 @@ const allMenypunkter: {
     navn: "§ 8-5 Friskmelding til arbeidsformidling",
     sti: "frisktilarbeid",
   },
+  [Menypunkter.UTENLANDSOPPHOLD]: {
+    navn: "§ 8-9 Søknad om utenlandsopphold",
+    sti: "utenlandsopphold",
+  },
   [Menypunkter.SENOPPFOLGING]: {
     navn: "Snart slutt på sykepengene",
     sti: "senoppfolging",
@@ -90,6 +96,11 @@ const allMenypunkter: {
     sti: "historikk",
   },
 };
+
+const activeMenypunktWithToggle: [keyof typeof ToggleNames, Menypunkter][] = [
+  ["isKartleggingssporsmalEnabled", Menypunkter.KARTLEGGINGSSPORSMAL],
+  ["isUtenlandsoppholdEnabled", Menypunkter.UTENLANDSOPPHOLD],
+];
 
 interface Props {
   aktivtMenypunkt: Menypunkter;
@@ -129,9 +140,15 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
         personoppgaver.data,
       ),
   );
-  const allMenypunktEntries: [Menypunkter, Menypunkt][] = Object.entries(
-    allMenypunkter,
-  ).map((value) => value as [Menypunkter, Menypunkt]);
+
+  const allMenypunktEntries = (
+    Object.entries(allMenypunkter) as [Menypunkter, Menypunkt][]
+  ).filter(([menypunkt]) =>
+    activeMenypunktWithToggle.every(
+      ([toggleName, activeMenypunkt]) =>
+        activeMenypunkt !== menypunkt || featureToggles.toggles[toggleName],
+    ),
+  );
 
   const setFocus = (index: number) => {
     if (refs.current[index]) {
@@ -173,12 +190,6 @@ export default function GlobalNavigasjon({ aktivtMenypunkt }: Props) {
   return (
     <ul aria-label="Navigasjon">
       {allMenypunktEntries.map(([menypunkt, { navn, sti }], index) => {
-        if (
-          !featureToggles.toggles.isKartleggingssporsmalEnabled &&
-          menypunkt === Menypunkter.KARTLEGGINGSSPORSMAL
-        ) {
-          return null;
-        }
         const isAktiv = menypunkt === aktivtMenypunkt;
         const className = cn("navigasjonspanel", {
           "navigasjonspanel--aktiv": isAktiv,

--- a/src/data/unleash/unleash_types.ts
+++ b/src/data/unleash/unleash_types.ts
@@ -10,6 +10,7 @@ export enum ToggleNames {
   isFlexjarKartleggingssporsmalEnabled = "isFlexjarKartleggingssporsmalEnabled", // Benytter Lumi, ikke Flexjar
   isForsokForsterketOppfolgingMerkingEnabled = "isForsokForsterketOppfolgingMerkingEnabled",
   isNyTilgangskontrollEnabled = "isNyTilgangskontrollEnabled",
+  isUtenlandsoppholdEnabled = "isUtenlandsoppholdEnabled",
 }
 
 export const defaultToggles: Toggles = {
@@ -19,4 +20,5 @@ export const defaultToggles: Toggles = {
   isFlexjarKartleggingssporsmalEnabled: false,
   isForsokForsterketOppfolgingMerkingEnabled: false,
   isNyTilgangskontrollEnabled: false,
+  isUtenlandsoppholdEnabled: false,
 };

--- a/src/sider/utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/sider/utenlandsopphold/Utenlandsopphold.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { Box } from "@navikt/ds-react";
+
+const texts = {
+  title: "Søknad om utenlandsopphold",
+  goofyText:
+    "Her kan du innvilge utenlandsopphold. Gitt mangel på knapper, må alt gjøres for hånd. Lykke til.",
+};
+
+export function Utenlandsopphold() {
+  return (
+    <Box
+      background="default"
+      padding="space-24"
+      className="flex flex-col *:mb-4"
+    >
+      <h1>{texts.title}</h1>
+      <p>{texts.goofyText}</p>
+    </Box>
+  );
+}

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSide.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSide.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import Side from "@/components/side/Side";
+import Sidetopp from "@/components/side/Sidetopp";
+import SideLaster from "@/components/side/SideLaster";
+import * as Tredelt from "@/components/side/TredeltSide";
+import { Menypunkter } from "@/components/globalnavigasjon/GlobalNavigasjon";
+import { NotificationProvider } from "@/context/notification/NotificationContext";
+import { Utenlandsopphold } from "@/sider/utenlandsopphold/Utenlandsopphold.tsx";
+import { Box } from "@navikt/ds-react";
+
+const texts = {
+  title: "Søknad om utenlandsopphold",
+};
+
+export function UtenlandsoppholdSide() {
+  return (
+    <Side tittel={texts.title} aktivtMenypunkt={Menypunkter.UTENLANDSOPPHOLD}>
+      <Sidetopp tittel={texts.title} />
+      <SideLaster isLoading={false} isError={false}>
+        <Tredelt.Container>
+          <Tredelt.FirstColumn className="-xl:mb-2">
+            <NotificationProvider>
+              <Utenlandsopphold />
+            </NotificationProvider>
+          </Tredelt.FirstColumn>
+          <Tredelt.SecondColumn>
+            <Box
+              background="default"
+              padding="space-24"
+              className="flex flex-col *:mb-4"
+            >
+              info og greier
+            </Box>
+          </Tredelt.SecondColumn>
+        </Tredelt.Container>
+      </SideLaster>
+    </Side>
+  );
+}

--- a/src/utils/globalNavigasjonUtils.ts
+++ b/src/utils/globalNavigasjonUtils.ts
@@ -221,6 +221,7 @@ export function numberOfTasks(
       );
     case Menypunkter.KARTLEGGINGSSPORSMAL:
       return getNumberOfKartleggingssporsmalOppgaver(kartleggingVurderinger);
+    case Menypunkter.UTENLANDSOPPHOLD:
     case Menypunkter.NOKKELINFORMASJON:
     case Menypunkter.SYKEPENGESOKNADER:
     case Menypunkter.HISTORIKK: {

--- a/test/components/GlobalNavigasjonTest.tsx
+++ b/test/components/GlobalNavigasjonTest.tsx
@@ -33,7 +33,10 @@ import { addDays, addWeeks } from "@/utils/datoUtils";
 import { VurderingType } from "@/sider/arbeidsuforhet/data/arbeidsuforhetTypes";
 import { senOppfolgingKandidatQueryKeys } from "@/data/senoppfolging/useSenOppfolgingKandidatQuery";
 import { unleashQueryKeys } from "@/data/unleash/unleashQueryHooks";
-import { mockUnleashResponse } from "@/mocks/unleashMocks";
+import {
+  mockUnleashResponse,
+  mockUnleashTogglesOffResponse,
+} from "@/mocks/unleashMocks";
 import {
   ferdigbehandletKandidatMock,
   senOppfolgingKandidatMock,
@@ -63,6 +66,13 @@ const mockUnleashWithFeatureToggles = () => {
   );
 };
 
+const mockUnleashWithoutFeatureToggles = () => {
+  queryClient.setQueryData(
+    unleashQueryKeys.toggles(navEnhet.id, ""),
+    () => mockUnleashTogglesOffResponse,
+  );
+};
+
 const renderGlobalNavigasjon = () =>
   render(
     <QueryClientProvider client={queryClient}>
@@ -82,6 +92,40 @@ describe("GlobalNavigasjon", () => {
     setEmptyQueryData(queryClient);
   });
   it("viser linker for alle menypunkter uten toggle", () => {
+    mockUnleashWithoutFeatureToggles();
+
+    renderGlobalNavigasjon();
+    const navnMenypunkter = [
+      "Nøkkelinformasjon",
+      "Sykmeldinger",
+      "Søknader om sykepenger",
+      "Dialog med behandler",
+      "Oppfølgingsplaner",
+      "Dialogmøter",
+      "§ 8-8 Aktivitetskrav",
+      "§ 8-8 Manglende medvirkning",
+      "§ 8-4 Arbeidsuførhet",
+      "§ 8-5 Friskmelding til arbeidsformidling",
+      "Snart slutt på sykepengene",
+      "Historikk",
+      "Vedtak",
+    ];
+    const menypunkterNotShown = [
+      "Kartleggingsspørsmål",
+      "§ 8-9 Søknad om utenlandsopphold",
+    ];
+
+    const linker = screen.getAllByRole("link");
+    linker.forEach((link, index) => {
+      expect(link.textContent).to.equal(navnMenypunkter[index]);
+    });
+    expect(
+      linker.some((link) => menypunkterNotShown.includes(link.textContent)),
+    ).to.equal(false);
+  });
+  it("viser linker for alle menypunkter med toggle", () => {
+    mockUnleashWithFeatureToggles();
+
     renderGlobalNavigasjon();
     const navnMenypunkter = [
       "Nøkkelinformasjon",
@@ -95,6 +139,7 @@ describe("GlobalNavigasjon", () => {
       "§ 8-8 Manglende medvirkning",
       "§ 8-4 Arbeidsuførhet",
       "§ 8-5 Friskmelding til arbeidsformidling",
+      "§ 8-9 Søknad om utenlandsopphold",
       "Snart slutt på sykepengene",
       "Historikk",
       "Vedtak",


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger på en tom side som vi kan jobbe videre med. Denne er feature toggled med en ny Unleash-toggle ved navn `isUtenlandsoppholdEnabled`. Fikset også litt tester på sider som er/ikke er feature toggled

### Screenshots 📸✨

<img width="3441" height="1354" alt="image" src="https://github.com/user-attachments/assets/4ba608cf-8777-4dc2-9802-a88754696dff" />