### PR TITLE
IS-fix: tag personkort

### DIFF
--- a/src/components/personkort/Personkort.tsx
+++ b/src/components/personkort/Personkort.tsx
@@ -21,8 +21,8 @@ export function Personkort() {
 
   return (
     <ExpansionCard size="small" aria-label="Personkort" className="mb-2">
-      <ExpansionCard.Header>
-        <ExpansionCard.Title size="small" className="flex w-full">
+      <ExpansionCard.Header className="[&>div]:w-full">
+        <ExpansionCard.Title size="small" className="flex">
           <PersonkortHeader />
         </ExpansionCard.Title>
       </ExpansionCard.Header>


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Lagt tags til venstre i personkortet

### Screenshots 📸✨
Før:
<img width="2854" height="394" alt="image" src="https://github.com/user-attachments/assets/f6d10872-915f-4179-a0a8-aaedd47d7fe6" />

Etter:
<img width="1403" height="179" alt="Skjermbilde 2026-06-24 kl  11 25 12" src="https://github.com/user-attachments/assets/842cefd6-741c-4c98-ac48-a7a9e07e9dbe" />

