### PR TITLE
IS-412: Add preview to søknad om utenlandsopphold

### DIFF
--- a/src/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts
@@ -1,0 +1,64 @@
+import { Periode } from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
+import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils.ts";
+
+export type UtenlandsoppholdDocumentTextsValues = {
+  soknadDato: Date;
+  perioder: Periode[];
+};
+
+export const getUtenlandsoppholdDocumentTexts = ({
+  soknadDato,
+  perioder,
+}: UtenlandsoppholdDocumentTextsValues) => {
+  const soknadDatoTekst = tilLesbarDatoMedArUtenManedNavn(soknadDato);
+  const perioderTekst = perioder
+    .map(
+      (periode) =>
+        `${tilLesbarDatoMedArUtenManedNavn(
+          periode.fom,
+        )} til og med ${tilLesbarDatoMedArUtenManedNavn(periode.tom)}`,
+    )
+    .join(", ");
+
+  return {
+    header: "Vedtak om utenlandsopphold",
+    innvilget: {
+      header: "Du har fått godkjent sykepenger under utenlandsopphold",
+      intro: `Vi viser til din søknad av ${soknadDatoTekst} om å beholde sykepengene under opphold i utlandet. Søknaden din er godkjent og du får beholde sykepengene dine ved opphold i utlandet i perioden ${perioderTekst}.`,
+    },
+    begrunnelse: {
+      header: "Begrunnelse for vedtaket",
+      body: "Du er for tiden sykmeldt og har søkt om å beholde sykepengene på reise utenfor EU/EØS. Du kan få utbetalt sykepenger under utenlandsopphold utenfor EU/EØS eller andre områder der trygdeforordningen gjelder i inntil fire uker (28 kalenderdager) i løpet av en tolvmånedersperiode.",
+      body2: `Du bekrefter i søknaden at det er avklart med arbeidsgiver og sykmelder at reisen ikke vil være til hinder for planlagt aktivitet og behandling. Vi vurderer videre at oppholdet ikke vil hindre Navs kontroll og oppfølging. Du får derfor innvilget din søknad om å beholde sykepenger ved opphold i utlandet i perioden ${perioderTekst}.`,
+      paragraf:
+        "Dette vedtaket er gjort etter folketrygdloven § 8-9 tredje ledd.",
+    },
+    oppmerksom: {
+      header: "Dette må du være oppmerksom på",
+      body: `Det er viktig at du er oppmerksom på at du har fått godkjent å beholde sykepenger under utenlandsopphold i perioden ${perioderTekst}. Dersom du oppholder deg utenfor EU/EØS eller andre områder der trygdeforordningen gjelder lengre enn dette, kan det få betydning for din videre rett til sykepenger.`,
+    },
+    endringSituasjon: {
+      header: "Hvis situasjonen din endrer seg",
+      body: "Endringer i situasjonen din kan påvirke retten din til sykepenger. Dersom du gir mangelfulle eller feilaktige opplysninger, kan det føre til at du må betale tilbake penger.",
+      lesMer: "Les mer om dette på: nav.no/endringer.",
+    },
+    sporsmal: {
+      header: "Har du spørsmål",
+      body: "Hvis du har spørsmål kan du kontakte oss via: nav.no/kontaktoss eller telefon 55 55 33 33.",
+    },
+    dineRettigheter: {
+      header: "Dine rettigheter",
+      innsyn: {
+        header: "Rett til innsyn",
+        body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller telefon 55 55 33 33.",
+      },
+      klage: {
+        header: "Rett til å klage",
+        body: "Hvis du ikke er enig i vedtaket, kan du klage innen seks uker fra du mottok dette brevet.",
+        lesMer: "Les mer om hvordan du klager her:",
+        url: "nav.no/klagerettigheter",
+        urlSykepenger: "nav.no/klage#sykepenger",
+      },
+    },
+  };
+};

