### PR TITLE
IS-4150: Add AVSLAG option for vedtak

### DIFF
--- a/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
@@ -10,7 +10,7 @@ export interface SoknaderResponseDTO {
 }
 
 export interface SoknadVedtakPostDTO {
-  utfall: "INNVILGET";
+  utfall: Utfall;
   innvilgedePerioder: PeriodeDTO[];
   document: DocumentComponentDto[];
 }
@@ -34,7 +34,7 @@ export interface PeriodeDTO {
 }
 
 export interface VedtakDTO {
-  utfall: string;
+  utfall: Utfall;
   innvilgedePerioder: PeriodeDTO[];
   fattetAv: string;
   fattetTidspunkt: string;
@@ -43,9 +43,12 @@ export interface VedtakDTO {
 export enum SoknadStatusDTO {
   MOTTATT = "MOTTATT",
   INNVILGET = "INNVILGET",
+  AVSLAG = "AVSLAG",
 }
 
 // Types
+export type Utfall = "INNVILGET" | "AVSLAG";
+
 export interface Soknad extends Omit<
   SoknadDTO,
   "innsendtTidspunkt" | "soktePerioder" | "vedtak"

--- a/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
+++ b/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
@@ -56,6 +56,32 @@ export const mockSoknaderResponse: SoknaderResponseDTO = {
   soknader: [soknadUtenVedtakMock, soknadMedVedtakMock],
 };
 
+/**
+ * Bygger en oppdatert søknad basert på et innsendt vedtak, slik backend ville
+ * gjort det. Delt mellom msw-handleren under (brukt lokalt i dev) og
+ * test-stubben i test/stubs/stubIsutenlandsopphold.ts, slik at begge
+ * simulerer samme oppførsel når et vedtak fattes.
+ */
+export function byggOppdatertSoknadMedVedtak(
+  soknad: SoknadDTO,
+  vedtak: SoknadVedtakPostDTO,
+  fattetAv: string,
+): SoknadDTO {
+  return {
+    ...soknad,
+    status:
+      vedtak.utfall === "INNVILGET"
+        ? SoknadStatusDTO.INNVILGET
+        : SoknadStatusDTO.AVSLAG,
+    vedtak: {
+      utfall: vedtak.utfall,
+      innvilgedePerioder: vedtak.innvilgedePerioder,
+      fattetAv,
+      fattetTidspunkt: dayjs().toISOString(),
+    },
+  };
+}
+
 export const mockIsutenlandsopphold = [
   http.post(`${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () => {
     return HttpResponse.json(mockSoknaderResponse);
@@ -77,16 +103,11 @@ export const mockIsutenlandsopphold = [
 
       return existingSoknad
         ? HttpResponse.json({
-            soknad: {
-              ...existingSoknad,
-              status: SoknadStatusDTO.INNVILGET,
-              vedtak: {
-                utfall: body.utfall,
-                innvilgedePerioder: body.innvilgedePerioder,
-                fattetTidspunkt: dayjs().toISOString(),
-                fattetAv: VEILEDER_IDENT_DEFAULT,
-              },
-            },
+            soknad: byggOppdatertSoknadMedVedtak(
+              existingSoknad,
+              body,
+              VEILEDER_IDENT_DEFAULT,
+            ),
           })
         : HttpResponse.text(`Did not find soknad with uuid ${soknadId}`, {
             status: 400,

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
@@ -1,50 +1,101 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   Alert,
   BodyShort,
   Box,
   Button,
-  Detail,
   Loader,
   LocalAlert,
+  Radio,
+  RadioGroup,
 } from "@navikt/ds-react";
 import {
   useSoknaderQuery,
   useVedtakMutation,
 } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { tilLesbarPeriodeMedArUtenManednavn } from "@/utils/datoUtils.ts";
+import {
+  tilLesbarDatoMedArUtenManedNavn,
+  tilLesbarPeriodeMedArUtenManednavn,
+} from "@/utils/datoUtils.ts";
 import { Forhandsvisning } from "@/components/Forhandsvisning";
 import { useUtenlandsoppholdSoknadDocument } from "@/hooks/utenlandsopphold/useUtenlandsoppholdSoknadDocument";
 import { useNotification } from "@/context/notification/NotificationContext.tsx";
 import { utenlandsoppholdPath } from "@/AppRouter.tsx";
-import { SoknadStatusDTO } from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
+import {
+  SoknadStatusDTO,
+  Utfall,
+} from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
+import { erProd } from "@/utils/miljoUtil.ts";
 
 const texts = {
   pending: "Henter søknader...",
   error: "Noe gikk galt ved henting av søknader. Vennligst prøv igjen senere.",
   didNotFindSoknad: "Fant ikke søknaden",
   modiaWarningHeader: "Begrenset behandling i Modia",
-  modiaWarningContent:
-    "Det er kun mulighet for å innvilge søknaden i Modia. Dersom søknaden skal delvis innvilges eller avslås, må vedtaket fattes i Infotrygd som tidligere.",
+  modiaWarningContent(isAvslagEnabled: boolean): string {
+    if (isAvslagEnabled) {
+      return "Det er kun mulig med utfallene 'innvilgelse' eller 'avslag' på søknaden her i Modia. Dersom søknaden skal delvis innvilges, må vedtaket fattes i Infotrygd som tidligere.";
+    } else {
+      return "Det er kun mulig med utfallet 'innvilgelse' på søknaden her i Modia. Dersom søknaden skal delvis innvilges eller avslås, må vedtaket fattes i Infotrygd som tidligere.";
+    }
+  },
   goToSoknad: "Vis hele søknaden",
-  singlePeriod: "Perioden det er søkt om innvilges i sin helhet",
-  multiplePeriods: "Periodene det er søkt om innvilges i sin helhet",
-  sendButton: "Godkjenn og send vedtak",
+  soknadTidspunkt: "Søknaden ble innsendt:",
+  singlePeriod: "Perioden det er søkt om:",
+  multiplePeriods: "Periodene det er søkt om:",
+  innvilgelse: "Innvilgelse: Godkjenn hele perioden",
+  avslag: "Avslag: Avslå hele perioden",
+  sendButton: "Send vedtak",
   previewContentLabel: "Forhåndsvisning",
   backButton: "Tilbake",
   vedtakFattetNotification:
     "Vedtaket om utenlandsopphold utenfor EØS er fattet og sendt til bruker. Dokumentet er journalført i Gosys.",
-  alertBehandlet: "Denne søknaden er allerede behandlet",
+  alertBehandlet: "Denne søknaden er allerede behandlet av",
 };
+
+// En midlertidig lokal feature-toggle, frem til vi har fått brevmaler på plass
+const isAvslagEnabled = !erProd();
 
 export function UtenlandsoppholdSoknad() {
   const { data, isPending, isError } = useSoknaderQuery();
   const { mutate, isPending: mutateIsPending } = useVedtakMutation();
   const { getVedtakDocument } = useUtenlandsoppholdSoknadDocument();
+  const [selectedUtfall, setSelectedUtfall] = useState<Utfall | null>(null);
 
   const navigate = useNavigate();
   const { setNotification } = useNotification();
+
+  function submit(soknadId: string) {
+    if (!selectedUtfall) {
+      return;
+    }
+    const innvilgedePerioder =
+      selectedUtfall === "INNVILGET"
+        ? soktePerioder.map((periode) => ({
+            fom: periode.fom.toISOString(),
+            tom: periode.tom.toISOString(),
+          }))
+        : selectedUtfall === "AVSLAG" // For å være eksplisitt
+          ? []
+          : [];
+    const requestDTO = {
+      soknadId: soknadId,
+      vedtak: {
+        utfall: selectedUtfall,
+        innvilgedePerioder: innvilgedePerioder,
+        document: vedtakDocument, // TODO: Må oppdateres basert på utfall
+      },
+    };
+    mutate(requestDTO, {
+      onSuccess: () => {
+        setNotification({
+          message: texts.vedtakFattetNotification,
+        });
+        navigate(`${utenlandsoppholdPath}`);
+      },
+    });
+  }
 
   const { utenlandsoppholdSoknadId } = useParams<{
     utenlandsoppholdSoknadId: string;
@@ -89,8 +140,17 @@ export function UtenlandsoppholdSoknad() {
           <LocalAlert.Header>
             <LocalAlert.Title>{texts.modiaWarningHeader}</LocalAlert.Title>
           </LocalAlert.Header>
-          <LocalAlert.Content>{texts.modiaWarningContent}</LocalAlert.Content>
+          <LocalAlert.Content>
+            {texts.modiaWarningContent(isAvslagEnabled)}
+          </LocalAlert.Content>
         </LocalAlert>
+
+        <BodyShort>
+          {texts.soknadTidspunkt}{" "}
+          {tilLesbarDatoMedArUtenManedNavn(
+            utenlandsoppholdSoknad.innsendtTidspunkt,
+          )}
+        </BodyShort>
 
         <div>
           <Button
@@ -104,7 +164,7 @@ export function UtenlandsoppholdSoknad() {
         </div>
 
         <div>
-          <Detail>{periodText}</Detail>
+          <BodyShort>{periodText}</BodyShort>
           {utenlandsoppholdSoknad.soktePerioder.map((periode, index) => (
             <BodyShort key={index} weight={"semibold"}>
               {tilLesbarPeriodeMedArUtenManednavn(periode.fom, periode.tom)}
@@ -113,56 +173,59 @@ export function UtenlandsoppholdSoknad() {
         </div>
 
         {soknadBehandlet && (
-          <Alert variant="info" size="small" className="w-fit p-4 mb-4">
-            {texts.alertBehandlet}
-          </Alert>
+          <>
+            <Alert variant="info" size="small" className="w-fit p-4">
+              {texts.alertBehandlet} {utenlandsoppholdSoknad.vedtak?.fattetAv}{" "}
+              {tilLesbarDatoMedArUtenManedNavn(
+                utenlandsoppholdSoknad.vedtak?.fattetTidspunkt,
+              )}
+            </Alert>
+            <Button
+              className="w-fit"
+              as={Link}
+              to={`/sykefravaer/utenlandsopphold`}
+              variant="primary"
+            >
+              {texts.backButton}
+            </Button>
+          </>
         )}
 
-        <div className="flex flex-row gap-4">
+        <div className="flex flex-col gap-4">
           {!soknadBehandlet && (
             <>
-              <Button
-                variant="primary"
-                onClick={() =>
-                  mutate(
-                    {
-                      soknadId: utenlandsoppholdSoknad.soknadId,
-                      vedtak: {
-                        utfall: "INNVILGET",
-                        innvilgedePerioder: soktePerioder.map((periode) => ({
-                          fom: periode.fom.toISOString(),
-                          tom: periode.tom.toISOString(),
-                        })),
-                        document: vedtakDocument,
-                      },
-                    },
-                    {
-                      onSuccess: () => {
-                        setNotification({
-                          message: texts.vedtakFattetNotification,
-                        });
-                        navigate(`${utenlandsoppholdPath}`);
-                      },
-                    },
-                  )
-                }
-                loading={mutateIsPending}
+              <RadioGroup
+                legend={"Velg utfall"}
+                value={selectedUtfall}
+                onChange={setSelectedUtfall}
               >
-                {texts.sendButton}
-              </Button>
-              <Forhandsvisning
-                contentLabel={texts.previewContentLabel}
-                getDocumentComponents={() => vedtakDocument}
-              />
+                <Radio value={"INNVILGET"}>{texts.innvilgelse}</Radio>
+                {isAvslagEnabled && (
+                  <Radio value={"AVSLAG"}>{texts.avslag}</Radio>
+                )}
+              </RadioGroup>
+              <div className="flex flex-row gap-4">
+                <Button
+                  variant="primary"
+                  onClick={() => submit(utenlandsoppholdSoknad.soknadId)}
+                  loading={mutateIsPending}
+                >
+                  {texts.sendButton}
+                </Button>
+                <Forhandsvisning
+                  contentLabel={texts.previewContentLabel}
+                  getDocumentComponents={() => vedtakDocument}
+                />
+                <Button
+                  as={Link}
+                  to={`/sykefravaer/utenlandsopphold`}
+                  variant="tertiary"
+                >
+                  {texts.backButton}
+                </Button>
+              </div>
             </>
           )}
-          <Button
-            as={Link}
-            to={`/sykefravaer/utenlandsopphold`}
-            variant={soknadBehandlet ? "primary" : "tertiary"}
-          >
-            {texts.backButton}
-          </Button>
         </div>
       </div>
     </Box>

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx
@@ -30,6 +30,7 @@ const texts = {
 const statusTexts: { [key in SoknadStatusDTO]: string } = {
   [SoknadStatusDTO.MOTTATT]: "Mottatt",
   [SoknadStatusDTO.INNVILGET]: "Innvilget",
+  [SoknadStatusDTO.AVSLAG]: "Avslag",
 };
 
 function getStatusColumn(soknad: Soknad) {

--- a/test/stubs/stubIsutenlandsopphold.ts
+++ b/test/stubs/stubIsutenlandsopphold.ts
@@ -1,0 +1,60 @@
+import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
+import { mockServer } from "../setup";
+import { http, HttpResponse } from "msw";
+import {
+  SoknadDTO,
+  SoknaderResponseDTO,
+  SoknadVedtakPostDTO,
+} from "@/data/utenlandsopphold/utenlandsoppholdTypes";
+import { VEILEDER_DEFAULT } from "@/mocks/common/mockConstants";
+import { byggOppdatertSoknadMedVedtak } from "@/mocks/isutenlandsopphold/mockIsutenlandsopphold";
+
+export const stubSoknaderQuery = (response: SoknaderResponseDTO) =>
+  mockServer.use(
+    http.post(`*${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () =>
+      HttpResponse.json(response),
+    ),
+  );
+
+/**
+ * Stubber både henting og innsending av søknader med en delt, muterbar tilstand,
+ * slik at et evt. refetch av søknadslisten etter et fattet vedtak reflekterer
+ * den oppdaterte statusen, i stedet for alltid å returnere den opprinnelige mocken.
+ */
+export const stubSoknaderMedMuterbarTilstand = (soknader: SoknadDTO[]) => {
+  let tilstand = soknader;
+
+  mockServer.use(
+    http.post(`*${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () =>
+      HttpResponse.json({ soknader: tilstand }),
+    ),
+    http.post<{ soknadId: string }, SoknadVedtakPostDTO>(
+      `*${ISUTENLANDSOPPHOLD_ROOT}/soknader/:soknadId/vedtak`,
+      async ({ request, params }) => {
+        const vedtak = await request.json();
+        const soknadId = params.soknadId;
+        const oppdatertSoknad = tilstand.find(
+          (soknad) => soknad.soknadId === soknadId,
+        );
+
+        if (!oppdatertSoknad) {
+          return HttpResponse.text(
+            `Did not find soknad with uuid ${soknadId}`,
+            { status: 400 },
+          );
+        }
+
+        const nySoknad = byggOppdatertSoknadMedVedtak(
+          oppdatertSoknad,
+          vedtak,
+          VEILEDER_DEFAULT.ident,
+        );
+        tilstand = tilstand.map((soknad) =>
+          soknad.soknadId === soknadId ? nySoknad : soknad,
+        );
+
+        return HttpResponse.json({ soknad: nySoknad });
+      },
+    ),
+  );
+};

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -7,6 +7,13 @@ export const clickButton = async (buttonText: string) =>
 export const getButton = (buttonText: string) =>
   screen.getByRole("button", { name: buttonText });
 
+export const clickRadio = async (radioLabel: string) =>
+  await userEvent.click(
+    screen.getByRole("radio", {
+      name: radioLabel,
+    }),
+  );
+
 export const clickTab = async (tabTitle: string) =>
   await userEvent.click(getTab(tabTitle));
 

--- a/test/utenlandsopphold/UtenlandsoppholdSoknadTest.tsx
+++ b/test/utenlandsopphold/UtenlandsoppholdSoknadTest.tsx
@@ -8,12 +8,6 @@ import { queryClientWithMockData } from "../testQueryClient";
 import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
 import { UtenlandsoppholdSoknad } from "@/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx";
 import { UtenlandsoppholdSoknader } from "@/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx";
-import {
-  SoknadDTO,
-  SoknaderResponseDTO,
-  SoknadStatusDTO,
-  SoknadVedtakPostDTO,
-} from "@/data/utenlandsopphold/utenlandsoppholdTypes";
 import { utenlandsoppholdQueryKeys } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
 import {
   ARBEIDSTAKER_DEFAULT,
@@ -23,10 +17,15 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { NotificationProvider } from "@/context/notification/NotificationContext";
 import {
   mockSoknaderResponse,
+  soknadMedVedtakMock,
   soknadUtenVedtakMock,
 } from "@/mocks/isutenlandsopphold/mockIsutenlandsopphold";
 import { utenlandsoppholdPath } from "@/AppRouter.tsx";
-import { clickButton } from "../testUtils";
+import { clickButton, clickRadio } from "../testUtils";
+import {
+  stubSoknaderMedMuterbarTilstand,
+  stubSoknaderQuery,
+} from "../stubs/stubIsutenlandsopphold";
 
 let queryClient: QueryClient;
 
@@ -52,61 +51,6 @@ const renderUtenlandsoppholdSoknad = (
       </MemoryRouter>
     </QueryClientProvider>,
   );
-
-const stubSoknaderQuery = (response: SoknaderResponseDTO) =>
-  mockServer.use(
-    http.post(`*${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () =>
-      HttpResponse.json(response),
-    ),
-  );
-
-/**
- * Stubber både henting og innsending av søknader med en delt, muterbar tilstand,
- * slik at et evt. refetch av søknadslisten etter et fattet vedtak reflekterer
- * den oppdaterte statusen, i stedet for alltid å returnere den opprinnelige mocken.
- */
-const stubSoknaderMedMuterbarTilstand = (soknader: SoknadDTO[]) => {
-  let tilstand = soknader;
-
-  mockServer.use(
-    http.post(`*${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () =>
-      HttpResponse.json({ soknader: tilstand }),
-    ),
-    http.post<{ soknadId: string }, SoknadVedtakPostDTO>(
-      `*${ISUTENLANDSOPPHOLD_ROOT}/soknader/:soknadId/vedtak`,
-      async ({ request, params }) => {
-        const vedtak = await request.json();
-        const soknadId = params.soknadId;
-        const oppdatertSoknad = tilstand.find(
-          (soknad) => soknad.soknadId === soknadId,
-        );
-
-        if (!oppdatertSoknad) {
-          return HttpResponse.text(
-            `Did not find soknad with uuid ${soknadId}`,
-            { status: 400 },
-          );
-        }
-
-        const nySoknad: SoknadDTO = {
-          ...oppdatertSoknad,
-          status: SoknadStatusDTO.INNVILGET,
-          vedtak: {
-            utfall: vedtak.utfall,
-            innvilgedePerioder: vedtak.innvilgedePerioder,
-            fattetAv: VEILEDER_DEFAULT.ident,
-            fattetTidspunkt: new Date().toISOString(),
-          },
-        };
-        tilstand = tilstand.map((soknad) =>
-          soknad.soknadId === soknadId ? nySoknad : soknad,
-        );
-
-        return HttpResponse.json({ soknad: nySoknad });
-      },
-    ),
-  );
-};
 
 describe("UtenlandsoppholdSoknad", () => {
   beforeEach(() => {
@@ -141,28 +85,22 @@ describe("UtenlandsoppholdSoknad", () => {
 
     renderUtenlandsoppholdSoknad();
 
-    expect(
-      await screen.findByRole("button", { name: "Godkjenn og send vedtak" }),
-    ).to.exist;
+    expect(await screen.findByRole("button", { name: "Send vedtak" })).to.exist;
     expect(screen.getByRole("button", { name: "Forhåndsvisning" })).to.exist;
     expect(screen.getByRole("button", { name: "Vis hele søknaden" })).to.exist;
     expect(screen.getByRole("button", { name: "Tilbake" })).to.exist;
   });
 
   it("viser melding om at søknaden er behandlet når status ikke er MOTTATT", async () => {
-    const behandletSoknad = {
-      ...soknadUtenVedtakMock,
-      status: SoknadStatusDTO.INNVILGET,
-    };
-    stubSoknaderQuery({ soknader: [behandletSoknad] });
+    stubSoknaderQuery({ soknader: [soknadMedVedtakMock] });
 
-    renderUtenlandsoppholdSoknad();
+    renderUtenlandsoppholdSoknad(soknadMedVedtakMock.soknadId);
 
-    expect(await screen.findByText("Denne søknaden er allerede behandlet")).to
+    expect(await screen.findByText(/Denne søknaden er allerede behandlet/)).to
       .exist;
   });
 
-  it("sender vedtak, viser notifikasjon og navigerer tilbake til listen der søknadens status nå vises som innvilget", async () => {
+  it("sender innvilget vedtak, viser notifikasjon og navigerer tilbake til listen der søknadens status nå vises som innvilget", async () => {
     stubSoknaderMedMuterbarTilstand(mockSoknaderResponse.soknader);
 
     renderUtenlandsoppholdSoknad(
@@ -175,8 +113,10 @@ describe("UtenlandsoppholdSoknad", () => {
 
     await clickButton("Start behandling");
 
-    await screen.findByRole("button", { name: "Godkjenn og send vedtak" });
-    await clickButton("Godkjenn og send vedtak");
+    await clickRadio("Innvilgelse: Godkjenn hele perioden");
+
+    await screen.findByRole("button", { name: "Send vedtak" });
+    await clickButton("Send vedtak");
 
     expect(
       await screen.findByText(
@@ -187,6 +127,40 @@ describe("UtenlandsoppholdSoknad", () => {
     expect(screen.queryByRole("button", { name: "Start behandling" })).to.not
       .exist;
     expect(await screen.findAllByText("Innvilget")).to.have.lengthOf(2);
+    expect(
+      await screen.findAllByText(
+        new RegExp(`^Behandlet .* av ${VEILEDER_DEFAULT.ident}$`),
+      ),
+    ).to.have.lengthOf(2);
+  });
+
+  it("sender avslag vedtak, viser notifikasjon og navigerer tilbake til listen der søknadens status nå vises som avslag", async () => {
+    stubSoknaderMedMuterbarTilstand(mockSoknaderResponse.soknader);
+
+    renderUtenlandsoppholdSoknad(
+      soknadUtenVedtakMock.soknadId,
+      utenlandsoppholdPath,
+    );
+
+    expect(await screen.findByRole("button", { name: "Start behandling" })).to
+      .exist;
+
+    await clickButton("Start behandling");
+
+    await clickRadio("Avslag: Avslå hele perioden");
+
+    await screen.findByRole("button", { name: "Send vedtak" });
+    await clickButton("Send vedtak");
+
+    expect(
+      await screen.findByText(
+        "Vedtaket om utenlandsopphold utenfor EØS er fattet og sendt til bruker. Dokumentet er journalført i Gosys.",
+      ),
+    ).to.exist;
+    expect(screen.queryByText("Fant ikke søknaden")).to.not.exist;
+    expect(screen.queryByRole("button", { name: "Start behandling" })).to.not
+      .exist;
+    expect(await screen.findAllByText("Avslag")).to.have.lengthOf(1);
     expect(
       await screen.findAllByText(
         new RegExp(`^Behandlet .* av ${VEILEDER_DEFAULT.ident}$`),
@@ -205,14 +179,14 @@ describe("UtenlandsoppholdSoknad", () => {
 
     renderUtenlandsoppholdSoknad();
 
-    await screen.findByRole("button", { name: "Godkjenn og send vedtak" });
-    await clickButton("Godkjenn og send vedtak");
+    await screen.findByRole("button", { name: "Send vedtak" });
+    await clickRadio("Innvilgelse: Godkjenn hele perioden");
+    await clickButton("Send vedtak");
 
     await waitFor(() => {
       const vedtakMutation = queryClient.getMutationCache().getAll().pop();
       expect(vedtakMutation?.state.status).to.equal("error");
     });
-    expect(screen.getByRole("button", { name: "Godkjenn og send vedtak" })).to
-      .exist;
+    expect(screen.getByRole("button", { name: "Send vedtak" })).to.exist;
   });
 });

--- a/test/utenlandsopphold/UtenlandsoppholdSoknaderTest.tsx
+++ b/test/utenlandsopphold/UtenlandsoppholdSoknaderTest.tsx
@@ -2,12 +2,8 @@ import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
-import { http, HttpResponse } from "msw";
-import { mockServer } from "../setup";
 import { queryClientWithMockData } from "../testQueryClient";
-import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
 import { UtenlandsoppholdSoknader } from "@/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx";
-import { SoknaderResponseDTO } from "@/data/utenlandsopphold/utenlandsoppholdTypes";
 import { utenlandsoppholdQueryKeys } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
 import {
   mockSoknaderResponse,
@@ -22,6 +18,7 @@ import {
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
 import { MemoryRouter } from "react-router-dom";
 import { NotificationProvider } from "@/context/notification/NotificationContext";
+import { stubSoknaderQuery } from "../stubs/stubIsutenlandsopphold";
 
 let queryClient: QueryClient;
 
@@ -34,13 +31,6 @@ const renderUtenlandsopphold = () =>
         </NotificationProvider>
       </MemoryRouter>
     </QueryClientProvider>,
-  );
-
-const stubSoknaderQuery = (response: SoknaderResponseDTO) =>
-  mockServer.use(
-    http.post(`*${ISUTENLANDSOPPHOLD_ROOT}/soknader/query`, () =>
-      HttpResponse.json(response),
-    ),
   );
 
 describe("UtenlandsoppholdSoknader", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,10 +1,12 @@
 import { defineConfig } from "vitest/config";
 import svgr from "vite-plugin-svgr";
+import path from "path";
 
 export default defineConfig({
   resolve: {
     tsconfigPaths: true,
   },
+  envDir: path.resolve(__dirname, "test"),
   plugins: [svgr({ include: "**/*.svg" })],
   test: {
     globals: true,


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Dro ut Avslag her i starten ettersom den var lettest (uten datepicker). Tror dette er et greit utgangspunkt. La inn en egen feature-toggle for å kunne pushe dette til prod uten at det blir tilgjengelig for de som har "innvilget" tilgjengelig. Jeg tok meg også noen friheter på å deler av designet.

- Lagt inn støtte for å velge radioknapp med Avslag --> Sånn det er lagt opp nå vil de i prod kun få ett radio-valg, som er innvilgelse. Regner med dette er greit, hvis ikke hadde det blitt en del if-else for å sjekke på toggelen rundt omkring
- Jeg la til info om når søknaden er sendt inn. Dette står i oversiktslisten, men ikke når man gå inn på selve søknaden for å fatte vedtaket, som jeg tenker er rart
- Oppdaterte teksten i alerten over hva som kan håndteres i Modia og hva som kan håndteres i Infotrygd.
- Nye tester og litt opprydning i testoppsettet
- La til den samme greia som jeg gjorde i [syfooversikt](https://github.com/navikt/syfooversikt/pull/815) for at copilot kan kjøre testene lokalt

- [x] Testet i dev at innvilget fortsatt funker

Hva som gjenstår (i fremtidige PRer):
- Siden burde håndteres som et skjema/"form" der man har validering på radioknappene, feks at man ikke kan trykke "Send vedtak" uten å ha valgt en radioknapp, med tilsvarende feilmeldinger som vi har på de andre sidene våre.
- Legge inn riktig dokumenttekster for avslag, per nå bruker den bare Innvilget-brevet

### Screenshots 📸✨

Vedtaksiden før:
<img width="1181" height="546" alt="image" src="https://github.com/user-attachments/assets/0a4f2f48-096c-4f75-a3e6-5ca1ccdf5ad4" />


Vedtaksiden nå:
<img width="1403" height="687" alt="image" src="https://github.com/user-attachments/assets/e01d9be3-efca-4213-81ef-7ffefdff943f" />

Oversikt over søknader, med oppdatert status:
<img width="1173" height="399" alt="image" src="https://github.com/user-attachments/assets/6cbb9fd8-92c8-45bc-947c-b502975e40dd" />

Dersom den allerede er behandlet:
<img width="1405" height="648" alt="image" src="https://github.com/user-attachments/assets/df7cbddd-b790-4ad8-bf42-11881a1d24c3" />

