### PR TITLE
IS-4167: Add list i read more på be om oppfølgingsplan

### DIFF
--- a/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
+++ b/src/sider/oppfolgingsplan/oppfolgingsplaner/BeOmOppfolgingsplan.tsx
@@ -1,10 +1,10 @@
 import {
   Alert,
   BodyLong,
-  BodyShort,
   Box,
   Button,
   Heading,
+  List,
   Radio,
   RadioGroup,
   ReadMore,
@@ -28,6 +28,7 @@ import LabelAndText from "@/components/LabelAndText";
 import { Controller, useForm } from "react-hook-form";
 import { useVirksomhetQuery } from "@/data/virksomhet/virksomhetQueryHooks";
 import { SkjemaInnsendingFeil } from "@/components/SkjemaInnsendingFeil";
+import { ListItem } from "@navikt/ds-react/List";
 
 const texts = {
   aktivForesporsel: "Obs! Det ble bedt om oppfølgingsplan fra",
@@ -44,19 +45,36 @@ const texts = {
   button: "Send forespørsel",
   foresporselSendt: "Forespørsel om oppfølgingsplan sendt",
   readMoreText: "Dette får nærmeste leder tilsendt i e-posten fra Nav",
+  readMoreContent: {
+    hei: "Hei,",
+    navBerOm:
+      "Nav ber om at du sender inn oppfølgingsplan for en av dine ansatte som er sykmeldt.",
+    slikGjorDuDet: "Slik gjør du det:",
+    steg1: "Logg inn på 'Min side - arbeidsgiver'.",
+    steg2:
+      "Klikk på 'bjella'. Der finner du meldingen om å lage oppfølgingsplan.",
+    harDuSporsmal: "Har du spørsmål, kan du kontakte oss på 55 55 33 36.",
+    duKanIkkeSvare: "Du kan ikke svare på denne meldingen.",
+    vennligHilsen: "Vennlig hilsen Nav.",
+  },
 };
 
 function ReadMoreContent() {
   return (
-    <BodyShort className="whitespace-pre-line">
-      {`Hei, \n
-      Nav ber om at du sender inn oppfølgingsplan for en av dine ansatte som er sykmeldt.
-      Logg inn på "Min side - arbeidsgiver". Klikk på varselet i "bjella" for å se hvem det gjelder. \n
-      Har du spørsmål, kan du kontakte oss på 55 55 33 36. \n
-      Vennlig hilsen Nav. \n
-      Du kan ikke svare på denne meldingen.
-      `}
-    </BodyShort>
+    <>
+      <BodyLong size="small">{texts.readMoreContent.hei}</BodyLong>
+      <BodyLong className="mb-4">{texts.readMoreContent.navBerOm}</BodyLong>
+      <Heading size="xsmall" level="4">
+        {texts.readMoreContent.slikGjorDuDet}
+      </Heading>
+      <List as="ol" size="small" className="mb-4">
+        <List.Item>{texts.readMoreContent.steg1}</List.Item>
+        <ListItem>{texts.readMoreContent.steg2}</ListItem>
+      </List>
+      <BodyLong size="small">{texts.readMoreContent.harDuSporsmal}</BodyLong>
+      <BodyLong size="small">{texts.readMoreContent.duKanIkkeSvare}</BodyLong>
+      <BodyLong size="small">{texts.readMoreContent.vennligHilsen}</BodyLong>
+    </>
   );
 }
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Endret utseende og tekst slik at det matcher det esyfo sender til arbeidsgiver når veileder ber om oppfølgingsplan

### Screenshots 📸✨
Før hos oss og hvordan det nå ser ut på esyfo sin side:
<img width="1424" height="610" alt="image" src="https://github.com/user-attachments/assets/06ea3401-49f1-4b9a-9370-ca874d68235c" />

Etter:
<img width="461" height="717" alt="Skjermbilde 2026-08-07 kl  14 31 44" src="https://github.com/user-attachments/assets/edb5cc7a-efec-4d9d-9bb2-206c02423f3e" />

