### PR TITLE
Add warn to basic linting rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["typescript", "react", "jsx-a11y"],
   "jsPlugins": ["eslint-plugin-no-only-tests"],
   "categories": {
-    "correctness": "off"
+    "correctness": "warn"
   },
   "env": {
     "builtin": true


### PR DESCRIPTION
Da vi gikk over til Oxlint, ble lintingreglene våre litt strengere enn med Eslint. Siden jeg ikke ville fikse alt i ett jafs, prøvde jeg å skru av `error` på en del ting som Eslint pleide å kaste `warn` på. I configen her skulle det altså så klart stått `"warn"` og ikke `"off"` :smile: Så nå får vi igjen advarsel om diverse greier, f.eks. at man ikke legger til `key` på et iterert element i React osv.

Til fremtiden kunne det vært nice å sette det til error, men da må _veldig_ mye fikses. Ikke alt er superviktig heller. En regel som _hadde_ vært veldig nice er `"suspicious": "error"`. Denne gir feil på rimelig viktige ting som kan forårsake ekte bugs, f.eks. shadowing. Dette har vi en del av fra før også, så jeg tar det ikke med i denne PRen.