### PR TITLE
IS-4028: Bytt til aksel kontaktinfo

### DIFF
--- a/src/components/personkort/PersonkortSykmeldt.tsx
+++ b/src/components/personkort/PersonkortSykmeldt.tsx
@@ -1,6 +1,4 @@
 import React from "react";
-import { PersonkortElement } from "./PersonkortElement";
-import PersonkortInformasjon from "./PersonkortInformasjon";
 import {
   formaterBostedsadresse,
   formaterKontaktadresse,
@@ -11,7 +9,7 @@ import { useValgtPersonident } from "@/hooks/useValgtBruker";
 import { formaterFnr } from "@/utils/fnrUtils";
 import { formatPhonenumber } from "@/utils/stringUtils";
 import { useKontaktinfoQuery } from "@/data/navbruker/navbrukerQueryHooks";
-import { PersonCircleIcon } from "@navikt/aksel-icons";
+import { BodyShort } from "@navikt/ds-react";
 
 const texts = {
   fnr: "F.nummer",
@@ -20,6 +18,7 @@ const texts = {
   bostedsadresse: "Bostedsadresse",
   kontaktadresse: "Kontaktadresse",
   oppholdsadresse: "Oppholdsadresse",
+  empty: "—",
 };
 
 export function PersonkortSykmeldt() {
@@ -60,21 +59,19 @@ export function PersonkortSykmeldt() {
   );
 
   return (
-    <PersonkortElement
-      tittel="Kontaktinformasjon"
-      antallKolonner={3}
-      icon={
-        <PersonCircleIcon
-          fontSize="1.5rem"
-          title="Bilde av person"
-          className="mr-2"
-        />
-      }
-    >
-      <PersonkortInformasjon
-        informasjonNokkelTekster={informasjonNokkelTekster}
-        informasjon={valgteElementer}
-      />
-    </PersonkortElement>
+    <div className="grid grid-cols-3 gap-y-4 gap-x-16 w-fit">
+      {Object.keys(valgteElementer).map((nokkel, idx) => {
+        return (
+          <div key={idx}>
+            <BodyShort size="small" weight="semibold">
+              {informasjonNokkelTekster.get(nokkel)}
+            </BodyShort>
+            <BodyShort size="small">
+              {valgteElementer[nokkel] ? valgteElementer[nokkel] : texts.empty}
+            </BodyShort>
+          </div>
+        );
+      })}
+    </div>
   );
 }

--- a/test/components/personkort/PersonkortSykmeldtTest.tsx
+++ b/test/components/personkort/PersonkortSykmeldtTest.tsx
@@ -24,13 +24,6 @@ describe("PersonkortSykmeldt", () => {
     setQueryDataWithPersonkortdata(queryClient);
   });
 
-  it("Skal vise PersonkortElement", () => {
-    renderPersonkortSykmeldt();
-    expect(screen.getByRole("heading", { name: "Kontaktinformasjon" })).to
-      .exist;
-    expect(screen.getByRole("img", { name: "Bilde av person" })).to.exist;
-  });
-
   it("Skal vise PersonkortInformasjon", () => {
     renderPersonkortSykmeldt();
     expect(screen.getByText("F.nummer")).to.exist;

--- a/test/components/personkort/PersonkortVisningTest.tsx
+++ b/test/components/personkort/PersonkortVisningTest.tsx
@@ -29,17 +29,6 @@ describe("PersonkortVisning", () => {
     stubFastlegerApi();
   });
 
-  it("Skal vise PersonkortSykmeldt, som initielt valg", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <PersonkortVisning visning={""} />
-      </QueryClientProvider>,
-    );
-
-    expect(screen.getByRole("heading", { name: "Kontaktinformasjon" })).to
-      .exist;
-  });
-
   it("Skal vise VisningLege, dersom visning for lege er valgt", async () => {
     const expectedLegeNavn = `${fastlegerMock[0].fornavn} ${fastlegerMock[0].etternavn}`;
     render(


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Byttet til aksel i kontaktinformasjon taben i personkortet

### Screenshots 📸✨
Før:
<img width="1415" height="382" alt="Skjermbilde 2026-06-25 kl  13 45 03" src="https://github.com/user-attachments/assets/bac3c09b-1dfc-40da-a4b0-d59af4f8c510" />


Etter:
<img width="1457" height="407" alt="Skjermbilde 2026-06-25 kl  12 51 06" src="https://github.com/user-attachments/assets/05712e9d-f31b-4c42-9129-90e6130cb395" />

