### PR TITLE
Fix optimize imports by using Intellij codestyle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ mockServiceWorker.js
 .env
 
 !/.idea/externalDependencies.xml
+!/.idea/codeStyles/

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,7 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <TypeScriptCodeStyleSettings version="0">
+      <option name="SPACES_WITHIN_IMPORTS" value="true" />
+    </TypeScriptCodeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>


### PR DESCRIPTION
Jeg har lagt til dette i de andre appene, var bare denne siste som manglet en fiks. Det er egentlig helt Intellij-spesifikt.

Kort fortalt er det slik at "Optimize imports" i Intellij kan finne på å legge til imports uten mellomrom, som Oxfmt vil klage på. Det virker som Oxfmt kjører _før_ "Optimize imports" on save, og da vil formatteringen bli feil selv om man egentlig håndhever formattering med Oxfmt. Dette fikser problemet :blush: 

Og ja, det er helt vanlig å sjekke inn filer fra `.idea` til git :call_me_hand: 