### PR TITLE
IS-4151: Justering av datetime-handling for isutenlandsopphold

### DIFF
--- a/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
+++ b/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
@@ -14,7 +14,7 @@ export const soknadUtenVedtakMock: SoknadDTO = {
   soknadId: "1a2b3c4d-5e6f-7890-abcd-ef0987654321",
   eksternId: "e16ff778-8475-47e1-b5dc-d2ce4ad6b9ee",
   status: SoknadStatusDTO.MOTTATT,
-  innsendtTidspunkt: "2026-05-15T08:30:00Z",
+  innsendtTidspunkt: "2026-05-15T08:30:00",
   soktePerioder: [
     {
       fom: "2026-06-01",
@@ -32,7 +32,7 @@ export const soknadMedVedtakMock: SoknadDTO = {
   soknadId: "9b1c2d3e-4f56-7890-abcd-ef1234567890",
   eksternId: "1735b402-f937-4958-8aa2-fe36aef70826",
   status: SoknadStatusDTO.INNVILGET,
-  innsendtTidspunkt: "2026-03-01T09:00:00Z",
+  innsendtTidspunkt: "2026-03-01T09:00:00",
   soktePerioder: [
     {
       fom: "2026-04-01",
@@ -48,7 +48,7 @@ export const soknadMedVedtakMock: SoknadDTO = {
       },
     ],
     fattetAv: "Z990000",
-    fattetTidspunkt: "2026-03-02T11:00:00Z",
+    fattetTidspunkt: "2026-03-02T11:00:00",
   },
 };
 
@@ -77,7 +77,7 @@ export function byggOppdatertSoknadMedVedtak(
       utfall: vedtak.utfall,
       innvilgedePerioder: vedtak.innvilgedePerioder,
       fattetAv,
-      fattetTidspunkt: dayjs().toISOString(),
+      fattetTidspunkt: dayjs().format("YYYY-MM-DDTHH:mm:ss"),
     },
   };
 }

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx
@@ -8,7 +8,6 @@ import {
 import {
   tilLesbarDatoMedArUtenManedNavn,
   tilLesbarPeriodeMedArUtenManednavn,
-  toDatePrettyPrint,
 } from "@/utils/datoUtils";
 import { Link } from "react-router-dom";
 import { useNotification } from "@/context/notification/NotificationContext.tsx";
@@ -20,7 +19,7 @@ const texts = {
   periode: "Søkt periode",
   saksbehandling: "Saksbehandling",
   saksbehandlingVedtak: (fattetTidspunkt: Date, fattetAv: string) =>
-    `Behandlet ${toDatePrettyPrint(fattetTidspunkt)} av ${fattetAv}`,
+    `Behandlet ${tilLesbarDatoMedArUtenManedNavn(fattetTidspunkt)} av ${fattetAv}`,
   saksbehandlingIngenVedtak: "Ubehandlet",
   status: "Status",
   startBehandling: "Start behandling",

--- a/test/utenlandsopphold/UtenlandsoppholdSoknaderTest.tsx
+++ b/test/utenlandsopphold/UtenlandsoppholdSoknaderTest.tsx
@@ -13,7 +13,6 @@ import {
 import {
   tilLesbarDatoMedArUtenManedNavn,
   tilLesbarPeriodeMedArUtenManednavn,
-  toDatePrettyPrint,
 } from "@/utils/datoUtils";
 import { ARBEIDSTAKER_DEFAULT } from "@/mocks/common/mockConstants";
 import { MemoryRouter } from "react-router-dom";
@@ -117,7 +116,7 @@ describe("UtenlandsoppholdSoknader", () => {
 
     expect(
       await screen.findByText(
-        `Behandlet ${toDatePrettyPrint(
+        `Behandlet ${tilLesbarDatoMedArUtenManedNavn(
           soknadMedVedtakMock.vedtak!.fattetTidspunkt,
         )} av ${soknadMedVedtakMock.vedtak!.fattetAv}`,
       ),


### PR DESCRIPTION
Ref: https://github.com/navikt/isutenlandsopphold/pull/53

Mest for å sikre at mock-data samsvarer med hva som faktisk kommer fra backend