--- a/src/hooks/utenlandsopphold/useUtenlandsoppholdSoknadDocument.ts
+++ b/src/hooks/utenlandsopphold/useUtenlandsoppholdSoknadDocument.ts
@@ -1,0 +1,59 @@
+import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes";
+import { useDocumentComponents } from "@/hooks/useDocumentComponents";
+import {
+  createHeaderH1,
+  createHeaderH2,
+  createHeaderH3,
+  createBulletPoints,
+  createParagraph,
+} from "@/utils/documentComponentUtils";
+import {
+  getUtenlandsoppholdDocumentTexts,
+  UtenlandsoppholdDocumentTextsValues,
+} from "@/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts";
+
+export const useUtenlandsoppholdSoknadDocument = (): {
+  getVedtakDocument(
+    values: UtenlandsoppholdDocumentTextsValues,
+  ): DocumentComponentDto[];
+} => {
+  const { getHilsen } = useDocumentComponents();
+
+  const getVedtakDocument = (
+    values: UtenlandsoppholdDocumentTextsValues,
+  ): DocumentComponentDto[] => {
+    const soknadTexts = getUtenlandsoppholdDocumentTexts(values);
+
+    return [
+      createHeaderH1(soknadTexts.header),
+      createHeaderH2(soknadTexts.innvilget.header),
+      createParagraph(soknadTexts.innvilget.intro),
+      createHeaderH2(soknadTexts.begrunnelse.header),
+      createParagraph(soknadTexts.begrunnelse.body),
+      createParagraph(soknadTexts.begrunnelse.body2),
+      createParagraph(soknadTexts.begrunnelse.paragraf),
+      createHeaderH2(soknadTexts.oppmerksom.header),
+      createParagraph(soknadTexts.oppmerksom.body),
+      createHeaderH2(soknadTexts.endringSituasjon.header),
+      createParagraph(soknadTexts.endringSituasjon.body),
+      createParagraph(soknadTexts.endringSituasjon.lesMer),
+      createHeaderH2(soknadTexts.sporsmal.header),
+      createParagraph(soknadTexts.sporsmal.body),
+      createHeaderH2(soknadTexts.dineRettigheter.header),
+      createHeaderH3(soknadTexts.dineRettigheter.innsyn.header),
+      createParagraph(soknadTexts.dineRettigheter.innsyn.body),
+      createHeaderH3(soknadTexts.dineRettigheter.klage.header),
+      createParagraph(soknadTexts.dineRettigheter.klage.body),
+      createParagraph(soknadTexts.dineRettigheter.klage.lesMer),
+      createBulletPoints(
+        soknadTexts.dineRettigheter.klage.url,
+        soknadTexts.dineRettigheter.klage.urlSykepenger,
+      ),
+      getHilsen(),
+    ];
+  };
+
+  return {
+    getVedtakDocument,
+  };
+};

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
@@ -11,6 +11,8 @@ import {
 import { useSoknaderQuery } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
 import { Link, useParams } from "react-router-dom";
 import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils.ts";
+import { Forhandsvisning } from "@/components/Forhandsvisning";
+import { useUtenlandsoppholdSoknadDocument } from "@/hooks/utenlandsopphold/useUtenlandsoppholdSoknadDocument";
 
 const texts = {
   pending: "Henter søknader...",
@@ -23,12 +25,13 @@ const texts = {
   singlePeriod: "Perioden det er søkt om innvilges i sin helhet",
   multiplePeriods: "Periodene det er søkt om innvilges i sin helhet",
   sendButton: "Godkjenn og send vedtak",
-  previewButton: "Forhåndsvisning",
+  previewContentLabel: "Forhåndsvisning",
   backButton: "Tilbake",
 };
 
 export function UtenlandsoppholdSoknad() {
   const { data, isPending, isError } = useSoknaderQuery();
+  const { getVedtakDocument } = useUtenlandsoppholdSoknadDocument();
 
   const { utenlandsoppholdSoknadId } = useParams<{
     utenlandsoppholdSoknadId: string;
@@ -76,7 +79,7 @@ export function UtenlandsoppholdSoknad() {
 
           <div>
             <Detail>{periodText}</Detail>
-            {soktePerioder?.map((periode, index) => (
+            {utenlandsoppholdSoknad.soktePerioder.map((periode, index) => (
               <BodyShort key={index} weight={"semibold"}>
                 {tilLesbarPeriodeMedArUtenManednavn(periode.fom, periode.tom)}
               </BodyShort>
@@ -87,7 +90,15 @@ export function UtenlandsoppholdSoknad() {
             <Button as="a" variant="primary">
               {texts.sendButton}
             </Button>
-            <Button variant="secondary">{texts.previewButton}</Button>
+            <Forhandsvisning
+              contentLabel={texts.previewContentLabel}
+              getDocumentComponents={() =>
+                getVedtakDocument({
+                  soknadDato: utenlandsoppholdSoknad.innsendtTidspunkt,
+                  perioder: utenlandsoppholdSoknad.soktePerioder,
+                })
+              }
+            />
             <Button
               as={Link}
               to={`/sykefravaer/utenlandsopphold`}


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Legger til preview av brev til bruker. Jeg gjør ingenting med APIet foreløpig, men dette kan man ta når man lager API for innsending av vedtak

### Screenshots 📸✨

<img width="3439" height="1354" alt="image" src="https://github.com/user-attachments/assets/fbcc3254-691b-4dcc-9837-bcea50b4bb2b" />
<img width="3439" height="1354" alt="image" src="https://github.com/user-attachments/assets/8a1f0a88-7ddd-427e-bc4c-75fdda9a3838" />
