### PR TITLE
IS-4150: Add Delvis Innvilget option

### DIFF
--- a/src/data/utenlandsopphold/utenlandsoppholdQueryHooks.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdQueryHooks.ts
@@ -41,12 +41,13 @@ export const useVedtakMutation = () => {
   const path = (soknadId: string) =>
     `${ISUTENLANDSOPPHOLD_ROOT}/soknader/${soknadId}/vedtak`;
   const postVedtak = ({
-    soknadId,
+    soknadIdPathParam,
     vedtak,
   }: {
-    soknadId: string;
+    soknadIdPathParam: string;
     vedtak: SoknadVedtakPostDTO;
-  }) => post<SoknadVedtakResponseDTO>(path(soknadId), vedtak, personident);
+  }) =>
+    post<SoknadVedtakResponseDTO>(path(soknadIdPathParam), vedtak, personident);
 
   return useMutation({
     mutationFn: postVedtak,

--- a/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
@@ -1,5 +1,5 @@
-// DTOs
 import { DocumentComponentDto } from "@/data/documentcomponent/documentComponentTypes.ts";
+import { addDays } from "@/utils/datoUtils.ts";
 
 export interface SoknaderQueryDTO {
   personident: string;
@@ -43,11 +43,12 @@ export interface VedtakDTO {
 export enum SoknadStatusDTO {
   MOTTATT = "MOTTATT",
   INNVILGET = "INNVILGET",
+  DELVIS_INNVILGET = "DELVIS_INNVILGET",
   AVSLAG = "AVSLAG",
 }
 
 // Types
-export type Utfall = "INNVILGET" | "AVSLAG";
+export type Utfall = "INNVILGET" | "DELVIS_INNVILGET" | "AVSLAG";
 
 export interface Soknad extends Omit<
   SoknadDTO,
@@ -90,3 +91,59 @@ export const parseSoknad = (soknad: SoknadDTO): Soknad => ({
   soktePerioder: soknad.soktePerioder.map(parsePeriode),
   vedtak: soknad.vedtak ? parseVedtak(soknad.vedtak) : null,
 });
+
+/**
+ * Trekker en enkelt periode (`fratrekk`) fra en annen periode (`periode`),
+ * og returnerer de(n) resterende delen(e). Kan returnere 0, 1 eller 2
+ * perioder, avhengig av om `fratrekk` overlapper starten, slutten, midten
+ * eller ingen del av `periode`.
+ */
+function trekkFraPeriode(periode: Periode, fratrekk: Periode): Periode[] {
+  const ingenOverlapp =
+    fratrekk.tom < periode.fom || fratrekk.fom > periode.tom;
+  if (ingenOverlapp) {
+    return [periode];
+  }
+
+  const gjenvarendePerioder: Periode[] = [];
+  if (fratrekk.fom > periode.fom) {
+    gjenvarendePerioder.push({
+      fom: periode.fom,
+      tom: addDays(fratrekk.fom, -1),
+    });
+  }
+  if (fratrekk.tom < periode.tom) {
+    gjenvarendePerioder.push({
+      fom: addDays(fratrekk.tom, 1),
+      tom: periode.tom,
+    });
+  }
+  return gjenvarendePerioder;
+}
+
+/**
+ * Beregner hvilke deler av `soktePerioder` som ikke er dekket av
+ * `innvilgedePerioder`, altså de periodene som blir avslått ved en
+ * delvis innvilgelse. Perioder i `innvilgedePerioder` med manglende
+ * `fom`/`tom` ignoreres.
+ */
+export function beregnAvslattePerioder(
+  soktePerioder: Periode[],
+  innvilgedePerioder: { fom?: Date; tom?: Date }[],
+): Periode[] {
+  const gyldigeInnvilgedePerioder = innvilgedePerioder.filter(
+    (periode): periode is Periode => !!periode.fom && !!periode.tom,
+  );
+
+  return soktePerioder.flatMap((soktPeriode) =>
+    gyldigeInnvilgedePerioder
+      .reduce(
+        (gjenvarendePerioder, innvilgetPeriode) =>
+          gjenvarendePerioder.flatMap((periode) =>
+            trekkFraPeriode(periode, innvilgetPeriode),
+          ),
+        [soktPeriode],
+      )
+      .filter((periode) => periode.fom <= periode.tom),
+  );
+}

--- a/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
+++ b/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
@@ -72,7 +72,9 @@ export function byggOppdatertSoknadMedVedtak(
     status:
       vedtak.utfall === "INNVILGET"
         ? SoknadStatusDTO.INNVILGET
-        : SoknadStatusDTO.AVSLAG,
+        : vedtak.utfall === "DELVIS_INNVILGET"
+          ? SoknadStatusDTO.DELVIS_INNVILGET
+          : SoknadStatusDTO.AVSLAG,
     vedtak: {
       utfall: vedtak.utfall,
       innvilgedePerioder: vedtak.innvilgedePerioder,

--- a/src/sider/utenlandsopphold/DelvisInnvilgelsePeriodeDatepicker.tsx
+++ b/src/sider/utenlandsopphold/DelvisInnvilgelsePeriodeDatepicker.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect } from "react";
+import { Button, DatePicker, useRangeDatepicker } from "@navikt/ds-react";
+import { PlusIcon, TrashIcon } from "@navikt/aksel-icons";
+import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import { Periode } from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
+import { addDays } from "@/utils/datoUtils.ts";
+
+const texts = {
+  fomLabel: "Fra og med dato",
+  tomLabel: "Til og med dato",
+  missingPeriode: "Vennligst angi periode",
+  periodeKryssesIkkeSoktePerioder:
+    "Perioden kan ikke krysse datoer det ikke er søkt om",
+  periodeOverlapperAnnenPeriode:
+    "Perioden kan ikke overlappe med en annen periode du har lagt til",
+  fjernPeriode: "Fjern periode",
+  leggTilPeriode: "Legg til flere godkjente perioder",
+};
+
+interface Hull {
+  from: Date;
+  to: Date;
+}
+
+interface Props {
+  soktePerioder: Periode[];
+}
+
+/**
+ * En eller flere datepickere i range-modus for å velge de periodene som skal
+ * delvis innvilges, innenfor de faktiske søkte periodene. Dager utenfor
+ * `soktePerioder`, inkludert eventuelle "hull" mellom flere søkte perioder,
+ * er deaktivert og kan ikke velges i kalenderen. I tillegg valideres hver
+ * periode, slik at den heller ikke kan angis ved å skrive datoer direkte inn
+ * i input-feltene, og slik at periodene brukeren legger til ikke kan
+ * overlappe hverandre.
+ */
+export function DelvisInnvilgelsePeriodeDatepicker({ soktePerioder }: Props) {
+  const { control, trigger } = useFormContext();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: "innvilgedePerioder",
+  });
+
+  // Vi legger til en rad med datepickers slik at brukeren alltid har minst én rad å fylle ut fra starten
+  useEffect(() => {
+    if (fields.length === 0) {
+      append({ fom: undefined, tom: undefined });
+    }
+  }, [fields.length, append]);
+
+  const sortertePerioder = [...soktePerioder].sort(
+    (a, b) => a.fom.getTime() - b.fom.getTime(),
+  );
+  const fromDate = sortertePerioder[0].fom;
+  const toDate = sortertePerioder[sortertePerioder.length - 1].tom;
+  const hull = sortertePerioder
+    .slice(1)
+    .map((periode, index) => ({
+      from: addDays(sortertePerioder[index].tom, 1),
+      to: addDays(periode.fom, -1),
+    }))
+    // Hvis to søkte perioder ligger inntil hverandre uten noe faktisk hull
+    // mellom seg, vil "from" bli senere enn "to" over. Denne må filtreres
+    // bort, ellers vil den inverterte rangen feilaktig blokkere/validere
+    // bort gyldige datoer som faktisk er dekket av de søkte periodene.
+    .filter((periode) => periode.from <= periode.to);
+
+  function revaliderAllePerioder() {
+    trigger(
+      fields.flatMap((_, index) => [
+        `innvilgedePerioder.${index}.fom`,
+        `innvilgedePerioder.${index}.tom`,
+      ]),
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {fields.map((field, index) => (
+        <DelvisInnvilgetPeriodeRad
+          key={field.id}
+          index={index}
+          fromDate={fromDate}
+          toDate={toDate}
+          hull={hull}
+          onPeriodeEndret={revaliderAllePerioder}
+          onFjern={fields.length > 1 ? () => remove(index) : undefined}
+        />
+      ))}
+      <div>
+        <Button
+          type="button"
+          variant="tertiary"
+          size="xsmall"
+          icon={<PlusIcon title="Pluss ikon" />}
+          onClick={() => append({ fom: undefined, tom: undefined })}
+        >
+          {texts.leggTilPeriode}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+interface RadProps {
+  index: number;
+  fromDate: Date;
+  toDate: Date;
+  hull: Hull[];
+  onPeriodeEndret: () => void;
+  onFjern?: () => void;
+}
+
+function DelvisInnvilgetPeriodeRad({
+  index,
+  fromDate,
+  toDate,
+  hull,
+  onPeriodeEndret,
+  onFjern,
+}: RadProps) {
+  const { control, getValues } = useFormContext();
+  const fomName = `innvilgedePerioder.${index}.fom`;
+  const tomName = `innvilgedePerioder.${index}.tom`;
+
+  function krysserHull(fom?: Date, tom?: Date) {
+    return (
+      !!fom &&
+      !!tom &&
+      hull.some((periode) => fom <= periode.to && tom >= periode.from)
+    );
+  }
+
+  function overlapperAnnenPeriode(fom?: Date, tom?: Date) {
+    if (!fom || !tom) {
+      return false;
+    }
+    const allePerioder: { fom?: Date; tom?: Date }[] =
+      getValues("innvilgedePerioder") ?? [];
+    return allePerioder.some(
+      (periode, periodeIndex) =>
+        periodeIndex !== index &&
+        periode.fom &&
+        periode.tom &&
+        fom <= periode.tom &&
+        periode.fom <= tom,
+    );
+  }
+
+  function validerPeriode(fom?: Date, tom?: Date) {
+    if (krysserHull(fom, tom)) {
+      return texts.periodeKryssesIkkeSoktePerioder;
+    }
+    if (overlapperAnnenPeriode(fom, tom)) {
+      return texts.periodeOverlapperAnnenPeriode;
+    }
+    return true;
+  }
+
+  const { field: fomField, fieldState: fomFieldState } = useController({
+    name: fomName,
+    control,
+    rules: {
+      required: texts.missingPeriode,
+      validate: (fom: Date) => validerPeriode(fom, getValues(tomName)),
+    },
+  });
+  const { field: tomField, fieldState: tomFieldState } = useController({
+    name: tomName,
+    control,
+    rules: {
+      required: texts.missingPeriode,
+      validate: (tom: Date) => validerPeriode(getValues(fomName), tom),
+    },
+  });
+
+  const { datepickerProps, fromInputProps, toInputProps } = useRangeDatepicker({
+    fromDate,
+    toDate,
+    disabled: hull,
+    onRangeChange: (range) => {
+      fomField.onChange(range?.from);
+      tomField.onChange(range?.to);
+      onPeriodeEndret();
+    },
+  });
+
+  return (
+    <div className="flex flex-row items-end gap-4">
+      <DatePicker {...datepickerProps} strategy="fixed" showWeekNumber>
+        <div className="flex flex-row gap-4">
+          <DatePicker.Input
+            {...fromInputProps}
+            label={texts.fomLabel}
+            size="small"
+            error={fomFieldState.error?.message}
+          />
+          <DatePicker.Input
+            {...toInputProps}
+            label={texts.tomLabel}
+            size="small"
+            error={tomFieldState.error?.message}
+          />
+        </div>
+      </DatePicker>
+      {onFjern && (
+        <Button
+          className="mb-1"
+          type="button"
+          variant="tertiary"
+          size="small"
+          icon={<TrashIcon title="Slett ikon" />}
+          onClick={onFjern}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
@@ -1,15 +1,18 @@
 import React from "react";
-import { useForm } from "react-hook-form";
+import dayjs from "dayjs";
+import { FormProvider, useForm } from "react-hook-form";
 import {
   Alert,
   BodyShort,
   Box,
   Button,
+  InlineMessage,
   Loader,
   LocalAlert,
   Radio,
   RadioGroup,
 } from "@navikt/ds-react";
+import { DelvisInnvilgelsePeriodeDatepicker } from "@/sider/utenlandsopphold/DelvisInnvilgelsePeriodeDatepicker.tsx";
 import {
   useSoknaderQuery,
   useVedtakMutation,
@@ -24,6 +27,7 @@ import { useUtenlandsoppholdSoknadDocument } from "@/hooks/utenlandsopphold/useU
 import { useNotification } from "@/context/notification/NotificationContext.tsx";
 import { utenlandsoppholdPath } from "@/AppRouter.tsx";
 import {
+  beregnAvslattePerioder,
   SoknadStatusDTO,
   Utfall,
 } from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
@@ -34,22 +38,24 @@ const texts = {
   error: "Noe gikk galt ved henting av søknader. Vennligst prøv igjen senere.",
   didNotFindSoknad: "Fant ikke søknaden",
   modiaWarningHeader: "Begrenset behandling i Modia",
-  modiaWarningContent(isAvslagEnabled: boolean): string {
-    if (isAvslagEnabled) {
-      return "Det er kun mulig med utfallene 'innvilgelse' eller 'avslag' på søknaden her i Modia. Dersom søknaden skal delvis innvilges, må vedtaket fattes i Infotrygd som tidligere.";
-    } else {
-      return "Det er kun mulig med utfallet 'innvilgelse' på søknaden her i Modia. Dersom søknaden skal delvis innvilges eller avslås, må vedtaket fattes i Infotrygd som tidligere.";
-    }
-  },
+  modiaWarningContent:
+    "Det er kun mulig med utfallet 'innvilgelse' på søknaden her i Modia. Dersom søknaden skal delvis innvilges eller avslås, må vedtaket fattes i Infotrygd som tidligere.",
   goToSoknad: "Vis hele søknaden",
   soknadTidspunkt: "Søknaden ble innsendt:",
   singlePeriod: "Perioden det er søkt om:",
   multiplePeriods: "Periodene det er søkt om:",
-  innvilgelse: "Innvilgelse: Godkjenn hele perioden",
-  avslag: "Avslag: Avslå hele perioden",
-  sendButton: "Send vedtak",
-  previewContentLabel: "Forhåndsvisning",
-  backButton: "Tilbake",
+  radioButtons: {
+    innvilgelse: "Innvilgelse: Godkjenn hele perioden",
+    delvisInnvilgelse: "Delvis innvilgelse: Godkjenn deler av perioden",
+    avslag: "Avslag: Avslå hele perioden",
+  },
+  buttons: {
+    sendButton: "Send vedtak",
+    previewContentLabel: "Forhåndsvisning",
+    backButton: "Tilbake",
+  },
+  ingenAvslattePerioderWarning:
+    "Du har valgt å innvilge alle perioder. Velg 'Innvilgelse' som utfall i stedet for 'Delvis innvilgelse'",
   vedtakFattetNotification:
     "Vedtaket om utenlandsopphold utenfor EØS er fattet og sendt til bruker. Dokumentet er journalført i Gosys.",
   alertBehandlet: "Denne søknaden er allerede behandlet av",
@@ -57,45 +63,72 @@ const texts = {
 };
 
 // En midlertidig lokal feature-toggle, frem til vi har fått brevmaler på plass
-const isAvslagEnabled = erLokal();
+const isAvslagAndDelvisInnvilgelseEnabled = erLokal();
+
+interface InnvilgetPeriode {
+  fom?: Date;
+  tom?: Date;
+}
 
 interface SkjemaValues {
   utfall: Utfall;
+  innvilgedePerioder: InnvilgetPeriode[];
 }
 
 export function UtenlandsoppholdSoknad() {
   const { data, isPending, isError } = useSoknaderQuery();
   const { mutate, isPending: mutateIsPending } = useVedtakMutation();
   const { getVedtakDocument } = useUtenlandsoppholdSoknadDocument();
+  const formMethods = useForm<SkjemaValues>({
+    defaultValues: { innvilgedePerioder: [] },
+  });
   const {
     register,
     handleSubmit,
+    setValue,
+    clearErrors,
+    watch,
     formState: { errors },
-  } = useForm<SkjemaValues>();
+  } = formMethods;
 
   const navigate = useNavigate();
   const { setNotification } = useNotification();
+  const valgtUtfall = watch("utfall");
+  const valgteInnvilgedePerioder = watch("innvilgedePerioder");
+
+  function handleUtfallChange(utfall: Utfall) {
+    if (utfall === "INNVILGET") {
+      setValue(
+        "innvilgedePerioder",
+        soktePerioder.map((periode) => ({
+          fom: periode.fom,
+          tom: periode.tom,
+        })),
+      );
+    } else {
+      // Resetter denne når man velger DELVIS_INNVILGET eller AVSLAG
+      setValue("innvilgedePerioder", []);
+    }
+    clearErrors("innvilgedePerioder");
+  }
 
   function submit(soknadId: string, values: SkjemaValues) {
-    const { utfall } = values;
-    const innvilgedePerioder =
-      utfall === "INNVILGET"
-        ? soktePerioder.map((periode) => ({
-            fom: periode.fom.toISOString(),
-            tom: periode.tom.toISOString(),
-          }))
-        : utfall === "AVSLAG" // For å være eksplisitt
-          ? []
-          : [];
-    const requestDTO = {
-      soknadId: soknadId,
+    const { utfall, innvilgedePerioder } = values;
+    const perioder = innvilgedePerioder
+      .filter((periode) => periode.fom && periode.tom)
+      .map((periode) => ({
+        fom: dayjs(periode.fom).format("YYYY-MM-DD"),
+        tom: dayjs(periode.tom).format("YYYY-MM-DD"),
+      }));
+    const request = {
+      soknadIdPathParam: soknadId,
       vedtak: {
         utfall: utfall,
-        innvilgedePerioder: innvilgedePerioder,
+        innvilgedePerioder: perioder,
         document: vedtakDocument, // TODO: Må oppdateres basert på utfall
       },
     };
-    mutate(requestDTO, {
+    mutate(request, {
       onSuccess: () => {
         setNotification({
           message: texts.vedtakFattetNotification,
@@ -136,6 +169,10 @@ export function UtenlandsoppholdSoknad() {
   const soktePerioder = utenlandsoppholdSoknad.soktePerioder;
   const periodText =
     soktePerioder.length > 1 ? texts.multiplePeriods : texts.singlePeriod;
+  const avslattePerioder =
+    valgtUtfall === "DELVIS_INNVILGET"
+      ? beregnAvslattePerioder(soktePerioder, valgteInnvilgedePerioder)
+      : [];
   const vedtakDocument = getVedtakDocument({
     soknadDato: utenlandsoppholdSoknad.innsendtTidspunkt,
     perioder: utenlandsoppholdSoknad.soktePerioder,
@@ -144,14 +181,14 @@ export function UtenlandsoppholdSoknad() {
   return (
     <Box background="default" padding="space-16" className="flex flex-col">
       <div className={"flex flex-col gap-8"}>
-        <LocalAlert status={"warning"}>
-          <LocalAlert.Header>
-            <LocalAlert.Title>{texts.modiaWarningHeader}</LocalAlert.Title>
-          </LocalAlert.Header>
-          <LocalAlert.Content>
-            {texts.modiaWarningContent(isAvslagEnabled)}
-          </LocalAlert.Content>
-        </LocalAlert>
+        {!isAvslagAndDelvisInnvilgelseEnabled && (
+          <LocalAlert status={"warning"}>
+            <LocalAlert.Header>
+              <LocalAlert.Title>{texts.modiaWarningHeader}</LocalAlert.Title>
+            </LocalAlert.Header>
+            <LocalAlert.Content>{texts.modiaWarningContent}</LocalAlert.Content>
+          </LocalAlert>
+        )}
 
         <BodyShort>
           {texts.soknadTidspunkt}{" "}
@@ -164,7 +201,7 @@ export function UtenlandsoppholdSoknad() {
           <Button
             as={Link}
             to={`/sykefravaer/sykepengesoknader/${utenlandsoppholdSoknad.eksternId}`}
-            size="medium"
+            size="small"
             variant="secondary"
           >
             {texts.goToSoknad}
@@ -172,9 +209,11 @@ export function UtenlandsoppholdSoknad() {
         </div>
 
         <div>
-          <BodyShort>{periodText}</BodyShort>
+          <BodyShort size="small" weight="semibold">
+            {periodText}
+          </BodyShort>
           {utenlandsoppholdSoknad.soktePerioder.map((periode, index) => (
-            <BodyShort key={index} weight={"semibold"}>
+            <BodyShort key={index} size="small">
               {tilLesbarPeriodeMedArUtenManednavn(periode.fom, periode.tom)}
             </BodyShort>
           ))}
@@ -194,49 +233,93 @@ export function UtenlandsoppholdSoknad() {
               to={`/sykefravaer/utenlandsopphold`}
               variant="primary"
             >
-              {texts.backButton}
+              {texts.buttons.backButton}
             </Button>
           </>
         )}
 
-        <div className="flex flex-col gap-4">
-          {!soknadBehandlet && (
+        {!soknadBehandlet && (
+          <FormProvider {...formMethods}>
             <form
               onSubmit={handleSubmit((values) =>
                 submit(utenlandsoppholdSoknad.soknadId, values),
               )}
-              className="flex flex-col gap-4"
+              className="flex flex-col gap-8"
             >
               <RadioGroup
                 legend={"Velg utfall"}
                 name="utfall"
+                size="small"
                 error={errors.utfall && texts.missingUtfall}
+                onChange={handleUtfallChange}
               >
                 <Radio
                   value={"INNVILGET"}
                   {...register("utfall", { required: true })}
                 >
-                  {texts.innvilgelse}
+                  {texts.radioButtons.innvilgelse}
                 </Radio>
-                {isAvslagEnabled && (
-                  <Radio
-                    value={"AVSLAG"}
-                    {...register("utfall", { required: true })}
-                  >
-                    {texts.avslag}
-                  </Radio>
+                {isAvslagAndDelvisInnvilgelseEnabled && (
+                  <>
+                    <Radio
+                      value={"DELVIS_INNVILGET"}
+                      {...register("utfall", { required: true })}
+                    >
+                      {texts.radioButtons.delvisInnvilgelse}
+                    </Radio>
+                    <Radio
+                      value={"AVSLAG"}
+                      {...register("utfall", { required: true })}
+                    >
+                      {texts.radioButtons.avslag}
+                    </Radio>
+                  </>
                 )}
               </RadioGroup>
+              {valgtUtfall === "DELVIS_INNVILGET" && (
+                <Box className="flex flex-col gap-4">
+                  <BodyShort size="small" weight="semibold">
+                    Velg perioden som skal godkjennes
+                  </BodyShort>
+                  <Box className="flex flex-row gap-20">
+                    <DelvisInnvilgelsePeriodeDatepicker
+                      soktePerioder={soktePerioder}
+                    />
+                    {valgteInnvilgedePerioder.every(
+                      (periode) => periode.tom,
+                    ) && (
+                      <div>
+                        <BodyShort size="small" weight="semibold">
+                          Periodene som avslås:
+                        </BodyShort>
+                        {avslattePerioder.map((periode, index) => (
+                          <BodyShort key={index} size="small">
+                            {tilLesbarPeriodeMedArUtenManednavn(
+                              periode.fom,
+                              periode.tom,
+                            )}
+                          </BodyShort>
+                        ))}
+                      </div>
+                    )}
+                  </Box>
+                  {avslattePerioder.length === 0 && (
+                    <InlineMessage status="warning" size="small">
+                      {texts.ingenAvslattePerioderWarning}
+                    </InlineMessage>
+                  )}
+                </Box>
+              )}
               <div className="flex flex-row gap-4">
                 <Button
                   variant="primary"
                   type="submit"
                   loading={mutateIsPending}
                 >
-                  {texts.sendButton}
+                  {texts.buttons.sendButton}
                 </Button>
                 <Forhandsvisning
-                  contentLabel={texts.previewContentLabel}
+                  contentLabel={texts.buttons.previewContentLabel}
                   getDocumentComponents={() => vedtakDocument}
                 />
                 <Button
@@ -244,12 +327,12 @@ export function UtenlandsoppholdSoknad() {
                   to={`/sykefravaer/utenlandsopphold`}
                   variant="tertiary"
                 >
-                  {texts.backButton}
+                  {texts.buttons.backButton}
                 </Button>
               </div>
             </form>
-          )}
-        </div>
+          </FormProvider>
+        )}
       </div>
     </Box>
   );

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx
@@ -29,6 +29,7 @@ const texts = {
 const statusTexts: { [key in SoknadStatusDTO]: string } = {
   [SoknadStatusDTO.MOTTATT]: "Mottatt",
   [SoknadStatusDTO.INNVILGET]: "Innvilget",
+  [SoknadStatusDTO.DELVIS_INNVILGET]: "Delvis innvilget",
   [SoknadStatusDTO.AVSLAG]: "Avslag",
 };
 

--- a/test/utenlandsopphold/UtenlandsoppholdSoknadTest.tsx
+++ b/test/utenlandsopphold/UtenlandsoppholdSoknadTest.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import { http, HttpResponse } from "msw";
 import { mockServer } from "../setup";
@@ -9,6 +10,7 @@ import { ISUTENLANDSOPPHOLD_ROOT } from "@/apiConstants";
 import { UtenlandsoppholdSoknad } from "@/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx";
 import { UtenlandsoppholdSoknader } from "@/sider/utenlandsopphold/UtenlandsoppholdSoknader.tsx";
 import { utenlandsoppholdQueryKeys } from "@/data/utenlandsopphold/utenlandsoppholdQueryHooks";
+import { SoknadVedtakPostDTO } from "@/data/utenlandsopphold/utenlandsoppholdTypes";
 import {
   ARBEIDSTAKER_DEFAULT,
   VEILEDER_DEFAULT,
@@ -21,7 +23,12 @@ import {
   soknadUtenVedtakMock,
 } from "@/mocks/isutenlandsopphold/mockIsutenlandsopphold";
 import { utenlandsoppholdPath } from "@/AppRouter.tsx";
-import { clickButton, clickRadio } from "../testUtils";
+import {
+  changeTextInput,
+  clickButton,
+  clickRadio,
+  getTextInput,
+} from "../testUtils";
 import {
   stubSoknaderMedMuterbarTilstand,
   stubSoknaderQuery,
@@ -166,6 +173,266 @@ describe("UtenlandsoppholdSoknad", () => {
         new RegExp(`^Behandlet .* av ${VEILEDER_DEFAULT.ident}$`),
       ),
     ).to.have.lengthOf(2);
+  });
+
+  describe("Delvis innvilgelse", () => {
+    it("viser periode-velger for delvis innvilgelse kun når det utfallet er valgt", async () => {
+      stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+      renderUtenlandsoppholdSoknad();
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+
+      expect(screen.queryByRole("textbox", { name: "Fra og med dato" })).to.not
+        .exist;
+
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+
+      expect(await screen.findByRole("textbox", { name: "Fra og med dato" })).to
+        .exist;
+      expect(screen.getByRole("textbox", { name: "Til og med dato" })).to.exist;
+
+      await clickRadio("Innvilgelse: Godkjenn hele perioden");
+
+      expect(screen.queryByRole("textbox", { name: "Fra og med dato" })).to.not
+        .exist;
+    });
+
+    it("viser valideringsfeil og sender ikke vedtak når delvis innvilgelse er valgt uten periode", async () => {
+      stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+      renderUtenlandsoppholdSoknad();
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+      await clickButton("Send vedtak");
+
+      expect(
+        await screen.findAllByText("Vennligst angi periode"),
+      ).to.have.lengthOf(2);
+
+      await waitFor(() => {
+        expect(queryClient.getMutationCache().getAll()).to.have.lengthOf(0);
+      });
+    });
+
+    it("viser valideringsfeil og sender ikke vedtak når valgt periode krysser datoer det ikke er søkt om", async () => {
+      stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+      renderUtenlandsoppholdSoknad();
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+
+      const fomInput = getTextInput("Fra og med dato");
+      const tomInput = getTextInput("Til og med dato");
+      // 05.06.2026 - 11.06.2026 krysser hullet 08.06.2026-09.06.2026 mellom soktePerioder
+      changeTextInput(fomInput, "05.06.2026");
+      changeTextInput(tomInput, "11.06.2026");
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickButton("Send vedtak");
+
+      expect(
+        await screen.findAllByText(
+          "Perioden kan ikke krysse datoer det ikke er søkt om",
+        ),
+      ).to.have.lengthOf(2);
+
+      await waitFor(() => {
+        expect(queryClient.getMutationCache().getAll()).to.have.lengthOf(0);
+      });
+    });
+
+    it("sender delvis innvilget vedtak med valgt periode, viser notifikasjon og navigerer tilbake til listen der søknadens status nå vises som delvis innvilget", async () => {
+      stubSoknaderMedMuterbarTilstand(mockSoknaderResponse.soknader);
+
+      renderUtenlandsoppholdSoknad(
+        soknadUtenVedtakMock.soknadId,
+        utenlandsoppholdPath,
+      );
+
+      expect(await screen.findByRole("button", { name: "Start behandling" })).to
+        .exist;
+
+      await clickButton("Start behandling");
+
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+
+      const fomInput = getTextInput("Fra og med dato");
+      const tomInput = getTextInput("Til og med dato");
+      changeTextInput(fomInput, "02.06.2026");
+      changeTextInput(tomInput, "05.06.2026");
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickButton("Send vedtak");
+
+      expect(
+        await screen.findByText(
+          "Vedtaket om utenlandsopphold utenfor EØS er fattet og sendt til bruker. Dokumentet er journalført i Gosys.",
+        ),
+      ).to.exist;
+      expect(screen.queryByText("Fant ikke søknaden")).to.not.exist;
+      expect(screen.queryByRole("button", { name: "Start behandling" })).to.not
+        .exist;
+      expect(await screen.findAllByText("Delvis innvilget")).to.have.lengthOf(
+        1,
+      );
+      expect(
+        await screen.findAllByText(
+          new RegExp(`^Behandlet .* av ${VEILEDER_DEFAULT.ident}$`),
+        ),
+      ).to.have.lengthOf(2);
+    });
+
+    it("kan legge til og fjerne flere godkjente perioder", async () => {
+      stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+      renderUtenlandsoppholdSoknad();
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+
+      await screen.findByRole("textbox", { name: "Fra og med dato" });
+      expect(screen.queryByRole("button", { name: "Slett ikon" })).to.not.exist;
+
+      await clickButton("Pluss ikon Legg til flere godkjente perioder");
+
+      expect(
+        await screen.findAllByRole("textbox", { name: "Fra og med dato" }),
+      ).to.have.lengthOf(2);
+      const fjernKnapper = screen.getAllByRole("button", {
+        name: "Slett ikon",
+      });
+      expect(fjernKnapper).to.have.lengthOf(2);
+
+      await userEvent.click(fjernKnapper[0]);
+
+      await waitFor(() => {
+        expect(
+          screen.getAllByRole("textbox", { name: "Fra og med dato" }),
+        ).to.have.lengthOf(1);
+      });
+      expect(screen.queryByRole("button", { name: "Slett ikon" })).to.not.exist;
+    });
+
+    it("viser valideringsfeil og sender ikke vedtak når to valgte perioder overlapper hverandre", async () => {
+      stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+      renderUtenlandsoppholdSoknad();
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+      await clickButton("Pluss ikon Legg til flere godkjente perioder");
+
+      const fomInputs = await screen.findAllByRole("textbox", {
+        name: "Fra og med dato",
+      });
+      const tomInputs = screen.getAllByRole("textbox", {
+        name: "Til og med dato",
+      });
+      // Begge periodene ligger innenfor 01.06.2026-07.06.2026, men overlapper hverandre
+      changeTextInput(fomInputs[0], "01.06.2026");
+      changeTextInput(tomInputs[0], "05.06.2026");
+      changeTextInput(fomInputs[1], "03.06.2026");
+      changeTextInput(tomInputs[1], "06.06.2026");
+
+      await clickButton("Send vedtak");
+
+      expect(
+        await screen.findAllByText(
+          "Perioden kan ikke overlappe med en annen periode du har lagt til",
+        ),
+      ).to.have.lengthOf(4);
+
+      await waitFor(() => {
+        expect(queryClient.getMutationCache().getAll()).to.have.lengthOf(0);
+      });
+    });
+
+    it("viser advarsel om at ingen perioder avslås når valgte perioder er like søkte perioder", async () => {
+      stubSoknaderQuery({ soknader: [soknadUtenVedtakMock] });
+
+      renderUtenlandsoppholdSoknad();
+
+      await screen.findByRole("button", { name: "Send vedtak" });
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+      await clickButton("Pluss ikon Legg til flere godkjente perioder");
+
+      const fomInputs = await screen.findAllByRole("textbox", {
+        name: "Fra og med dato",
+      });
+      const tomInputs = screen.getAllByRole("textbox", {
+        name: "Til og med dato",
+      });
+      // Perioden matcher nøyaktig soknadUtenVedtakMock sine soktePerioder
+      changeTextInput(fomInputs[0], "01.06.2026");
+      changeTextInput(tomInputs[0], "07.06.2026");
+      changeTextInput(fomInputs[1], "10.06.2026");
+      changeTextInput(tomInputs[1], "12.06.2026");
+
+      expect(
+        await screen.findByText(
+          "Du har valgt å innvilge alle perioder. Velg 'Innvilgelse' som utfall i stedet for 'Delvis innvilgelse'",
+        ),
+      ).to.exist;
+    });
+
+    it("sender delvis innvilget vedtak med flere valgte perioder", async () => {
+      stubSoknaderMedMuterbarTilstand(mockSoknaderResponse.soknader);
+
+      renderUtenlandsoppholdSoknad(
+        soknadUtenVedtakMock.soknadId,
+        utenlandsoppholdPath,
+      );
+
+      expect(await screen.findByRole("button", { name: "Start behandling" })).to
+        .exist;
+
+      await clickButton("Start behandling");
+
+      await clickRadio("Delvis innvilgelse: Godkjenn deler av perioden");
+      await screen.findByRole("textbox", { name: "Fra og med dato" });
+      await clickButton("Pluss ikon Legg til flere godkjente perioder");
+
+      const fomInputs = await screen.findAllByRole("textbox", {
+        name: "Fra og med dato",
+      });
+      const tomInputs = screen.getAllByRole("textbox", {
+        name: "Til og med dato",
+      });
+      changeTextInput(fomInputs[0], "02.06.2026");
+      changeTextInput(tomInputs[0], "05.06.2026");
+      changeTextInput(fomInputs[1], "10.06.2026");
+      changeTextInput(tomInputs[1], "12.06.2026");
+
+      await clickButton("Send vedtak");
+
+      expect(
+        await screen.findByText(
+          "Vedtaket om utenlandsopphold utenfor EØS er fattet og sendt til bruker. Dokumentet er journalført i Gosys.",
+        ),
+      ).to.exist;
+
+      await waitFor(() => {
+        const vedtakMutation = queryClient.getMutationCache().getAll()[0];
+        const variables = vedtakMutation.state.variables as {
+          soknadId: string;
+          vedtak: SoknadVedtakPostDTO;
+        };
+        expect(variables.vedtak.utfall).to.equal("DELVIS_INNVILGET");
+        expect(variables.vedtak.innvilgedePerioder).to.deep.equal([
+          {
+            fom: "2026-06-02",
+            tom: "2026-06-05",
+          },
+          {
+            fom: "2026-06-10",
+            tom: "2026-06-12",
+          },
+        ]);
+      });
+    });
   });
 
   it("viser valideringsfeil og sender ikke vedtak når ingen utfall er valgt", async () => {


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

- Mulighet for å velge delvis innvilget option
- Datovelger-logikk med flere perioder
- Datovelger-sjekker på hull
- Utregning av avslag-perioder når noen perioder er innvilget
- Hint om å bruke "Innvilgelse" dersom man velger alle dagene ved delvis innvilgelse
- En del styling-endringer her og der etter samtale med Ingrid og Stine

Sparret med Copilot for å få til dette med å velge flere perioder dynamisk, tror jeg har fått testet de fleste casene. Sikkert ikke så ofte en veileder velger flere perioder, men skal være mulig å gjøre i alle fall.

### Screenshots 📸✨

Filmen skal vise alt av funksjonaliteter.
https://github.com/user-attachments/assets/b5624654-4139-49a4-a164-312068b72951

Feilsituasjoner, med både overlappende valgte perioder og valgte perioder over "hull" som ikke er søkt om.
https://github.com/user-attachments/assets/0c146846-d71b-4b89-baed-318ed5796c8a


