### PR TITLE
IS-4150: Add begrunnelse-field and brevmaler

### DIFF
--- a/src/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts
@@ -3,62 +3,150 @@ import { tilLesbarDatoMedArUtenManedNavn } from "@/utils/datoUtils.ts";
 
 export type UtenlandsoppholdDocumentTextsValues = {
   soknadDato: Date;
-  perioder: Periode[];
 };
 
-export const getUtenlandsoppholdDocumentTexts = ({
-  soknadDato,
-  perioder,
-}: UtenlandsoppholdDocumentTextsValues) => {
-  const soknadDatoTekst = tilLesbarDatoMedArUtenManedNavn(soknadDato);
-  const perioderTekst = perioder
+export type InnvilgetDocumentTextsValues =
+  UtenlandsoppholdDocumentTextsValues & {
+    innvilgedePerioder: Periode[];
+  };
+
+export type AvslagDocumentTextsValues = UtenlandsoppholdDocumentTextsValues & {
+  avslattePerioder: Periode[];
+  begrunnelse: string;
+};
+
+export type DelvisInnvilgetDocumentTextsValues =
+  UtenlandsoppholdDocumentTextsValues & {
+    innvilgedePerioder: Periode[];
+    avslattePerioder: Periode[];
+    begrunnelse: string;
+  };
+
+function perioderTilTekst(perioder: Periode[]) {
+  return perioder
     .map(
       (periode) =>
         `${tilLesbarDatoMedArUtenManedNavn(
           periode.fom,
         )} til og med ${tilLesbarDatoMedArUtenManedNavn(periode.tom)}`,
     )
-    .join(", ");
+    .join(", og ");
+}
+
+/**
+ * Tekster som er identiske uavhengig av utfallet på vedtaket.
+ */
+export const getFellesTekster = () => ({
+  endringSituasjon: {
+    header: "Hvis situasjonen din endrer seg",
+    body: "Endringer i situasjonen din kan påvirke retten din til sykepenger. Dersom du gir mangelfulle eller feilaktige opplysninger, kan det føre til at du må betale tilbake penger.",
+    lesMer: "Les mer om dette på: nav.no/endringer.",
+  },
+  sporsmal: {
+    header: "Har du spørsmål",
+    body: "Hvis du har spørsmål kan du kontakte oss via: nav.no/kontaktoss eller telefon 55 55 33 33.",
+  },
+  dineRettigheter: {
+    header: "Dine rettigheter",
+    innsyn: {
+      header: "Rett til innsyn",
+      body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller telefon 55 55 33 33.",
+    },
+    klage: {
+      header: "Rett til å klage",
+      body: "Hvis du ikke er enig i vedtaket, kan du klage innen seks uker fra du mottok dette brevet.",
+      lesMer: "Les mer om hvordan du klager her:",
+      url: "nav.no/klagerettigheter",
+      urlSykepenger: "nav.no/klage#sykepenger",
+    },
+  },
+});
+
+export const getInnvilgetTexts = ({
+  soknadDato,
+  innvilgedePerioder,
+}: InnvilgetDocumentTextsValues) => {
+  const soknadDatoTekst = tilLesbarDatoMedArUtenManedNavn(soknadDato);
+  const innvilgedePerioderTekst = perioderTilTekst(innvilgedePerioder);
 
   return {
-    header: "Vedtak om utenlandsopphold",
+    tittel: "Vedtak om innvilgelse av utenlandsopphold",
     innvilget: {
       header: "Du har fått godkjent sykepenger under utenlandsopphold",
-      intro: `Vi viser til din søknad av ${soknadDatoTekst} om å beholde sykepengene under opphold i utlandet. Søknaden din er godkjent og du får beholde sykepengene dine ved opphold i utlandet i perioden ${perioderTekst}.`,
+      intro: `Vi viser til din søknad av ${soknadDatoTekst} om å beholde sykepengene under opphold i utlandet. Søknaden din er godkjent og du får beholde sykepengene dine ved opphold i utlandet i perioden ${innvilgedePerioderTekst}.`,
     },
     begrunnelse: {
       header: "Begrunnelse for vedtaket",
       body: "Du er for tiden sykmeldt og har søkt om å beholde sykepengene på reise utenfor EU/EØS. Du kan få utbetalt sykepenger under utenlandsopphold utenfor EU/EØS eller andre områder der trygdeforordningen gjelder i inntil fire uker (28 kalenderdager) i løpet av en tolvmånedersperiode.",
-      body2: `Du bekrefter i søknaden at det er avklart med arbeidsgiver og sykmelder at reisen ikke vil være til hinder for planlagt aktivitet og behandling. Vi vurderer videre at oppholdet ikke vil hindre Navs kontroll og oppfølging. Du får derfor innvilget din søknad om å beholde sykepenger ved opphold i utlandet i perioden ${perioderTekst}.`,
+      body2: `Du bekrefter i søknaden at det er avklart med arbeidsgiver og sykmelder at reisen ikke vil være til hinder for planlagt aktivitet og behandling. Vi vurderer videre at oppholdet ikke vil hindre Navs kontroll og oppfølging. Du får derfor innvilget din søknad om å beholde sykepenger ved opphold i utlandet i perioden ${innvilgedePerioderTekst}.`,
       paragraf:
         "Dette vedtaket er gjort etter folketrygdloven § 8-9 tredje ledd.",
     },
     oppmerksom: {
       header: "Dette må du være oppmerksom på",
-      body: `Det er viktig at du er oppmerksom på at du har fått godkjent å beholde sykepenger under utenlandsopphold i perioden ${perioderTekst}. Dersom du oppholder deg utenfor EU/EØS eller andre områder der trygdeforordningen gjelder lengre enn dette, kan det få betydning for din videre rett til sykepenger.`,
+      // TODO: Mulig vi skal endre litt på ordly her
+      body: `Det er viktig at du er oppmerksom på at du har fått godkjent å beholde sykepenger under utenlandsopphold i perioden ${innvilgedePerioderTekst}. Dersom du oppholder deg utenfor EU/EØS eller andre områder der trygdeforordningen gjelder lengre enn dette, kan det få betydning for din videre rett til sykepenger.`,
     },
-    endringSituasjon: {
-      header: "Hvis situasjonen din endrer seg",
-      body: "Endringer i situasjonen din kan påvirke retten din til sykepenger. Dersom du gir mangelfulle eller feilaktige opplysninger, kan det føre til at du må betale tilbake penger.",
-      lesMer: "Les mer om dette på: nav.no/endringer.",
+    ...getFellesTekster(),
+  };
+};
+
+export const getAvslagTexts = ({
+  soknadDato,
+  avslattePerioder,
+}: AvslagDocumentTextsValues) => {
+  const soknadDatoTekst = tilLesbarDatoMedArUtenManedNavn(soknadDato);
+  const avslattePerioderTekst = perioderTilTekst(avslattePerioder);
+
+  return {
+    tittel: "Vedtak om avslag på utenlandsopphold",
+    avslag: {
+      header: "Du har fått avslag på sykepenger under utenlandsopphold",
+      intro: `Vi viser til din søknad av ${soknadDatoTekst} om å beholde sykepengene under opphold i utlandet. Søknaden din er avslått og du får ikke utbetalt sykepengene dine ved opphold i utlandet i perioden ${avslattePerioderTekst}.`,
     },
-    sporsmal: {
-      header: "Har du spørsmål",
-      body: "Hvis du har spørsmål kan du kontakte oss via: nav.no/kontaktoss eller telefon 55 55 33 33.",
+    begrunnelse: {
+      header: "Begrunnelse for vedtaket",
+      body: "Du er for tiden sykmeldt og har søkt om å beholde sykepengene på reise utenfor EU/EØS. Du kan få utbetalt sykepenger under utenlandsopphold utenfor EU/EØS eller andre områder der trygdeforordningen gjelder i inntil fire uker (28 kalenderdager) i løpet av en tolvmånedersperiode.",
+      utfall: "Nav har avslått søknaden din.",
+      paragraf:
+        "Dette vedtaket er gjort etter folketrygdloven § 8-9 tredje ledd.",
     },
-    dineRettigheter: {
-      header: "Dine rettigheter",
-      innsyn: {
-        header: "Rett til innsyn",
-        body: "Du kan se opplysninger i saken ved å logge deg inn på nav.no. Du kan også kontakte oss på nav.no/kontaktoss eller telefon 55 55 33 33.",
-      },
-      klage: {
-        header: "Rett til å klage",
-        body: "Hvis du ikke er enig i vedtaket, kan du klage innen seks uker fra du mottok dette brevet.",
-        lesMer: "Les mer om hvordan du klager her:",
-        url: "nav.no/klagerettigheter",
-        urlSykepenger: "nav.no/klage#sykepenger",
-      },
+    oppmerksom: {
+      header: "Dette må du være oppmerksom på",
+      body: "Dersom du likevel velger å reise kan dette få betydning for din videre rett til sykepenger.",
     },
+    ...getFellesTekster(),
+  };
+};
+
+export const getDelvisInnvilgetTexts = ({
+  soknadDato,
+  innvilgedePerioder,
+  avslattePerioder,
+}: DelvisInnvilgetDocumentTextsValues) => {
+  const soknadDatoTekst = tilLesbarDatoMedArUtenManedNavn(soknadDato);
+  const innvilgedePerioderTekst = perioderTilTekst(innvilgedePerioder);
+  const avslattePerioderTekst = perioderTilTekst(avslattePerioder);
+
+  return {
+    tittel: "Vedtak om delvis innvilgelse av utenlandsopphold",
+    delvisInnvilget: {
+      header:
+        "Du har fått godkjent deler av perioden med sykepenger under utenlandsopphold",
+      intro: `Vi viser til din søknad av ${soknadDatoTekst} om å beholde sykepengene under opphold i utlandet. Søknaden din er delvis godkjent og du får beholde sykepengene dine ved opphold i utlandet i perioden ${innvilgedePerioderTekst}. Du har fått avslag på å beholde sykepengene dine i utlandet i perioden ${avslattePerioderTekst}.`,
+    },
+    begrunnelse: {
+      header: "Begrunnelse for vedtaket",
+      body: "Du er for tiden sykmeldt og har søkt om å beholde sykepengene på reise utenfor EU/EØS. Du kan få utbetalt sykepenger under utenlandsopphold utenfor EU/EØS eller andre områder der trygdeforordningen gjelder i inntil fire uker (28 kalenderdager) i løpet av en tolvmånedersperiode.",
+      utfall: "Nav har innvilget deler av perioden du har søkt om.",
+      paragraf:
+        "Dette vedtaket er gjort etter folketrygdloven § 8-9 tredje ledd.",
+    },
+    oppmerksom: {
+      header: "Dette må du være oppmerksom på",
+      // TODO: Mulig denne skal endres på
+      body: `Det er viktig at du er oppmerksom på at du har fått godkjent å beholde sykepenger under utenlandsopphold kun fra ${innvilgedePerioderTekst}. Dersom du oppholder deg utenfor EU/EØS eller andre områder der trygdeforordningen gjelder lengre enn dette, kan det få betydning for din videre rett til sykepenger.`,
+    },
+    ...getFellesTekster(),
   };
 };

--- a/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
+++ b/src/data/utenlandsopphold/utenlandsoppholdTypes.ts
@@ -13,6 +13,7 @@ export interface SoknadVedtakPostDTO {
   utfall: Utfall;
   innvilgedePerioder: PeriodeDTO[];
   document: DocumentComponentDto[];
+  begrunnelse: string | null;
 }
 
 export interface SoknadVedtakResponseDTO {
@@ -38,6 +39,7 @@ export interface VedtakDTO {
   innvilgedePerioder: PeriodeDTO[];
   fattetAv: string;
   fattetTidspunkt: string;
+  begrunnelse: string | null;
 }
 
 export enum SoknadStatusDTO {

--- a/src/hooks/utenlandsopphold/useUtenlandsoppholdSoknadDocument.ts
+++ b/src/hooks/utenlandsopphold/useUtenlandsoppholdSoknadDocument.ts
@@ -8,52 +8,127 @@ import {
   createParagraph,
 } from "@/utils/documentComponentUtils";
 import {
-  getUtenlandsoppholdDocumentTexts,
-  UtenlandsoppholdDocumentTextsValues,
+  AvslagDocumentTextsValues,
+  DelvisInnvilgetDocumentTextsValues,
+  getAvslagTexts,
+  getDelvisInnvilgetTexts,
+  getFellesTekster,
+  getInnvilgetTexts,
+  InnvilgetDocumentTextsValues,
 } from "@/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts";
 
 export const useUtenlandsoppholdSoknadDocument = (): {
-  getVedtakDocument(
-    values: UtenlandsoppholdDocumentTextsValues,
+  getInnvilgetDocument(
+    values: InnvilgetDocumentTextsValues,
+  ): DocumentComponentDto[];
+  getAvslagDocument(values: AvslagDocumentTextsValues): DocumentComponentDto[];
+  getDelvisInnvilgetDocument(
+    values: DelvisInnvilgetDocumentTextsValues,
   ): DocumentComponentDto[];
 } => {
   const { getHilsen } = useDocumentComponents();
 
-  const getVedtakDocument = (
-    values: UtenlandsoppholdDocumentTextsValues,
-  ): DocumentComponentDto[] => {
-    const soknadTexts = getUtenlandsoppholdDocumentTexts(values);
+  const createFellesAvslutning = (): DocumentComponentDto[] => {
+    const texts = getFellesTekster();
 
     return [
-      createHeaderH1(soknadTexts.header),
-      createHeaderH2(soknadTexts.innvilget.header),
-      createParagraph(soknadTexts.innvilget.intro),
-      createHeaderH2(soknadTexts.begrunnelse.header),
-      createParagraph(soknadTexts.begrunnelse.body),
-      createParagraph(soknadTexts.begrunnelse.body2),
-      createParagraph(soknadTexts.begrunnelse.paragraf),
-      createHeaderH2(soknadTexts.oppmerksom.header),
-      createParagraph(soknadTexts.oppmerksom.body),
-      createHeaderH2(soknadTexts.endringSituasjon.header),
-      createParagraph(soknadTexts.endringSituasjon.body),
-      createParagraph(soknadTexts.endringSituasjon.lesMer),
-      createHeaderH2(soknadTexts.sporsmal.header),
-      createParagraph(soknadTexts.sporsmal.body),
-      createHeaderH2(soknadTexts.dineRettigheter.header),
-      createHeaderH3(soknadTexts.dineRettigheter.innsyn.header),
-      createParagraph(soknadTexts.dineRettigheter.innsyn.body),
-      createHeaderH3(soknadTexts.dineRettigheter.klage.header),
-      createParagraph(soknadTexts.dineRettigheter.klage.body),
-      createParagraph(soknadTexts.dineRettigheter.klage.lesMer),
+      createHeaderH2(texts.endringSituasjon.header),
+      createParagraph(texts.endringSituasjon.body),
+      createParagraph(texts.endringSituasjon.lesMer),
+      createHeaderH2(texts.sporsmal.header),
+      createParagraph(texts.sporsmal.body),
+      createHeaderH2(texts.dineRettigheter.header),
+      createHeaderH3(texts.dineRettigheter.innsyn.header),
+      createParagraph(texts.dineRettigheter.innsyn.body),
+      createHeaderH3(texts.dineRettigheter.klage.header),
+      createParagraph(texts.dineRettigheter.klage.body),
+      createParagraph(texts.dineRettigheter.klage.lesMer),
       createBulletPoints(
-        soknadTexts.dineRettigheter.klage.url,
-        soknadTexts.dineRettigheter.klage.urlSykepenger,
+        texts.dineRettigheter.klage.url,
+        texts.dineRettigheter.klage.urlSykepenger,
       ),
       getHilsen(),
     ];
   };
 
+  const getInnvilgetDocument = (
+    values: InnvilgetDocumentTextsValues,
+  ): DocumentComponentDto[] => {
+    const texts = getInnvilgetTexts(values);
+
+    return [
+      createHeaderH1(texts.tittel),
+      createHeaderH2(texts.innvilget.header),
+      createParagraph(texts.innvilget.intro),
+      createHeaderH2(texts.begrunnelse.header),
+      createParagraph(texts.begrunnelse.body),
+      createParagraph(texts.begrunnelse.body2),
+      createParagraph(texts.begrunnelse.paragraf),
+      createHeaderH2(texts.oppmerksom.header),
+      createParagraph(texts.oppmerksom.body),
+      ...createFellesAvslutning(),
+    ];
+  };
+
+  const getAvslagDocument = (
+    values: AvslagDocumentTextsValues,
+  ): DocumentComponentDto[] => {
+    const texts = getAvslagTexts(values);
+
+    const documentComponents = [
+      createHeaderH1(texts.tittel),
+      createHeaderH2(texts.avslag.header),
+      createParagraph(texts.avslag.intro),
+      createHeaderH2(texts.begrunnelse.header),
+      createParagraph(texts.begrunnelse.body),
+      createParagraph(texts.begrunnelse.utfall),
+    ];
+
+    if (values.begrunnelse) {
+      documentComponents.push(createParagraph(values.begrunnelse));
+    }
+
+    documentComponents.push(
+      createParagraph(texts.begrunnelse.paragraf),
+      createHeaderH2(texts.oppmerksom.header),
+      createParagraph(texts.oppmerksom.body),
+      ...createFellesAvslutning(),
+    );
+
+    return documentComponents;
+  };
+
+  const getDelvisInnvilgetDocument = (
+    values: DelvisInnvilgetDocumentTextsValues,
+  ): DocumentComponentDto[] => {
+    const texts = getDelvisInnvilgetTexts(values);
+
+    const documentComponents = [
+      createHeaderH1(texts.tittel),
+      createHeaderH2(texts.delvisInnvilget.header),
+      createParagraph(texts.delvisInnvilget.intro),
+      createHeaderH2(texts.begrunnelse.header),
+      createParagraph(texts.begrunnelse.body),
+      createParagraph(texts.begrunnelse.utfall),
+    ];
+
+    if (values.begrunnelse) {
+      documentComponents.push(createParagraph(values.begrunnelse));
+    }
+
+    documentComponents.push(
+      createParagraph(texts.begrunnelse.paragraf),
+      createHeaderH2(texts.oppmerksom.header),
+      createParagraph(texts.oppmerksom.body),
+      ...createFellesAvslutning(),
+    );
+
+    return documentComponents;
+  };
+
   return {
-    getVedtakDocument,
+    getInnvilgetDocument,
+    getAvslagDocument,
+    getDelvisInnvilgetDocument,
   };
 };

--- a/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
+++ b/src/mocks/isutenlandsopphold/mockIsutenlandsopphold.ts
@@ -49,6 +49,7 @@ export const soknadMedVedtakMock: SoknadDTO = {
     ],
     fattetAv: "Z990000",
     fattetTidspunkt: "2026-03-02T11:00:00",
+    begrunnelse: null,
   },
 };
 
@@ -80,6 +81,7 @@ export function byggOppdatertSoknadMedVedtak(
       innvilgedePerioder: vedtak.innvilgedePerioder,
       fattetAv,
       fattetTidspunkt: dayjs().format("YYYY-MM-DDTHH:mm:ss"),
+      begrunnelse: vedtak.begrunnelse,
     },
   };
 }

--- a/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
+++ b/src/sider/utenlandsopphold/UtenlandsoppholdSoknad.tsx
@@ -11,6 +11,7 @@ import {
   LocalAlert,
   Radio,
   RadioGroup,
+  Textarea,
 } from "@navikt/ds-react";
 import { DelvisInnvilgelsePeriodeDatepicker } from "@/sider/utenlandsopphold/DelvisInnvilgelsePeriodeDatepicker.tsx";
 import {
@@ -28,6 +29,7 @@ import { useNotification } from "@/context/notification/NotificationContext.tsx"
 import { utenlandsoppholdPath } from "@/AppRouter.tsx";
 import {
   beregnAvslattePerioder,
+  Periode,
   SoknadStatusDTO,
   Utfall,
 } from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
@@ -60,7 +62,15 @@ const texts = {
     "Vedtaket om utenlandsopphold utenfor EØS er fattet og sendt til bruker. Dokumentet er journalført i Gosys.",
   alertBehandlet: "Denne søknaden er allerede behandlet av",
   missingUtfall: "Du må velge et utfall for å fatte vedtaket",
+  begrunnelse: {
+    label: "Begrunnelse (obligatorisk)",
+    description:
+      "Begrunnelsen blir en del av en større brevmal. Åpne forhåndsvisning for å se hele vedtaket.",
+    missing: "Vennligst angi begrunnelse",
+  },
 };
+
+const begrunnelseMaxLength = 5000;
 
 // En midlertidig lokal feature-toggle, frem til vi har fått brevmaler på plass
 const isAvslagAndDelvisInnvilgelseEnabled = erLokal();
@@ -73,12 +83,17 @@ interface InnvilgetPeriode {
 interface SkjemaValues {
   utfall: Utfall;
   innvilgedePerioder: InnvilgetPeriode[];
+  begrunnelse: string;
 }
 
 export function UtenlandsoppholdSoknad() {
   const { data, isPending, isError } = useSoknaderQuery();
   const { mutate, isPending: mutateIsPending } = useVedtakMutation();
-  const { getVedtakDocument } = useUtenlandsoppholdSoknadDocument();
+  const {
+    getInnvilgetDocument,
+    getAvslagDocument,
+    getDelvisInnvilgetDocument,
+  } = useUtenlandsoppholdSoknadDocument();
   const formMethods = useForm<SkjemaValues>({
     defaultValues: { innvilgedePerioder: [] },
   });
@@ -95,6 +110,7 @@ export function UtenlandsoppholdSoknad() {
   const { setNotification } = useNotification();
   const valgtUtfall = watch("utfall");
   const valgteInnvilgedePerioder = watch("innvilgedePerioder");
+  const valgtBegrunnelse = watch("begrunnelse");
 
   function handleUtfallChange(utfall: Utfall) {
     if (utfall === "INNVILGET") {
@@ -105,6 +121,8 @@ export function UtenlandsoppholdSoknad() {
           tom: periode.tom,
         })),
       );
+      setValue("begrunnelse", "");
+      clearErrors("begrunnelse");
     } else {
       // Resetter denne når man velger DELVIS_INNVILGET eller AVSLAG
       setValue("innvilgedePerioder", []);
@@ -113,7 +131,7 @@ export function UtenlandsoppholdSoknad() {
   }
 
   function submit(soknadId: string, values: SkjemaValues) {
-    const { utfall, innvilgedePerioder } = values;
+    const { utfall, innvilgedePerioder, begrunnelse } = values;
     const perioder = innvilgedePerioder
       .filter((periode) => periode.fom && periode.tom)
       .map((periode) => ({
@@ -125,7 +143,8 @@ export function UtenlandsoppholdSoknad() {
       vedtak: {
         utfall: utfall,
         innvilgedePerioder: perioder,
-        document: vedtakDocument, // TODO: Må oppdateres basert på utfall
+        document: vedtakDocument,
+        begrunnelse: utfall === "INNVILGET" ? null : begrunnelse,
       },
     };
     mutate(request, {
@@ -172,11 +191,39 @@ export function UtenlandsoppholdSoknad() {
   const avslattePerioder =
     valgtUtfall === "DELVIS_INNVILGET"
       ? beregnAvslattePerioder(soktePerioder, valgteInnvilgedePerioder)
-      : [];
-  const vedtakDocument = getVedtakDocument({
-    soknadDato: utenlandsoppholdSoknad.innsendtTidspunkt,
-    perioder: utenlandsoppholdSoknad.soktePerioder,
-  });
+      : valgtUtfall === "AVSLAG"
+        ? soktePerioder
+        : [];
+
+  // Ettersom man kan være i en tilstand der man har valgt fom, men ikke tom, i DELVIS_INNVILGET
+  // må vi filtrere ut undefined-verdier i overgangen fra InnvilgetPeriode-typen til Periode-typen
+  const gyldigeInnvilgedePerioder: Periode[] = valgteInnvilgedePerioder.filter(
+    (periode): periode is Periode => !!periode.fom && !!periode.tom,
+  );
+
+  const vedtakDocument = (() => {
+    switch (valgtUtfall) {
+      case "AVSLAG":
+        return getAvslagDocument({
+          soknadDato: utenlandsoppholdSoknad.innsendtTidspunkt,
+          avslattePerioder: avslattePerioder,
+          begrunnelse: valgtBegrunnelse ?? "",
+        });
+      case "DELVIS_INNVILGET":
+        return getDelvisInnvilgetDocument({
+          soknadDato: utenlandsoppholdSoknad.innsendtTidspunkt,
+          innvilgedePerioder: gyldigeInnvilgedePerioder,
+          avslattePerioder: avslattePerioder,
+          begrunnelse: valgtBegrunnelse ?? "",
+        });
+      case "INNVILGET":
+      default:
+        return getInnvilgetDocument({
+          soknadDato: utenlandsoppholdSoknad.innsendtTidspunkt,
+          innvilgedePerioder: gyldigeInnvilgedePerioder,
+        });
+    }
+  })();
 
   return (
     <Box background="default" padding="space-16" className="flex flex-col">
@@ -310,11 +357,31 @@ export function UtenlandsoppholdSoknad() {
                   )}
                 </Box>
               )}
+              {(valgtUtfall === "DELVIS_INNVILGET" ||
+                valgtUtfall === "AVSLAG") && (
+                <Textarea
+                  {...register("begrunnelse", {
+                    maxLength: begrunnelseMaxLength,
+                    required: texts.begrunnelse.missing,
+                  })}
+                  value={watch("begrunnelse")}
+                  label={texts.begrunnelse.label}
+                  description={texts.begrunnelse.description}
+                  error={errors.begrunnelse?.message}
+                  size="small"
+                  minRows={6}
+                  maxLength={begrunnelseMaxLength}
+                />
+              )}
               <div className="flex flex-row gap-4">
                 <Button
                   variant="primary"
                   type="submit"
                   loading={mutateIsPending}
+                  disabled={
+                    valgtUtfall === "DELVIS_INNVILGET" &&
+                    avslattePerioder.length === 0
+                  }
                 >
                   {texts.buttons.sendButton}
                 </Button>

--- a/test/utenlandsopphold/UtenlandsoppholdSoknadTest.tsx
+++ b/test/utenlandsopphold/UtenlandsoppholdSoknadTest.tsx
@@ -156,6 +156,11 @@ describe("UtenlandsoppholdSoknad", () => {
 
     await clickRadio("Avslag: Avslå hele perioden");
 
+    changeTextInput(
+      getTextInput("Begrunnelse (obligatorisk)"),
+      "Vurdering av avslag",
+    );
+
     await screen.findByRole("button", { name: "Send vedtak" });
     await clickButton("Send vedtak");
 
@@ -173,6 +178,30 @@ describe("UtenlandsoppholdSoknad", () => {
         new RegExp(`^Behandlet .* av ${VEILEDER_DEFAULT.ident}$`),
       ),
     ).to.have.lengthOf(2);
+
+    await waitFor(() => {
+      const vedtakMutation = queryClient.getMutationCache().getAll()[0];
+      const variables = vedtakMutation.state.variables as {
+        soknadId: string;
+        vedtak: SoknadVedtakPostDTO;
+      };
+      expect(variables.vedtak.begrunnelse).to.equal("Vurdering av avslag");
+      expect(
+        variables.vedtak.document.some((component) =>
+          component.texts.includes("Vurdering av avslag"),
+        ),
+      ).to.equal(true);
+      // Hele søknadsperioden avslås, siden det ikke er valgt noen innvilgede perioder
+      expect(
+        variables.vedtak.document.some((component) =>
+          component.texts.some(
+            (text) =>
+              text.includes("01.06.2026 til og med 07.06.2026") &&
+              text.includes("10.06.2026 til og med 12.06.2026"),
+          ),
+        ),
+      ).to.equal(true);
+    });
   });
 
   describe("Delvis innvilgelse", () => {
@@ -263,6 +292,10 @@ describe("UtenlandsoppholdSoknad", () => {
       const tomInput = getTextInput("Til og med dato");
       changeTextInput(fomInput, "02.06.2026");
       changeTextInput(tomInput, "05.06.2026");
+      changeTextInput(
+        getTextInput("Begrunnelse (obligatorisk)"),
+        "Vurdering av delvis innvilgelse",
+      );
 
       await screen.findByRole("button", { name: "Send vedtak" });
       await clickButton("Send vedtak");
@@ -283,6 +316,32 @@ describe("UtenlandsoppholdSoknad", () => {
           new RegExp(`^Behandlet .* av ${VEILEDER_DEFAULT.ident}$`),
         ),
       ).to.have.lengthOf(2);
+
+      await waitFor(() => {
+        const vedtakMutation = queryClient.getMutationCache().getAll()[0];
+        const variables = vedtakMutation.state.variables as {
+          soknadId: string;
+          vedtak: SoknadVedtakPostDTO;
+        };
+        expect(variables.vedtak.begrunnelse).to.equal(
+          "Vurdering av delvis innvilgelse",
+        );
+        expect(
+          variables.vedtak.document.some((component) =>
+            component.texts.includes("Vurdering av delvis innvilgelse"),
+          ),
+        ).to.equal(true);
+        // Innvilget periode 02.06-05.06 fører til at resten av søknadsperiodene avslås
+        expect(
+          variables.vedtak.document.some((component) =>
+            component.texts.some(
+              (text) =>
+                text.includes("02.06.2026 til og med 05.06.2026") &&
+                !text.includes("01.06.2026"),
+            ),
+          ),
+        ).to.equal(true);
+      });
     });
 
     it("kan legge til og fjerne flere godkjente perioder", async () => {
@@ -376,6 +435,9 @@ describe("UtenlandsoppholdSoknad", () => {
           "Du har valgt å innvilge alle perioder. Velg 'Innvilgelse' som utfall i stedet for 'Delvis innvilgelse'",
         ),
       ).to.exist;
+      expect(
+        screen.getByRole("button", { name: "Send vedtak" }),
+      ).to.have.property("disabled", true);
     });
 
     it("sender delvis innvilget vedtak med flere valgte perioder", async () => {
@@ -405,6 +467,10 @@ describe("UtenlandsoppholdSoknad", () => {
       changeTextInput(tomInputs[0], "05.06.2026");
       changeTextInput(fomInputs[1], "10.06.2026");
       changeTextInput(tomInputs[1], "12.06.2026");
+      changeTextInput(
+        getTextInput("Begrunnelse (obligatorisk)"),
+        "Vurdering av delvis innvilgelse",
+      );
 
       await clickButton("Send vedtak");
 

--- a/test/utenlandsopphold/utenlandsoppholdDocumentTextsTest.ts
+++ b/test/utenlandsopphold/utenlandsoppholdDocumentTextsTest.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAvslagTexts,
+  getDelvisInnvilgetTexts,
+  getInnvilgetTexts,
+} from "@/data/utenlandsopphold/utenlandsoppholdDocumentTexts.ts";
+import { Periode } from "@/data/utenlandsopphold/utenlandsoppholdTypes.ts";
+
+const soknadDato = new Date("2026-05-15");
+
+const enPeriode: Periode[] = [
+  { fom: new Date("2026-06-01"), tom: new Date("2026-06-07") },
+];
+
+const flerePerioder: Periode[] = [
+  { fom: new Date("2026-06-01"), tom: new Date("2026-06-07") },
+  { fom: new Date("2026-06-10"), tom: new Date("2026-06-12") },
+];
+
+describe("utenlandsoppholdDocumentTexts", () => {
+  describe("getInnvilgetTexts", () => {
+    it("formaterer en enkelt innvilget periode", () => {
+      const texts = getInnvilgetTexts({
+        soknadDato,
+        innvilgedePerioder: enPeriode,
+      });
+
+      expect(texts.tittel).to.equal(
+        "Vedtak om innvilgelse av utenlandsopphold",
+      );
+      expect(texts.innvilget.intro).to.contain(
+        "01.06.2026 til og med 07.06.2026",
+      );
+    });
+
+    it("formaterer flere innvilgede perioder adskilt med 'og'", () => {
+      const texts = getInnvilgetTexts({
+        soknadDato,
+        innvilgedePerioder: flerePerioder,
+      });
+
+      expect(texts.innvilget.intro).to.contain(
+        "01.06.2026 til og med 07.06.2026, og 10.06.2026 til og med 12.06.2026",
+      );
+    });
+  });
+
+  describe("getAvslagTexts", () => {
+    it("viser avslåtte perioder, ikke innvilgede perioder, i introteksten", () => {
+      const texts = getAvslagTexts({
+        soknadDato,
+        avslattePerioder: flerePerioder,
+        begrunnelse: "En begrunnelse",
+      });
+
+      expect(texts.tittel).to.equal("Vedtak om avslag på utenlandsopphold");
+      expect(texts.avslag.intro).to.contain(
+        "01.06.2026 til og med 07.06.2026, og 10.06.2026 til og med 12.06.2026",
+      );
+    });
+  });
+
+  describe("getDelvisInnvilgetTexts", () => {
+    it("viser både innvilgede og avslåtte perioder i introteksten", () => {
+      const innvilgedePerioder: Periode[] = [
+        { fom: new Date("2026-06-01"), tom: new Date("2026-06-05") },
+      ];
+      const avslattePerioder: Periode[] = [
+        { fom: new Date("2026-06-06"), tom: new Date("2026-06-07") },
+      ];
+
+      const texts = getDelvisInnvilgetTexts({
+        soknadDato,
+        innvilgedePerioder,
+        avslattePerioder,
+        begrunnelse: "En begrunnelse",
+      });
+
+      expect(texts.tittel).to.equal(
+        "Vedtak om delvis innvilgelse av utenlandsopphold",
+      );
+      expect(texts.delvisInnvilget.intro).to.contain(
+        "01.06.2026 til og med 05.06.2026",
+      );
+      expect(texts.delvisInnvilget.intro).to.contain(
+        "06.06.2026 til og med 07.06.2026",
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

- Oppdatert typene for DTOene fra APIet basert på https://github.com/navikt/isutenlandsopphold/pull/56/changes
- Lagt til begrunnelsesfelt som dukker opp for delvis innvilget og avslag
- Endret fra den ene brevmalen til å dekke alle tre utfall
- Utfallene bestemmer også hva slags parametere `getDocument`-funksjonene tar inn
- En del tester

### Screenshots 📸✨

Innvilget:
<img width="771" height="693" alt="image" src="https://github.com/user-attachments/assets/bf413c94-1e15-4a33-9778-b20473fdcae9" />

Delvis innvilget med to perioder:
<img width="752" height="719" alt="image" src="https://github.com/user-attachments/assets/3ed56717-be4a-42a5-9453-18bdd8c65471" />

Avslag:
<img width="769" height="701" alt="image" src="https://github.com/user-attachments/assets/bf7c54a4-b70a-4d03-bfc8-c4afebe747f2" />

Begrunnelsesfelt med validering, klikk for å se video
https://github.com/user-attachments/assets/7c0ed47e-37f6-42b5-901e-7fd3ff8dd560

