### PR TITLE
IS-4111: Add view for soknader 8-9

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -81,6 +81,7 @@ spec:
         - application: ispengestopp
         - application: ispersonoppgave
         - application: istilgangskontroll
+        - application: isutenlandsopphold
         - application: syfobehandlendeenhet
         - application: syfoperson
         - application: syfooversiktsrv
@@ -251,3 +252,7 @@ spec:
       value: "dev-gcp.team-esyfo.sykepengedager-informasjon"
     - name: SYKEPENGEDAGER_INFORMASJON_HOST
       value: "http://sykepengedager-informasjon.team-esyfo"
+    - name: ISUTENLANDSOPPHOLD_AAD_APP_CLIENT_ID
+      value: "dev-gcp.teamsykefravr.isutenlandsopphold"
+    - name: ISUTENLANDSOPPHOLD_HOST
+      value: "http://isutenlandsopphold"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -81,6 +81,7 @@ spec:
         - application: ispengestopp
         - application: ispersonoppgave
         - application: istilgangskontroll
+        - application: isutenlandsopphold
         - application: syfobehandlendeenhet
         - application: syfoperson
         - application: syfooversiktsrv
@@ -250,3 +251,7 @@ spec:
       value: "prod-gcp.team-esyfo.sykepengedager-informasjon"
     - name: SYKEPENGEDAGER_INFORMASJON_HOST
       value: "http://sykepengedager-informasjon.team-esyfo"
+    - name: ISUTENLANDSOPPHOLD_AAD_APP_CLIENT_ID
+      value: "prod-gcp.teamsykefravr.isutenlandsopphold"
+    - name: ISUTENLANDSOPPHOLD_HOST
+      value: "http://isutenlandsopphold"

--- a/server/config.ts
+++ b/server/config.ts
@@ -374,6 +374,16 @@ export const auth = {
     }),
     removePathPrefix: true,
   },
