### PR TITLE
IS-4159: add warning gammelt format oppfølgingsplan

### DIFF
--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/GammeltFormatWarning.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/GammeltFormatWarning.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Link, LocalAlert } from "@navikt/ds-react";
+
+const texts = {
+  title:
+    "Fra og med 1. september vises ikke lenger oppfølgingsplaner i gammelt format i Modia!",
+  lenke: "Ny oppfølgingsplan ble lansert 27. april (åpner i ny fane)",
+  content:
+    ", og fra 31. juli var det ikke lenger mulig å sende inn oppfølgingsplan på det gamle formatet på nav.no. Fra og med 1. september vil ikke historiske oppfølgingsplaner på det gamle formatet vises i Modia SYFO, men de vil fortsatt være tilgjengelige i Gosys.",
+};
+
+const lenke =
+  "https://navno.sharepoint.com/sites/fag-og-ytelser-arbeid-sykefravarsoppfolging-og-sykepenger/SitePages/Oppf%C3%B8lgingsplanen-lanseres-nasjonalt-27.-april.aspx?web=1";
+
+export function GammeltFormatWarning() {
+  return (
+    <LocalAlert status="announcement" className="mb-6">
+      <LocalAlert.Header>
+        <LocalAlert.Title>{texts.title}</LocalAlert.Title>
+      </LocalAlert.Header>
+      <LocalAlert.Content>
+        <Link href={lenke} inlineText target="_blank" rel="noopener noreferrer">
+          {texts.lenke}
+        </Link>
+        {texts.content}
+      </LocalAlert.Content>
+    </LocalAlert>
+  );
+}

--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/OppfolgingsplanerOversikt.tsx
@@ -20,6 +20,7 @@ import { oppfolgingsplanSurvey } from "@/components/lumi/oppfolgingsplanSurvey";
 import { useOppfolgingsplaner } from "@/sider/oppfolgingsplan/hooks/useOppfolgingsplaner";
 import { useOppfolgingstilfellePersonQuery } from "@/data/oppfolgingstilfelle/person/oppfolgingstilfellePersonQueryHooks.ts";
 import { EksternLenke } from "@/components/EksternLenke.tsx";
+import { GammeltFormatWarning } from "@/sider/oppfolgingsplan/oppfolgingsplaner/GammeltFormatWarning.tsx";
 
 const texts = {
   pageTitle: "Oppfølgingsplaner",
@@ -110,6 +111,7 @@ export default function OppfolgingsplanerOversikt() {
     >
       <SideLaster isLoading={isLoading} isError={isError}>
         <Sidetopp tittel={texts.pageTitle} />
+        <GammeltFormatWarning />
         <Tredelt.Container className="-xl:flex-col-reverse">
           <Tredelt.FirstColumn className="-xl:mb-2">
             <AktiveOppfolgingsplaner


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Lagt til warning om at oppfølgingsplaner i gammelt format ikke lenger vises i Modia

### Screenshots 📸✨
<img width="1414" height="645" alt="Skjermbilde 2026-08-06 kl  12 57 40" src="https://github.com/user-attachments/assets/98ff86f1-0e45-45a4-a71e-dc455d2177e8" />