+  isutenlandsopphold: {
+    applicationName: "isutenlandsopphold",
+    clientId: envVar({
+      name: "ISUTENLANDSOPPHOLD_AAD_APP_CLIENT_ID",
+    }),
+    host: envVar({
+      name: "ISUTENLANDSOPPHOLD_HOST",
+    }),
+    removePathPrefix: true,
+  },
   pensjonPenUfore: {
     applicationName: "pensjon-pen",
     clientId: envVar({

--- a/server/proxy.ts
+++ b/server/proxy.ts
@@ -320,6 +320,10 @@ export const setupProxy = (): express.Router => {
     proxyOnBehalfOf(Config.auth.isoppfolgingsplan),
   );
   router.use("/pensjon-pen", proxyOnBehalfOf(Config.auth.pensjonPenUfore));
+  router.use(
+    "/isutenlandsopphold",
+    proxyOnBehalfOf(Config.auth.isutenlandsopphold),
+  );
 
   return router;
 };

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -97,7 +97,7 @@ export const get = <ResponseData>(
 export const post = <ResponseData>(
   url: string,
   data: Record<string, any>,
-  personIdent?: string,
+  personIdent?: string, // TODO: Burde ikke være mulig å sende med denne på POST, skal i så fall være i body
 ): Promise<ResponseData> => {
   return axios
     .post(url, data, {

--- a/src/apiConstants.ts
+++ b/src/apiConstants.ts
@@ -46,3 +46,4 @@ export const PENSJON_PEN_UFOREGRAD_ROOT = "/pensjon-pen/api/uforetrygd";
 export const LUMI_API_ROOT = "/lumi-api/api/azure/v1";
 export const UNLEASH_ROOT = "/unleash";
 export const VEILARBOPPFOLGING_ROOT = "/veilarboppfolging/api/v2";
+export const ISUTENLANDSOPPHOLD_ROOT = "/isutenlandsopphold/api/v1";

--- a/src/data/utenlandsopphold/utenlandsoppholdQueryHooks.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdQueryHooks.ts
@@ -1,0 +1,57 @@
+import { useValgtPersonident } from "@/hooks/useValgtBruker";
+import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
+import { post } from "@/api/axios";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Periode,
+  PeriodeDTO,
+  Soknad,
+  SoknadDTO,
+  SoknaderRequestDTO,
+  SoknaderResponseDTO,
+  Vedtak,
+  VedtakDTO,
+} from "@/data/utenlandsopphold/utenlandsoppholdTypes";
+
+export const utenlandsoppholdQueryKeys = {
+  soknader: (personident: string) => ["utenlandsoppholdSoknader", personident],
+};
+
+/**
+ * Henter søknader på § 8-9 utenlandsopphold for en person.
+ * Endepunktet er en POST på personident, men brukes som en GET.
+ */
+export const useSoknaderQuery = () => {
+  const personident = useValgtPersonident();
+  const path = `${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`;
+  const requestDTO: SoknaderRequestDTO = { personident };
+  const fetchSoknader = () => post<SoknaderResponseDTO>(path, requestDTO);
+
+  return useQuery({
+    queryKey: utenlandsoppholdQueryKeys.soknader(personident),
+    queryFn: fetchSoknader,
+    enabled: !!personident,
+    select: (data) => ({
+      soknader: data.soknader.map(parseSoknad),
+    }),
+  });
+};
+
+const parsePeriode = (periode: PeriodeDTO): Periode => ({
+  ...periode,
+  fom: new Date(periode.fom),
+  tom: new Date(periode.tom),
+});
+
+const parseVedtak = (vedtak: VedtakDTO): Vedtak => ({
+  ...vedtak,
+  innvilgetePerioder: vedtak.innvilgetePerioder.map(parsePeriode),
+  fattetTidspunkt: new Date(vedtak.fattetTidspunkt),
+});
+
+const parseSoknad = (soknad: SoknadDTO): Soknad => ({
+  ...soknad,
+  innsendtTidspunkt: new Date(soknad.innsendtTidspunkt),
+  soktePerioder: soknad.soktePerioder.map(parsePeriode),
+  vedtak: soknad.vedtak ? parseVedtak(soknad.vedtak) : null,
+});

--- a/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
@@ -1,0 +1,54 @@
+export interface SoknaderRequestDTO {
+  personident: string;
+}
+
+export interface SoknaderResponseDTO {
+  soknader: SoknadDTO[];
+}
+
+export interface SoknadDTO {
+  soknadId: string;
+  status: SoknadStatusDTO;
+  innsendtTidspunkt: string;
+  soktePerioder: PeriodeDTO[];
+  vedtak: VedtakDTO | null;
+}
+
+export interface PeriodeDTO {
+  fom: string;
+  tom: string;
+}
+
+export interface VedtakDTO {
+  utfall: string;
+  innvilgetePerioder: PeriodeDTO[];
+  fattetAv: string;
+  fattetTidspunkt: string;
+}
+
+export enum SoknadStatusDTO {
+  MOTTATT = "MOTTATT",
+  INNVILGET = "INNVILGET",
+}
+
+export interface Soknad extends Omit<
+  SoknadDTO,
+  "innsendtTidspunkt" | "soktePerioder" | "vedtak"
+> {
+  innsendtTidspunkt: Date;
+  soktePerioder: Periode[];
+  vedtak: Vedtak | null;
+}
+
+export interface Periode extends Omit<PeriodeDTO, "fom" | "tom"> {
+  fom: Date;
+  tom: Date;
+}
+
+export interface Vedtak extends Omit<
+  VedtakDTO,
+  "innvilgetePerioder" | "fattetTidspunkt"
+> {
+  innvilgetePerioder: Periode[];
+  fattetTidspunkt: Date;
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -22,6 +22,7 @@ import { mockSyfosmregister } from "@/mocks/syfosmregister/mockSyfosmregister";
 import { mockSyfooppfolgingsplanservice } from "@/mocks/syfooppfolgingsplanservice/mockSyfooppfolgingsplanservice";
 import { mockIspersonoppgave } from "@/mocks/ispersonoppgave/mockIspersonoppgave";
 import { mockIstilgangskontroll } from "@/mocks/istilgangskontroll/mockIstilgangskontroll";
+import { mockIsutenlandsopphold } from "@/mocks/isutenlandsopphold/mockIsutenlandsopphold";
 import { mockLpsOppfolgingsplanerMottak } from "@/mocks/lpsoppfolgingsplanmottak/mockLpsOppfolgingsplanMottak";
 import { mockMerOppfolging } from "@/mocks/meroppfolging-backend/merOppfolgingMock";
 import { mockModiacontextholder } from "@/mocks/modiacontextholder/mockModiacontextholder";
@@ -72,6 +73,7 @@ const handlers = [
   ...mockIspengestopp,
   ...mockIspersonoppgave,
   mockIstilgangskontroll,
+  ...mockIsutenlandsopphold,
   ...mockSyfooppfolgingsplanservice,
   ...mockLpsOppfolgingsplanerMottak,
   ...mockSyfooppfolgingsplanbackend,

--- a/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
+++ b/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
@@ -1,0 +1,57 @@
+import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
+import {
+  SoknaderResponseDTO,
+  SoknadDTO,
+  SoknadStatusDTO,
+} from "@/data/utenlandsopphold/utenlandsoppholdTypes";
+import { http, HttpResponse } from "msw";
+
+export const soknadUtenVedtakMock: SoknadDTO = {
+  soknadId: "1a2b3c4d-5e6f-7890-abcd-ef0987654321",
+  status: SoknadStatusDTO.MOTTATT,
+  innsendtTidspunkt: "2026-05-15T08:30:00Z",
+  soktePerioder: [
+    {
+      fom: "2026-06-01",
+      tom: "2026-06-07",
+    },
+    {
+      fom: "2026-06-10",
+      tom: "2026-06-12",
+    },
+  ],
+  vedtak: null,
+};
+
+export const soknadMedVedtakMock: SoknadDTO = {
+  soknadId: "9b1c2d3e-4f56-7890-abcd-ef1234567890",
+  status: SoknadStatusDTO.INNVILGET,
+  innsendtTidspunkt: "2026-03-01T09:00:00Z",
+  soktePerioder: [
+    {
+      fom: "2026-04-01",
+      tom: "2026-04-10",
+    },
+  ],
+  vedtak: {
+    utfall: "INNVILGET",
+    innvilgetePerioder: [
+      {
+        fom: "2026-04-01",
+        tom: "2026-04-05",
+      },
+    ],
+    fattetAv: "Z990000",
+    fattetTidspunkt: "2026-03-02T11:00:00Z",
+  },
+};
+
+export const mockSoknaderResponse: SoknaderResponseDTO = {
+  soknader: [soknadUtenVedtakMock, soknadMedVedtakMock],
+};
+
+export const mockIsutenlandsopphold = [
+  http.post(`${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () => {
+    return HttpResponse.json(mockSoknaderResponse);
+  }),
+];

--- a/src/sider/utenlandsopphold/Utenlandsopphold.tsx
+++ b/src/sider/utenlandsopphold/Utenlandsopphold.tsx
@@ -1,21 +1,96 @@
 import React from "react";
-import { Box } from "@navikt/ds-react";
+import { Alert, BodyShort, Box, Button, Loader, Table } from "@navikt/ds-react";
+import { useSoknaderQuery } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
+import {
+  Soknad,
+  SoknadStatusDTO,
+} from "@/data/utenlandsopphold/utenlandsoppholdTypes";
+import {
+  tilLesbarDatoMedArstall,
+  tilLesbarPeriodeMedArUtenManednavn,
+} from "@/utils/datoUtils";
 
 const texts = {
-  title: "Søknad om utenlandsopphold",
-  goofyText:
-    "Her kan du innvilge utenlandsopphold. Gitt mangel på knapper, må alt gjøres for hånd. Lykke til.",
+  pending: "Henter søknader...",
+  error: "Noe gikk galt ved henting av søknader. Vennligst prøv igjen senere.",
+  innsendtTidspunkt: "Innsendt tidspunkt",
+  periode: "Søkt periode",
+  status: "Status",
+  startBehandling: "Start behandling",
+  ingenSoknader: "Ingen mottatte søknader eller fattede vedtak",
 };
 
+const statusTexts: { [key in SoknadStatusDTO]: string } = {
+  [SoknadStatusDTO.MOTTATT]: "Mottatt",
+  [SoknadStatusDTO.INNVILGET]: "Innvilget",
+};
+
+function getStatusColumn(soknad: Soknad) {
+  if (!soknad.vedtak) {
+    return (
+      // TODO: Legge på onclick til vedtaksiden her
+      <Button size="small" variant="secondary">
+        {texts.startBehandling}
+      </Button>
+    );
+  }
+  return statusTexts[soknad.status] ?? soknad.status; // Forslag: Kan gjøres om til feks grønn, gul og rød Tag etterhvert
+}
+
+function sorterEtterInnsendtTidspunktNyestForst(soknader: Soknad[]) {
+  return [...soknader].sort(
+    (a, b) => b.innsendtTidspunkt.getTime() - a.innsendtTidspunkt.getTime(),
+  );
+}
+
 export function Utenlandsopphold() {
+  const { data, isPending, isError } = useSoknaderQuery();
+
   return (
-    <Box
-      background="default"
-      padding="space-24"
-      className="flex flex-col *:mb-4"
-    >
-      <h1>{texts.title}</h1>
-      <p>{texts.goofyText}</p>
+    <Box background="default" padding="space-16" className="flex flex-col">
+      {isPending ? (
+        <Loader size="xlarge" title={texts.pending} />
+      ) : isError ? (
+        <Alert size="small" variant="error">
+          {texts.error}
+        </Alert>
+      ) : !data.soknader.length ? (
+        <BodyShort>{texts.ingenSoknader}</BodyShort>
+      ) : (
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell scope="col">
+                {texts.innsendtTidspunkt}
+              </Table.HeaderCell>
+              <Table.HeaderCell scope="col">{texts.periode}</Table.HeaderCell>
+              <Table.HeaderCell scope="col">{texts.status}</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {sorterEtterInnsendtTidspunktNyestForst(data.soknader).map(
+              (soknad) => (
+                <Table.Row key={soknad.soknadId}>
+                  <Table.HeaderCell scope="row">
+                    {tilLesbarDatoMedArstall(soknad.innsendtTidspunkt)}
+                  </Table.HeaderCell>
+                  <Table.DataCell>
+                    {soknad.soktePerioder.map((periode, index) => (
+                      <div key={index}>
+                        {tilLesbarPeriodeMedArUtenManednavn(
+                          periode.fom,
+                          periode.tom,
+                        )}
+                      </div>
+                    ))}
+                  </Table.DataCell>
+                  <Table.DataCell>{getStatusColumn(soknad)}</Table.DataCell>
+                </Table.Row>
+              ),
+            )}
+          </Table.Body>
+        </Table>
+      )}
     </Box>
   );
 }

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSide.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSide.tsx
@@ -9,7 +9,7 @@ import { Utenlandsopphold } from "@/sider/utenlandsopphold/Utenlandsopphold.tsx"
 import { Box } from "@navikt/ds-react";
 
 const texts = {
-  title: "Søknad om utenlandsopphold",
+  title: "Søknad om sykepenger under opphold utenfor EØS",
 };
 
 export function UtenlandsoppholdSide() {

--- a/test/utenlandsopphold/UtenlandsoppholdTest.tsx
+++ b/test/utenlandsopphold/UtenlandsoppholdTest.tsx
@@ -1,0 +1,125 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { http, HttpResponse } from "msw";
+import { mockServer } from "../setup";
+import { queryClientWithMockData } from "../testQueryClient";
+import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
+import { Utenlandsopphold } from "@/sider/utenlandsopphold/Utenlandsopphold.tsx";
+import { SoknaderResponseDTO } from "@/data/utenlandsopphold/utenlandsoppholdTypes";
+import { utenlandsoppholdQueryKeys } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
+import {
+  mockSoknaderResponse,
+  soknadMedVedtakMock,
+  soknadUtenVedtakMock,
+} from "@/mocks/isutenlandsopphold/mockIsutenlandsopphold";
+import {
+  tilLesbarDatoMedArstall,
+  tilLesbarPeriodeMedArUtenManednavn,
+} from "@/utils/datoUtils";
+import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
+
+let queryClient: QueryClient;
+
+const renderUtenlandsopphold = () =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <Utenlandsopphold />
+    </QueryClientProvider>,
+  );
+
+const stubSoknaderQuery = (response: SoknaderResponseDTO) =>
+  mockServer.use(
+    http.post(`*${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () =>
+      HttpResponse.json(response),
+    ),
+  );
+
+describe("Utenlandsopphold", () => {
+  beforeEach(() => {
+    queryClient = queryClientWithMockData();
+  });
+
+  it("viser feilmelding når henting av søknader feiler", async () => {
+    queryClient.setQueryDefaults(
+      utenlandsoppholdQueryKeys.soknader(ARBEIDSTAKER_DEFAULT.personIdent),
+      { retry: false },
+    );
+
+    renderUtenlandsopphold();
+
+    expect(
+      await screen.findByText(
+        "Noe gikk galt ved henting av søknader. Vennligst prøv igjen senere.",
+      ),
+    ).to.exist;
+  });
+
+  it("viser søknader sortert på innsendt tidspunkt med nyeste først", async () => {
+    stubSoknaderQuery(mockSoknaderResponse);
+
+    renderUtenlandsopphold();
+
+    const rowHeaders = await screen.findAllByRole("rowheader");
+
+    expect(rowHeaders[0].textContent).to.equal(
+      tilLesbarDatoMedArstall(soknadUtenVedtakMock.innsendtTidspunkt),
+    );
+    expect(rowHeaders[1].textContent).to.equal(
+      tilLesbarDatoMedArstall(soknadMedVedtakMock.innsendtTidspunkt),
+    );
+  });
+
+  it("viser flere søkte perioder for en søknad", async () => {
+    stubSoknaderQuery(mockSoknaderResponse);
+
+    renderUtenlandsopphold();
+
+    expect(
+      await screen.findByText(
+        tilLesbarPeriodeMedArUtenManednavn(
+          soknadUtenVedtakMock.soktePerioder[0].fom,
+          soknadUtenVedtakMock.soktePerioder[0].tom,
+        ),
+      ),
+    ).to.exist;
+    expect(
+      screen.getByText(
+        tilLesbarPeriodeMedArUtenManednavn(
+          soknadUtenVedtakMock.soktePerioder[1].fom,
+          soknadUtenVedtakMock.soktePerioder[1].tom,
+        ),
+      ),
+    ).to.exist;
+  });
+
+  it("viser knapp for å starte behandling når søknaden ikke har vedtak", async () => {
+    stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+    renderUtenlandsopphold();
+
+    expect(await screen.findByRole("button", { name: "Start behandling" })).to
+      .exist;
+  });
+
+  it("viser søknadsstatus i stedet for knapp når søknaden har vedtak", async () => {
+    stubSoknaderQuery({ soknader: [soknadMedVedtakMock] });
+
+    renderUtenlandsopphold();
+
+    expect(await screen.findByText("Innvilget")).to.exist;
+    expect(screen.queryByRole("button", { name: "Start behandling" })).to.not
+      .exist;
+  });
+
+  it("viser melding om ingen søknader når listen er tom", async () => {
+    stubSoknaderQuery({ soknader: [] });
+
+    renderUtenlandsopphold();
+
+    expect(
+      await screen.findByText("Ingen mottatte søknader eller fattede vedtak"),
+    ).to.exist;
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

- Ny komponent for å liste opp søknader for en person
- Legger til DTOer fra `/soknader` endepunkt
- ReactQuery for POSTen
- naiserator-config og BFF proxy støtte
- mockdata og tester

### Screenshots 📸✨

<img width="1422" height="624" alt="image" src="https://github.com/user-attachments/assets/313b76ea-7444-4ab7-9d51-eb54b18a8be7" />
<img width="1251" height="306" alt="image" src="https://github.com/user-attachments/assets/d1978530-c475-4823-9c15-e67918808f85" />
<img width="1326" height="233" alt="image" src="https://github.com/user-attachments/assets/7b7f1600-6f39-4280-af63-f8346ca8fa87" />
